### PR TITLE
feat: mobile responsive layout for iOS and Android

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -28,11 +28,32 @@ html,
 body {
   margin: 0;
   padding: 0;
+  -webkit-text-size-adjust: 100%;
 }
 
 body {
   background: #020617;
   color: #e2e8f0;
+  /* Prevent overscroll bounce on iOS */
+  overscroll-behavior: none;
+}
+
+/* Safe area padding for notched phones (iPhone X+, Android cutouts) */
+.safe-bottom {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+/* Touch-friendly tap targets on mobile */
+@media (max-width: 767px) {
+  button, a, [role="button"] {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  /* Prevent text selection on interactive elements during tap */
+  button {
+    -webkit-touch-callout: none;
+    user-select: none;
+  }
 }
 
 ::-webkit-scrollbar {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,22 @@
 import './globals.css';
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+};
 
 export const metadata: Metadata = {
   title: 'Mobius Civic AI Terminal',
   description:
     'A civic Bloomberg-style command terminal for Mobius Substrate.',
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: 'black-translucent',
+    title: 'Mobius Terminal',
+  },
 };
 
 export default function RootLayout({

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -419,8 +419,8 @@ export default function TerminalPage() {
           onSelect={setSelectedNav}
         />
 
-        <main className="col-span-7 max-lg:col-span-9 max-md:col-span-1 border-r border-slate-800 bg-slate-950">
-          <div className="grid h-full grid-rows-[auto_auto_auto_1fr] gap-4 p-4">
+        <main className="col-span-7 max-lg:col-span-9 max-md:col-span-1 border-r border-slate-800 max-md:border-r-0 bg-slate-950">
+          <div className="grid h-full grid-rows-[auto_auto_auto_1fr] gap-4 p-4 max-md:pb-20">
             {CHAMBER_DESCRIPTIONS[selectedNav] && (
               <div className="rounded-xl border border-dashed border-slate-800 bg-slate-900/40 p-4">
                 <div className="text-xs font-mono uppercase tracking-[0.2em] text-sky-300">
@@ -503,7 +503,7 @@ export default function TerminalPage() {
             )}
 
             {showMetrics && (
-              <section className="grid grid-cols-2 gap-4">
+              <section className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <IntegrityMonitorCard
                   gi={gi}
                   onClick={() =>
@@ -531,7 +531,7 @@ export default function TerminalPage() {
         <DetailInspectorRail target={inspectorTarget} />
       </div>
 
-      <footer className="flex items-center justify-between border-t border-slate-800 bg-slate-950 px-4 py-2 text-xs font-mono text-slate-500">
+      <footer className="hidden md:flex items-center justify-between border-t border-slate-800 bg-slate-950 px-4 py-2 text-xs font-mono text-slate-500">
         <span className="shrink-0">MOBIUS TERMINAL V1</span>
         <div className="flex items-center gap-2">
           <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-400 shrink-0" />

--- a/components/terminal/AgentCortexPanel.tsx
+++ b/components/terminal/AgentCortexPanel.tsx
@@ -17,7 +17,7 @@ export default function AgentCortexPanel({
         title="Agent Cortex"
         subtitle="Live substrate operator map"
       />
-      <div className="mt-3 grid grid-cols-2 gap-3 xl:grid-cols-4">
+      <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3 xl:grid-cols-4">
         {agents.map((agent) => (
           <button
             key={agent.id}

--- a/components/terminal/DetailInspectorRail.tsx
+++ b/components/terminal/DetailInspectorRail.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useState } from 'react';
 import type { InspectorTarget, Tripwire } from '@/lib/terminal/types';
 import { confidenceLabel, statusColor, tripwireStyle, giScoreColor, metricBarColor, cn } from '@/lib/terminal/utils';
 import SectionLabel from './SectionLabel';
@@ -567,32 +570,78 @@ function AlertView({ data }: { data: InspectorTarget & { kind: 'alert' } }) {
 
 // ── Main component ───────────────────────────────────────────
 
+function InspectorContent({ target }: { target: InspectorTarget }) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+      <SectionLabel
+        title="Detail Inspector"
+        subtitle={SUBTITLES[target.kind]}
+      />
+
+      <div className="mt-4">
+        {target.kind === 'epicon' && <EpiconView data={target} />}
+        {target.kind === 'agent' && <AgentView data={target} />}
+        {target.kind === 'tripwire' && <TripwireView data={target} />}
+        {target.kind === 'gi' && <GIView data={target} />}
+        {target.kind === 'ledger' && <LedgerView data={target} />}
+        {target.kind === 'shard' && <ShardView data={target} />}
+        {target.kind === 'sentinel' && <SentinelView data={target} />}
+        {target.kind === 'alert' && <AlertView data={target} />}
+      </div>
+    </div>
+  );
+}
+
 export default function DetailInspectorRail({
   target,
 }: {
   target: InspectorTarget;
 }) {
-  return (
-    <aside className="col-span-3 max-lg:col-span-2 max-md:col-span-1 bg-slate-950/90">
-      <div className="h-full p-4">
-        <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-          <SectionLabel
-            title="Detail Inspector"
-            subtitle={SUBTITLES[target.kind]}
-          />
+  const [mobileOpen, setMobileOpen] = useState(false);
 
-          <div className="mt-4">
-            {target.kind === 'epicon' && <EpiconView data={target} />}
-            {target.kind === 'agent' && <AgentView data={target} />}
-            {target.kind === 'tripwire' && <TripwireView data={target} />}
-            {target.kind === 'gi' && <GIView data={target} />}
-            {target.kind === 'ledger' && <LedgerView data={target} />}
-            {target.kind === 'shard' && <ShardView data={target} />}
-            {target.kind === 'sentinel' && <SentinelView data={target} />}
-            {target.kind === 'alert' && <AlertView data={target} />}
-          </div>
+  return (
+    <>
+      {/* ── Desktop / Tablet: sidebar rail ── */}
+      <aside className="max-md:hidden col-span-3 max-lg:col-span-2 bg-slate-950/90">
+        <div className="h-full p-4">
+          <InspectorContent target={target} />
+        </div>
+      </aside>
+
+      {/* ── Mobile: toggle button + bottom sheet ── */}
+      <button
+        onClick={() => setMobileOpen((v) => !v)}
+        className={cn(
+          'md:hidden fixed right-3 z-50 flex items-center gap-1.5 rounded-full border px-3 py-2 text-xs font-mono shadow-lg transition-all',
+          mobileOpen
+            ? 'bottom-[55%] border-sky-500/40 bg-sky-500/20 text-sky-300'
+            : 'bottom-[68px] border-slate-700 bg-slate-900 text-slate-300',
+        )}
+      >
+        <span className="text-sm">{mobileOpen ? '▼' : '▲'}</span>
+        Inspector
+      </button>
+
+      {/* Backdrop */}
+      {mobileOpen && (
+        <div
+          className="md:hidden fixed inset-0 z-30 bg-black/50"
+          onClick={() => setMobileOpen(false)}
+        />
+      )}
+
+      {/* Sheet */}
+      <div
+        className={cn(
+          'md:hidden fixed left-0 right-0 bottom-0 z-40 bg-slate-950 border-t border-slate-800 transition-transform duration-300 safe-bottom',
+          mobileOpen ? 'translate-y-0' : 'translate-y-full',
+        )}
+        style={{ maxHeight: '55vh' }}
+      >
+        <div className="overflow-y-auto p-4" style={{ maxHeight: '55vh', paddingBottom: '70px' }}>
+          <InspectorContent target={target} />
         </div>
       </div>
-    </aside>
+    </>
   );
 }

--- a/components/terminal/SidebarNav.tsx
+++ b/components/terminal/SidebarNav.tsx
@@ -17,6 +17,9 @@ const NAV_ICONS: Partial<Record<NavKey, string>> = {
   settings: '⚙',
 };
 
+// Subset shown in the mobile bottom bar (most important chambers)
+const MOBILE_NAV: NavKey[] = ['pulse', 'agents', 'ledger', 'markets', 'geopolitics', 'search'];
+
 export default function SidebarNav({
   items,
   selected,
@@ -27,58 +30,126 @@ export default function SidebarNav({
   onSelect: (key: NavKey) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const [mobileExpanded, setMobileExpanded] = useState(false);
 
   return (
-    <aside className={cn(
-      'border-r border-slate-800 bg-slate-950/80 transition-all duration-200',
-      'col-span-2 lg:col-span-2',
-      'max-lg:col-span-1 max-lg:w-14',
-    )}>
-      {/* Header — toggle on small screens */}
-      <div className="border-b border-slate-800 px-4 py-3">
-        <button
-          onClick={() => setExpanded((v) => !v)}
-          className="text-xs font-mono uppercase tracking-[0.25em] text-slate-400 lg:cursor-default"
-        >
-          <span className="hidden lg:inline">Chambers</span>
-          <span className="lg:hidden">☰</span>
-        </button>
-      </div>
-
-      <nav className={cn(
-        'p-3 lg:block',
-        expanded ? 'max-lg:absolute max-lg:z-30 max-lg:left-0 max-lg:top-[105px] max-lg:w-48 max-lg:rounded-r-xl max-lg:border max-lg:border-slate-800 max-lg:bg-slate-950 max-lg:shadow-2xl' : '',
+    <>
+      {/* ── Desktop / Tablet sidebar (hidden on mobile) ── */}
+      <aside className={cn(
+        'border-r border-slate-800 bg-slate-950/80 transition-all duration-200',
+        'col-span-2 lg:col-span-2',
+        'max-lg:col-span-1 max-lg:w-14',
+        'max-md:hidden',
       )}>
-        <div className="space-y-1">
-          {items.map((item) => {
-            const active = item.key === selected;
+        {/* Header — toggle on tablet */}
+        <div className="border-b border-slate-800 px-4 py-3">
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            className="text-xs font-mono uppercase tracking-[0.25em] text-slate-400 lg:cursor-default"
+          >
+            <span className="hidden lg:inline">Chambers</span>
+            <span className="lg:hidden">☰</span>
+          </button>
+        </div>
+
+        <nav className={cn(
+          'p-3 lg:block',
+          expanded ? 'max-lg:absolute max-lg:z-30 max-lg:left-0 max-lg:top-[105px] max-lg:w-48 max-lg:rounded-r-xl max-lg:border max-lg:border-slate-800 max-lg:bg-slate-950 max-lg:shadow-2xl' : '',
+        )}>
+          <div className="space-y-1">
+            {items.map((item) => {
+              const active = item.key === selected;
+              return (
+                <button
+                  key={item.key}
+                  onClick={() => {
+                    onSelect(item.key);
+                    setExpanded(false);
+                  }}
+                  className={cn(
+                    'flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm font-sans transition',
+                    active
+                      ? 'bg-sky-500/10 text-sky-300 ring-1 ring-sky-500/30'
+                      : 'text-slate-300 hover:bg-slate-900 hover:text-white',
+                  )}
+                >
+                  {/* Show icon-only on tablet when collapsed */}
+                  <span className={cn(expanded ? '' : 'max-lg:hidden')}>{item.label}</span>
+                  <span className={cn('lg:hidden font-mono text-xs', expanded ? 'hidden' : '')}>{NAV_ICONS[item.key] ?? '·'}</span>
+                  {item.badge ? (
+                    <span className={cn('rounded-full bg-amber-500/20 px-2 py-0.5 text-[10px] text-amber-300', expanded ? '' : 'max-lg:hidden')}>
+                      {item.badge}
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        </nav>
+      </aside>
+
+      {/* ── Mobile bottom tab bar (visible only on mobile) ── */}
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 z-40 border-t border-slate-800 bg-slate-950/95 backdrop-blur safe-bottom">
+        <div className="flex items-stretch">
+          {MOBILE_NAV.map((key) => {
+            const item = items.find((i) => i.key === key);
+            if (!item) return null;
+            const active = selected === key;
             return (
               <button
-                key={item.key}
-                onClick={() => {
-                  onSelect(item.key);
-                  setExpanded(false);
-                }}
+                key={key}
+                onClick={() => { onSelect(key); setMobileExpanded(false); }}
                 className={cn(
-                  'flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm font-sans transition',
+                  'flex flex-1 flex-col items-center justify-center gap-0.5 py-2 text-[10px] font-mono uppercase tracking-wider transition min-h-[52px]',
                   active
-                    ? 'bg-sky-500/10 text-sky-300 ring-1 ring-sky-500/30'
-                    : 'text-slate-300 hover:bg-slate-900 hover:text-white',
+                    ? 'text-sky-300 bg-sky-500/10'
+                    : 'text-slate-400 active:bg-slate-900',
                 )}
               >
-                {/* Show icon-only on small screens when collapsed */}
-                <span className={cn(expanded ? '' : 'max-lg:hidden')}>{item.label}</span>
-                <span className={cn('lg:hidden font-mono text-xs', expanded ? 'hidden' : '')}>{NAV_ICONS[item.key] ?? '·'}</span>
-                {item.badge ? (
-                  <span className={cn('rounded-full bg-amber-500/20 px-2 py-0.5 text-[10px] text-amber-300', expanded ? '' : 'max-lg:hidden')}>
-                    {item.badge}
-                  </span>
-                ) : null}
+                <span className="text-base leading-none">{NAV_ICONS[key]}</span>
+                <span>{item.label.slice(0, 5)}</span>
               </button>
             );
           })}
+          {/* More button — expands full nav */}
+          <button
+            onClick={() => setMobileExpanded((v) => !v)}
+            className={cn(
+              'flex flex-1 flex-col items-center justify-center gap-0.5 py-2 text-[10px] font-mono uppercase tracking-wider transition min-h-[52px]',
+              mobileExpanded ? 'text-sky-300 bg-sky-500/10' : 'text-slate-400 active:bg-slate-900',
+            )}
+          >
+            <span className="text-base leading-none">···</span>
+            <span>More</span>
+          </button>
         </div>
+
+        {/* Expanded mobile nav overlay */}
+        {mobileExpanded && (
+          <div className="border-t border-slate-800 bg-slate-950 p-3">
+            <div className="grid grid-cols-4 gap-2">
+              {items.filter((i) => !MOBILE_NAV.includes(i.key)).map((item) => {
+                const active = selected === item.key;
+                return (
+                  <button
+                    key={item.key}
+                    onClick={() => { onSelect(item.key); setMobileExpanded(false); }}
+                    className={cn(
+                      'flex flex-col items-center gap-1 rounded-lg p-2 text-[10px] font-mono uppercase tracking-wider transition min-h-[48px]',
+                      active
+                        ? 'text-sky-300 bg-sky-500/10 ring-1 ring-sky-500/30'
+                        : 'text-slate-400 active:bg-slate-900',
+                    )}
+                  >
+                    <span className="text-sm">{NAV_ICONS[item.key]}</span>
+                    <span>{item.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
       </nav>
-    </aside>
+    </>
   );
 }

--- a/components/terminal/SubstrateStatusCard.tsx
+++ b/components/terminal/SubstrateStatusCard.tsx
@@ -63,7 +63,7 @@ export default function SubstrateStatusCard({
         </div>
       </div>
 
-      <div className="mt-4 grid grid-cols-2 gap-2 xl:grid-cols-5">
+      <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-5">
         {sentinels.map((s) => (
           <button
             key={s.id}


### PR DESCRIPTION
Transforms the desktop-only terminal into a fully responsive mobile experience:

Layout:
- SidebarNav becomes a bottom tab bar on mobile (6 quick-access chambers + "More" overflow with remaining 4)
- DetailInspectorRail becomes a slide-up bottom sheet with backdrop
- Main content goes single-column with proper bottom padding
- Desktop footer hidden on mobile (bottom nav replaces it)

Responsive grids:
- Metrics section: 1-col on mobile, 2-col on sm+
- Agent Cortex: 1-col on mobile, 2-col on sm+, 4-col on xl
- Sentinel Council: 2-col on mobile, 3-col on sm+, 5-col on xl

Mobile polish:
- Viewport meta with user-scalable=false (no zoom fighting)
- Apple Web App meta for iOS home screen support
- Safe area insets for notched phones (iPhone X+, Android cutouts)
- Touch-friendly tap targets (min 48-52px)
- Disabled tap highlight and overscroll bounce
- Smooth sheet transitions with backdrop overlay

https://claude.ai/code/session_01Ty6Lf7t9g9CnR8fDZ7FhxG