### PR TITLE
feat: ECHO snapshot ledger — mobius-bot style docs/echo/ documentation

### DIFF
--- a/app/api/echo/ingest/route.ts
+++ b/app/api/echo/ingest/route.ts
@@ -4,14 +4,18 @@
  * GET  /api/echo/ingest — Check ingest status
  * POST /api/echo/ingest — Trigger a new ingest cycle (called by Vercel Cron)
  *
- * Vercel Cron hits this endpoint every 2 hours.
+ * Vercel Cron hits this endpoint daily at 6 AM UTC.
+ * Feed route auto-re-ingests when data is stale (>2h).
  * Can also be triggered manually: curl -X POST /api/echo/ingest
+ *
+ * After ingest, generates a docs/echo/ snapshot (JSON ledger + dashboard).
  */
 
 import { NextResponse } from 'next/server';
 import { fetchAllSources } from '@/lib/echo/sources';
 import { transformBatch } from '@/lib/echo/transform';
-import { pushIngestResult, getEchoStatus } from '@/lib/echo/store';
+import { pushIngestResult, getEchoStatus, getEchoEpicon, getEchoLedger, getEchoAlerts } from '@/lib/echo/store';
+import { writeSnapshot } from '@/lib/echo/snapshot-writer';
 
 export const dynamic = 'force-dynamic';
 
@@ -47,6 +51,19 @@ export async function POST() {
     // 3. Push to store
     pushIngestResult(result);
 
+    // 4. Generate docs/echo/ snapshot (fire-and-forget, non-blocking)
+    let snapshotWritten = false;
+    try {
+      snapshotWritten = await writeSnapshot(
+        getEchoStatus(),
+        getEchoEpicon(),
+        getEchoLedger(),
+        getEchoAlerts(),
+      );
+    } catch {
+      // Snapshot writing is best-effort
+    }
+
     return NextResponse.json({
       agent: 'ECHO',
       action: 'ingest',
@@ -58,6 +75,7 @@ export async function POST() {
         ledger: result.ledger.length,
         alerts: result.alerts.length,
       },
+      snapshot: snapshotWritten ? 'written' : 'skipped',
       duration: Date.now() - startTime,
       timestamp: result.timestamp,
     });

--- a/app/api/echo/snapshot/route.ts
+++ b/app/api/echo/snapshot/route.ts
@@ -1,0 +1,78 @@
+/**
+ * ECHO Snapshot API Route
+ *
+ * POST /api/echo/snapshot — Generate docs/echo/ snapshot from current store
+ * GET  /api/echo/snapshot — Returns the latest snapshot data (read-only)
+ *
+ * In local/CI environments, writes files to docs/echo/*.
+ * Always returns the snapshot payload so external bots can commit it.
+ */
+
+import { NextResponse } from 'next/server';
+import {
+  getEchoEpicon,
+  getEchoLedger,
+  getEchoAlerts,
+  getEchoStatus,
+} from '@/lib/echo/store';
+import { buildSnapshot, buildDashboard } from '@/lib/echo/ledger-writer';
+import { writeSnapshot } from '@/lib/echo/snapshot-writer';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const status = getEchoStatus();
+  const epicon = getEchoEpicon();
+  const ledger = getEchoLedger();
+  const alerts = getEchoAlerts();
+
+  if (status.totalIngested === 0) {
+    return NextResponse.json({
+      agent: 'ECHO',
+      action: 'snapshot',
+      result: 'empty',
+      message: 'No ingest data in store. Trigger an ingest first.',
+    });
+  }
+
+  const now = new Date().toISOString();
+  const snapshot = buildSnapshot(status.cycleId, epicon, ledger, alerts, now);
+
+  return NextResponse.json({
+    agent: 'ECHO',
+    action: 'snapshot',
+    result: 'ok',
+    snapshot,
+    dashboard: buildDashboard(snapshot),
+  });
+}
+
+export async function POST() {
+  const status = getEchoStatus();
+  const epicon = getEchoEpicon();
+  const ledger = getEchoLedger();
+  const alerts = getEchoAlerts();
+
+  if (status.totalIngested === 0) {
+    return NextResponse.json({
+      agent: 'ECHO',
+      action: 'snapshot',
+      result: 'empty',
+      message: 'No ingest data in store. Trigger an ingest first.',
+    });
+  }
+
+  const filesWritten = await writeSnapshot(status, epicon, ledger, alerts);
+
+  const now = new Date().toISOString();
+  const snapshot = buildSnapshot(status.cycleId, epicon, ledger, alerts, now);
+
+  return NextResponse.json({
+    agent: 'ECHO',
+    action: 'snapshot',
+    result: 'ok',
+    files_written: filesWritten,
+    snapshot,
+    dashboard_preview: buildDashboard(snapshot).slice(0, 200) + '...',
+  });
+}

--- a/docs/echo/dashboard.md
+++ b/docs/echo/dashboard.md
@@ -1,0 +1,16 @@
+# ECHO Ingest Dashboard
+
+**Repo:** `kaizencycle/mobius-civic-ai-terminal`
+**Generated:** `—`
+**Cycle:** `—`
+**Sources ingested:** `0`
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| EPICON events | 0 |
+| Ledger entries | 0 |
+| Active alerts | 0 |
+
+_Awaiting first ingest cycle._

--- a/docs/echo/data.json
+++ b/docs/echo/data.json
@@ -1,0 +1,12 @@
+{
+  "repo": "kaizencycle/mobius-civic-ai-terminal",
+  "generated_at": null,
+  "cycle_id": null,
+  "source_counts": { "gdelt": 0, "usgs": 0, "coingecko": 0, "total": 0 },
+  "by_severity": { "high": 0, "medium": 0, "low": 0 },
+  "by_category": { "geopolitical": 0, "market": 0, "infrastructure": 0, "governance": 0 },
+  "alert_count": 0,
+  "ledger_count": 0,
+  "epicon_count": 0,
+  "epicon_sig": {}
+}

--- a/docs/echo/history/events.json
+++ b/docs/echo/history/events.json
@@ -1,0 +1,5 @@
+{
+  "repo": "kaizencycle/mobius-civic-ai-terminal",
+  "updated_at": null,
+  "events": []
+}

--- a/docs/echo/history/index.json
+++ b/docs/echo/history/index.json
@@ -1,0 +1,5 @@
+{
+  "repo": "kaizencycle/mobius-civic-ai-terminal",
+  "updated_at": null,
+  "timeline": []
+}

--- a/lib/echo/ledger-writer.ts
+++ b/lib/echo/ledger-writer.ts
@@ -1,0 +1,257 @@
+/**
+ * ECHO Ledger Writer
+ *
+ * Generates JSON snapshots and a markdown dashboard from ECHO ingest data,
+ * mirroring the mobius-bot divergence documentation pattern:
+ *
+ *   docs/echo/dashboard.md        — human-readable summary
+ *   docs/echo/data.json           — current snapshot
+ *   docs/echo/history/{ts}.json   — timestamped snapshots
+ *   docs/echo/history/events.json — cumulative event log
+ *   docs/echo/history/index.json  — timeline of all snapshots
+ */
+
+import type { EpiconItem, LedgerEntry, CivicRadarAlert } from '@/lib/terminal/types';
+
+// ── Types ────────────────────────────────────────────────────
+
+export type EchoSnapshot = {
+  repo: string;
+  generated_at: string;
+  cycle_id: string;
+  source_counts: {
+    gdelt: number;
+    usgs: number;
+    coingecko: number;
+    total: number;
+  };
+  by_severity: {
+    high: number;
+    medium: number;
+    low: number;
+  };
+  by_category: {
+    geopolitical: number;
+    market: number;
+    infrastructure: number;
+    governance: number;
+  };
+  alert_count: number;
+  ledger_count: number;
+  epicon_count: number;
+  epicon_sig: Record<string, {
+    title: string;
+    category: string;
+    severity: string;
+    confidence: number;
+    agent: string;
+    source: string;
+  }>;
+};
+
+export type EchoEvent = {
+  ts: string;
+  cycle_id: string;
+  action: string;
+  sources: number;
+  epicon: number;
+  ledger: number;
+  alerts: number;
+};
+
+export type EchoTimeline = {
+  repo: string;
+  updated_at: string;
+  timeline: EchoSnapshot[];
+};
+
+export type EchoEventLog = {
+  repo: string;
+  updated_at: string;
+  events: EchoEvent[];
+};
+
+const REPO = 'kaizencycle/mobius-civic-ai-terminal';
+const MAX_TIMELINE_ENTRIES = 100;
+const MAX_EVENTS = 500;
+
+// ── Snapshot builder ─────────────────────────────────────────
+
+export function buildSnapshot(
+  cycleId: string,
+  epicon: EpiconItem[],
+  ledger: LedgerEntry[],
+  alerts: CivicRadarAlert[],
+  timestamp: string,
+): EchoSnapshot {
+  const bySeverity = { high: 0, medium: 0, low: 0 };
+  const byCategory = { geopolitical: 0, market: 0, infrastructure: 0, governance: 0 };
+  const sourceCounts = { gdelt: 0, usgs: 0, coingecko: 0, total: 0 };
+
+  for (const item of epicon) {
+    byCategory[item.category] = (byCategory[item.category] ?? 0) + 1;
+
+    // Map confidence tier back to severity
+    if (item.confidenceTier >= 3) bySeverity.high++;
+    else if (item.confidenceTier >= 2) bySeverity.medium++;
+    else bySeverity.low++;
+
+    // Count sources
+    for (const s of item.sources) {
+      if (s === 'GDELT') sourceCounts.gdelt++;
+      else if (s === 'USGS') sourceCounts.usgs++;
+      else if (s === 'CoinGecko') sourceCounts.coingecko++;
+    }
+    sourceCounts.total++;
+  }
+
+  // Build epicon signature map (like pr_sig in divergence)
+  const epiconSig: EchoSnapshot['epicon_sig'] = {};
+  for (const item of epicon.slice(0, 20)) {
+    epiconSig[item.id] = {
+      title: item.title.slice(0, 80),
+      category: item.category,
+      severity: item.confidenceTier >= 3 ? 'high' : item.confidenceTier >= 2 ? 'medium' : 'low',
+      confidence: item.confidenceTier,
+      agent: item.ownerAgent,
+      source: item.sources[0] ?? 'unknown',
+    };
+  }
+
+  return {
+    repo: REPO,
+    generated_at: timestamp,
+    cycle_id: cycleId,
+    source_counts: sourceCounts,
+    by_severity: bySeverity,
+    by_category: byCategory,
+    alert_count: alerts.length,
+    ledger_count: ledger.length,
+    epicon_count: epicon.length,
+    epicon_sig: epiconSig,
+  };
+}
+
+// ── Event builder ────────────────────────────────────────────
+
+export function buildEvent(
+  cycleId: string,
+  sourceCount: number,
+  epiconCount: number,
+  ledgerCount: number,
+  alertCount: number,
+  timestamp: string,
+): EchoEvent {
+  return {
+    ts: timestamp,
+    cycle_id: cycleId,
+    action: 'ingest',
+    sources: sourceCount,
+    epicon: epiconCount,
+    ledger: ledgerCount,
+    alerts: alertCount,
+  };
+}
+
+// ── Dashboard markdown builder ───────────────────────────────
+
+export function buildDashboard(snapshot: EchoSnapshot): string {
+  const lines: string[] = [
+    '# ECHO Ingest Dashboard',
+    '',
+    `**Repo:** \`${snapshot.repo}\`  `,
+    `**Generated:** \`${snapshot.generated_at}\`  `,
+    `**Cycle:** \`${snapshot.cycle_id}\`  `,
+    `**Sources ingested:** \`${snapshot.source_counts.total}\``,
+    '',
+    '## Summary',
+    '',
+    '| Metric | Count |',
+    '|--------|-------|',
+    `| EPICON events | ${snapshot.epicon_count} |`,
+    `| Ledger entries | ${snapshot.ledger_count} |`,
+    `| Active alerts | ${snapshot.alert_count} |`,
+    '',
+    '## By Severity',
+    '',
+    '| Severity | Count |',
+    '|----------|-------|',
+    `| High | ${snapshot.by_severity.high} |`,
+    `| Medium | ${snapshot.by_severity.medium} |`,
+    `| Low | ${snapshot.by_severity.low} |`,
+    '',
+    '## By Category',
+    '',
+    '| Category | Count |',
+    '|----------|-------|',
+    `| Geopolitical | ${snapshot.by_category.geopolitical} |`,
+    `| Market | ${snapshot.by_category.market} |`,
+    `| Infrastructure | ${snapshot.by_category.infrastructure} |`,
+    `| Governance | ${snapshot.by_category.governance} |`,
+    '',
+    '## Sources',
+    '',
+    '| Source | Events |',
+    '|--------|--------|',
+    `| GDELT | ${snapshot.source_counts.gdelt} |`,
+    `| USGS | ${snapshot.source_counts.usgs} |`,
+    `| CoinGecko | ${snapshot.source_counts.coingecko} |`,
+    '',
+    '## EPICON Signals',
+    '',
+  ];
+
+  const entries = Object.entries(snapshot.epicon_sig);
+  if (entries.length === 0) {
+    lines.push('_No signals in current cycle._');
+  } else {
+    lines.push('| ID | Title | Category | Severity | Agent |');
+    lines.push('|----|-------|----------|----------|-------|');
+    for (const [id, sig] of entries) {
+      lines.push(`| ${id} | ${sig.title} | ${sig.category} | ${sig.severity} | ${sig.agent} |`);
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ── File content builders (for API route to write) ───────────
+
+export function appendToTimeline(
+  existing: EchoTimeline | null,
+  snapshot: EchoSnapshot,
+): EchoTimeline {
+  const timeline = existing?.timeline ?? [];
+  timeline.push(snapshot);
+
+  // Cap size
+  while (timeline.length > MAX_TIMELINE_ENTRIES) {
+    timeline.shift();
+  }
+
+  return {
+    repo: REPO,
+    updated_at: snapshot.generated_at,
+    timeline,
+  };
+}
+
+export function appendToEventLog(
+  existing: EchoEventLog | null,
+  event: EchoEvent,
+): EchoEventLog {
+  const events = existing?.events ?? [];
+  events.push(event);
+
+  // Cap size
+  while (events.length > MAX_EVENTS) {
+    events.shift();
+  }
+
+  return {
+    repo: REPO,
+    updated_at: event.ts,
+    events,
+  };
+}

--- a/lib/echo/snapshot-writer.ts
+++ b/lib/echo/snapshot-writer.ts
@@ -1,0 +1,101 @@
+/**
+ * ECHO Snapshot Writer
+ *
+ * Writes docs/echo/ files from current store state.
+ * Used by the ingest route and snapshot API route.
+ *
+ * Returns true if files were written, false if filesystem is read-only.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { EpiconItem, LedgerEntry, CivicRadarAlert } from '@/lib/terminal/types';
+import {
+  buildSnapshot,
+  buildEvent,
+  buildDashboard,
+  appendToTimeline,
+  appendToEventLog,
+  type EchoTimeline,
+  type EchoEventLog,
+} from './ledger-writer';
+
+const DOCS_ROOT = path.join(process.cwd(), 'docs', 'echo');
+const HISTORY_DIR = path.join(DOCS_ROOT, 'history');
+
+async function readJsonSafe<T>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function tsFileName(iso: string): string {
+  return iso.replace(/[-:]/g, '').replace(/\.\d+Z$/, 'Z') + '.json';
+}
+
+export async function writeSnapshot(
+  status: { cycleId: string; totalIngested: number },
+  epicon: EpiconItem[],
+  ledger: LedgerEntry[],
+  alerts: CivicRadarAlert[],
+): Promise<boolean> {
+  if (status.totalIngested === 0) return false;
+
+  const now = new Date().toISOString();
+  const snapshot = buildSnapshot(status.cycleId, epicon, ledger, alerts, now);
+  const event = buildEvent(
+    status.cycleId,
+    status.totalIngested,
+    epicon.length,
+    ledger.length,
+    alerts.length,
+    now,
+  );
+  const dashboard = buildDashboard(snapshot);
+
+  try {
+    await fs.mkdir(HISTORY_DIR, { recursive: true });
+
+    // data.json — current snapshot
+    await fs.writeFile(
+      path.join(DOCS_ROOT, 'data.json'),
+      JSON.stringify(snapshot, null, 2) + '\n',
+    );
+
+    // dashboard.md
+    await fs.writeFile(path.join(DOCS_ROOT, 'dashboard.md'), dashboard);
+
+    // history/{timestamp}.json
+    await fs.writeFile(
+      path.join(HISTORY_DIR, tsFileName(now)),
+      JSON.stringify(snapshot, null, 2) + '\n',
+    );
+
+    // history/index.json — timeline
+    const existingTimeline = await readJsonSafe<EchoTimeline>(
+      path.join(HISTORY_DIR, 'index.json'),
+    );
+    const timeline = appendToTimeline(existingTimeline, snapshot);
+    await fs.writeFile(
+      path.join(HISTORY_DIR, 'index.json'),
+      JSON.stringify(timeline, null, 2) + '\n',
+    );
+
+    // history/events.json — event log
+    const existingEvents = await readJsonSafe<EchoEventLog>(
+      path.join(HISTORY_DIR, 'events.json'),
+    );
+    const eventLog = appendToEventLog(existingEvents, event);
+    await fs.writeFile(
+      path.join(HISTORY_DIR, 'events.json'),
+      JSON.stringify(eventLog, null, 2) + '\n',
+    );
+
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Adds a JSON ledger workflow mirroring the mobius-bot divergence pattern from Mobius-Substrate. Each ingest cycle now generates:

  docs/echo/dashboard.md        — human-readable summary table
  docs/echo/data.json           — current snapshot (counts, severity, signals)
  docs/echo/history/{ts}.json   — timestamped snapshots
  docs/echo/history/events.json — cumulative event log
  docs/echo/history/index.json  — timeline of all snapshots

Architecture:
- lib/echo/ledger-writer.ts  — pure snapshot/dashboard builders
- lib/echo/snapshot-writer.ts — filesystem writer (local/CI)
- app/api/echo/snapshot/      — GET reads, POST writes snapshot
- Ingest route now auto-generates snapshot after each cycle

https://claude.ai/code/session_01Ty6Lf7t9g9CnR8fDZ7FhxG