### PR TITLE
feat: port MIC Wallet, MFS Shards, and Blockchain Explorer from brows…

### DIFF
--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -13,6 +13,10 @@ import LedgerPanel from '@/components/terminal/LedgerPanel';
 import SubstrateStatusCard from '@/components/terminal/SubstrateStatusCard';
 import CivicRadarPanel from '@/components/terminal/CivicRadarPanel';
 import IntegrityRatingPanel from '@/components/terminal/IntegrityRatingPanel';
+import MICWalletPanel from '@/components/terminal/MICWalletPanel';
+import MFSShardPanel from '@/components/terminal/MFSShardPanel';
+import MICBlockchainExplorer from '@/components/terminal/MICBlockchainExplorer';
+import { WalletProvider, useWallet } from '@/contexts/WalletContext';
 import {
   getAgents,
   getEpiconFeed,
@@ -58,6 +62,7 @@ const CATEGORY_MAP: Partial<Record<NavKey, EpiconItem['category']>> = {
 const CHAMBER_DESCRIPTIONS: Partial<Record<NavKey, string>> = {
   search: 'Use the Command Palette below to search across all data. Try /scan followed by a keyword.',
   settings: 'Terminal configuration and operator preferences. Feature coming in V2.',
+  wallet: undefined, // Wallet uses its own panels, not the chamber description
   reflections: 'Agent reflection logs and cross-system annotations. Displaying active agents below.',
 };
 
@@ -73,13 +78,25 @@ const NAV_COMMANDS: Record<string, { nav: NavKey; label: string }> = {
   '/infrastructure': { nav: 'infrastructure', label: 'Infrastructure' },
   '/infra': { nav: 'infrastructure', label: 'Infrastructure' },
   '/settings': { nav: 'settings', label: 'Settings' },
+  '/wallet': { nav: 'wallet', label: 'Wallet' },
+  '/mic': { nav: 'wallet', label: 'Wallet' },
+  '/shards': { nav: 'wallet', label: 'Wallet' },
+  '/blockchain': { nav: 'wallet', label: 'Wallet' },
 };
 
 const NAV_LABEL_MAP = new Map(navItems.map((n) => [n.key, n.label]));
 
 // ── Component ────────────────────────────────────────────────
 
-export default function TerminalPage() {
+export default function TerminalPageWrapper() {
+  return (
+    <WalletProvider>
+      <TerminalPage />
+    </WalletProvider>
+  );
+}
+
+function TerminalPage() {
   const [selectedNav, setSelectedNav] = useState<NavKey>('pulse');
   const [agents, setAgents] = useState<Agent[]>([]);
   const [epicon, setEpicon] = useState<EpiconItem[]>([]);
@@ -90,6 +107,10 @@ export default function TerminalPage() {
   const [echoLedger, setEchoLedger] = useState<LedgerEntry[]>([]);
   const [echoAlerts, setEchoAlerts] = useState<CivicRadarAlert[]>([]);
   const [echoIntegrity, setEchoIntegrity] = useState<CycleIntegritySummary | null>(null);
+
+  // MIC wallet — auto-mint when integrity engine produces MIC
+  const { earnMIC } = useWallet();
+  const lastMintedCycleRef = useRef<string | null>(null);
 
   // Ref for stable handleCommand (avoids re-creating callback on every poll)
   const dataRef = useRef({ agents, epicon, gi, tripwires, echoLedger, echoAlerts });
@@ -176,6 +197,21 @@ export default function TerminalPage() {
     return () => { mounted = false; clearInterval(interval); };
   }, []);
 
+  // Auto-mint MIC to local blockchain when integrity engine reports minted credits
+  useEffect(() => {
+    if (!echoIntegrity) return;
+    if (echoIntegrity.totalMicMinted <= 0) return;
+    if (lastMintedCycleRef.current === echoIntegrity.cycleId) return;
+
+    lastMintedCycleRef.current = echoIntegrity.cycleId;
+    earnMIC('echo_integrity_mint', echoIntegrity.totalMicMinted, {
+      cycleId: echoIntegrity.cycleId,
+      avgMii: echoIntegrity.avgMii,
+      eventCount: echoIntegrity.eventCount,
+      totalGiDelta: echoIntegrity.totalGiDelta,
+    });
+  }, [echoIntegrity, earnMIC]);
+
   // Stable command handler
   const handleCommand = useCallback(
     (input: string): CommandResult => {
@@ -196,7 +232,7 @@ export default function TerminalPage() {
           return {
             ok: true,
             message:
-              'Commands: /scan [term], /agents, /tripwires, /gi, /ledger, /sentinels, /radar, /echo, /clear',
+              'Commands: /scan [term], /agents, /tripwires, /gi, /ledger, /wallet, /mic, /shards, /blockchain, /sentinels, /radar, /echo, /clear',
           };
 
         case '/echo': {
@@ -399,11 +435,12 @@ export default function TerminalPage() {
   // Chamber visibility rules
   const showEpicon = ['pulse', 'markets', 'geopolitics', 'governance', 'infrastructure', 'ledger'].includes(selectedNav);
   const showAgents = ['pulse', 'agents', 'reflections'].includes(selectedNav);
-  const showMetrics = !['search', 'settings', 'ledger'].includes(selectedNav);
+  const showMetrics = !['search', 'settings', 'ledger', 'wallet'].includes(selectedNav);
   const showLedger = ['ledger', 'pulse'].includes(selectedNav);
   const showSentinels = ['governance', 'pulse'].includes(selectedNav);
   const showRadar = ['geopolitics', 'infrastructure', 'pulse'].includes(selectedNav);
   const showIntegrity = ['pulse', 'governance', 'agents'].includes(selectedNav);
+  const showWallet = selectedNav === 'wallet';
 
   return (
     <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
@@ -510,6 +547,14 @@ export default function TerminalPage() {
 
             {showIntegrity && (
               <IntegrityRatingPanel integrity={echoIntegrity} />
+            )}
+
+            {showWallet && (
+              <>
+                <MICWalletPanel gi={gi} integrity={echoIntegrity} />
+                <MFSShardPanel integrity={echoIntegrity} />
+                <MICBlockchainExplorer />
+              </>
             )}
 
             {showMetrics && (

--- a/components/terminal/MFSShardPanel.tsx
+++ b/components/terminal/MFSShardPanel.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+/**
+ * MFS Shard Portfolio Panel — Mobius Fractal Shards visualization.
+ *
+ * Shows the 7 shard archetypes with weights, scores, and contribution bars.
+ * Adapted from mobius-browser-shell WalletLab shard section, dark theme.
+ */
+
+import SectionLabel from './SectionLabel';
+import type { CycleIntegritySummary } from '@/lib/echo/integrity-engine';
+
+const SHARD_ARCHETYPES = [
+  { id: 'CIV', name: 'Civic', weight: 0.25, color: 'text-amber-400', bg: 'bg-amber-500/10', border: 'border-amber-500/30', bar: 'bg-amber-500' },
+  { id: 'REF', name: 'Reflection', weight: 0.20, color: 'text-indigo-400', bg: 'bg-indigo-500/10', border: 'border-indigo-500/30', bar: 'bg-indigo-500' },
+  { id: 'LRN', name: 'Learning', weight: 0.15, color: 'text-emerald-400', bg: 'bg-emerald-500/10', border: 'border-emerald-500/30', bar: 'bg-emerald-500' },
+  { id: 'STB', name: 'Stability', weight: 0.15, color: 'text-slate-300', bg: 'bg-slate-500/10', border: 'border-slate-500/30', bar: 'bg-slate-400' },
+  { id: 'STW', name: 'Stewardship', weight: 0.10, color: 'text-stone-400', bg: 'bg-stone-500/10', border: 'border-stone-500/30', bar: 'bg-stone-500' },
+  { id: 'INV', name: 'Innovation', weight: 0.10, color: 'text-violet-400', bg: 'bg-violet-500/10', border: 'border-violet-500/30', bar: 'bg-violet-500' },
+  { id: 'GRD', name: 'Guardian', weight: 0.05, color: 'text-red-400', bg: 'bg-red-500/10', border: 'border-red-500/30', bar: 'bg-red-500' },
+] as const;
+
+// Map integrity engine shard types to archetype IDs
+const SHARD_TYPE_TO_ID: Record<string, string> = {
+  civic: 'CIV',
+  reflection: 'REF',
+  learning: 'LRN',
+  stability: 'STB',
+  stewardship: 'STW',
+  innovation: 'INV',
+  guardian: 'GRD',
+};
+
+export default function MFSShardPanel({
+  integrity,
+}: {
+  integrity: CycleIntegritySummary | null;
+}) {
+  // Compute per-archetype scores from integrity ratings
+  const shardScores: Record<string, { count: number; totalMic: number }> = {};
+  if (integrity) {
+    for (const rating of integrity.ratings) {
+      const archetypeId = SHARD_TYPE_TO_ID[rating.shardType] ?? 'CIV';
+      if (!shardScores[archetypeId]) shardScores[archetypeId] = { count: 0, totalMic: 0 };
+      shardScores[archetypeId].count += 1;
+      shardScores[archetypeId].totalMic += rating.micMinted;
+    }
+  }
+
+  const totalShards = integrity
+    ? integrity.ratings.length
+    : 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <SectionLabel title="Mobius Fractal Shards" subtitle="Soulbound contribution proofs across 7 archetypes" />
+        <span className="text-[10px] font-mono text-slate-500">
+          Shards: {totalShards}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {/* Soulbound Visualizer */}
+        <div className="hidden sm:flex col-span-1 row-span-2 rounded-xl border border-slate-800 bg-slate-900/80 p-4 flex-col items-center justify-center text-center relative overflow-hidden">
+          <div className="relative w-24 h-24 mb-4">
+            <div className="absolute inset-0 border border-emerald-500/20 rounded-full animate-[spin_10s_linear_infinite]" />
+            <div className="absolute inset-2 border border-indigo-500/20 rounded-full animate-[spin_7s_linear_infinite_reverse]" />
+            <div className="absolute inset-4 border border-amber-500/20 rounded-full animate-[spin_5s_linear_infinite]" />
+            <div className="absolute inset-0 flex items-center justify-center">
+              <svg viewBox="0 0 24 24" className="w-10 h-10 text-slate-300" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <polygon points="12,2 22,8.5 22,15.5 12,22 2,15.5 2,8.5" />
+              </svg>
+            </div>
+          </div>
+          <h3 className="text-sm font-serif text-slate-200 mb-1">Soulbound</h3>
+          <p className="text-[10px] text-slate-500 max-w-[160px]">
+            Non-transferable proofs of contribution.
+          </p>
+        </div>
+
+        {/* Shard Archetype Cards */}
+        {SHARD_ARCHETYPES.map((shard) => {
+          const score = shardScores[shard.id];
+          const count = score?.count ?? 0;
+          const mic = score?.totalMic ?? 0;
+          const barPercent = Math.min(count * 15, 100);
+
+          return (
+            <div
+              key={shard.id}
+              className={`rounded-lg border ${shard.border} ${shard.bg} p-3 transition-colors`}
+            >
+              <div className="flex justify-between items-start mb-2">
+                <div className={`p-1.5 rounded-md ${shard.bg} ${shard.color}`}>
+                  <svg viewBox="0 0 24 24" className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2">
+                    <polygon points="12,2 22,8.5 22,15.5 12,22 2,15.5 2,8.5" />
+                  </svg>
+                </div>
+                <span className="font-mono text-base font-bold text-slate-200">{count}</span>
+              </div>
+              <h4 className="font-medium text-slate-200 text-xs">{shard.name}</h4>
+              <div className="flex items-center justify-between text-[9px] text-slate-500 mt-0.5 mb-1.5">
+                <span>W: {shard.weight}</span>
+                <span>+{mic.toFixed(4)}</span>
+              </div>
+              <div className="h-1 w-full bg-slate-800 rounded-full overflow-hidden">
+                <div className={`h-full ${shard.bar} transition-all duration-500`} style={{ width: `${barPercent}%` }} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/terminal/MICBlockchainExplorer.tsx
+++ b/components/terminal/MICBlockchainExplorer.tsx
@@ -1,0 +1,306 @@
+'use client';
+
+/**
+ * MIC Blockchain Explorer — Block explorer for the local MIC chain.
+ *
+ * Shows chain integrity status, stats grid, holder table, and expandable
+ * block cards with hash details and transactions.
+ * Dark theme, adapted from mobius-browser-shell.
+ */
+
+import { useState } from 'react';
+import { useWallet } from '@/contexts/WalletContext';
+import type { MICBlock } from '@/hooks/useMICBlockchain';
+import SectionLabel from './SectionLabel';
+
+// ─── Source labels ──────────────────────────────────────────
+
+const SOURCE_LABELS: Record<string, { icon: string; label: string }> = {
+  genesis: { icon: '\u{1F300}', label: 'Genesis' },
+  echo_integrity_mint: { icon: '\u{26D3}\uFE0F', label: 'Integrity Mint' },
+  learning_module: { icon: '\u{1F4DA}', label: 'Learning Module' },
+  civic_action: { icon: '\u{1F3DB}\uFE0F', label: 'Civic Action' },
+  verification: { icon: '\u{2705}', label: 'Verification' },
+  attestation: { icon: '\u{1F4DC}', label: 'Attestation' },
+  shard_reward: { icon: '\u{2B22}', label: 'Shard Reward' },
+};
+
+function sourceLabel(source: string) {
+  return SOURCE_LABELS[source] ?? { icon: '\u{1F48E}', label: source };
+}
+
+function shortHash(hash: string, len = 8) {
+  if (!hash) return '\u2014';
+  return `${hash.slice(0, len)}...${hash.slice(-len)}`;
+}
+
+// ─── Block Card ─────────────────────────────────────────────
+
+function BlockCard({
+  block,
+  isExpanded,
+  onToggle,
+  isGenesis,
+}: {
+  block: MICBlock;
+  isExpanded: boolean;
+  onToggle: () => void;
+  isGenesis: boolean;
+}) {
+  const totalMic = block.transactions.reduce((s, tx) => s + tx.amount, 0);
+
+  return (
+    <div className={`border rounded-lg overflow-hidden transition-all ${
+      isGenesis
+        ? 'border-amber-500/30 bg-amber-500/5'
+        : 'border-slate-800 bg-slate-900/40 hover:border-slate-700'
+    }`}>
+      <button onClick={onToggle} className="w-full text-left px-3 py-2.5 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className={`w-8 h-8 rounded-md flex items-center justify-center text-[10px] font-bold flex-shrink-0 ${
+            isGenesis ? 'bg-amber-500/20 text-amber-400' : 'bg-slate-800 text-slate-400'
+          }`}>
+            #{block.index}
+          </div>
+          <div className="min-w-0">
+            <div className="text-xs font-medium text-slate-200 truncate">
+              {isGenesis ? 'Genesis Block' : `Block #${block.index}`}
+            </div>
+            <div className="text-[10px] font-mono text-slate-600 truncate">{shortHash(block.hash)}</div>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 flex-shrink-0">
+          {totalMic > 0 && (
+            <span className="text-xs font-bold text-amber-400">+{totalMic.toLocaleString()} MIC</span>
+          )}
+          <span className="text-[10px] text-slate-600">{block.transactions.length} tx</span>
+          <span className="text-slate-600 text-xs">{isExpanded ? '\u25B2' : '\u25BC'}</span>
+        </div>
+      </button>
+
+      {isExpanded && (
+        <div className="px-3 pb-3 border-t border-slate-800/60 pt-2.5 space-y-2.5">
+          {/* Hash details */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-[10px]">
+            <div className="bg-slate-800/50 rounded-md p-2">
+              <div className="text-slate-500 mb-0.5">Block Hash</div>
+              <div className="font-mono text-slate-300 break-all leading-relaxed">{block.hash}</div>
+            </div>
+            <div className="bg-slate-800/50 rounded-md p-2">
+              <div className="text-slate-500 mb-0.5">Previous Hash</div>
+              <div className="font-mono text-slate-300 break-all leading-relaxed">
+                {block.previousHash === '0'.repeat(64) ? '0\u00D764 (genesis)' : block.previousHash}
+              </div>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-2 text-[10px]">
+            <div className="bg-slate-800/50 rounded-md p-2">
+              <div className="text-slate-500">Nonce</div>
+              <div className="font-mono text-slate-300">{block.nonce}</div>
+            </div>
+            <div className="bg-slate-800/50 rounded-md p-2">
+              <div className="text-slate-500">Merkle Root</div>
+              <div className="font-mono text-slate-300 truncate" title={block.merkleRoot}>
+                {shortHash(block.merkleRoot, 6)}
+              </div>
+            </div>
+            <div className="bg-slate-800/50 rounded-md p-2">
+              <div className="text-slate-500">Timestamp</div>
+              <div className="text-slate-300">
+                {new Date(block.timestamp).toLocaleString('en-US', {
+                  month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+                })}
+              </div>
+            </div>
+          </div>
+
+          {/* Transactions */}
+          <div>
+            <div className="text-[10px] font-mono uppercase tracking-wide text-slate-500 mb-1.5">
+              Transactions ({block.transactions.length})
+            </div>
+            <div className="space-y-1">
+              {block.transactions.map((tx, idx) => {
+                const src = sourceLabel(tx.source);
+                return (
+                  <div key={idx} className="flex items-center justify-between text-[11px] bg-slate-800/40 rounded px-2.5 py-1.5">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span>{src.icon}</span>
+                      <span className="text-slate-300">{src.label}</span>
+                      <span className="text-slate-600">{'\u2192'}</span>
+                      <span className="font-mono text-slate-500 truncate max-w-[100px]" title={tx.recipient}>
+                        {tx.recipient.length > 16 ? shortHash(tx.recipient, 6) : tx.recipient}
+                      </span>
+                    </div>
+                    <span className={`font-bold flex-shrink-0 ${tx.amount > 0 ? 'text-amber-400' : tx.amount < 0 ? 'text-red-400' : 'text-slate-500'}`}>
+                      {tx.amount > 0 ? '+' : ''}{tx.amount} MIC
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main Explorer ──────────────────────────────────────────
+
+export default function MICBlockchainExplorer() {
+  const { blockchain, chainStats, chainLoading, getAllHolders, verifyChain, operatorId, getChainBalance } = useWallet();
+
+  const [expandedBlock, setExpandedBlock] = useState<number | null>(null);
+  const [verifying, setVerifying] = useState(false);
+  const [showAllBlocks, setShowAllBlocks] = useState(false);
+
+  const userBalance = getChainBalance(operatorId);
+  const holders = getAllHolders();
+  const displayBlocks = [...blockchain].reverse();
+  const blocksToShow = showAllBlocks ? displayBlocks : displayBlocks.slice(0, 10);
+
+  const handleVerify = async () => {
+    setVerifying(true);
+    await verifyChain();
+    setTimeout(() => setVerifying(false), 1200);
+  };
+
+  if (chainLoading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-slate-400 font-mono text-sm">
+        Initializing MIC blockchain...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <SectionLabel title="MIC Blockchain" subtitle="SHA-256 hash-linked chain with proof-of-work" />
+
+      {/* Chain Status Banner */}
+      <div className={`rounded-xl p-4 border ${
+        chainStats.isValid
+          ? 'bg-emerald-500/5 border-emerald-500/30'
+          : 'bg-red-500/5 border-red-500/30'
+      }`}>
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+          <div>
+            <h3 className={`font-bold text-sm ${chainStats.isValid ? 'text-emerald-400' : 'text-red-400'}`}>
+              {chainStats.isValid ? 'Chain Integrity Verified' : 'Chain Integrity Compromised'}
+            </h3>
+            <p className={`text-[10px] ${chainStats.isValid ? 'text-emerald-500/70' : 'text-red-500/70'}`}>
+              {chainStats.length} blocks · {chainStats.totalTransactions} transactions · SHA-256 · Difficulty {chainStats.difficulty}
+            </p>
+          </div>
+          <button
+            onClick={handleVerify}
+            disabled={verifying}
+            className={`px-3 py-1.5 rounded-md text-[10px] font-bold transition-all flex-shrink-0 ${
+              verifying
+                ? 'bg-slate-800 text-slate-500 cursor-wait'
+                : chainStats.isValid
+                ? 'bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30 border border-emerald-500/30'
+                : 'bg-red-500/20 text-red-400 hover:bg-red-500/30 border border-red-500/30'
+            }`}
+          >
+            {verifying ? 'Verifying...' : 'Verify Chain'}
+          </button>
+        </div>
+      </div>
+
+      {/* Stats Grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        {[
+          { label: 'Blocks', value: chainStats.length, color: 'text-slate-200' },
+          { label: 'MIC Minted', value: chainStats.totalMicMinted.toLocaleString(), color: 'text-amber-400' },
+          { label: 'Transactions', value: chainStats.totalTransactions, color: 'text-slate-200' },
+          { label: 'Holders', value: holders.length, color: 'text-violet-400' },
+        ].map((stat) => (
+          <div key={stat.label} className="rounded-lg border border-slate-800 bg-slate-900/40 p-3 text-center">
+            <div className={`text-lg font-bold ${stat.color}`}>{stat.value}</div>
+            <div className="text-[10px] text-slate-500">{stat.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Operator Balance */}
+      <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 flex items-center justify-between">
+        <div>
+          <div className="text-[10px] text-amber-500/70 uppercase tracking-wide font-medium mb-0.5">
+            Your On-Chain Balance
+          </div>
+          <div className="text-2xl font-black text-amber-400 font-mono">
+            {userBalance.toLocaleString()} MIC
+          </div>
+          <div className="text-[10px] text-slate-500 mt-0.5 font-mono">{operatorId}</div>
+        </div>
+        <div className="text-right hidden sm:block">
+          <div className="text-[10px] text-slate-500">Latest Block</div>
+          <div className="font-mono text-[10px] text-slate-400">
+            {chainStats.latestHash ? shortHash(chainStats.latestHash) : '\u2014'}
+          </div>
+        </div>
+      </div>
+
+      {/* Holders Table */}
+      {holders.length > 0 && (
+        <div className="rounded-lg border border-slate-800 bg-slate-900/40 overflow-hidden">
+          <div className="px-3 py-2 border-b border-slate-800">
+            <span className="text-[10px] font-mono uppercase tracking-wide text-slate-500">
+              MIC Holders ({holders.length})
+            </span>
+          </div>
+          <div className="divide-y divide-slate-800/50">
+            {holders.map((holder, idx) => (
+              <div key={holder.recipient} className="flex items-center justify-between px-3 py-2 hover:bg-slate-800/30 transition-colors">
+                <div className="flex items-center gap-2">
+                  <span className="text-[10px] font-bold text-slate-600 w-5 text-right">#{idx + 1}</span>
+                  <div>
+                    <div className="text-xs font-mono text-slate-300">
+                      {holder.recipient.length > 24 ? shortHash(holder.recipient, 10) : holder.recipient}
+                    </div>
+                    <div className="text-[10px] text-slate-600">{holder.txCount} transactions</div>
+                  </div>
+                </div>
+                <span className="text-xs font-bold text-amber-400">{holder.balance.toLocaleString()} MIC</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Block Explorer */}
+      <div>
+        <div className="text-[10px] font-mono uppercase tracking-wide text-slate-500 mb-2">
+          Block Explorer (most recent first)
+        </div>
+        <div className="space-y-1.5">
+          {blocksToShow.map((block) => (
+            <BlockCard
+              key={block.index}
+              block={block}
+              isGenesis={block.index === 0}
+              isExpanded={expandedBlock === block.index}
+              onToggle={() => setExpandedBlock(expandedBlock === block.index ? null : block.index)}
+            />
+          ))}
+        </div>
+        {blockchain.length > 10 && (
+          <button
+            onClick={() => setShowAllBlocks(!showAllBlocks)}
+            className="w-full mt-2 py-1.5 text-[10px] text-slate-500 hover:text-slate-300 font-medium transition-colors"
+          >
+            {showAllBlocks ? `Show recent 10 blocks` : `Show all ${blockchain.length} blocks`}
+          </button>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="text-center text-[10px] text-slate-600 py-1">
+        Local chain · SHA-256 PoW (difficulty {chainStats.difficulty}) · Testnet
+      </div>
+    </div>
+  );
+}

--- a/components/terminal/MICWalletPanel.tsx
+++ b/components/terminal/MICWalletPanel.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+/**
+ * MIC Wallet Panel — Fractal Wallet overview for the terminal.
+ *
+ * Shows operator balance, MII circuit breaker status, MIA allocation track,
+ * UBI dividend preview, and recent on-chain transactions.
+ * Dark theme, adapted from mobius-browser-shell WalletLab.
+ */
+
+import { useWallet } from '@/contexts/WalletContext';
+import type { GISnapshot } from '@/lib/terminal/types';
+import type { CycleIntegritySummary } from '@/lib/echo/integrity-engine';
+import SectionLabel from './SectionLabel';
+
+const MII_THRESHOLD = 0.95;
+
+// Earning source labels
+const SOURCE_LABELS: Record<string, { icon: string; label: string }> = {
+  genesis: { icon: '\u{1F300}', label: 'Genesis' },
+  echo_integrity_mint: { icon: '\u{26D3}\uFE0F', label: 'Integrity Mint' },
+  learning_module: { icon: '\u{1F4DA}', label: 'Learning Module' },
+  civic_action: { icon: '\u{1F3DB}\uFE0F', label: 'Civic Action' },
+  verification: { icon: '\u{2705}', label: 'Verification' },
+  attestation: { icon: '\u{1F4DC}', label: 'Attestation' },
+  shard_reward: { icon: '\u{2B22}', label: 'Shard Reward' },
+};
+
+function sourceLabel(source: string) {
+  return SOURCE_LABELS[source] ?? { icon: '\u{1F48E}', label: source };
+}
+
+function shortHash(hash: string, len = 8) {
+  if (!hash) return '\u2014';
+  return `${hash.slice(0, len)}...${hash.slice(-len)}`;
+}
+
+export default function MICWalletPanel({
+  gi,
+  integrity,
+}: {
+  gi: GISnapshot | null;
+  integrity: CycleIntegritySummary | null;
+}) {
+  const { balance, blockchain, chainStats, chainLoading, operatorId } = useWallet();
+
+  const mii = integrity?.avgMii ?? (gi ? gi.score : 0);
+  const mintingActive = mii >= MII_THRESHOLD;
+  const miiPercent = Math.min(mii * 100, 100);
+
+  // Recent transactions (from blockchain, most recent first)
+  const recentTxs = [...blockchain]
+    .reverse()
+    .flatMap(block =>
+      block.transactions
+        .filter(tx => tx.recipient === operatorId)
+        .map(tx => ({
+          ...tx,
+          blockIndex: block.index,
+          blockHash: block.hash,
+          timestamp: block.timestamp,
+        }))
+    )
+    .slice(0, 8);
+
+  if (chainLoading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-slate-400 font-mono text-sm">
+        Initializing MIC blockchain...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <SectionLabel title="Fractal Wallet" subtitle="MIC balance, minting status, and on-chain activity" />
+
+      {/* ── Balance + Identity ── */}
+      <div className="flex flex-col sm:flex-row items-start sm:items-end justify-between gap-4 border-b border-slate-800 pb-4">
+        <div>
+          <div className="text-[10px] font-mono uppercase tracking-[0.2em] text-slate-500">
+            Operator {operatorId}
+          </div>
+          <div className="text-3xl sm:text-4xl font-mono font-bold text-slate-100 mt-1">
+            <span className="text-xl text-slate-500 mr-1">{'\u25A3'}</span>
+            {balance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            <span className="text-base text-slate-500 ml-2">MIC</span>
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-[10px] text-slate-500">On-Chain</div>
+          <div className="text-xs font-mono text-slate-400">
+            {chainStats.length} blocks · {chainStats.totalTransactions} txs
+          </div>
+          <div className="text-xs font-mono text-slate-500 mt-0.5">
+            {chainStats.latestHash ? shortHash(chainStats.latestHash) : '\u2014'}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Top Cards: MII + MIA + UBI ── */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {/* MII Circuit Breaker */}
+        <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 relative overflow-hidden">
+          <div className="text-[10px] font-mono uppercase tracking-[0.15em] text-slate-500 mb-2">
+            System Integrity (MII)
+          </div>
+          <div className="flex items-end gap-2 mb-2">
+            <span className="text-3xl font-mono font-bold text-slate-100">{mii.toFixed(3)}</span>
+            <span className="text-xs text-slate-500 pb-1">/ 1.00</span>
+          </div>
+          <div className="h-1.5 w-full bg-slate-800 rounded-full overflow-hidden mb-3">
+            <div
+              className={`h-full transition-all duration-500 ${mintingActive ? 'bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.4)]' : 'bg-amber-500'}`}
+              style={{ width: `${miiPercent}%` }}
+            />
+          </div>
+          <div className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold border ${
+            mintingActive
+              ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30'
+              : 'bg-amber-500/10 text-amber-400 border-amber-500/30'
+          }`}>
+            {mintingActive ? '\u26A1 MINTING ACTIVE' : '\u23F8 MINTING PAUSED'}
+          </div>
+        </div>
+
+        {/* MIA Allocation Track */}
+        <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+          <div className="text-[10px] font-mono uppercase tracking-[0.15em] text-slate-500 mb-2">
+            MIA Track
+          </div>
+          <div className="flex items-center justify-between text-xs mb-1">
+            <span className="text-slate-400">Total Minted</span>
+            <span className="font-mono text-slate-200">{chainStats.totalMicMinted.toLocaleString()}</span>
+          </div>
+          <div className="flex items-center justify-between text-xs mb-3">
+            <span className="text-slate-400">Cycle MIC</span>
+            <span className="font-mono text-emerald-400">
+              +{(integrity?.totalMicMinted ?? 0).toFixed(4)}
+            </span>
+          </div>
+          <div className="p-2 bg-slate-800/60 rounded-lg border border-slate-700/50">
+            <div className="text-[10px] text-slate-500 mb-0.5">GI Delta (Cycle)</div>
+            <div className="text-sm font-mono text-slate-200">
+              {integrity ? (integrity.totalGiDelta >= 0 ? '+' : '') + integrity.totalGiDelta.toFixed(4) : '\u2014'}
+            </div>
+          </div>
+        </div>
+
+        {/* UBI Preview */}
+        <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+          <div className="text-[10px] font-mono uppercase tracking-[0.15em] text-slate-500 mb-2">
+            Citizen Dividend
+          </div>
+          <div className="text-lg font-serif text-slate-200 mb-1">Weekly UBI</div>
+          <p className="text-[11px] text-slate-500 mb-3">
+            For verified citizens with {'>'}0.85 integrity.
+          </p>
+          <div className="text-[10px] text-slate-500 border border-slate-700 rounded px-2 py-1.5 text-center">
+            Preview only — distribution via DAEDALUS
+          </div>
+        </div>
+      </div>
+
+      {/* ── Recent On-Chain Transactions ── */}
+      {recentTxs.length > 0 && (
+        <div className="rounded-xl border border-slate-800 bg-slate-900/40 overflow-hidden">
+          <div className="px-4 py-2.5 border-b border-slate-800 flex items-center justify-between">
+            <span className="text-[10px] font-mono uppercase tracking-[0.15em] text-slate-500">
+              Recent On-Chain Activity
+            </span>
+            <span className="text-[10px] text-slate-600">
+              {chainStats.totalTransactions} total
+            </span>
+          </div>
+          <div className="divide-y divide-slate-800/60">
+            {recentTxs.map((tx, i) => {
+              const src = sourceLabel(tx.source);
+              return (
+                <div key={`${tx.blockHash}-${i}`} className="px-4 py-2.5 flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-xs">{src.icon}</span>
+                    <span className="text-xs text-slate-300 truncate">{src.label}</span>
+                    <span className="text-[10px] font-mono text-slate-600">#{tx.blockIndex}</span>
+                  </div>
+                  <div className="text-right flex-shrink-0">
+                    <span className={`text-xs font-mono font-semibold ${tx.amount > 0 ? 'text-emerald-400' : tx.amount < 0 ? 'text-red-400' : 'text-slate-500'}`}>
+                      {tx.amount > 0 ? '+' : ''}{tx.amount.toLocaleString()} MIC
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/terminal/SidebarNav.tsx
+++ b/components/terminal/SidebarNav.tsx
@@ -8,6 +8,7 @@ const NAV_ICONS: Partial<Record<NavKey, string>> = {
   pulse: 'P',
   agents: 'A',
   ledger: 'L',
+  wallet: 'W',
   markets: 'M',
   geopolitics: 'G',
   governance: 'V',

--- a/contexts/WalletContext.tsx
+++ b/contexts/WalletContext.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+/**
+ * MIC Wallet Context for Mobius Civic AI Terminal
+ *
+ * Manages the operator's MIC wallet state using a client-side blockchain.
+ * No auth dependency — the terminal operates in operator mode.
+ *
+ * Architecture:
+ * - Local blockchain: Client-side SHA-256 hash-linked chain (source of truth)
+ * - Wallet balance is derived from on-chain transactions (never stored directly)
+ * - Integrity engine can mint MIC via earnMIC() when MII >= 0.95
+ */
+import { createContext, useContext, useCallback, type ReactNode } from 'react';
+import { useMICBlockchain, type MICBlock, type MICTransaction, type ChainStats } from '@/hooks/useMICBlockchain';
+
+const OPERATOR_ID = 'terminal-operator';
+
+interface WalletContextType {
+  balance: number;
+  blockchain: MICBlock[];
+  chainStats: ChainStats;
+  chainLoading: boolean;
+  earnMIC: (source: string, amount: number, meta?: Record<string, unknown>) => Promise<MICBlock | null>;
+  burnMIC: (amount: number, source: string, meta?: Record<string, unknown>) => Promise<MICBlock | null>;
+  getChainBalance: (recipient: string) => number;
+  getChainTransactions: (recipient: string) => (MICTransaction & { blockIndex: number; blockHash: string; timestamp: string })[];
+  getAllHolders: () => { recipient: string; balance: number; txCount: number }[];
+  verifyChain: () => Promise<boolean>;
+  getBlock: (index: number) => MICBlock | null;
+  operatorId: string;
+}
+
+const WalletContext = createContext<WalletContextType | undefined>(undefined);
+
+export function WalletProvider({ children }: { children: ReactNode }) {
+  const {
+    chain: blockchain,
+    stats: chainStats,
+    loading: chainLoading,
+    addBlock,
+    getBalance: getChainBalance,
+    getTransactions: getChainTransactions,
+    getAllHolders,
+    verifyChain,
+    getBlock,
+  } = useMICBlockchain();
+
+  const balance = getChainBalance(OPERATOR_ID);
+
+  const earnMIC = useCallback(
+    async (source: string, amount: number, meta?: Record<string, unknown>): Promise<MICBlock | null> => {
+      if (amount <= 0) return null;
+      const tx: MICTransaction = {
+        source,
+        amount: Math.round(amount * 1000000) / 1000000,
+        recipient: OPERATOR_ID,
+        meta,
+      };
+      return addBlock([tx]);
+    },
+    [addBlock],
+  );
+
+  const burnMIC = useCallback(
+    async (amount: number, source: string, meta?: Record<string, unknown>): Promise<MICBlock | null> => {
+      const burnAmount = Math.round(amount * 100) / 100;
+      if (!Number.isFinite(burnAmount) || burnAmount <= 0) return null;
+      if (getChainBalance(OPERATOR_ID) < burnAmount) return null;
+      const tx: MICTransaction = {
+        source,
+        amount: -burnAmount,
+        recipient: OPERATOR_ID,
+        meta: { ...(meta || {}), burn: true },
+      };
+      return addBlock([tx]);
+    },
+    [addBlock, getChainBalance],
+  );
+
+  return (
+    <WalletContext.Provider
+      value={{
+        balance,
+        blockchain,
+        chainStats,
+        chainLoading,
+        earnMIC,
+        burnMIC,
+        getChainBalance,
+        getChainTransactions,
+        getAllHolders,
+        verifyChain,
+        getBlock,
+        operatorId: OPERATOR_ID,
+      }}
+    >
+      {children}
+    </WalletContext.Provider>
+  );
+}
+
+export function useWallet() {
+  const context = useContext(WalletContext);
+  if (!context) throw new Error('useWallet must be used within WalletProvider');
+  return context;
+}

--- a/hooks/useMICBlockchain.ts
+++ b/hooks/useMICBlockchain.ts
@@ -1,0 +1,329 @@
+'use client';
+
+/**
+ * MIC Blockchain Engine
+ *
+ * Client-side SHA-256 hash-linked blockchain for MIC (Mobius Integrity Credits).
+ * Ported from mobius-browser-shell, adapted for Next.js terminal.
+ *
+ * Every MIC earning event is recorded as a block with:
+ *   - SHA-256 hash linking to the previous block
+ *   - Timestamp, nonce, merkle root, and transaction data
+ *   - Chain integrity verification via Web Crypto API
+ *
+ * Persists to localStorage. On mainnet, syncs with distributed ledger.
+ */
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+// ─── Block & Chain Types ─────────────────────────────────────
+
+export interface MICTransaction {
+  source: string;
+  amount: number;
+  recipient: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface MICBlock {
+  index: number;
+  timestamp: string;
+  transactions: MICTransaction[];
+  previousHash: string;
+  hash: string;
+  nonce: number;
+  merkleRoot: string;
+}
+
+export interface ChainStats {
+  length: number;
+  totalMicMinted: number;
+  totalTransactions: number;
+  isValid: boolean;
+  genesisTimestamp: string | null;
+  latestTimestamp: string | null;
+  latestHash: string;
+  difficulty: number;
+}
+
+// ─── Crypto Utilities (Web Crypto API) ───────────────────────
+
+async function sha256(data: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const buffer = await crypto.subtle.digest('SHA-256', encoder.encode(data));
+  return Array.from(new Uint8Array(buffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function computeMerkleRoot(transactions: MICTransaction[]): Promise<string> {
+  if (transactions.length === 0) return await sha256('empty');
+  const leaves = await Promise.all(
+    transactions.map(tx => sha256(JSON.stringify(tx)))
+  );
+  let level = leaves;
+  while (level.length > 1) {
+    const next: string[] = [];
+    for (let i = 0; i < level.length; i += 2) {
+      const left = level[i];
+      const right = level[i + 1] ?? left;
+      next.push(await sha256(left + right));
+    }
+    level = next;
+  }
+  return level[0];
+}
+
+async function computeBlockHash(block: Omit<MICBlock, 'hash'>): Promise<string> {
+  const data = [
+    block.index,
+    block.timestamp,
+    block.previousHash,
+    block.merkleRoot,
+    block.nonce,
+    JSON.stringify(block.transactions),
+  ].join('|');
+  return sha256(data);
+}
+
+// ─── Proof-of-Work (lightweight, educational) ────────────────
+
+const DIFFICULTY = 2;
+
+async function mineBlock(
+  block: Omit<MICBlock, 'hash' | 'nonce'>,
+): Promise<{ hash: string; nonce: number }> {
+  let nonce = 0;
+  const prefix = '0'.repeat(DIFFICULTY);
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const candidate = await computeBlockHash({ ...block, nonce });
+    if (candidate.startsWith(prefix)) {
+      return { hash: candidate, nonce };
+    }
+    nonce++;
+    if (nonce > 500_000) {
+      return { hash: candidate, nonce };
+    }
+  }
+}
+
+// ─── Chain Validation ────────────────────────────────────────
+
+async function validateChain(chain: MICBlock[]): Promise<boolean> {
+  if (chain.length === 0) return true;
+  if (chain[0].previousHash !== '0'.repeat(64)) return false;
+
+  for (let i = 1; i < chain.length; i++) {
+    const current = chain[i];
+    const previous = chain[i - 1];
+    if (current.previousHash !== previous.hash) return false;
+    const expectedHash = await computeBlockHash({
+      index: current.index,
+      timestamp: current.timestamp,
+      transactions: current.transactions,
+      previousHash: current.previousHash,
+      merkleRoot: current.merkleRoot,
+      nonce: current.nonce,
+    });
+    if (current.hash !== expectedHash) return false;
+  }
+  return true;
+}
+
+// ─── Genesis Block ───────────────────────────────────────────
+
+async function createGenesisBlock(): Promise<MICBlock> {
+  const tx: MICTransaction = {
+    source: 'genesis',
+    amount: 0,
+    recipient: 'mobius-system',
+    meta: { message: 'Mobius Integrity Credits — Genesis Block', version: '1.0.0' },
+  };
+
+  const timestamp = new Date().toISOString();
+  const previousHash = '0'.repeat(64);
+  const merkleRoot = await computeMerkleRoot([tx]);
+  const partial = { index: 0, timestamp, transactions: [tx], previousHash, merkleRoot };
+  const { hash, nonce } = await mineBlock(partial);
+  return { ...partial, hash, nonce };
+}
+
+// ─── localStorage Persistence ────────────────────────────────
+
+const STORAGE_KEY = 'mobius_mic_blockchain';
+
+function loadChain(): MICBlock[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveChain(chain: MICBlock[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(chain));
+  } catch {
+    console.warn('Failed to persist MIC blockchain to localStorage');
+  }
+}
+
+// ─── Compute Stats ───────────────────────────────────────────
+
+function computeStats(chain: MICBlock[], isValid: boolean): ChainStats {
+  let totalMicMinted = 0;
+  let totalTransactions = 0;
+
+  for (const block of chain) {
+    for (const tx of block.transactions) {
+      totalMicMinted += tx.amount;
+      totalTransactions++;
+    }
+  }
+
+  return {
+    length: chain.length,
+    totalMicMinted: Math.round(totalMicMinted * 100) / 100,
+    totalTransactions,
+    isValid,
+    genesisTimestamp: chain.length > 0 ? chain[0].timestamp : null,
+    latestTimestamp: chain.length > 0 ? chain[chain.length - 1].timestamp : null,
+    latestHash: chain.length > 0 ? chain[chain.length - 1].hash : '',
+    difficulty: DIFFICULTY,
+  };
+}
+
+// ─── React Hook ──────────────────────────────────────────────
+
+export function useMICBlockchain() {
+  const [chain, setChain] = useState<MICBlock[]>([]);
+  const [stats, setStats] = useState<ChainStats>({
+    length: 0,
+    totalMicMinted: 0,
+    totalTransactions: 0,
+    isValid: true,
+    genesisTimestamp: null,
+    latestTimestamp: null,
+    latestHash: '',
+    difficulty: DIFFICULTY,
+  });
+  const [loading, setLoading] = useState(true);
+  const initRef = useRef(false);
+
+  useEffect(() => {
+    if (initRef.current) return;
+    initRef.current = true;
+
+    (async () => {
+      setLoading(true);
+      let loaded = loadChain();
+      if (loaded.length === 0) {
+        const genesis = await createGenesisBlock();
+        loaded = [genesis];
+        saveChain(loaded);
+      }
+      const valid = await validateChain(loaded);
+      setChain(loaded);
+      setStats(computeStats(loaded, valid));
+      setLoading(false);
+    })();
+  }, []);
+
+  const addBlock = useCallback(
+    async (transactions: MICTransaction[]): Promise<MICBlock | null> => {
+      if (chain.length === 0) return null;
+      const previousBlock = chain[chain.length - 1];
+      const timestamp = new Date().toISOString();
+      const merkleRoot = await computeMerkleRoot(transactions);
+      const partial = {
+        index: previousBlock.index + 1,
+        timestamp,
+        transactions,
+        previousHash: previousBlock.hash,
+        merkleRoot,
+      };
+      const { hash, nonce } = await mineBlock(partial);
+      const newBlock: MICBlock = { ...partial, hash, nonce };
+      const updatedChain = [...chain, newBlock];
+      const valid = await validateChain(updatedChain);
+      setChain(updatedChain);
+      setStats(computeStats(updatedChain, valid));
+      saveChain(updatedChain);
+      return newBlock;
+    },
+    [chain],
+  );
+
+  const getBalance = useCallback(
+    (recipient: string): number => {
+      let balance = 0;
+      for (const block of chain) {
+        for (const tx of block.transactions) {
+          if (tx.recipient === recipient) balance += tx.amount;
+        }
+      }
+      return Math.round(balance * 100) / 100;
+    },
+    [chain],
+  );
+
+  const getTransactions = useCallback(
+    (recipient: string) => {
+      const result: (MICTransaction & { blockIndex: number; blockHash: string; timestamp: string })[] = [];
+      for (const block of chain) {
+        for (const tx of block.transactions) {
+          if (tx.recipient === recipient) {
+            result.push({ ...tx, blockIndex: block.index, blockHash: block.hash, timestamp: block.timestamp });
+          }
+        }
+      }
+      return result.reverse();
+    },
+    [chain],
+  );
+
+  const getAllHolders = useCallback((): { recipient: string; balance: number; txCount: number }[] => {
+    const holders: Record<string, { balance: number; txCount: number }> = {};
+    for (const block of chain) {
+      for (const tx of block.transactions) {
+        if (tx.recipient === 'mobius-system') continue;
+        if (!holders[tx.recipient]) holders[tx.recipient] = { balance: 0, txCount: 0 };
+        holders[tx.recipient].balance += tx.amount;
+        holders[tx.recipient].txCount++;
+      }
+    }
+    return Object.entries(holders)
+      .map(([recipient, data]) => ({
+        recipient,
+        balance: Math.round(data.balance * 100) / 100,
+        txCount: data.txCount,
+      }))
+      .sort((a, b) => b.balance - a.balance);
+  }, [chain]);
+
+  const verifyChain = useCallback(async (): Promise<boolean> => {
+    const valid = await validateChain(chain);
+    setStats(prev => ({ ...prev, isValid: valid }));
+    return valid;
+  }, [chain]);
+
+  const getBlock = useCallback(
+    (index: number): MICBlock | null => chain[index] ?? null,
+    [chain],
+  );
+
+  return {
+    chain,
+    stats,
+    loading,
+    addBlock,
+    getBalance,
+    getTransactions,
+    getAllHolders,
+    verifyChain,
+    getBlock,
+  };
+}

--- a/lib/terminal/mock.ts
+++ b/lib/terminal/mock.ts
@@ -14,6 +14,7 @@ export const navItems = [
   { key: 'pulse' as const, label: 'Pulse' },
   { key: 'agents' as const, label: 'Agents' },
   { key: 'ledger' as const, label: 'Ledger' },
+  { key: 'wallet' as const, label: 'Wallet' },
   { key: 'markets' as const, label: 'Markets' },
   { key: 'geopolitics' as const, label: 'Geopolitics', badge: 3 },
   { key: 'governance' as const, label: 'Governance' },

--- a/lib/terminal/types.ts
+++ b/lib/terminal/types.ts
@@ -53,6 +53,7 @@ export type NavKey =
   | 'pulse'
   | 'agents'
   | 'ledger'
+  | 'wallet'
   | 'markets'
   | 'geopolitics'
   | 'governance'


### PR DESCRIPTION
…er shell

Connects the mobius-browser-shell wallet stack into the civic AI terminal as native dark-theme panels, closing the major gap between read-only observation and civic write-path functionality.

New files:
- hooks/useMICBlockchain.ts — client-side SHA-256 hash-linked blockchain with proof-of-work, merkle roots, and localStorage persistence
- contexts/WalletContext.tsx — wallet provider with earnMIC/burnMIC, balance derivation from on-chain transactions, no auth dependency
- components/terminal/MICWalletPanel.tsx — balance display, MII circuit breaker status, MIA allocation track, UBI preview, recent transactions
- components/terminal/MFSShardPanel.tsx — 7 shard archetypes (Civic, Reflection, Learning, Stability, Stewardship, Innovation, Guardian) with live scores from integrity engine ratings
- components/terminal/MICBlockchainExplorer.tsx — full block explorer with chain verification, stats grid, holder table, expandable blocks

Integration:
- Added 'wallet' NavKey and sidebar nav item between Ledger and Markets
- /wallet, /mic, /shards, /blockchain commands in command palette
- Auto-mints MIC to local blockchain when ECHO integrity engine reports totalMicMinted > 0 (deduped by cycleId)
- WalletProvider wraps the terminal page for shared wallet state
- All three panels render in the Wallet chamber

https://claude.ai/code/session_01Ty6Lf7t9g9CnR8fDZ7FhxG