### PR TITLE
feat: ZEUS verification + MII reputation layer + Create EPICON modal

### DIFF
--- a/app/api/epicon/create/route.ts
+++ b/app/api/epicon/create/route.ts
@@ -1,0 +1,122 @@
+/**
+ * EPICON Create API Route
+ *
+ * POST /api/epicon/create — Accept a user-submitted EPICON signal
+ * GET  /api/epicon/create — Return all user-submitted EPICONs
+ *
+ * Flow:
+ *   User submits via CreateEpiconModal or /submit command
+ *   → Assigns a cycle-aware EPICON ID
+ *   → Stores in shared store (accessible by ZEUS verify route)
+ *   → Increments author profile epicon_count + recalculates MII
+ *   → Returns the created record
+ */
+
+import { NextResponse } from 'next/server';
+import { getEchoStatus } from '@/lib/echo/store';
+import {
+  storeEpicon,
+  getAllSubmittedEpicons,
+  incrementEpiconCount,
+  type StoredEpicon,
+} from '@/lib/mobius/stores';
+
+export const dynamic = 'force-dynamic';
+
+let submissionCounter = 0;
+
+function generateEpiconId(): string {
+  const { cycleId } = getEchoStatus();
+  submissionCounter += 1;
+  const idx = String(submissionCounter).padStart(3, '0');
+  const ts = Date.now().toString(36).slice(-4).toUpperCase();
+  return `EPICON-${cycleId}-USR-${idx}-${ts}`;
+}
+
+type CreateRequest = {
+  title: string;
+  summary: string;
+  category: string;
+  sources: string[];
+  tags: string[];
+  confidenceTier: number;
+  submittedBy?: string;
+  submittedByLogin?: string;
+};
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as CreateRequest;
+
+    if (!body.title?.trim()) {
+      return NextResponse.json({ ok: false, error: 'Title is required' }, { status: 400 });
+    }
+    if (!body.summary?.trim()) {
+      return NextResponse.json({ ok: false, error: 'Summary is required' }, { status: 400 });
+    }
+    if (!body.sources?.length || !body.sources[0]?.trim()) {
+      return NextResponse.json({ ok: false, error: 'At least one source is required' }, { status: 400 });
+    }
+
+    const epiconId = generateEpiconId();
+    const now = new Date().toISOString();
+
+    let authorProfile = null;
+    if (body.submittedByLogin) {
+      authorProfile = incrementEpiconCount(body.submittedByLogin);
+    }
+
+    const record: StoredEpicon = {
+      id: epiconId,
+      title: body.title.trim(),
+      summary: body.summary.trim(),
+      category: body.category || 'geopolitical',
+      status: 'pending',
+      confidenceTier: Math.max(0, Math.min(4, body.confidenceTier ?? 1)),
+      ownerAgent: 'ECHO',
+      sources: body.sources.filter((s) => s.trim()),
+      tags: body.tags?.filter((t) => t.trim()) ?? [],
+      timestamp: now,
+      trace: [
+        `User submitted EPICON from terminal${body.submittedBy ? ` (${body.submittedBy})` : ''}`,
+        'ECHO intake — signal logged as pending',
+        'Awaiting HERMES routing and ZEUS verification',
+      ],
+      submittedBy: body.submittedBy,
+      submittedByLogin: body.submittedByLogin,
+      submittedByMii: authorProfile?.miiScore,
+      verificationOutcome: null,
+      zeusNote: null,
+      createdAt: now,
+    };
+
+    storeEpicon(record);
+
+    return NextResponse.json({
+      ok: true,
+      epicon: record,
+      authorProfile: authorProfile
+        ? {
+            login: authorProfile.login,
+            miiScore: authorProfile.miiScore,
+            nodeTier: authorProfile.nodeTier,
+            epiconCount: authorProfile.epiconCount,
+          }
+        : null,
+    });
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid request body' },
+      { status: 400 },
+    );
+  }
+}
+
+export async function GET() {
+  const epicons = getAllSubmittedEpicons();
+  return NextResponse.json({
+    ok: true,
+    epicons,
+    count: epicons.length,
+  });
+}

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,0 +1,66 @@
+/**
+ * Mobius Profile API Route
+ *
+ * GET  /api/profile?login=xxx — Get a participant's Mobius profile
+ * POST /api/profile — Ensure a profile exists (create if new)
+ */
+
+import { NextResponse } from 'next/server';
+import { getProfile, ensureProfile } from '@/lib/mobius/stores';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const login = searchParams.get('login');
+
+  if (!login) {
+    return NextResponse.json({ ok: false, error: 'login parameter is required' }, { status: 400 });
+  }
+
+  const profile = getProfile(login);
+  if (!profile) {
+    return NextResponse.json({
+      ok: false,
+      error: `No profile found for ${login}`,
+      profile: {
+        login,
+        displayName: login,
+        miiScore: 0.50,
+        nodeTier: 'participant',
+        epiconCount: 0,
+        verificationHits: 0,
+        verificationMisses: 0,
+        createdAt: new Date().toISOString(),
+        lastActiveAt: new Date().toISOString(),
+      },
+    });
+  }
+
+  return NextResponse.json({ ok: true, profile });
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as {
+      login: string;
+      displayName: string;
+    };
+
+    if (!body.login?.trim()) {
+      return NextResponse.json({ ok: false, error: 'login is required' }, { status: 400 });
+    }
+
+    const profile = ensureProfile(
+      body.login.trim(),
+      body.displayName?.trim() || body.login.trim(),
+    );
+
+    return NextResponse.json({ ok: true, profile });
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid request body' },
+      { status: 400 },
+    );
+  }
+}

--- a/app/api/zeus/verify/route.ts
+++ b/app/api/zeus/verify/route.ts
@@ -1,0 +1,103 @@
+/**
+ * ZEUS Verification API Route
+ *
+ * POST /api/zeus/verify — Verify a submitted EPICON
+ *
+ * Flow:
+ *   ZEUS (or custodian) reviews a pending EPICON
+ *   → Outcome: hit (accurate) or miss (inaccurate/contradicted)
+ *   → EPICON status updated (verified / contradicted)
+ *   → Author profile stats updated (hits/misses)
+ *   → MII recalculated
+ *   → Node tier recalculated
+ *
+ * Principle: high MII = faster review priority, NOT automatic acceptance.
+ */
+
+import { NextResponse } from 'next/server';
+import {
+  getStoredEpicon,
+  updateEpicon,
+  recordVerification,
+} from '@/lib/mobius/stores';
+
+export const dynamic = 'force-dynamic';
+
+type VerifyRequest = {
+  epiconId: string;
+  outcome: 'hit' | 'miss';
+  finalStatus: 'verified' | 'contradicted';
+  finalConfidenceTier: number;
+  zeusNote?: string;
+};
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as VerifyRequest;
+
+    if (!body.epiconId) {
+      return NextResponse.json({ ok: false, error: 'epiconId is required' }, { status: 400 });
+    }
+    if (!body.outcome || !['hit', 'miss'].includes(body.outcome)) {
+      return NextResponse.json({ ok: false, error: 'outcome must be "hit" or "miss"' }, { status: 400 });
+    }
+    if (!body.finalStatus || !['verified', 'contradicted'].includes(body.finalStatus)) {
+      return NextResponse.json({ ok: false, error: 'finalStatus must be "verified" or "contradicted"' }, { status: 400 });
+    }
+
+    const epicon = getStoredEpicon(body.epiconId);
+    if (!epicon) {
+      return NextResponse.json({
+        ok: false,
+        error: `EPICON ${body.epiconId} not found in submission store`,
+      }, { status: 404 });
+    }
+
+    // Prevent double-verification
+    if (epicon.verificationOutcome) {
+      return NextResponse.json({
+        ok: false,
+        error: `EPICON ${body.epiconId} already verified (outcome: ${epicon.verificationOutcome})`,
+      }, { status: 409 });
+    }
+
+    const updatedEpicon = updateEpicon(body.epiconId, {
+      status: body.finalStatus,
+      confidenceTier: Math.max(0, Math.min(4, body.finalConfidenceTier ?? epicon.confidenceTier)),
+      verificationOutcome: body.outcome,
+      zeusNote: body.zeusNote || null,
+      trace: [
+        ...epicon.trace,
+        `ZEUS verification: ${body.outcome} — status → ${body.finalStatus}, confidence → T${body.finalConfidenceTier}`,
+        ...(body.zeusNote ? [`ZEUS note: ${body.zeusNote}`] : []),
+      ],
+    });
+
+    let updatedProfile = null;
+    if (epicon.submittedByLogin) {
+      updatedProfile = recordVerification(epicon.submittedByLogin, body.outcome);
+    }
+
+    return NextResponse.json({
+      ok: true,
+      epiconId: body.epiconId,
+      outcome: body.outcome,
+      epicon: updatedEpicon,
+      profile: updatedProfile
+        ? {
+            login: updatedProfile.login,
+            miiScore: updatedProfile.miiScore,
+            nodeTier: updatedProfile.nodeTier,
+            verificationHits: updatedProfile.verificationHits,
+            verificationMisses: updatedProfile.verificationMisses,
+            epiconCount: updatedProfile.epiconCount,
+          }
+        : null,
+    });
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid request body' },
+      { status: 400 },
+    );
+  }
+}

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -18,6 +18,7 @@ import IntegrityRatingPanel from '@/components/terminal/IntegrityRatingPanel';
 import MICWalletPanel from '@/components/terminal/MICWalletPanel';
 import MFSShardPanel from '@/components/terminal/MFSShardPanel';
 import MICBlockchainExplorer from '@/components/terminal/MICBlockchainExplorer';
+import CreateEpiconModal from '@/components/terminal/CreateEpiconModal';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { WalletProvider, useWallet } from '@/contexts/WalletContext';
 import {
@@ -111,6 +112,7 @@ function TerminalPage() {
   const [echoLedger, setEchoLedger] = useState<LedgerEntry[]>([]);
   const [echoAlerts, setEchoAlerts] = useState<CivicRadarAlert[]>([]);
   const [echoIntegrity, setEchoIntegrity] = useState<CycleIntegritySummary | null>(null);
+  const [showCreateEpicon, setShowCreateEpicon] = useState(false);
 
   // MIC wallet — auto-mint when integrity engine produces MIC
   const { earnMIC } = useWallet();
@@ -236,8 +238,13 @@ function TerminalPage() {
           return {
             ok: true,
             message:
-              'Commands: /scan [term], /agents, /tripwires, /gi, /signal, /ledger, /wallet, /mic, /shards, /blockchain, /sentinels, /radar, /echo, /clear',
+              'Commands: /submit, /scan [term], /agents, /tripwires, /gi, /signal, /ledger, /wallet, /mic, /shards, /blockchain, /sentinels, /radar, /echo, /clear',
           };
+
+        case '/submit':
+        case '/create':
+          setShowCreateEpicon(true);
+          return { ok: true, message: 'Opening EPICON submission modal...' };
 
         case '/echo': {
           // Trigger manual ECHO ingest
@@ -608,6 +615,47 @@ function TerminalPage() {
 
         <DetailInspectorRail target={inspectorTarget} />
       </div>
+
+      <CreateEpiconModal
+        open={showCreateEpicon}
+        onClose={() => setShowCreateEpicon(false)}
+        onSubmit={async (draft) => {
+          const sources = [draft.source1, draft.source2, draft.source3]
+            .map((s) => s.trim())
+            .filter(Boolean);
+          const tags = draft.tags.split(',').map((t) => t.trim()).filter(Boolean);
+          const confidenceMap: Record<string, number> = { low: 1, medium: 2, high: 3 };
+
+          const res = await fetch('/api/epicon/create', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              title: draft.title,
+              summary: draft.summary,
+              category: draft.category,
+              sources,
+              tags,
+              confidenceTier: confidenceMap[draft.confidence] ?? 1,
+            }),
+          });
+          const data = await res.json();
+          if (!data.ok) throw new Error(data.error || 'Submission failed');
+
+          // Optimistic UI — add to feed immediately
+          setEpicon((prev) => [{
+            id: data.epicon.id,
+            title: data.epicon.title,
+            summary: data.epicon.summary,
+            category: data.epicon.category,
+            status: 'pending' as const,
+            confidenceTier: data.epicon.confidenceTier as 0 | 1 | 2 | 3 | 4,
+            ownerAgent: 'ECHO',
+            sources: data.epicon.sources,
+            timestamp: data.epicon.timestamp,
+            trace: data.epicon.trace,
+          }, ...prev].slice(0, 30));
+        }}
+      />
 
       <footer className="flex items-center justify-between border-t border-slate-800 bg-slate-950 px-4 py-2 text-xs font-mono text-slate-500">
         <span className="shrink-0">MOBIUS TERMINAL V1</span>

--- a/components/terminal/CreateEpiconModal.tsx
+++ b/components/terminal/CreateEpiconModal.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { useState } from 'react';
+
+type EpiconDraft = {
+  title: string;
+  summary: string;
+  category: 'geopolitical' | 'market' | 'governance' | 'infrastructure';
+  confidence: 'low' | 'medium' | 'high';
+  source1: string;
+  source2: string;
+  source3: string;
+  tags: string;
+};
+
+const EMPTY_DRAFT: EpiconDraft = {
+  title: '',
+  summary: '',
+  category: 'geopolitical',
+  confidence: 'medium',
+  source1: '',
+  source2: '',
+  source3: '',
+  tags: '',
+};
+
+const CATEGORIES: { value: EpiconDraft['category']; label: string }[] = [
+  { value: 'geopolitical', label: 'Geopolitical' },
+  { value: 'market', label: 'Market' },
+  { value: 'governance', label: 'Governance' },
+  { value: 'infrastructure', label: 'Infrastructure' },
+];
+
+export default function CreateEpiconModal({
+  open,
+  onClose,
+  onSubmit,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (draft: EpiconDraft) => Promise<void>;
+}) {
+  const [draft, setDraft] = useState<EpiconDraft>(EMPTY_DRAFT);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  if (!open) return null;
+
+  const canSubmit =
+    draft.title.trim().length > 0 &&
+    draft.summary.trim().length > 0 &&
+    draft.source1.trim().length > 0;
+
+  const handleSubmit = async () => {
+    if (!canSubmit || submitting) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      await onSubmit(draft);
+      setDraft(EMPTY_DRAFT);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Submission failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const set = (field: keyof EpiconDraft) => (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+  ) => setDraft((d) => ({ ...d, [field]: e.target.value }));
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/85 backdrop-blur-sm p-4">
+      <div className="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-2xl border border-slate-800 bg-slate-900 p-5 shadow-2xl">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-xs font-mono uppercase tracking-[0.24em] text-sky-300">
+              Create EPICON
+            </div>
+            <div className="mt-1 text-sm text-slate-400">
+              Submit a structured signal for Mobius agent processing
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-md border border-slate-700 px-3 py-1 text-sm font-mono text-slate-300 hover:bg-slate-800 transition"
+          >
+            ESC
+          </button>
+        </div>
+
+        {/* Pipeline visualization */}
+        <div className="mt-4 flex items-center gap-2 rounded-lg border border-dashed border-slate-700 px-3 py-2 text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500">
+          <span className="text-sky-400">You submit</span>
+          <span>→</span>
+          <span className="text-cyan-400">ECHO logs</span>
+          <span>→</span>
+          <span className="text-orange-400">HERMES routes</span>
+          <span>→</span>
+          <span className="text-amber-400">ZEUS verifies</span>
+          <span>→</span>
+          <span className="text-violet-400">ATLAS synthesizes</span>
+        </div>
+
+        {/* Form */}
+        <div className="mt-5 space-y-4">
+          {/* Title */}
+          <label className="block">
+            <div className="mb-1.5 text-xs font-mono uppercase tracking-[0.18em] text-slate-400">
+              Title <span className="text-rose-400">*</span>
+            </div>
+            <input
+              value={draft.title}
+              onChange={set('title')}
+              placeholder="Ex: Shipping disruption reported near Strait of Hormuz"
+              className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2.5 text-sm font-mono text-white outline-none placeholder:text-slate-600 focus:border-sky-500/40"
+            />
+          </label>
+
+          {/* Summary */}
+          <label className="block">
+            <div className="mb-1.5 text-xs font-mono uppercase tracking-[0.18em] text-slate-400">
+              Summary <span className="text-rose-400">*</span>
+            </div>
+            <textarea
+              value={draft.summary}
+              onChange={set('summary')}
+              placeholder="Describe what happened, what you observed, and why it matters."
+              rows={4}
+              className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2.5 text-sm font-mono text-white outline-none placeholder:text-slate-600 focus:border-sky-500/40 resize-none"
+            />
+          </label>
+
+          {/* Category + Confidence */}
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="block">
+              <div className="mb-1.5 text-xs font-mono uppercase tracking-[0.18em] text-slate-400">
+                Category
+              </div>
+              <select
+                value={draft.category}
+                onChange={set('category')}
+                className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2.5 text-sm font-mono text-white outline-none focus:border-sky-500/40"
+              >
+                {CATEGORIES.map((c) => (
+                  <option key={c.value} value={c.value} className="bg-slate-950">
+                    {c.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block">
+              <div className="mb-1.5 text-xs font-mono uppercase tracking-[0.18em] text-slate-400">
+                Confidence Estimate
+              </div>
+              <select
+                value={draft.confidence}
+                onChange={set('confidence')}
+                className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2.5 text-sm font-mono text-white outline-none focus:border-sky-500/40"
+              >
+                <option value="low" className="bg-slate-950">Low</option>
+                <option value="medium" className="bg-slate-950">Medium</option>
+                <option value="high" className="bg-slate-950">High</option>
+              </select>
+            </label>
+          </div>
+
+          {/* Sources */}
+          <div className="space-y-2">
+            <div className="text-xs font-mono uppercase tracking-[0.18em] text-slate-400">
+              Sources <span className="text-rose-400">*</span>
+              <span className="ml-2 normal-case tracking-normal text-slate-500">min 1 required</span>
+            </div>
+            <input
+              value={draft.source1}
+              onChange={set('source1')}
+              placeholder="https:// (primary source)"
+              className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2.5 text-sm font-mono text-white outline-none placeholder:text-slate-600 focus:border-sky-500/40"
+            />
+            <input
+              value={draft.source2}
+              onChange={set('source2')}
+              placeholder="https:// (optional cross-reference)"
+              className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2.5 text-sm font-mono text-white outline-none placeholder:text-slate-600 focus:border-sky-500/40"
+            />
+            <input
+              value={draft.source3}
+              onChange={set('source3')}
+              placeholder="https:// (optional third source)"
+              className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2.5 text-sm font-mono text-white outline-none placeholder:text-slate-600 focus:border-sky-500/40"
+            />
+          </div>
+
+          {/* Tags */}
+          <label className="block">
+            <div className="mb-1.5 text-xs font-mono uppercase tracking-[0.18em] text-slate-400">
+              Tags <span className="normal-case tracking-normal text-slate-500">comma-separated</span>
+            </div>
+            <input
+              value={draft.tags}
+              onChange={set('tags')}
+              placeholder="iran, energy, shipping, hormuz"
+              className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2.5 text-sm font-mono text-white outline-none placeholder:text-slate-600 focus:border-sky-500/40"
+            />
+          </label>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div className="mt-4 rounded-lg border border-rose-500/20 bg-rose-500/10 px-3 py-2.5 text-sm font-mono text-rose-300">
+            {error}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="mt-5 flex items-center justify-between">
+          <div className="text-xs font-mono text-slate-500">
+            Status will be set to <span className="text-sky-300">pending</span> · ZEUS verifies after submission
+          </div>
+          <div className="flex gap-3">
+            <button
+              onClick={onClose}
+              className="rounded-lg border border-slate-700 px-4 py-2 text-sm font-mono text-slate-300 hover:bg-slate-800 transition"
+            >
+              Cancel
+            </button>
+            <button
+              disabled={!canSubmit || submitting}
+              onClick={handleSubmit}
+              className={`rounded-lg border px-4 py-2 text-sm font-mono transition ${
+                canSubmit && !submitting
+                  ? 'border-sky-500/30 bg-sky-500/10 text-sky-300 hover:bg-sky-500/20'
+                  : 'cursor-not-allowed border-slate-700 bg-slate-800 text-slate-500'
+              }`}
+            >
+              {submitting ? 'Submitting...' : 'Submit EPICON'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/mobius/stores.ts
+++ b/lib/mobius/stores.ts
@@ -1,0 +1,183 @@
+/**
+ * Mobius Profile + EPICON Stores
+ *
+ * In-memory stores shared across API routes.
+ * V1: volatile (resets on cold start / redeploy).
+ * V2: persist to database or git-backed ledger.
+ *
+ * MII Formula (V1):
+ *   accuracy = hits / max(1, hits + misses)
+ *   contribution_bonus = min(0.10, epicon_count * 0.005)
+ *   MII = 0.30 + (accuracy * 0.60) + contribution_bonus
+ *   clamped [0.0, 1.0]
+ *
+ * Tier thresholds:
+ *   >= 0.90  signal-node
+ *   >= 0.80  node-2
+ *   >= 0.65  node-1
+ *   >= 0.50  participant
+ *   <  0.50  observer
+ */
+
+// ── Types ────────────────────────────────────────────────────
+
+export type NodeTier = 'observer' | 'participant' | 'node-1' | 'node-2' | 'signal-node';
+
+export type MobiusProfile = {
+  login: string;
+  displayName: string;
+  miiScore: number;
+  nodeTier: NodeTier;
+  epiconCount: number;
+  verificationHits: number;
+  verificationMisses: number;
+  createdAt: string;
+  lastActiveAt: string;
+};
+
+export type StoredEpicon = {
+  id: string;
+  title: string;
+  summary: string;
+  category: string;
+  status: 'pending' | 'verified' | 'contradicted';
+  confidenceTier: number;
+  ownerAgent: string;
+  sources: string[];
+  tags: string[];
+  timestamp: string;
+  trace: string[];
+  submittedBy?: string;
+  submittedByLogin?: string;
+  submittedByMii?: number;
+  verificationOutcome?: 'hit' | 'miss' | null;
+  zeusNote?: string | null;
+  createdAt: string;
+};
+
+// ── Stores ───────────────────────────────────────────────────
+
+const profileStore = new Map<string, MobiusProfile>();
+const epiconStore = new Map<string, StoredEpicon>();
+
+// Seed custodian profile
+profileStore.set('kaizencycle', {
+  login: 'kaizencycle',
+  displayName: 'Michael Judan',
+  miiScore: 0.64,
+  nodeTier: 'node-1',
+  epiconCount: 12,
+  verificationHits: 9,
+  verificationMisses: 1,
+  createdAt: '2026-03-13T07:46:00Z',
+  lastActiveAt: new Date().toISOString(),
+});
+
+// ── MII Calculation ──────────────────────────────────────────
+
+function clamp(value: number, min = 0, max = 1): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function calculateMII(profile: MobiusProfile): number {
+  const { verificationHits, verificationMisses, epiconCount } = profile;
+  const accuracy = verificationHits / Math.max(1, verificationHits + verificationMisses);
+  const contributionBonus = Math.min(0.10, epiconCount * 0.005);
+  return Math.round(clamp(0.30 + accuracy * 0.60 + contributionBonus) * 100) / 100;
+}
+
+export function calculateTier(miiScore: number): NodeTier {
+  if (miiScore >= 0.90) return 'signal-node';
+  if (miiScore >= 0.80) return 'node-2';
+  if (miiScore >= 0.65) return 'node-1';
+  if (miiScore >= 0.50) return 'participant';
+  return 'observer';
+}
+
+// ── Profile operations ───────────────────────────────────────
+
+export function getProfile(login: string): MobiusProfile | null {
+  return profileStore.get(login) ?? null;
+}
+
+export function ensureProfile(login: string, displayName: string): MobiusProfile {
+  const existing = profileStore.get(login);
+  if (existing) {
+    existing.lastActiveAt = new Date().toISOString();
+    return existing;
+  }
+
+  const profile: MobiusProfile = {
+    login,
+    displayName,
+    miiScore: 0.50,
+    nodeTier: 'participant',
+    epiconCount: 0,
+    verificationHits: 0,
+    verificationMisses: 0,
+    createdAt: new Date().toISOString(),
+    lastActiveAt: new Date().toISOString(),
+  };
+  profileStore.set(login, profile);
+  return profile;
+}
+
+export function incrementEpiconCount(login: string): MobiusProfile | null {
+  const profile = profileStore.get(login);
+  if (!profile) return null;
+
+  profile.epiconCount += 1;
+  profile.lastActiveAt = new Date().toISOString();
+  profile.miiScore = calculateMII(profile);
+  profile.nodeTier = calculateTier(profile.miiScore);
+  return profile;
+}
+
+export function recordVerification(
+  login: string,
+  outcome: 'hit' | 'miss',
+): MobiusProfile | null {
+  const profile = profileStore.get(login);
+  if (!profile) return null;
+
+  if (outcome === 'hit') {
+    profile.verificationHits += 1;
+  } else {
+    profile.verificationMisses += 1;
+  }
+
+  profile.lastActiveAt = new Date().toISOString();
+  profile.miiScore = calculateMII(profile);
+  profile.nodeTier = calculateTier(profile.miiScore);
+  return profile;
+}
+
+// ── EPICON operations ────────────────────────────────────────
+
+export function storeEpicon(epicon: StoredEpicon): void {
+  epiconStore.set(epicon.id, epicon);
+  if (epiconStore.size > 100) {
+    const oldest = epiconStore.keys().next().value;
+    if (oldest) epiconStore.delete(oldest);
+  }
+}
+
+export function getStoredEpicon(id: string): StoredEpicon | null {
+  return epiconStore.get(id) ?? null;
+}
+
+export function getAllSubmittedEpicons(): StoredEpicon[] {
+  return Array.from(epiconStore.values()).sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+}
+
+export function updateEpicon(
+  id: string,
+  updates: Partial<StoredEpicon>,
+): StoredEpicon | null {
+  const existing = epiconStore.get(id);
+  if (!existing) return null;
+  Object.assign(existing, updates);
+  return existing;
+}


### PR DESCRIPTION
V2 participatory layer — transforms Mobius from a dashboard into a system you can contribute to and that learns who to trust.

New files:
- lib/mobius/stores.ts: Shared profile + EPICON stores with MII calculation engine. MII = 0.30 + (accuracy * 0.60) + contribution bonus, clamped [0,1]. Five-tier system: observer → participant → node-1 → node-2 → signal-node. Seeded with custodian profile.

- app/api/epicon/create/route.ts: POST creates a user-submitted EPICON with cycle-aware ID (EPICON-C-XXX-USR-001-HASH), stores in shared store, increments author's EPICON count and recalculates MII. GET returns all submitted EPICONs.

- app/api/zeus/verify/route.ts: POST verifies a pending EPICON. Outcome (hit/miss) updates the EPICON status (verified/contradicted), updates author profile (hits/misses), recalculates MII and tier. Double-verification prevented (409 Conflict).

- app/api/profile/route.ts: GET returns a participant profile by login. POST ensures a profile exists (creates with 0.50 baseline if new).

- components/terminal/CreateEpiconModal.tsx: Full submission form with title, summary, category, confidence estimate, 3 source fields, tags, pipeline visualization, validation, error handling.

Terminal page wiring:
- /submit and /create commands open the modal from command palette
- Optimistic UI: submitted EPICONs appear in feed immediately
- /help updated with new commands

The complete reputation-learning loop:
  submit → store → ZEUS verify → MII recalculate → tier update

Principle: high MII = faster review priority, NOT automatic acceptance.

https://claude.ai/code/session_01Ty6Lf7t9g9CnR8fDZ7FhxG