### PR TITLE
feat(epicon): add external candidate feed and ZEUS verification loop

### DIFF
--- a/app/api/adapters/ingest/route.ts
+++ b/app/api/adapters/ingest/route.ts
@@ -8,6 +8,7 @@ import {
   mockOpenClawSignals,
 } from '@/packages/adapters/mock/mockSignals';
 import { OpenClawAdapter } from '@/packages/adapters/openclaw/OpenClawAdapter';
+import { addCandidates } from '@/lib/epicon/store';
 
 export const dynamic = 'force-dynamic';
 
@@ -29,6 +30,22 @@ export async function GET() {
     (sum, item) => sum + item.candidates.length,
     0,
   );
+
+  const allCandidates = [
+    ...botsOfWallStreet.candidates,
+    ...moltbook.candidates,
+    ...openclaw.candidates,
+  ].map((candidate) => ({
+    title: candidate.title,
+    summary: candidate.summary,
+    category: candidate.category,
+    confidence_tier: candidate.confidence_tier,
+    external_source_system: candidate.external_source_system,
+    external_source_actor: candidate.external_source_actor,
+    zeus_note: undefined,
+  }));
+
+  addCandidates(allCandidates);
 
   return NextResponse.json({
     ok: true,

--- a/app/api/epicon/candidates/route.ts
+++ b/app/api/epicon/candidates/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { getCandidates } from '@/lib/epicon/store';
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    candidates: getCandidates(),
+  });
+}

--- a/app/api/epicon/verify/route.ts
+++ b/app/api/epicon/verify/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyCandidate } from '@/lib/epicon/store';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+
+  const updated = verifyCandidate({
+    id: body.id,
+    outcome: body.outcome,
+    confidence_tier: body.confidence_tier,
+    zeus_note: body.zeus_note,
+  });
+
+  if (!updated) {
+    return NextResponse.json(
+      { ok: false, error: 'Candidate not found' },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    candidate: updated,
+  });
+}

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -9,6 +9,7 @@ import SuggestedNextActions, { type SuggestedAction } from '@/components/termina
 import TerminalShellFallback from '@/components/terminal/TerminalShellFallback';
 import SidebarNav from '@/components/terminal/SidebarNav';
 import EpiconFeedPanel from '@/components/terminal/EpiconFeedPanel';
+import CandidateFeed from '@/components/epicon/CandidateFeed';
 import AgentCortexPanel from '@/components/terminal/AgentCortexPanel';
 import IntegrityMonitorCard from '@/components/terminal/IntegrityMonitorCard';
 import TripwireWatchCard from '@/components/terminal/TripwireWatchCard';
@@ -676,17 +677,26 @@ function TerminalPage() {
             )}
 
             {showEpicon && selectedNav !== 'ledger' && (
-              <EpiconFeedPanel
-                items={filteredEpicon}
-                selectedId={
-                  inspectorTarget.kind === 'epicon'
-                    ? inspectorTarget.data.id
-                    : ''
-                }
-                onSelect={(item) =>
-                  setInspectorTarget({ kind: 'epicon', data: item })
-                }
-              />
+              <>
+                <EpiconFeedPanel
+                  items={filteredEpicon}
+                  selectedId={
+                    inspectorTarget.kind === 'epicon'
+                      ? inspectorTarget.data.id
+                      : ''
+                  }
+                  onSelect={(item) =>
+                    setInspectorTarget({ kind: 'epicon', data: item })
+                  }
+                />
+
+                <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-4">
+                  <div className="mb-3 text-xs font-mono uppercase tracking-[0.2em] text-amber-300">
+                    External Candidate Feed
+                  </div>
+                  <CandidateFeed />
+                </div>
+              </>
             )}
 
             {showAgents && (

--- a/components/epicon/CandidateCard.tsx
+++ b/components/epicon/CandidateCard.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+type Candidate = {
+  id: string;
+  title: string;
+  summary: string;
+  category: string;
+  status: 'pending' | 'verified' | 'contradicted';
+  confidence_tier: number;
+  external_source_system?: string;
+  zeus_note?: string;
+};
+
+type Props = {
+  item: Candidate;
+  onVerify: (id: string, outcome: 'verified' | 'contradicted') => Promise<void>;
+};
+
+function tone(status: Candidate['status']) {
+  switch (status) {
+    case 'verified':
+      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300';
+    case 'contradicted':
+      return 'border-rose-500/30 bg-rose-500/10 text-rose-300';
+    default:
+      return 'border-amber-500/30 bg-amber-500/10 text-amber-300';
+  }
+}
+
+export default function CandidateCard({ item, onVerify }: Props) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-black/40 p-4 text-white">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="mb-1 text-xs opacity-60">
+            {item.external_source_system} • {item.category}
+          </div>
+          <div className="font-semibold">{item.title}</div>
+        </div>
+
+        <div
+          className={`rounded-md border px-2 py-1 text-[10px] uppercase tracking-[0.12em] ${tone(item.status)}`}
+        >
+          {item.status}
+        </div>
+      </div>
+
+      <div className="mt-2 text-sm opacity-80">{item.summary}</div>
+
+      <div className="mt-3 text-xs opacity-50">
+        confidence: {item.confidence_tier}
+      </div>
+
+      {item.zeus_note ? (
+        <div className="mt-3 rounded-lg border border-slate-800 bg-slate-950 p-2 text-xs text-slate-300">
+          ZEUS: {item.zeus_note}
+        </div>
+      ) : null}
+
+      {item.status === 'pending' ? (
+        <div className="mt-4 flex gap-2">
+          <button
+            onClick={() => onVerify(item.id, 'verified')}
+            className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-300 hover:bg-emerald-500/20"
+          >
+            ZEUS Verify
+          </button>
+          <button
+            onClick={() => onVerify(item.id, 'contradicted')}
+            className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-300 hover:bg-rose-500/20"
+          >
+            ZEUS Contradict
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/epicon/CandidateFeed.tsx
+++ b/components/epicon/CandidateFeed.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import CandidateCard from './CandidateCard';
+
+type Candidate = {
+  id: string;
+  title: string;
+  summary: string;
+  category: string;
+  status: 'pending' | 'verified' | 'contradicted';
+  confidence_tier: number;
+  external_source_system?: string;
+  zeus_note?: string;
+};
+
+export default function CandidateFeed() {
+  const [data, setData] = useState<Candidate[]>([]);
+
+  async function load() {
+    const res = await fetch('/api/epicon/candidates', { cache: 'no-store' });
+    const json = await res.json();
+    setData(json.candidates || []);
+  }
+
+  async function onVerify(id: string, outcome: 'verified' | 'contradicted') {
+    const res = await fetch('/api/epicon/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id,
+        outcome,
+        confidence_tier: outcome === 'verified' ? 2 : 0,
+        zeus_note:
+          outcome === 'verified'
+            ? 'Cross-source alignment sufficient for verified candidate status.'
+            : 'Contradiction or insufficient support detected by ZEUS.',
+      }),
+    });
+
+    if (!res.ok) {
+      console.error('ZEUS verification failed');
+      return;
+    }
+
+    await load();
+  }
+
+  useEffect(() => {
+    load();
+    const interval = setInterval(load, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="space-y-3">
+      {data.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-slate-800 bg-black/20 p-4 text-sm text-slate-400">
+          External candidate lane empty. Trigger adapter ingest to populate pending EPICON candidates.
+        </div>
+      ) : null}
+
+      {data.map((item) => (
+        <CandidateCard key={item.id} item={item} onVerify={onVerify} />
+      ))}
+    </div>
+  );
+}

--- a/lib/epicon/store.ts
+++ b/lib/epicon/store.ts
@@ -1,0 +1,53 @@
+export type ExternalCandidate = {
+  id: string;
+  title: string;
+  summary: string;
+  category: string;
+  status: 'pending' | 'verified' | 'contradicted';
+  confidence_tier: number;
+  external_source_system?: string;
+  external_source_actor?: string;
+  created_at: string;
+  zeus_note?: string;
+};
+
+const store: ExternalCandidate[] = [];
+
+export function addCandidates(
+  newItems: Omit<ExternalCandidate, 'id' | 'created_at' | 'status'>[],
+) {
+  for (const item of newItems) {
+    store.unshift({
+      ...item,
+      id: `${item.external_source_system || 'ext'}-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`,
+      created_at: new Date().toISOString(),
+      status: 'pending',
+    });
+  }
+
+  if (store.length > 100) {
+    store.length = 100;
+  }
+}
+
+export function getCandidates() {
+  return store;
+}
+
+export function verifyCandidate(input: {
+  id: string;
+  outcome: 'verified' | 'contradicted';
+  confidence_tier: number;
+  zeus_note?: string;
+}) {
+  const candidate = store.find((x) => x.id === input.id);
+  if (!candidate) return null;
+
+  candidate.status = input.outcome;
+  candidate.confidence_tier = input.confidence_tier;
+  candidate.zeus_note = input.zeus_note;
+
+  return candidate;
+}


### PR DESCRIPTION
### Motivation
- Provide a first end-to-end external-signal vertical slice that takes adapter candidates into a visible terminal lane and enables manual ZEUS verification actions. 
- Keep the iteration shippable by using an in-memory store and avoiding DB, persistence, or automatic verification.

### Description
- Add an in-memory external candidate store and richer candidate model in `lib/epicon/store.ts` with status (`pending|verified|contradicted`), `confidence_tier`, `zeus_note`, and capped retention. 
- Persist normalized adapter ingest outputs into the external candidate lane by calling `addCandidates(...)` from `app/api/adapters/ingest/route.ts`. 
- Expose a candidate listing route at `app/api/epicon/candidates/route.ts` and a ZEUS action route at `app/api/epicon/verify/route.ts` that updates candidate status and confidence via `verifyCandidate(...)`. 
- Add a minimal terminal-compatible UI: `components/epicon/CandidateFeed.tsx` (5s polling) and `components/epicon/CandidateCard.tsx` (displays title, summary, category, source, confidence, status, ZEUS Verify/Contradict buttons) and wire the feed into the terminal at `app/terminal/page.tsx`.

### Testing
- Ran `npm run build` and Next.js production build completed successfully with pages generated. 
- Ran `npm run lint`, which triggers the repo's interactive Next.js ESLint bootstrap and therefore did not produce a non-interactive lint report in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc18b1dec8832db127f464e8ac7bc3)