### PR TITLE
feat(adapters): add Mobius Agent Adapter System v0.1

### DIFF
--- a/docs/Mobius_Agent_Adapter_System_v0.1.md
+++ b/docs/Mobius_Agent_Adapter_System_v0.1.md
@@ -1,0 +1,142 @@
+# Mobius Agent Adapter System v0.1
+
+## Purpose
+
+Allow external agent ecosystems to plug into Mobius as signal sources without inheriting trust automatically.
+
+---
+
+## Core Principle
+
+> External agents may generate signals.  
+> Only Mobius may graduate signals into trusted history.
+
+---
+
+## Flow
+
+```text
+External Agent System
+(OpenClaw / Moltbook / Bots of Wall Street / future sources)
+        ↓
+Adapter
+(normalize + label source)
+        ↓
+ECHO
+(intake)
+        ↓
+HERMES
+(route + categorize)
+        ↓
+EPICON
+(structured event)
+        ↓
+ZEUS
+(verify + score)
+        ↓
+ATLAS / AUREA
+(reason + synthesize)
+        ↓
+Terminal + Ledger
+```
+
+---
+
+## Rules
+
+1. All external signals are unverified by default.
+2. External systems cannot directly publish verified EPICONs.
+3. Every adapted signal must include source system metadata.
+4. ZEUS controls confidence upgrades.
+5. Source systems receive reliability scores over time.
+
+---
+
+## Initial Adapter Targets
+
+- OpenClaw
+- Moltbook
+- Bots of Wall Street
+
+---
+
+## Trust Boundary
+
+Adapters are part of the intake surface, not the truth layer.
+
+External systems must not be able to:
+- bypass ZEUS
+- mutate MII
+- overwrite ledger continuity
+- silently inherit trust
+
+---
+
+## External Signal Contract
+
+External signals should be normalized into a shared structure before entering EPICON evaluation.
+
+Required concepts:
+- source system
+- source actor if available
+- observation timestamp
+- category
+- title
+- summary
+- raw payload
+- optional source URL
+- optional tags
+
+---
+
+## Normalized EPICON Candidate Contract
+
+A normalized candidate must:
+- remain pending
+- start at low confidence
+- identify ECHO as owner agent
+- preserve source system traceability
+- include routing / verification trace
+
+---
+
+## Compatibility Rule
+
+Fork the interface. Share the ledger.
+
+Mobius-compatible terminals and adapters may customize experience and workflows, but must preserve:
+- identity continuity
+- EPICON compatibility
+- ZEUS verification boundaries
+- cycle continuity
+- replayable historical trace
+
+---
+
+## Source Reliability
+
+Mobius should score external ecosystems over time.
+
+Source reliability is intended to answer:
+- does this ecosystem produce useful signals?
+- does it drift?
+- does it overproduce noise?
+- how often do its claims verify?
+
+This score does not replace ZEUS.
+It informs intake and routing.
+
+---
+
+## Guardrails
+
+- read-only ingestion by default
+- no direct privileged execution
+- no silent schema mutation
+- no bypass of Mobius identity, EPICON, or verification layers
+
+---
+
+## One-Line Intent
+
+Mobius observes agent ecosystems without being absorbed by their noise.

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -1,0 +1,59 @@
+# Mobius Adapters
+
+## Purpose
+
+Mobius adapters connect external signal ecosystems to the Mobius pipeline without granting them automatic trust.
+
+Adapters allow Mobius to ingest:
+
+- agent ecosystems
+- market bot systems
+- narrative networks
+- external workflow outputs
+
+All adapted signals are treated as:
+
+- external
+- unverified
+- pending further routing and verification
+
+---
+
+## Core Principle
+
+> External systems may generate signals.  
+> Mobius determines what survives as trusted history.
+
+---
+
+## Initial adapter targets
+
+- OpenClaw
+- Moltbook
+- Bots of Wall Street
+
+---
+
+## Shared rules
+
+All adapters must:
+
+- preserve source-system metadata
+- preserve source-actor metadata if available
+- default to unverified / pending status
+- avoid bypassing ZEUS
+- avoid mutating core identity or ledger state
+
+---
+
+## Mobius trust boundary
+
+Adapters are part of the intake surface, not the truth layer.
+
+Truth graduation remains inside:
+
+- ECHO
+- HERMES
+- ZEUS
+- ATLAS / AUREA
+- EPICON + Ledger

--- a/packages/adapters/bots-of-wall-street/README.md
+++ b/packages/adapters/bots-of-wall-street/README.md
@@ -1,0 +1,148 @@
+# Bots of Wall Street Adapter
+
+## Purpose
+
+The Bots of Wall Street adapter allows Mobius to ingest market claims from AI-finance debate environments as **raw market signal inputs**.
+
+These systems are useful for:
+
+- market chatter
+- synthetic sentiment
+- repeated valuation narratives
+- prediction clustering
+
+They are **not** treated as verified financial intelligence by default.
+
+---
+
+## Core Rule
+
+> Bots of Wall Street may generate market opinions.  
+> Mobius evaluates whether any of them matter.
+
+---
+
+## What this adapter should do
+
+- ingest AI-generated market posts or claims
+- normalize them into `ExternalSignal`
+- preserve ticker, agent, and source metadata
+- convert repeated or potentially useful claims into EPICON candidates
+- keep all such candidates pending until ZEUS review
+
+---
+
+## Expected input examples
+
+Examples of Bots of Wall Street-originating signals:
+
+- bullish or bearish ticker posts
+- valuation arguments
+- momentum claims
+- macro narratives tied to equities
+- price predictions
+- recurring thesis clusters
+
+---
+
+## Best use inside Mobius
+
+This adapter is useful for:
+
+- market narrative monitoring
+- sentiment clustering
+- prediction tracking
+- debate-to-EPICON conversion
+- source reliability scoring over time
+
+---
+
+## Suggested mapping
+
+### ExternalSignal
+- `source_system`: `"bots_of_wall_street"`
+- `category`: usually `market`, sometimes `narrative`
+- `source_actor`: bot handle or agent identity
+- `title`: normalized ticker claim title
+- `summary`: concise thesis summary
+- `raw_payload`: original post or thread object
+- `tags`: include ticker symbols where possible
+
+### NormalizedEpiconCandidate
+- `status`: `pending`
+- `confidence_tier`: `0` or `1`
+- `owner_agent`: `ECHO`
+
+---
+
+## Trust boundary
+
+This adapter must **not**:
+
+- equate frequency of claims with correctness
+- publish verified market entries directly
+- bypass ZEUS
+- assign high confidence from sentiment alone
+- overwrite historical misses
+
+---
+
+## Example use case
+
+```text
+Multiple bots repeat:
+"$NVDA demand is collapsing"
+
+↓
+
+Adapter clusters repeated claim
+
+↓
+
+ECHO records pending market EPICON candidate
+
+↓
+
+HERMES tags semiconductors / sentiment / market
+
+↓
+
+ZEUS checks against earnings, guidance, and price action
+
+↓
+
+Outcome is later tracked as hit or miss
+```
+
+---
+
+## Why this matters
+
+Bots of Wall Street-like systems show what agent ecosystems think.
+
+Mobius answers:
+- which claims persist?
+- which claims verify?
+- which agents or ecosystems deserve weight?
+
+This turns raw AI-finance discourse into tracked, auditable intelligence.
+
+---
+
+## Future implementation ideas
+
+- ticker claim adapter
+- prediction tracking adapter
+- bot thesis clustering
+- source reliability leaderboard
+
+---
+
+## Mobius compatibility note
+
+This adapter is compatible with Mobius only if it preserves:
+
+- market claim traceability
+- pending-first status
+- later ZEUS verification
+- source-system accountability

--- a/packages/adapters/moltbook/README.md
+++ b/packages/adapters/moltbook/README.md
@@ -1,0 +1,136 @@
+# Moltbook Adapter
+
+## Purpose
+
+The Moltbook adapter allows Mobius to ingest signals from Moltbook-style agent social ecosystems as **external, unverified narrative inputs**.
+
+Moltbook-like systems are valuable because they reveal:
+
+- what agents are talking about
+- which narratives are spreading
+- where consensus or drift is emerging
+- how synthetic discourse evolves over time
+
+They are not a truth layer by themselves.
+
+---
+
+## Core Rule
+
+> Moltbook may surface narrative movement.  
+> Mobius decides what survives as signal.
+
+---
+
+## What this adapter should do
+
+- ingest posts, threads, and agent discourse from Moltbook-like systems
+- normalize them into `ExternalSignal`
+- preserve source-system and source-actor identity where possible
+- detect clusters of repeated claims
+- hand off candidate signals to ECHO and HERMES
+
+---
+
+## Expected input examples
+
+Examples of Moltbook-originating signals:
+
+- agent posts
+- thread replies
+- repeated claims across many agents
+- trending topics
+- synthetic debate clusters
+- narrative cascades
+
+---
+
+## Best use inside Mobius
+
+This adapter is especially useful for:
+
+- narrative detection
+- sentiment clustering
+- early-stage signal emergence
+- drift analysis
+- contradiction tracking
+
+---
+
+## Suggested mapping
+
+### ExternalSignal
+- `source_system`: `"moltbook"`
+- `category`: often `narrative`, sometimes `market` or `geopolitical`
+- `source_actor`: agent handle if present
+- `title`: normalized short claim title
+- `summary`: brief explanation of the post or thread signal
+- `raw_payload`: original post/thread object
+
+---
+
+## Trust boundary
+
+This adapter must **not**:
+
+- treat popularity as truth
+- auto-upgrade repeated claims to verified status
+- bypass ZEUS verification
+- collapse multiple agent opinions into certainty
+- silently rewrite or suppress contradictory history
+
+---
+
+## Promotion logic
+
+A Moltbook signal may become a `NormalizedEpiconCandidate` when:
+
+- multiple independent actors repeat the same claim
+- the claim is externally relevant
+- it aligns with real-world data or can be checked against it
+- it has civic value beyond entertainment or noise
+
+---
+
+## Example use case
+
+```text
+20 Moltbook agents begin repeating:
+"Brent crude breaks $110 if Hormuz closes"
+
+↓
+
+Adapter clusters repeated claim
+
+↓
+
+ECHO records as unverified external signal
+
+↓
+
+HERMES categorizes as market/narrative
+
+↓
+
+ZEUS checks against actual oil price and shipping data
+```
+
+---
+
+## Future implementation ideas
+
+- trending topic adapter
+- narrative cluster adapter
+- cross-agent contradiction adapter
+- sentiment-to-EPICON candidate promotion
+
+---
+
+## Mobius compatibility note
+
+This adapter is compatible with Mobius only if it preserves:
+
+- source metadata
+- unverified-by-default handling
+- explicit verification boundaries
+- replayable narrative history

--- a/packages/adapters/openclaw/README.md
+++ b/packages/adapters/openclaw/README.md
@@ -1,0 +1,116 @@
+# OpenClaw Adapter
+
+## Purpose
+
+The OpenClaw adapter allows Mobius to ingest signals from OpenClaw-based agent systems as **unverified external inputs**.
+
+OpenClaw outputs are treated as:
+
+- agent task results
+- agent-generated reports
+- tool-use traces
+- structured or semi-structured reasoning artifacts
+
+They are **not** treated as trusted truth by default.
+
+---
+
+## Core Rule
+
+> OpenClaw may generate signals.  
+> Only Mobius may graduate signals into trusted history.
+
+---
+
+## What this adapter should do
+
+- ingest OpenClaw outputs
+- normalize them into `ExternalSignal`
+- convert eligible items into `NormalizedEpiconCandidate`
+- preserve source metadata
+- mark all signals as unverified by default
+
+---
+
+## Expected input examples
+
+Examples of OpenClaw-originating signals:
+
+- agent task completion logs
+- research summaries
+- tool execution outcomes
+- structured analysis objects
+- multi-agent conversation snapshots
+
+---
+
+## Normalization goals
+
+Every ingested OpenClaw signal should preserve:
+
+- `source_system = "openclaw"`
+- `source_actor` if available
+- timestamp of observation
+- raw payload
+- source URL or source reference if available
+
+Then map into a Mobius-compatible EPICON candidate.
+
+---
+
+## Trust boundary
+
+This adapter must **not**:
+
+- publish verified EPICONs directly
+- bypass ZEUS
+- mutate MII
+- write final truth-state into the ledger
+- trigger privileged system actions automatically
+
+---
+
+## Suggested mapping
+
+### ExternalSignal
+- `source_system`: `"openclaw"`
+- `category`: derived from task or agent context
+- `title`: short task/result title
+- `summary`: concise result summary
+- `raw_payload`: original OpenClaw object
+
+### NormalizedEpiconCandidate
+- `status`: `pending`
+- `confidence_tier`: `0` or `1`
+- `owner_agent`: `ECHO`
+
+---
+
+## Promotion logic
+
+OpenClaw output should only be promoted to EPICON candidate when:
+
+- it has civic or operational relevance
+- it is not purely internal agent chatter
+- it can be meaningfully categorized
+- it is useful for later ZEUS verification
+
+---
+
+## Future implementation ideas
+
+- task result adapter
+- multi-agent conversation adapter
+- tool execution outcome adapter
+- anomaly event adapter
+
+---
+
+## Mobius compatibility note
+
+This adapter is compatible with Mobius only if it preserves:
+
+- EPICON shape
+- verification boundaries
+- ledger continuity
+- source transparency

--- a/packages/adapters/types.ts
+++ b/packages/adapters/types.ts
@@ -1,0 +1,49 @@
+export type ExternalSignalCategory =
+  | 'market'
+  | 'geopolitical'
+  | 'governance'
+  | 'infrastructure'
+  | 'narrative';
+
+export type EpiconCompatibleCategory =
+  | 'market'
+  | 'geopolitical'
+  | 'governance'
+  | 'infrastructure';
+
+export type ExternalSignal = {
+  external_id: string;
+  source_system: string;
+  source_actor?: string;
+  observed_at: string;
+  category: ExternalSignalCategory;
+  title: string;
+  summary: string;
+  raw_payload: unknown;
+  source_url?: string;
+  tags?: string[];
+};
+
+export type NormalizedEpiconCandidate = {
+  title: string;
+  summary: string;
+  category: EpiconCompatibleCategory;
+  status: 'pending';
+  confidence_tier: 0 | 1;
+  owner_agent: 'ECHO';
+  sources: string[];
+  trace: string[];
+  tags?: string[];
+  external_source_system: string;
+  external_source_actor?: string;
+  external_source_reliability?: number;
+};
+
+export interface SourceAdapter {
+  id: string;
+  sourceSystem: string;
+  ingest(input: unknown): Promise<ExternalSignal[]>;
+  normalize(
+    signal: ExternalSignal
+  ): Promise<NormalizedEpiconCandidate | null>;
+}

--- a/packages/core/source-reliability/calculateSourceReliability.ts
+++ b/packages/core/source-reliability/calculateSourceReliability.ts
@@ -1,0 +1,8 @@
+export function calculateSourceReliability(
+  hits: number,
+  misses: number
+): number {
+  const accuracy = hits / Math.max(1, hits + misses);
+  const score = 0.2 + accuracy * 0.7;
+  return Math.max(0, Math.min(1, Number(score.toFixed(2))));
+}

--- a/packages/core/source-reliability/types.ts
+++ b/packages/core/source-reliability/types.ts
@@ -1,0 +1,7 @@
+export type SourceReliabilityRecord = {
+  source_system: string;
+  verified_hits: number;
+  verified_misses: number;
+  reliability_score: number;
+  last_updated: string;
+};


### PR DESCRIPTION
### Motivation

- Provide a safe, typed intake layer so external agent ecosystems can be observed without inheriting trust.  
- Define a clear adapter contract and trust boundary so signals from systems like OpenClaw, Moltbook, and Bots of Wall Street enter Mobius as unverified candidates.  
- Start tracking ecosystem-level reliability so the platform can learn which external sources are useful over time.  

### Description

- Add a design doc `docs/Mobius_Agent_Adapter_System_v0.1.md` that defines flow, rules, trust boundary, and promotion/guardrail guidance for external adapters.  
- Add shared adapter types in `packages/adapters/types.ts` including `ExternalSignal`, `NormalizedEpiconCandidate`, `ExternalSignalCategory`, and the `SourceAdapter` interface.  
- Add a minimal source-reliability record type and helper in `packages/core/source-reliability/types.ts` and `packages/core/source-reliability/calculateSourceReliability.ts` to compute ecosystem reliability scores.  
- Add README stubs for the adapter layer and the three initial targets at `packages/adapters/README.md`, `packages/adapters/openclaw/README.md`, `packages/adapters/moltbook/README.md`, and `packages/adapters/bots-of-wall-street/README.md`, documenting that all external signals are `pending`/unverified by default and must route through ZEUS for verification.  
- This change is docs/types/helpers only and does not modify EPICON core schema, MII logic, runtime dependencies, or verification authority.  

### Testing

- Ran `npx tsc --noEmit` to validate TypeScript types and it completed successfully.  
- Invoked `npm run lint` but the process was interrupted by an interactive Next.js ESLint configuration prompt, so no non-interactive lint pass completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc043c7508832db64fa56c85b6a048)