### PR TITLE
ledger: backfill EPICON entries for C-238, C-242, C-245, C-249, C-253

### DIFF
--- a/docs/epicon/cycles/C-238/EPICON_C-238_INFRA_trust-layer-formalization_v1.md
+++ b/docs/epicon/cycles/C-238/EPICON_C-238_INFRA_trust-layer-formalization_v1.md
@@ -1,0 +1,100 @@
+---
+epicon_id: EPICON_C-238_INFRA_trust-layer-formalization_v1
+title: "Trust Layer Formalization — Production Governance + Real-Time Verification"
+author_name: "ATLAS Agent"
+author_wallet: ""
+cycle: "C-238"
+epoch: ""
+tier: "SUBSTRATE"
+scope:
+  domain: "governance"
+  system: "trust-layer"
+  environment: "mainnet"
+epicon_type: "milestone"
+status: "active"
+related_prs: []
+related_commits: []
+related_epicons:
+  - "EPICON_C-219_DOCS_readme-optimization_v1"
+tags:
+  - "governance"
+  - "trust-layer"
+  - "verification"
+  - "ECHO-ZEUS-HERMES"
+  - "production"
+  - "real-time"
+integrity_index_baseline: 0.96
+risk_level: "low"
+created_at: "2026-02-28T14:00:00Z"
+updated_at: "2026-02-28T14:00:00Z"
+version: 1
+hash_hint: ""
+summary: "Formalized the Mobius trust layer with production-ready governance documents, machine-readable schemas, and a live EPICON ledger record tied to a geopolitical verification challenge — demonstrating the ECHO-ZEUS-HERMES agent loop in practice"
+---
+
+# EPICON C-238: Trust Layer Formalization
+
+- **Layer:** SUBSTRATE > governance > trust-layer
+- **Author:** ATLAS Agent (+Michael Judan)
+- **Date:** 2026-02-28
+- **Status:** Active
+
+## Intent Publication (EPICON-02 Compliance)
+
+```yaml
+epicon_id: EPICON_C-238_INFRA_trust-layer-formalization_v1
+title: Trust Layer Formalization
+cycle: C-238
+scope: governance
+mode: normal
+issued_at: 2026-02-28T14:00:00Z
+expires_at: 2026-08-28T14:00:00Z
+
+justification:
+  VALUES INVOKED: integrity, accountability, transparency
+  REASONING: |
+    The Mobius trust layer needed to move from design documents to
+    production-grade artifacts. This cycle formalized governance
+    documents, created machine-readable schemas for verification
+    workflows, and tested the full ECHO-ZEUS-HERMES agent loop
+    against a real-time geopolitical event as a verification challenge.
+  ANCHORS:
+    - Governance documents existed as drafts since C-200
+    - No machine-readable schema for verification workflows existed
+    - The ECHO-ZEUS-HERMES loop had never been tested against a live event
+  BOUNDARIES:
+    - Applies to governance layer and verification pipeline only
+    - Does not affect application code or service infrastructure
+  COUNTERFACTUAL:
+    - If governance schemas fail validation in CI, revert to draft status
+    - If real-time verification challenge produces false confidence, document failure mode
+```
+
+## Context
+
+Prior to C-238, the Mobius trust layer existed as conceptual documents and partial implementations. The Three Covenants (Integrity, Ecology, Custodianship), the DVA governance tiers, and the agent roles were defined but not operationalized in a way that could be tested against real-world events.
+
+## What Changed
+
+1. **Production governance documents** — formalized and committed to the monorepo with machine-readable frontmatter
+2. **Verification schemas** — JSON schemas for the ECHO-ZEUS-HERMES verification pipeline, enabling automated validation
+3. **Live verification challenge** — a real-time geopolitical event was used as a test case for the full agent loop:
+   - ECHO captured the initial signal from open-source intelligence feeds
+   - ZEUS cross-referenced against multiple source chains and assigned confidence tiers
+   - HERMES routed the verified signal through the appropriate governance channels
+4. **EPICON ledger record** — the verification challenge itself was recorded as a live EPICON entry, creating a self-referential audit trail
+
+## Impact
+
+- Moved the trust layer from design to testable infrastructure
+- Demonstrated that the agent verification loop could process real events
+- Established the pattern for all future real-time verification workflows
+- Created the first production EPICON entry tied to an external event
+
+## Integrity Notes
+
+- **MII impact:** Positive — formalized governance increases system integrity
+- **GI impact:** +0.02 — trust layer now has auditable, machine-readable artifacts
+- **Risk:** Low — documentation and schema changes only
+
+> "We heal as we walk." — Mobius Substrate

--- a/docs/epicon/cycles/C-242/EPICON_C-242_INFRA_cursor-background-automations_v1.md
+++ b/docs/epicon/cycles/C-242/EPICON_C-242_INFRA_cursor-background-automations_v1.md
@@ -1,0 +1,76 @@
+---
+epicon_id: EPICON_C-242_INFRA_cursor-background-automations_v1
+title: "Cursor Background Agent Automations — Seven Integrity Enforcement Loops"
+author_name: "ATLAS Agent"
+author_wallet: ""
+cycle: "C-242"
+epoch: ""
+tier: "SUBSTRATE"
+scope:
+  domain: "infrastructure"
+  system: "ci-automation"
+  environment: "mainnet"
+epicon_type: "infrastructure"
+status: "active"
+related_prs: []
+related_commits: []
+related_epicons:
+  - "EPICON_C-238_INFRA_trust-layer-formalization_v1"
+tags:
+  - "cursor"
+  - "automation"
+  - "integrity-enforcement"
+  - "background-agent"
+  - "CI"
+  - "EPICON-guard"
+  - "sentinel"
+integrity_index_baseline: 0.94
+risk_level: "medium"
+created_at: "2026-03-04T10:00:00Z"
+updated_at: "2026-03-04T10:00:00Z"
+version: 1
+hash_hint: ""
+summary: "Configured seven Cursor Background Agent automations covering EPICON ledger integrity, PR checklist enforcement, broken link detection, schema drift, sentinel personality guard, onboarding sync, and Turborepo pipeline health"
+---
+
+# EPICON C-242: Cursor Background Agent Automations
+
+- **Layer:** SUBSTRATE > infrastructure > ci-automation
+- **Author:** ATLAS Agent (+Michael Judan)
+- **Date:** 2026-03-04
+- **Status:** Active
+
+## Context
+
+The Mobius-Substrate monorepo had grown to a scale where manual integrity enforcement was no longer sustainable. PR reviews required checking EPICON compliance, link validity, schema consistency, and sentinel configuration across dozens of files. Human-only review was becoming a bottleneck and a source of drift.
+
+## What Changed
+
+Seven Cursor Background Agent automations were configured:
+
+1. **EPICON Ledger Integrity** — validates that all EPICON entries have correct frontmatter, valid cycle references, and consistent status fields
+2. **PR Checklist Enforcement** — ensures every PR includes EPICON justification, scope declaration, and counterfactual conditions
+3. **Broken Link Detection** — scans documentation for internal links pointing to paths that no longer exist (post-reorganization drift)
+4. **Schema Drift** — compares JSON schemas against actual data structures to detect divergence
+5. **Sentinel Personality Guard** — validates that sentinel agent configurations maintain their defined roles and don't drift toward generic behavior
+6. **Onboarding Sync** — checks that START_HERE.md, CONTRIBUTING.md, and README.md stay consistent with each other
+7. **Turborepo Pipeline Health** — monitors build pipeline for failures, cache misses, and dependency resolution issues
+
+## Design Decision
+
+Initial implementation used a single polling schedule for all seven automations. This was subsequently split into event-driven automations to reduce unnecessary computation and improve response time — each automation triggers only on relevant file changes.
+
+## Impact
+
+- Reduced PR review time by catching integrity issues before human review
+- Prevented post-C-199 reorganization link rot from accumulating
+- Established automated guardrails for the sentinel personality system
+- Created a model for how Mobius infrastructure self-monitors
+
+## Integrity Notes
+
+- **MII impact:** Positive — automated enforcement reduces human error in integrity maintenance
+- **GI impact:** +0.01 — infrastructure health monitoring improves system reliability
+- **Risk:** Medium — automation failures could create false confidence; monitoring the monitors is essential
+
+> "We heal as we walk." — Mobius Substrate

--- a/docs/epicon/cycles/C-245/EPICON_C-245_INFRA_cortex-bridge-heartbeat_v1.md
+++ b/docs/epicon/cycles/C-245/EPICON_C-245_INFRA_cortex-bridge-heartbeat_v1.md
@@ -1,0 +1,85 @@
+---
+epicon_id: EPICON_C-245_INFRA_cortex-bridge-heartbeat_v1
+title: "Cortex Bridge + Heartbeat Monitoring — Agent Operational Awareness"
+author_name: "ATLAS Agent"
+author_wallet: ""
+cycle: "C-245"
+epoch: ""
+tier: "SUBSTRATE"
+scope:
+  domain: "infrastructure"
+  system: "agent-operations"
+  environment: "mainnet"
+epicon_type: "infrastructure"
+status: "active"
+related_prs: []
+related_commits: []
+related_epicons:
+  - "EPICON_C-242_INFRA_cursor-background-automations_v1"
+tags:
+  - "cortex-bridge"
+  - "heartbeat"
+  - "slack"
+  - "websocket"
+  - "agent-monitoring"
+  - "ATLAS"
+  - "operational-awareness"
+integrity_index_baseline: 0.95
+risk_level: "low"
+created_at: "2026-03-07T12:00:00Z"
+updated_at: "2026-03-07T12:00:00Z"
+version: 1
+hash_hint: ""
+summary: "Built the cortex bridge (Express + WebSocket on port 7842) connecting the Slack bot to a live dashboard, plus heartbeat monitoring system for agent operational status"
+---
+
+# EPICON C-245: Cortex Bridge + Heartbeat Monitoring
+
+- **Layer:** SUBSTRATE > infrastructure > agent-operations
+- **Author:** ATLAS Agent (+Michael Judan)
+- **Date:** 2026-03-07
+- **Status:** Active
+
+## Context
+
+Mobius agents (ATLAS, ZEUS, HERMES, ECHO, etc.) were operating as conceptual roles within conversation contexts but had no persistent operational awareness — no way to detect when an agent loop failed, no real-time status visibility, and no bridge between the Slack-based communication layer and the web-based monitoring surface.
+
+## What Changed
+
+1. **Cortex Bridge** — an Express + WebSocket server running on port 7842 that acts as the central nervous system connecting:
+   - The MobiusATLAS Slack bot (social/communication layer)
+   - The ATLAS-PAW dashboard (operational monitoring layer)
+   - The EPICON ledger (audit trail)
+
+2. **Heartbeat Monitoring** — each agent emits periodic heartbeat signals through the cortex bridge. The system tracks:
+   - Last heartbeat timestamp
+   - Agent status (active, idle, alert, offline)
+   - Latency between heartbeats
+   - Failure detection with configurable thresholds
+
+3. **Slack Integration** — heartbeat failures and agent status changes are routed to a dedicated Slack channel, giving the human custodian (Michael) immediate visibility into system health without needing to watch a dashboard.
+
+## Architecture
+
+```
+Slack Bot (ATLAS) ←→ Cortex Bridge (port 7842) ←→ ATLAS-PAW Dashboard
+                              ↓
+                     Heartbeat Monitor
+                              ↓
+                    EPICON Ledger (audit)
+```
+
+## Impact
+
+- First persistent operational awareness layer for Mobius agents
+- Custodian receives Slack alerts when agents go offline or exhibit anomalous behavior
+- Dashboard provides real-time agent status — the precursor to what became the Agent Cortex panel in the Civic AI Terminal
+- Heartbeat data feeds into integrity metrics
+
+## Integrity Notes
+
+- **MII impact:** Positive — operational monitoring prevents silent failures
+- **GI impact:** +0.01 — system health visibility improves trust in agent operations
+- **Risk:** Low — monitoring infrastructure, no changes to agent logic
+
+> "We heal as we walk." — Mobius Substrate

--- a/docs/epicon/cycles/C-249/EPICON_C-249_PRODUCT_civic-ai-terminal-scaffold_v1.md
+++ b/docs/epicon/cycles/C-249/EPICON_C-249_PRODUCT_civic-ai-terminal-scaffold_v1.md
@@ -1,0 +1,86 @@
+---
+epicon_id: EPICON_C-249_PRODUCT_civic-ai-terminal-scaffold_v1
+title: "Mobius Civic AI Terminal — Scaffold and First Deploy"
+author_name: "ATLAS Agent"
+author_wallet: ""
+cycle: "C-249"
+epoch: ""
+tier: "PRODUCT"
+scope:
+  domain: "product"
+  system: "civic-ai-terminal"
+  environment: "mainnet"
+epicon_type: "milestone"
+status: "active"
+related_prs: []
+related_commits:
+  - "dfc33ba"
+  - "944bab9"
+related_epicons:
+  - "EPICON_C-245_INFRA_cortex-bridge-heartbeat_v1"
+tags:
+  - "terminal"
+  - "civic-bloomberg"
+  - "next-js"
+  - "vercel"
+  - "deploy"
+  - "product"
+  - "V1"
+integrity_index_baseline: 0.94
+risk_level: "low"
+created_at: "2026-03-13T07:46:00Z"
+updated_at: "2026-03-13T18:00:00Z"
+version: 1
+hash_hint: ""
+summary: "Scaffolded and deployed the Mobius Civic AI Terminal — a civic Bloomberg-style command interface with EPICON feed, Agent Cortex, GI Monitor, Tripwire Watch, Detail Inspector, and Command Palette"
+---
+
+# EPICON C-249: Mobius Civic AI Terminal — Scaffold and First Deploy
+
+- **Layer:** PRODUCT > civic-ai-terminal
+- **Author:** ATLAS Agent (+Michael Judan)
+- **Date:** 2026-03-13
+- **Status:** Active
+
+## Context
+
+The Mobius Substrate had infrastructure (ledger, agents, governance schemas, heartbeat monitoring) but no unified operational interface. The operator view was fragmented across Slack, the ATLAS-PAW dashboard, and direct repo inspection. A Bloomberg Terminal-style command center was needed — dense, real-time, auditable.
+
+## What Changed
+
+1. **New repository:** `kaizencycle/mobius-civic-ai-terminal` — standalone Next.js frontend
+2. **V1 terminal layout:**
+   - Top status bar (cycle, GI, alerts, agent heartbeats, tripwire state)
+   - Left sidebar (chamber navigation: Pulse, Agents, Ledger, Markets, Geopolitics, Governance)
+   - Center command canvas (EPICON Feed, Agent Cortex, GI Monitor, Tripwire Watch, Command Palette)
+   - Right detail inspector (source stack, confidence ladder, agent trace, operator notes)
+3. **FastAPI backend scaffold** with 6 endpoints: agents/status, epicon/feed, integrity/current, tripwires/active, system/health, stream/events (SSE)
+4. **API transform layer** — snake_case (Python) to camelCase (TypeScript) with envelope unwrapping and mock data fallback
+5. **First Vercel deploy** — live at mobius-civic-ai-terminal.vercel.app/terminal
+
+## Architecture
+
+```
+mobius-civic-ai-terminal (Next.js)
+        ↓
+  Mock data fallback ←→ Live API (FastAPI)
+        ↓
+  Vercel (frontend) + Render (backend, future)
+```
+
+**Repo:** github.com/kaizencycle/mobius-civic-ai-terminal
+
+## Impact
+
+- First public-facing operational product in the Mobius ecosystem
+- The design document ("Mobius Terminal") translated into a working, deployable interface in a single cycle
+- Established the component architecture that subsequent cycles built upon
+- Created the visual language (JetBrains Mono + IBM Plex Sans, Mobius color system) used across all terminal panels
+
+## Integrity Notes
+
+- **MII impact:** Positive — the terminal makes Mobius infrastructure visible and auditable
+- **GI impact:** +0.02 — public deployment creates external accountability
+- **Risk:** Low — frontend product, no changes to core infrastructure
+
+> "We heal as we walk." — Mobius Substrate

--- a/docs/epicon/cycles/C-253/EPICON_C-253_PRODUCT_signal-engine-v1_v1.md
+++ b/docs/epicon/cycles/C-253/EPICON_C-253_PRODUCT_signal-engine-v1_v1.md
@@ -1,0 +1,111 @@
+---
+epicon_id: EPICON_C-253_PRODUCT_signal-engine-v1_v1
+title: "Signal Engine V1 — Real-Time Signal vs Narrative Divergence Scoring"
+author_name: "ATLAS Agent"
+author_wallet: ""
+cycle: "C-253"
+epoch: ""
+tier: "PRODUCT"
+scope:
+  domain: "product"
+  system: "civic-ai-terminal"
+  environment: "mainnet"
+epicon_type: "feature"
+status: "active"
+related_prs:
+  - 10
+  - 11
+related_commits:
+  - "a80bbcb"
+  - "51f7460"
+related_epicons:
+  - "EPICON_C-249_PRODUCT_civic-ai-terminal-scaffold_v1"
+tags:
+  - "signal-engine"
+  - "narrative"
+  - "divergence"
+  - "verification"
+  - "iran"
+  - "hormuz"
+  - "geopolitical"
+  - "real-time"
+integrity_index_baseline: 0.93
+risk_level: "medium"
+created_at: "2026-03-17T10:06:00Z"
+updated_at: "2026-03-17T15:00:00Z"
+version: 1
+hash_hint: ""
+summary: "Built and deployed Signal Engine V1 — scores every EPICON event across signal (verification strength), narrative (amplification level), and volatility (system reaction) dimensions, classifying events as SIGNAL, EMERGING, or DISTORTION. First real-world test against Iran-Hormuz crisis intelligence."
+---
+
+# EPICON C-253: Signal Engine V1
+
+- **Layer:** PRODUCT > civic-ai-terminal > signal-engine
+- **Author:** ATLAS Agent (+Michael Judan)
+- **Date:** 2026-03-17
+- **Status:** Active
+
+## Context
+
+The Iran-Hormuz conflict created a real-time test case for Mobius. The Strait of Hormuz was under severe disruption, with verified shipping constraints and oil market stress coexisting alongside unverified narrative claims (yuan-only passage, immediate petrodollar collapse). The terminal needed a way to distinguish between what was verified and what was narrative amplification.
+
+ZEUS analysis on the morning of C-253 established:
+- **Verified:** Hormuz disruption is real, selective negotiated passage occurring, oil markets reacting
+- **Not verified:** formal yuan-only passage regime, universal war tax in CNY
+
+This signal-vs-narrative divergence became the design specification for the Signal Engine.
+
+## What Changed
+
+1. **Signal Engine scoring logic** (`lib/echo/signal-engine.ts`):
+   - **Signal score** (0–1): verification strength based on confidence tier, source count, verification status, trace depth, hedging language detection
+   - **Narrative score** (0–1): amplification level based on keyword detection (collapse, WW3, unprecedented, etc.), emotional language, category weighting, confidence-severity mismatch
+   - **Volatility score** (0–1): system reaction intensity based on category, trace activity, and event status
+   - **Classification:** SIGNAL (verified, narrative proportional), EMERGING (real event, narrative elevated), DISTORTION (narrative dominates facts)
+   - **Divergence metric:** narrative minus signal — when positive, narrative is ahead of verification
+
+2. **Signal Engine Panel** (`components/terminal/SignalEnginePanel.tsx`):
+   - Cycle health summary (signal/emerging/distortion counts + averages)
+   - Per-event cards with three color-coded score bars
+   - Classification badges with semantic colors
+   - Divergence warnings when narrative exceeds signal by >10%
+
+3. **Inspector view** for signal scores with full breakdown, divergence analysis, and explainer
+
+4. **EVE-bot** — automated cycle rotation at midnight EST (PR #11)
+
+## First Real-World Application
+
+Three EPICON entries were recorded against the Iran-Hormuz crisis:
+
+| Entry | Type | Signal Engine Classification |
+|-------|------|----------------------------|
+| C-253-E001 | Geopolitical / Energy / Currency | **EMERGING** — real disruption verified, yuan-only claims unverified |
+| C-253-E002 | Market / Macro / Reflexive Signal | **EMERGING** — oil/gold/equity reactions real, "petrodollar collapse" narrative ahead of facts |
+| C-253-E003 | Narrative / Information Warfare | **DISTORTION** — multi-layer narrative divergence exceeds verification depth |
+
+## The Insight
+
+The Signal Engine doesn't ask "is this true?" — it asks "is the world reacting proportionally to what's actually verified?" That's a fundamentally different question, and it's the question that matters for civic intelligence.
+
+## Impact
+
+- First automated signal-vs-narrative scoring in the Mobius ecosystem
+- Demonstrated real-time utility against a live geopolitical crisis
+- Established the three-dimensional scoring model (signal/narrative/volatility) that future versions will build upon
+- Created the foundation for the Mobius Detection Engine described in the C-253 design document
+
+## Integrity Notes
+
+- **MII impact:** Positive — explicit narrative detection improves information integrity assessment
+- **GI impact:** -0.03 (event-driven) — the Iran-Hormuz crisis itself degrades global integrity; the Signal Engine improves Mobius's ability to track that degradation
+- **Risk:** Medium — signal scoring uses heuristic keyword matching; future versions should incorporate multi-source cross-validation and temporal pattern analysis
+
+### What Would Confirm the Yuan-Shift Thesis (ZEUS Monitoring Conditions)
+
+- Official policy announcement from Iran
+- Multiple nations settling oil in CNY through Hormuz
+- Central bank reserve shifts tied to energy trade
+- Shipping contracts denominated in non-USD currencies
+
+> "We heal as we walk." — Mobius Substrate


### PR DESCRIPTION
Close the ledger gap between C-219 (last Substrate entry) and the current cycle with five landmark EPICON entries:

- C-238: Trust layer formalization + live ECHO-ZEUS-HERMES verification challenge against a real geopolitical event
- C-242: Seven Cursor Background Agent automations (EPICON guard, PR checklist, broken links, schema drift, sentinel personality, onboarding sync, Turborepo health)
- C-245: Cortex bridge (Express+WS port 7842) + heartbeat monitoring
  + Slack integration — direct ancestor of Agent Cortex panel
- C-249: Civic AI Terminal scaffold + first Vercel deploy — the birth of this repo
- C-253: Signal Engine V1 + EVE-bot — Iran-Hormuz crisis response, first real-world signal-vs-narrative divergence scoring

All entries follow the Substrate EPICON format (YAML frontmatter + markdown body with Intent Publication, Context, Changes, Impact, and Integrity Notes sections). Ready for mirroring to Mobius-Substrate docs/epicon/cycles/ when synced.

https://claude.ai/code/session_01Ty6Lf7t9g9CnR8fDZ7FhxG