### PR TITLE
feat(terminal): ship live integrity ribbon, attestation replay rail, and resilient shell (EPICON C-254)

### DIFF
--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -2,6 +2,11 @@
 
 import { useEffect, useState, useCallback, useRef } from 'react';
 import TopStatusBar from '@/components/terminal/TopStatusBar';
+import LiveIntegrityRibbon from '@/components/terminal/LiveIntegrityRibbon';
+import AttestationReplayRail from '@/components/terminal/AttestationReplayRail';
+import ConsensusPreviewStrip from '@/components/terminal/ConsensusPreviewStrip';
+import SuggestedNextActions, { type SuggestedAction } from '@/components/terminal/SuggestedNextActions';
+import TerminalShellFallback from '@/components/terminal/TerminalShellFallback';
 import SidebarNav from '@/components/terminal/SidebarNav';
 import EpiconFeedPanel from '@/components/terminal/EpiconFeedPanel';
 import AgentCortexPanel from '@/components/terminal/AgentCortexPanel';
@@ -21,6 +26,7 @@ import MICWalletPanel from '@/components/terminal/MICWalletPanel';
 import MFSShardPanel from '@/components/terminal/MFSShardPanel';
 import MICBlockchainExplorer from '@/components/terminal/MICBlockchainExplorer';
 import CreateEpiconModal from '@/components/terminal/CreateEpiconModal';
+import { useTerminalFreshness } from '@/hooks/useTerminalFreshness';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { WalletProvider, useWallet } from '@/contexts/WalletContext';
 import {
@@ -115,6 +121,10 @@ function TerminalPage() {
   const [echoAlerts, setEchoAlerts] = useState<CivicRadarAlert[]>([]);
   const [echoIntegrity, setEchoIntegrity] = useState<CycleIntegritySummary | null>(null);
   const [showCreateEpicon, setShowCreateEpicon] = useState(false);
+  const [operatorMessage, setOperatorMessage] = useState('Terminal live. Awaiting operator action.');
+
+  const mergedLedger = [...echoLedger, ...mockLedger];
+  const { freshness } = useTerminalFreshness(mergedLedger);
 
   // MIC wallet — auto-mint when integrity engine produces MIC
   const { earnMIC } = useWallet();
@@ -444,11 +454,7 @@ function TerminalPage() {
   );
 
   if (!gi || !inspectorTarget) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-300 font-mono">
-        Loading Mobius Terminal...
-      </div>
-    );
+    return <TerminalShellFallback statusLabel="Booting Mobius Terminal · syncing integrity surfaces" />;
   }
 
   // Derived view state
@@ -462,7 +468,6 @@ function TerminalPage() {
       : agents.filter((a) => a.status !== 'idle');
 
   // Merged data: live ECHO + mock
-  const mergedLedger = [...echoLedger, ...mockLedger];
   const mergedAlerts = [...echoAlerts, ...mockCivicAlerts];
 
   // Signal Engine scoring
@@ -483,6 +488,122 @@ function TerminalPage() {
   const showWallet = selectedNav === 'wallet';
   const showSignal = ['pulse', 'governance', 'geopolitics', 'markets'].includes(selectedNav);
 
+  const dominantTripwireState = allTripwires.some((tw) => tw.severity === 'high')
+    ? 'degraded'
+    : allTripwires.some((tw) => tw.severity === 'medium')
+      ? 'watch'
+      : 'stable';
+
+  const consensusAgents = (() => {
+    if (showCreateEpicon) {
+      return [
+        { name: 'ZEUS', verdict: 'approve' as const, note: 'Verification lane ready for operator-submitted signal.' },
+        { name: 'EVE', verdict: 'caution' as const, note: 'Check ethics impact before publishing outward.' },
+        { name: 'AUREA', verdict: 'approve' as const, note: 'Synthesis path available once evidence lands.' },
+        { name: 'HERMES', verdict: 'approve' as const, note: 'Routing prepared for intake and escalation.' },
+        { name: 'JADE', verdict: 'pending' as const, note: 'Annotation layer opens after submission.' },
+        { name: 'ATLAS', verdict: 'caution' as const, note: 'Tripwire scan will run on submit.' },
+      ];
+    }
+
+    if (inspectorTarget.kind === 'epicon') {
+      const event = inspectorTarget.data;
+      return [
+        { name: 'ZEUS', verdict: event.status === 'contradicted' ? 'block' as const : 'approve' as const, note: `Confidence tier ${event.confidenceTier} attestation ready.` },
+        { name: 'EVE', verdict: event.status === 'pending' ? 'caution' as const : 'approve' as const, note: 'Public impact review remains visible.' },
+        { name: 'AUREA', verdict: 'approve' as const, note: 'Strategic synthesis can be generated from current trace.' },
+        { name: 'HERMES', verdict: 'approve' as const, note: 'Routing path mapped from intake to chamber context.' },
+        { name: 'JADE', verdict: 'pending' as const, note: 'Human annotation slot available for operator notes.' },
+        { name: 'ATLAS', verdict: dominantTripwireState === 'degraded' ? 'caution' as const : 'approve' as const, note: 'Anomaly posture matches current tripwire state.' },
+      ];
+    }
+
+    return [
+      { name: 'ZEUS', verdict: 'approve' as const, note: 'Verification fabric nominal.' },
+      { name: 'EVE', verdict: 'approve' as const, note: 'Ethics observer online.' },
+      { name: 'AUREA', verdict: 'approve' as const, note: 'Synthesis layer stable.' },
+      { name: 'HERMES', verdict: streamStatus === 'offline' ? 'caution' as const : 'approve' as const, note: 'Routing follows stream posture.' },
+      { name: 'JADE', verdict: 'pending' as const, note: 'Annotation opens when operator context is supplied.' },
+      { name: 'ATLAS', verdict: dominantTripwireState === 'degraded' ? 'caution' as const : 'approve' as const, note: 'Risk preview mirrors active tripwires.' },
+    ];
+  })();
+
+  const suggestedActions: SuggestedAction[] = (() => {
+    if (showCreateEpicon) {
+      return [
+        { id: 'submit.epicon', label: 'Complete EPICON draft', description: 'Attach sources, confidence, and tags before sending to ECHO.' },
+        { id: 'request.consensus', label: 'Request consensus', description: 'Preview ZEUS/EVE/AUREA review before operator submission.' },
+        { id: 'open.tripwire', label: 'Inspect tripwire posture', description: 'Check whether this signal should enter a watch lane first.' },
+      ];
+    }
+
+    if (inspectorTarget.kind === 'epicon') {
+      return [
+        { id: 'ledger.open', label: 'Open ledger record', description: 'Jump to the correlated ledger write for this EPICON.' },
+        { id: 'consensus.request', label: 'Request consensus', description: 'Preview cross-agent verdicts before escalating or publishing.' },
+        { id: 'tripwire.escalate', label: 'Escalate to tripwire', description: 'Promote the event into infrastructure watch if risk increases.' },
+        { id: 'annotate.jade', label: 'Annotate with JADE', description: 'Capture human context and morale signals in the trace.' },
+        { id: 'inspect.wallet', label: 'Open wallet impact', description: 'Review MIC / MII implications from integrity movement.' },
+      ];
+    }
+
+    return [
+      { id: 'scan.epicon', label: 'Scan related EPICONs', description: 'Search the active feed for adjacent events or categories.' },
+      { id: 'open.ledger', label: 'Open ledger chamber', description: 'Review the immutable record for the current cycle.' },
+      { id: 'open.wallet', label: 'Inspect wallet impact', description: 'Check MIC minting and MFS shard activity.' },
+    ];
+  })();
+
+  const handleSuggestedAction = (actionId: string) => {
+    setOperatorMessage(`Operator action queued: ${actionId}`);
+
+    if (actionId === 'open.ledger' || actionId === 'ledger.open') {
+      setSelectedNav('ledger');
+      const latest = mergedLedger[0];
+      if (latest) setInspectorTarget({ kind: 'ledger', data: latest });
+      return;
+    }
+
+    if (actionId === 'tripwire.escalate' || actionId === 'open.tripwire') {
+      setSelectedNav('infrastructure');
+      const active = allTripwires[0];
+      if (active) setInspectorTarget({ kind: 'tripwire', data: active });
+      return;
+    }
+
+    if (actionId === 'inspect.wallet' || actionId === 'open.wallet') {
+      setSelectedNav('wallet');
+      return;
+    }
+
+    if (actionId === 'annotate.jade') {
+      setSelectedNav('reflections');
+      const jade = agents.find((agent) => agent.id === 'jade');
+      if (jade) setInspectorTarget({ kind: 'agent', data: jade });
+      return;
+    }
+
+    if (actionId === 'scan.epicon') {
+      setSelectedNav('search');
+      return;
+    }
+
+    if (actionId === 'submit.epicon') {
+      setShowCreateEpicon(true);
+      return;
+    }
+
+    if (actionId === 'request.consensus' || actionId === 'consensus.request') {
+      setOperatorMessage('Consensus request staged across ZEUS, EVE, AUREA, HERMES, JADE, and ATLAS.');
+    }
+  };
+
+  const liveRibbonMii = echoIntegrity?.avgMii ?? (mockSentinels.reduce((sum, sentinel) => sum + sentinel.integrity, 0) / mockSentinels.length);
+  const liveRibbonMicDelta = echoIntegrity?.totalMicMinted ?? Math.max(0, gi.delta * 100);
+  const relatedLedgerEntry = inspectorTarget.kind === 'epicon'
+    ? mergedLedger.find((entry) => entry.summary.includes(inspectorTarget.data.id) || entry.summary.toLowerCase().includes(inspectorTarget.data.title.toLowerCase().slice(0, 24)))
+    : undefined;
+
   return (
     <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
       <TopStatusBar
@@ -497,6 +618,24 @@ function TerminalPage() {
         }}
       />
 
+      <LiveIntegrityRibbon
+        gi={gi.score}
+        mii={liveRibbonMii}
+        micDelta={liveRibbonMicDelta}
+        tripwireState={dominantTripwireState}
+        lastLedgerSyncLabel={freshness.lastLedgerSyncLabel}
+        lastIngestLabel={freshness.lastIngestLabel}
+        lastCycleAdvanceLabel={freshness.lastCycleAdvanceLabel}
+        cycleId={currentCycleId()}
+        streamLabel={streamStatus === 'live' ? 'LIVE' : streamStatus === 'reconnecting' ? 'RECONNECTING' : 'OFFLINE'}
+      />
+
+      <ConsensusPreviewStrip
+        title={showCreateEpicon ? 'Consensus Preview · Submission Lane' : 'Consensus Preview · Operator Lane'}
+        subtitle={operatorMessage}
+        agents={consensusAgents}
+      />
+
       <div className="grid flex-1 grid-cols-12 max-md:grid-cols-1">
         <SidebarNav
           items={navItems}
@@ -506,16 +645,21 @@ function TerminalPage() {
 
         <main className="col-span-7 max-lg:col-span-9 max-md:col-span-1 border-r border-slate-800 max-md:border-r-0 bg-slate-950">
           <div className="grid h-full grid-rows-[auto_auto_auto_1fr] gap-4 p-4">
-            {CHAMBER_DESCRIPTIONS[selectedNav] && (
-              <div className="rounded-xl border border-dashed border-slate-800 bg-slate-900/40 p-4">
-                <div className="text-xs font-mono uppercase tracking-[0.2em] text-sky-300">
-                  {NAV_LABEL_MAP.get(selectedNav)} Chamber
+            <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="text-xs font-mono uppercase tracking-[0.2em] text-sky-300">
+                    {NAV_LABEL_MAP.get(selectedNav)} Chamber
+                  </div>
+                  <div className="mt-2 text-sm font-sans text-slate-400">
+                    {CHAMBER_DESCRIPTIONS[selectedNav] ?? 'Operational state is visible before command entry. Use the live ribbon, replay rail, and consensus strip to inspect trust, freshness, and next actions from first paint.'}
+                  </div>
                 </div>
-                <div className="mt-2 text-sm font-sans text-slate-400">
-                  {CHAMBER_DESCRIPTIONS[selectedNav]}
+                <div className="max-w-md text-xs font-mono uppercase tracking-[0.15em] text-slate-500">
+                  {operatorMessage}
                 </div>
               </div>
-            )}
+            </div>
 
             {showLedger && (
               <LedgerPanel
@@ -635,12 +779,30 @@ function TerminalPage() {
               </section>
             )}
 
-            <CommandPalette onExecute={handleCommand} />
+            <CommandPalette onExecute={(command) => { const result = handleCommand(command); setOperatorMessage(result.message); return result; }} />
+
+            <SuggestedNextActions
+              title={showCreateEpicon ? 'Suggested Next Actions · Submission Flow' : 'Suggested Next Actions'}
+              actions={suggestedActions}
+              onSelect={handleSuggestedAction}
+            />
           </div>
         </main>
 
         <DetailInspectorRail
           target={inspectorTarget}
+          prependContent={inspectorTarget.kind === 'epicon' ? (
+            <AttestationReplayRail
+              event={inspectorTarget.data}
+              relatedLedger={relatedLedgerEntry}
+              onAction={(actionId) => {
+                setOperatorMessage(`Replay rail action queued: ${actionId}`);
+                if (actionId === 'compare') {
+                  setSelectedNav('governance');
+                }
+              }}
+            />
+          ) : null}
           onZeusVerify={async (payload: ZeusVerifyPayload): Promise<ZeusVerifyResult> => {
             try {
               const res = await fetch('/api/zeus/verify', {
@@ -673,7 +835,10 @@ function TerminalPage() {
 
       <CreateEpiconModal
         open={showCreateEpicon}
-        onClose={() => setShowCreateEpicon(false)}
+        onClose={() => {
+          setShowCreateEpicon(false);
+          setOperatorMessage('EPICON submission lane closed. Terminal returned to live monitoring.');
+        }}
         onSubmit={async (draft) => {
           const sources = [draft.source1, draft.source2, draft.source3]
             .map((s) => s.trim())
@@ -697,6 +862,8 @@ function TerminalPage() {
           if (!data.ok) throw new Error(data.error || 'Submission failed');
 
           // Optimistic UI — add to feed immediately
+          setOperatorMessage(`EPICON ${data.epicon.id} staged for ZEUS verification.`);
+
           setEpicon((prev) => [{
             id: data.epicon.id,
             title: data.epicon.title,

--- a/components/terminal/AttestationReplayRail.tsx
+++ b/components/terminal/AttestationReplayRail.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import type { EpiconItem, LedgerEntry } from '@/lib/terminal/types';
+import { cn } from '@/lib/terminal/utils';
+
+export type ReplayAction = {
+  id: string;
+  label: string;
+  note: string;
+};
+
+function statusTone(status: EpiconItem['status']) {
+  if (status === 'verified') return 'text-emerald-300 border-emerald-500/20 bg-emerald-500/10';
+  if (status === 'contradicted') return 'text-rose-300 border-rose-500/20 bg-rose-500/10';
+  return 'text-amber-300 border-amber-500/20 bg-amber-500/10';
+}
+
+export default function AttestationReplayRail({
+  event,
+  relatedLedger,
+  onAction,
+}: {
+  event: EpiconItem;
+  relatedLedger?: LedgerEntry;
+  onAction?: (actionId: string) => void;
+}) {
+  const confidenceProgression = Array.from({ length: 5 }, (_, idx) => idx <= event.confidenceTier);
+  const actions: ReplayAction[] = [
+    { id: 'replay', label: 'Replay', note: 'Re-run the attestation path from intake to ledger.' },
+    { id: 'challenge', label: 'Challenge', note: 'Open a contradiction lane for operator review.' },
+    { id: 'compare', label: 'Compare', note: 'Cross-check this EPICON against related shards and alerts.' },
+  ];
+
+  return (
+    <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-xs font-mono font-semibold uppercase tracking-[0.2em] text-sky-300">
+            Attestation Replay Rail
+          </div>
+          <div className="mt-1 text-sm font-sans text-slate-400">
+            Drill down from signal intake to ledger anchoring for the selected EPICON.
+          </div>
+        </div>
+        <span className={cn('rounded-md border px-2 py-1 text-[10px] font-mono uppercase tracking-[0.15em]', statusTone(event.status))}>
+          {event.status}
+        </span>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-3 xl:grid-cols-2">
+        <div className="rounded-lg border border-slate-800 bg-slate-950 p-3">
+          <div className="text-[11px] font-mono uppercase tracking-[0.15em] text-slate-500">source stack</div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {event.sources.map((source) => (
+              <span key={source} className="rounded-md border border-slate-800 bg-slate-900 px-2 py-1 text-[11px] font-mono text-slate-300">
+                {source}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-slate-800 bg-slate-950 p-3">
+          <div className="text-[11px] font-mono uppercase tracking-[0.15em] text-slate-500">verification owner</div>
+          <div className="mt-2 text-sm font-sans text-slate-200">{event.ownerAgent}</div>
+          <div className="mt-3 text-[11px] font-mono uppercase tracking-[0.15em] text-slate-500">ledger write</div>
+          <div className="mt-1 text-sm font-sans text-slate-300">
+            {relatedLedger ? `${relatedLedger.status.toUpperCase()} · ${relatedLedger.id}` : 'Awaiting correlated ledger entry'}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-lg border border-slate-800 bg-slate-950 p-3">
+        <div className="text-[11px] font-mono uppercase tracking-[0.15em] text-slate-500">confidence progression</div>
+        <div className="mt-2 grid grid-cols-5 gap-2">
+          {confidenceProgression.map((active, idx) => (
+            <div
+              key={idx}
+              className={cn(
+                'rounded-md border px-2 py-2 text-center text-[11px] font-mono uppercase tracking-[0.12em]',
+                active
+                  ? 'border-sky-500/40 bg-sky-500/15 text-sky-300'
+                  : 'border-slate-800 bg-slate-900 text-slate-500',
+              )}
+            >
+              T{idx}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-lg border border-slate-800 bg-slate-950 p-3">
+        <div className="text-[11px] font-mono uppercase tracking-[0.15em] text-slate-500">agent handoff trace</div>
+        <div className="mt-2 space-y-2">
+          {event.trace.map((step, index) => (
+            <div key={`${event.id}-${index}`} className="rounded-md border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-300">
+              <span className="mr-2 font-mono text-slate-500">{String(index + 1).padStart(2, '0')}</span>
+              {step}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-2 md:grid-cols-3">
+        {actions.map((action) => (
+          <button
+            key={action.id}
+            onClick={() => onAction?.(action.id)}
+            className="rounded-lg border border-slate-800 bg-slate-950 px-3 py-3 text-left transition hover:border-slate-700 hover:bg-slate-900"
+          >
+            <div className="text-xs font-mono uppercase tracking-[0.15em] text-sky-300">{action.label}</div>
+            <div className="mt-1 text-xs font-sans text-slate-400">{action.note}</div>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/terminal/CommandPalette.tsx
+++ b/components/terminal/CommandPalette.tsx
@@ -55,6 +55,10 @@ export default function CommandPalette({
         </div>
       )}
 
+      <div className="mt-3 rounded-lg border border-dashed border-slate-800 bg-slate-950/50 px-3 py-2 text-[11px] font-mono uppercase tracking-[0.12em] text-slate-500">
+        Suggested: /submit · /scan tripwire · /ledger · /wallet · /echo
+      </div>
+
       <form
         onSubmit={handleSubmit}
         className="mt-3 flex items-center gap-3 rounded-lg border border-slate-800 bg-slate-950 px-3 py-2"

--- a/components/terminal/ConsensusPreviewStrip.tsx
+++ b/components/terminal/ConsensusPreviewStrip.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { cn } from '@/lib/terminal/utils';
+
+export type ConsensusAgentState = {
+  name: string;
+  verdict: 'approve' | 'caution' | 'block' | 'pending';
+  note: string;
+};
+
+const VERDICT_TONE: Record<ConsensusAgentState['verdict'], string> = {
+  approve: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-300',
+  caution: 'border-amber-500/20 bg-amber-500/10 text-amber-300',
+  block: 'border-rose-500/20 bg-rose-500/10 text-rose-300',
+  pending: 'border-slate-700 bg-slate-900 text-slate-300',
+};
+
+export default function ConsensusPreviewStrip({
+  title,
+  subtitle,
+  agents,
+}: {
+  title?: string;
+  subtitle?: string;
+  agents: ConsensusAgentState[];
+}) {
+  return (
+    <section className="border-b border-slate-800 bg-slate-950/80 px-4 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div className="text-xs font-mono font-semibold uppercase tracking-[0.2em] text-sky-300">
+            {title ?? 'Consensus Preview'}
+          </div>
+          <div className="mt-1 text-xs font-sans text-slate-500">
+            {subtitle ?? 'ZEUS, EVE, AUREA, HERMES, JADE, and ATLAS posture before major operator actions.'}
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {agents.map((agent) => (
+            <div key={agent.name} className={cn('min-w-[122px] rounded-md border px-3 py-2', VERDICT_TONE[agent.verdict])}>
+              <div className="text-[11px] font-mono uppercase tracking-[0.15em]">{agent.name}</div>
+              <div className="mt-1 text-[11px] font-mono uppercase tracking-[0.15em] opacity-90">{agent.verdict}</div>
+              <div className="mt-1 text-xs font-sans text-current/80">{agent.note}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/terminal/DetailInspectorRail.tsx
+++ b/components/terminal/DetailInspectorRail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import type { InspectorTarget, Tripwire } from '@/lib/terminal/types';
 import { confidenceLabel, statusColor, tripwireStyle, giScoreColor, metricBarColor, cn } from '@/lib/terminal/utils';
 import SectionLabel from './SectionLabel';
@@ -833,9 +833,11 @@ function InspectorContent({
 export default function DetailInspectorRail({
   target,
   onZeusVerify,
+  prependContent,
 }: {
   target: InspectorTarget;
   onZeusVerify?: (payload: ZeusVerifyPayload) => Promise<ZeusVerifyResult>;
+  prependContent?: ReactNode;
 }) {
   const [mobileOpen, setMobileOpen] = useState(false);
 
@@ -843,7 +845,8 @@ export default function DetailInspectorRail({
     <>
       {/* ── Desktop / Tablet: sidebar rail ── */}
       <aside className="max-md:hidden col-span-3 max-lg:col-span-2 bg-slate-950/90">
-        <div className="h-full p-4">
+        <div className="h-full space-y-4 p-4">
+          {prependContent}
           <InspectorContent target={target} onZeusVerify={onZeusVerify} />
         </div>
       </aside>
@@ -879,7 +882,10 @@ export default function DetailInspectorRail({
         style={{ maxHeight: '55vh' }}
       >
         <div className="overflow-y-auto p-4" style={{ maxHeight: '55vh', paddingBottom: '70px' }}>
-          <InspectorContent target={target} onZeusVerify={onZeusVerify} />
+          <div className="space-y-4">
+            {prependContent}
+            <InspectorContent target={target} onZeusVerify={onZeusVerify} />
+          </div>
         </div>
       </div>
     </>

--- a/components/terminal/EpiconFeedPanel.tsx
+++ b/components/terminal/EpiconFeedPanel.tsx
@@ -61,6 +61,11 @@ export default function EpiconFeedPanel({
         />
       </div>
       <div className="mt-3 space-y-3">
+        {sorted.length === 0 && (
+          <div className="rounded-lg border border-dashed border-slate-800 bg-slate-950/60 p-4 text-sm font-sans text-slate-400">
+            No EPICON events are active in this chamber yet. Use <span className="font-mono text-sky-300">/submit</span> to open a new event or switch back to Pulse for the full live feed.
+          </div>
+        )}
         {sorted.map((item) => (
           <button
             key={item.id}

--- a/components/terminal/LiveIntegrityRibbon.tsx
+++ b/components/terminal/LiveIntegrityRibbon.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { cn } from '@/lib/terminal/utils';
+
+export type IntegrityTone = 'stable' | 'watch' | 'degraded';
+
+export type LiveIntegrityRibbonProps = {
+  gi: number;
+  mii: number;
+  micDelta: number;
+  tripwireState: IntegrityTone;
+  lastLedgerSyncLabel: string;
+  lastIngestLabel: string;
+  lastCycleAdvanceLabel: string;
+  cycleId: string;
+  streamLabel: string;
+};
+
+function formatScore(value: number) {
+  if (Number.isNaN(value)) return '--';
+  return value.toFixed(2);
+}
+
+const TONE_STYLES: Record<IntegrityTone, string> = {
+  stable: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-300',
+  watch: 'border-amber-500/20 bg-amber-500/10 text-amber-300',
+  degraded: 'border-rose-500/20 bg-rose-500/10 text-rose-300',
+};
+
+function MetricChip({ label, value, tone }: { label: string; value: string; tone?: IntegrityTone }) {
+  return (
+    <div
+      className={cn(
+        'rounded-md border px-2.5 py-1 text-[10px] font-mono uppercase tracking-[0.15em] text-slate-300',
+        tone ? TONE_STYLES[tone] : 'border-slate-800 bg-slate-900/80',
+      )}
+    >
+      <span className="text-slate-500">{label}</span>{' '}
+      <span className="text-current">{value}</span>
+    </div>
+  );
+}
+
+export default function LiveIntegrityRibbon({
+  gi,
+  mii,
+  micDelta,
+  tripwireState,
+  lastLedgerSyncLabel,
+  lastIngestLabel,
+  lastCycleAdvanceLabel,
+  cycleId,
+  streamLabel,
+}: LiveIntegrityRibbonProps) {
+  const micLabel = `${micDelta >= 0 ? '+' : ''}${micDelta.toFixed(1)}`;
+
+  return (
+    <section className="border-b border-slate-800 bg-slate-950/90 px-4 py-2 backdrop-blur">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="mr-2 text-[11px] font-mono font-semibold uppercase tracking-[0.22em] text-sky-300">
+          Live Integrity Ribbon
+        </div>
+        <MetricChip label="cycle" value={cycleId} />
+        <MetricChip label="gi" value={formatScore(gi)} tone={gi >= 0.9 ? 'stable' : gi >= 0.78 ? 'watch' : 'degraded'} />
+        <MetricChip label="mii" value={formatScore(mii)} tone={mii >= 0.9 ? 'stable' : mii >= 0.78 ? 'watch' : 'degraded'} />
+        <MetricChip label="mic" value={micLabel} tone={micDelta >= 0 ? 'stable' : 'degraded'} />
+        <MetricChip label="tripwire" value={tripwireState.toUpperCase()} tone={tripwireState} />
+        <MetricChip label="ledger" value={lastLedgerSyncLabel} />
+        <MetricChip label="ingest" value={lastIngestLabel} />
+        <MetricChip label="cycle advance" value={lastCycleAdvanceLabel} />
+        <MetricChip label="stream" value={streamLabel} />
+      </div>
+    </section>
+  );
+}

--- a/components/terminal/SubstrateStatusCard.tsx
+++ b/components/terminal/SubstrateStatusCard.tsx
@@ -27,7 +27,9 @@ export default function SubstrateStatusCard({
 }) {
   const activeSentinels = sentinels.filter((s) => s.status !== 'standby').length;
   const avgIntegrity =
-    sentinels.reduce((sum, s) => sum + s.integrity, 0) / sentinels.length;
+    sentinels.length > 0
+      ? sentinels.reduce((sum, s) => sum + s.integrity, 0) / sentinels.length
+      : 0;
 
   return (
     <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
@@ -64,6 +66,11 @@ export default function SubstrateStatusCard({
       </div>
 
       <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-5">
+        {sentinels.length === 0 && (
+          <div className="col-span-full rounded-lg border border-dashed border-slate-800 bg-slate-950/60 p-4 text-sm font-sans text-slate-400">
+            Sentinel council data is unavailable. Consensus preview remains in degraded mode until providers report in.
+          </div>
+        )}
         {sentinels.map((s) => (
           <button
             key={s.id}

--- a/components/terminal/SuggestedNextActions.tsx
+++ b/components/terminal/SuggestedNextActions.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+export type SuggestedAction = {
+  id: string;
+  label: string;
+  description: string;
+};
+
+export default function SuggestedNextActions({
+  title = 'Suggested Next Actions',
+  actions,
+  onSelect,
+}: {
+  title?: string;
+  actions: SuggestedAction[];
+  onSelect?: (actionId: string) => void;
+}) {
+  return (
+    <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+      <div className="text-xs font-mono font-semibold uppercase tracking-[0.2em] text-sky-300">
+        {title}
+      </div>
+      <div className="mt-1 text-sm font-sans text-slate-400">
+        Keep operators in motion with the most likely follow-on steps.
+      </div>
+
+      <div className="mt-4 grid gap-2">
+        {actions.map((action) => (
+          <button
+            key={action.id}
+            onClick={() => onSelect?.(action.id)}
+            className="rounded-lg border border-slate-800 bg-slate-950 px-3 py-3 text-left transition hover:border-slate-700 hover:bg-slate-900"
+          >
+            <div className="text-sm font-sans font-medium text-white">{action.label}</div>
+            <div className="mt-1 text-xs font-sans text-slate-400">{action.description}</div>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/terminal/TerminalShellFallback.tsx
+++ b/components/terminal/TerminalShellFallback.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+export default function TerminalShellFallback({
+  statusLabel = 'Booting Mobius Terminal...',
+}: {
+  statusLabel?: string;
+}) {
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="border-b border-slate-800 bg-slate-950/90 px-4 py-3 backdrop-blur">
+        <div className="text-sm font-mono font-semibold uppercase tracking-[0.28em] text-sky-300">
+          Mobius Terminal
+        </div>
+        <div className="mt-1 text-xs font-sans text-slate-500">
+          Bloomberg-style civic command console for EPICON visibility, verification, and operator routing.
+        </div>
+      </div>
+
+      <div className="border-b border-slate-800 bg-slate-900/50 px-4 py-2 text-xs font-mono uppercase tracking-[0.15em] text-slate-400">
+        {statusLabel}
+      </div>
+
+      <div className="border-b border-slate-800 bg-slate-950/80 px-4 py-3">
+        <div className="flex flex-wrap gap-2">
+          {['GI --', 'MII --', 'MIC --', 'TRIPWIRE WATCH', 'LEDGER syncing', 'INGEST checking', 'CYCLE checking'].map((item) => (
+            <div key={item} className="rounded-md border border-slate-800 bg-slate-900 px-2.5 py-1 text-[10px] font-mono uppercase tracking-[0.15em] text-slate-500">
+              {item}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid min-h-[calc(100vh-140px)] grid-cols-12 max-md:grid-cols-1">
+        <aside className="col-span-2 border-r border-slate-800 bg-slate-950/50 p-4 max-md:border-r-0 max-md:border-b">
+          <div className="space-y-2 text-xs font-mono uppercase tracking-[0.15em] text-slate-500">
+            <div className="rounded-md border border-slate-800 bg-slate-900 px-3 py-2">Pulse</div>
+            <div className="rounded-md border border-slate-800 bg-slate-900 px-3 py-2">Agents</div>
+            <div className="rounded-md border border-slate-800 bg-slate-900 px-3 py-2">Ledger</div>
+            <div className="rounded-md border border-slate-800 bg-slate-900 px-3 py-2">Tripwire</div>
+            <div className="rounded-md border border-slate-800 bg-slate-900 px-3 py-2">Wallet</div>
+          </div>
+        </aside>
+
+        <main className="col-span-7 border-r border-slate-800 p-4 max-md:border-r-0">
+          <div className="rounded-xl border border-dashed border-slate-800 bg-slate-900/40 p-4">
+            <div className="text-xs font-mono uppercase tracking-[0.18em] text-sky-300">Resilient shell</div>
+            <div className="mt-2 text-sm text-slate-400">
+              If live data is delayed, the terminal still explains what it does, shows freshness placeholders, and signals degraded or disconnected states instead of rendering a blank loading screen.
+            </div>
+          </div>
+
+          <div className="mt-4 space-y-3">
+            {[0, 1, 2].map((item) => (
+              <div key={item} className="h-20 rounded-xl border border-slate-800 bg-slate-900/60" />
+            ))}
+          </div>
+        </main>
+
+        <section className="col-span-3 p-4">
+          <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+            <div className="text-xs font-mono uppercase tracking-[0.18em] text-slate-500">Inspector fallback</div>
+            <div className="mt-2 h-56 rounded-lg border border-slate-800 bg-slate-950" />
+            <div className="mt-3 text-xs text-slate-500">
+              Degraded mode keeps the operator context visible while live hydration completes.
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/components/terminal/TripwireWatchCard.tsx
+++ b/components/terminal/TripwireWatchCard.tsx
@@ -33,6 +33,11 @@ export default function TripwireWatchCard({
         )}
       </div>
       <div className="mt-3 space-y-3">
+        {tripwires.length === 0 && (
+          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3 text-sm font-sans text-emerald-300">
+            No active tripwires. Substrate posture is nominal and ready for new watch conditions.
+          </div>
+        )}
         {tripwires.map((t) => (
           <button
             key={t.id}

--- a/hooks/useTerminalFreshness.ts
+++ b/hooks/useTerminalFreshness.ts
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
+import type { LedgerEntry } from '@/lib/terminal/types';
+
+export type TerminalFreshnessSnapshot = {
+  lastLedgerSyncLabel: string;
+  lastIngestLabel: string;
+  lastCycleAdvanceLabel: string;
+};
+
+function formatRelative(timestamp?: string | null) {
+  if (!timestamp) return 'unknown';
+
+  const value = new Date(timestamp);
+  if (Number.isNaN(value.getTime())) return timestamp;
+
+  const deltaMs = Date.now() - value.getTime();
+  const deltaMinutes = Math.round(deltaMs / 60000);
+
+  if (Math.abs(deltaMinutes) < 1) return 'just now';
+  if (Math.abs(deltaMinutes) < 60) return `${deltaMinutes}m ago`;
+
+  const deltaHours = Math.round(deltaMinutes / 60);
+  if (Math.abs(deltaHours) < 24) return `${deltaHours}h ago`;
+
+  const deltaDays = Math.round(deltaHours / 24);
+  return `${deltaDays}d ago`;
+}
+
+function formatMobiusTimestamp(timestamp?: string | null) {
+  if (!timestamp) return 'unknown';
+  const value = new Date(timestamp);
+  if (Number.isNaN(value.getTime())) return timestamp;
+  return value.toLocaleString('en-US', {
+    timeZone: 'America/New_York',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+export function useTerminalFreshness(ledger: LedgerEntry[]) {
+  const [lastIngest, setLastIngest] = useState<string | null>(null);
+  const [lastCycleAdvance, setLastCycleAdvance] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const load = async () => {
+      try {
+        const [echoRes, cycleRes] = await Promise.all([
+          fetch('/api/echo/feed', { cache: 'no-store' }),
+          fetch('/api/eve/cycle-advance', { cache: 'no-store' }),
+        ]);
+
+        if (!mounted) return;
+
+        if (echoRes.ok) {
+          const echo = await echoRes.json();
+          setLastIngest(echo?.status?.lastIngest ?? null);
+        }
+
+        if (cycleRes.ok) {
+          const cycle = await cycleRes.json();
+          setLastCycleAdvance(cycle?.timestamp ?? null);
+        }
+      } catch {
+        if (!mounted) return;
+      } finally {
+        if (mounted) setIsLoading(false);
+      }
+    };
+
+    load();
+    const interval = window.setInterval(load, 60000);
+    return () => {
+      mounted = false;
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  const freshestLedger = ledger[0]?.timestamp;
+
+  const freshness = useMemo<TerminalFreshnessSnapshot>(() => ({
+    lastLedgerSyncLabel: freshestLedger ? formatMobiusTimestamp(freshestLedger) : 'awaiting ledger',
+    lastIngestLabel: formatRelative(lastIngest),
+    lastCycleAdvanceLabel:
+      lastCycleAdvance ? `${currentCycleId(new Date(lastCycleAdvance))} · ${formatMobiusTimestamp(lastCycleAdvance)}` : 'unknown',
+  }), [freshestLedger, lastIngest, lastCycleAdvance]);
+
+  return { freshness, isLoading };
+}


### PR DESCRIPTION
### Motivation

- Surface operational state and integrity cues at first paint so the terminal feels like an operational operator console rather than a blank loading shell. 
- Provide an inspectable attestation/replay path for EPICON events to improve explainability and auditability. 
- Improve resiliency and operator guidance with a pre-hydration shell, freshness indicators, consensus preview, and suggested next actions to reduce friction.

### Description

- Add new operator-surface components: `components/terminal/LiveIntegrityRibbon.tsx`, `components/terminal/AttestationReplayRail.tsx`, `components/terminal/ConsensusPreviewStrip.tsx`, `components/terminal/SuggestedNextActions.tsx`, and `components/terminal/TerminalShellFallback.tsx` to present live integrity, replay, consensus preview, suggested actions, and a resilient shell UI. 
- Add a freshness hook `hooks/useTerminalFreshness.ts` that polls `GET /api/echo/feed` and `GET /api/eve/cycle-advance` and formats ledger/ingest/cycle freshness labels. 
- Integrate the new surfaces into the terminal route by updating `app/terminal/page.tsx` to render the live integrity ribbon, consensus preview strip, suggested-actions panel, and to prepend the attestation replay rail into the inspector flow, plus operator messaging wiring. 
- Improve degraded/empty-state UX across existing components by making `DetailInspectorRail` accept prepended content, and adding intentional empty/fallback copy to `components/terminal/EpiconFeedPanel.tsx`, `TripwireWatchCard.tsx`, `SubstrateStatusCard.tsx`, and `CommandPalette.tsx` so the UI communicates health and next steps before deep hydration. 

### Testing

- Ran build with `npm run build` and the Next.js production build completed successfully. 
- Ran lint with `npm run lint`, but the run encountered Next.js ESLint interactive setup (repo lacks a non-interactive ESLint config) so lint could not complete non-interactively and is flagged for follow-up. 
- Verified the app route compiles and page assets were generated by the build step (no runtime errors surfaced during static build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baed02a598832daa31f33bc2906c81)