### PR TITLE
feat: add sorting controls to EPICON Feed, Civic Ledger, and Civic Radar

### DIFF
--- a/components/terminal/CivicRadarPanel.tsx
+++ b/components/terminal/CivicRadarPanel.tsx
@@ -1,6 +1,10 @@
+'use client';
+
+import { useState, useMemo } from 'react';
 import type { CivicRadarAlert } from '@/lib/terminal/types';
 import { cn } from '@/lib/terminal/utils';
 import SectionLabel from './SectionLabel';
+import SortBar, { type SortOption } from './SortBar';
 
 const SEVERITY_STYLES: Record<CivicRadarAlert['severity'], string> = {
   critical: 'text-red-300 border-red-500/30 bg-red-500/10',
@@ -18,6 +22,32 @@ const CATEGORY_STYLES: Record<CivicRadarAlert['category'], string> = {
   governance: 'text-emerald-300',
 };
 
+type RadarSortKey = 'severity' | 'time' | 'category';
+
+const SORT_OPTIONS: SortOption<RadarSortKey>[] = [
+  { key: 'severity', label: 'Severity' },
+  { key: 'time', label: 'Time' },
+  { key: 'category', label: 'Category' },
+];
+
+const SEVERITY_RANK: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1, info: 0 };
+
+function sortAlerts(alerts: CivicRadarAlert[], key: RadarSortKey, dir: 'asc' | 'desc'): CivicRadarAlert[] {
+  const mult = dir === 'desc' ? -1 : 1;
+  return [...alerts].sort((a, b) => {
+    switch (key) {
+      case 'severity':
+        return mult * ((SEVERITY_RANK[a.severity] ?? 0) - (SEVERITY_RANK[b.severity] ?? 0));
+      case 'time':
+        return mult * (new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+      case 'category':
+        return mult * a.category.localeCompare(b.category);
+      default:
+        return 0;
+    }
+  });
+}
+
 export default function CivicRadarPanel({
   alerts,
   selectedId,
@@ -27,16 +57,29 @@ export default function CivicRadarPanel({
   selectedId?: string;
   onSelect?: (alert: CivicRadarAlert) => void;
 }) {
+  const [sortKey, setSortKey] = useState<RadarSortKey>('severity');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+
+  const sorted = useMemo(() => sortAlerts(alerts, sortKey, sortDir), [alerts, sortKey, sortDir]);
+
   const criticalCount = alerts.filter(
     (a) => a.severity === 'critical' || a.severity === 'high',
   ).length;
 
   return (
     <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-      <SectionLabel
-        title="Civic Radar"
-        subtitle="Browser Shell — threat intelligence feed"
-      />
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <SectionLabel
+          title="Civic Radar"
+          subtitle="Browser Shell — threat intelligence feed"
+        />
+        <SortBar
+          options={SORT_OPTIONS}
+          active={sortKey}
+          direction={sortDir}
+          onSort={(k, d) => { setSortKey(k); setSortDir(d); }}
+        />
+      </div>
 
       {criticalCount > 0 && (
         <div className="mt-3 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs font-mono text-red-300">
@@ -45,7 +88,7 @@ export default function CivicRadarPanel({
       )}
 
       <div className="mt-3 space-y-2">
-        {alerts.map((alert) => (
+        {sorted.map((alert) => (
           <button
             key={alert.id}
             onClick={() => onSelect?.(alert)}

--- a/components/terminal/EpiconFeedPanel.tsx
+++ b/components/terminal/EpiconFeedPanel.tsx
@@ -1,6 +1,39 @@
+'use client';
+
+import { useState, useMemo } from 'react';
 import type { EpiconItem } from '@/lib/terminal/types';
 import { confidenceLabel, epiconStatusStyle, cn } from '@/lib/terminal/utils';
 import SectionLabel from './SectionLabel';
+import SortBar, { type SortOption } from './SortBar';
+
+type EpiconSortKey = 'time' | 'confidence' | 'category' | 'status';
+
+const SORT_OPTIONS: SortOption<EpiconSortKey>[] = [
+  { key: 'time', label: 'Time' },
+  { key: 'confidence', label: 'Confidence' },
+  { key: 'category', label: 'Category' },
+  { key: 'status', label: 'Status' },
+];
+
+const STATUS_RANK: Record<string, number> = { verified: 2, pending: 1, contradicted: 0 };
+
+function sortEpicon(items: EpiconItem[], key: EpiconSortKey, dir: 'asc' | 'desc'): EpiconItem[] {
+  const mult = dir === 'desc' ? -1 : 1;
+  return [...items].sort((a, b) => {
+    switch (key) {
+      case 'time':
+        return mult * (new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+      case 'confidence':
+        return mult * (a.confidenceTier - b.confidenceTier);
+      case 'category':
+        return mult * a.category.localeCompare(b.category);
+      case 'status':
+        return mult * ((STATUS_RANK[a.status] ?? 0) - (STATUS_RANK[b.status] ?? 0));
+      default:
+        return 0;
+    }
+  });
+}
 
 export default function EpiconFeedPanel({
   items,
@@ -11,11 +44,24 @@ export default function EpiconFeedPanel({
   selectedId: string;
   onSelect: (item: EpiconItem) => void;
 }) {
+  const [sortKey, setSortKey] = useState<EpiconSortKey>('time');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+
+  const sorted = useMemo(() => sortEpicon(items, sortKey, sortDir), [items, sortKey, sortDir]);
+
   return (
     <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-      <SectionLabel title="EPICON Feed" subtitle="Live audited event stream" />
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <SectionLabel title="EPICON Feed" subtitle="Live audited event stream" />
+        <SortBar
+          options={SORT_OPTIONS}
+          active={sortKey}
+          direction={sortDir}
+          onSort={(k, d) => { setSortKey(k); setSortDir(d); }}
+        />
+      </div>
       <div className="mt-3 space-y-3">
-        {items.map((item) => (
+        {sorted.map((item) => (
           <button
             key={item.id}
             onClick={() => onSelect(item)}

--- a/components/terminal/LedgerPanel.tsx
+++ b/components/terminal/LedgerPanel.tsx
@@ -1,6 +1,10 @@
+'use client';
+
+import { useState, useMemo } from 'react';
 import type { LedgerEntry } from '@/lib/terminal/types';
 import { cn } from '@/lib/terminal/utils';
 import SectionLabel from './SectionLabel';
+import SortBar, { type SortOption } from './SortBar';
 
 const TYPE_STYLES: Record<LedgerEntry['type'], string> = {
   epicon: 'text-sky-300 border-sky-500/30 bg-sky-500/10',
@@ -16,6 +20,35 @@ const STATUS_STYLES: Record<LedgerEntry['status'], string> = {
   reverted: 'text-red-300',
 };
 
+type LedgerSortKey = 'time' | 'type' | 'gi_delta' | 'status';
+
+const SORT_OPTIONS: SortOption<LedgerSortKey>[] = [
+  { key: 'time', label: 'Time' },
+  { key: 'type', label: 'Type' },
+  { key: 'gi_delta', label: 'GI Delta' },
+  { key: 'status', label: 'Status' },
+];
+
+const LEDGER_STATUS_RANK: Record<string, number> = { committed: 2, pending: 1, reverted: 0 };
+
+function sortLedger(entries: LedgerEntry[], key: LedgerSortKey, dir: 'asc' | 'desc'): LedgerEntry[] {
+  const mult = dir === 'desc' ? -1 : 1;
+  return [...entries].sort((a, b) => {
+    switch (key) {
+      case 'time':
+        return mult * (new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+      case 'type':
+        return mult * a.type.localeCompare(b.type);
+      case 'gi_delta':
+        return mult * (a.integrityDelta - b.integrityDelta);
+      case 'status':
+        return mult * ((LEDGER_STATUS_RANK[a.status] ?? 0) - (LEDGER_STATUS_RANK[b.status] ?? 0));
+      default:
+        return 0;
+    }
+  });
+}
+
 export default function LedgerPanel({
   entries,
   selectedId,
@@ -25,14 +58,27 @@ export default function LedgerPanel({
   selectedId?: string;
   onSelect?: (entry: LedgerEntry) => void;
 }) {
+  const [sortKey, setSortKey] = useState<LedgerSortKey>('time');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+
+  const sorted = useMemo(() => sortLedger(entries, sortKey, sortDir), [entries, sortKey, sortDir]);
+
   return (
     <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-      <SectionLabel
-        title="Civic Ledger"
-        subtitle="Immutable event record — Mobius Substrate"
-      />
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <SectionLabel
+          title="Civic Ledger"
+          subtitle="Immutable event record — Mobius Substrate"
+        />
+        <SortBar
+          options={SORT_OPTIONS}
+          active={sortKey}
+          direction={sortDir}
+          onSort={(k, d) => { setSortKey(k); setSortDir(d); }}
+        />
+      </div>
       <div className="mt-3 space-y-2">
-        {entries.map((entry) => (
+        {sorted.map((entry) => (
           <button
             key={entry.id}
             onClick={() => onSelect?.(entry)}

--- a/components/terminal/SortBar.tsx
+++ b/components/terminal/SortBar.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { cn } from '@/lib/terminal/utils';
+
+export type SortOption<K extends string = string> = {
+  key: K;
+  label: string;
+};
+
+export default function SortBar<K extends string>({
+  options,
+  active,
+  direction,
+  onSort,
+}: {
+  options: SortOption<K>[];
+  active: K;
+  direction: 'asc' | 'desc';
+  onSort: (key: K, direction: 'asc' | 'desc') => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="text-[10px] font-mono uppercase tracking-[0.15em] text-slate-500 mr-1">
+        Sort
+      </span>
+      {options.map((opt) => {
+        const isActive = opt.key === active;
+        return (
+          <button
+            key={opt.key}
+            onClick={() => {
+              if (isActive) {
+                onSort(opt.key, direction === 'asc' ? 'desc' : 'asc');
+              } else {
+                onSort(opt.key, 'desc');
+              }
+            }}
+            className={cn(
+              'rounded-md border px-2 py-1 text-[10px] font-mono uppercase tracking-[0.1em] transition',
+              isActive
+                ? 'border-sky-500/30 bg-sky-500/10 text-sky-300'
+                : 'border-slate-800 bg-slate-950 text-slate-400 hover:text-slate-300 hover:border-slate-700',
+            )}
+          >
+            {opt.label}
+            {isActive && (
+              <span className="ml-1">{direction === 'desc' ? '↓' : '↑'}</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a shared SortBar component and per-feed sorting with toggle direction (click active sort to flip asc/desc):

EPICON Feed: Time, Confidence, Category, Status
Civic Ledger: Time, Type, GI Delta, Status
Civic Radar: Severity (default desc), Time, Category

Sorting is client-side via useMemo for instant response. Each panel defaults to its most useful sort (time desc for feeds, severity desc for radar).

https://claude.ai/code/session_01Ty6Lf7t9g9CnR8fDZ7FhxG