### PR TITLE
feat: radial GI monitor + compact terminal chrome

### DIFF
--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -26,6 +26,7 @@ import { WalletProvider } from '@/contexts/WalletContext';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { navItems, mockCivicAlerts, mockSentinels } from '@/lib/terminal/mock';
 import type { NavKey } from '@/lib/terminal/types';
+import { cn } from '@/lib/terminal/utils';
 import { useTerminalCommands } from '@/hooks/useTerminalCommands';
 import { useTerminalData } from '@/hooks/useTerminalData';
 
@@ -37,9 +38,34 @@ const CreateEpiconModal = dynamic(() => import('@/components/terminal/CreateEpic
 const CHAMBER_DESCRIPTIONS: Partial<Record<NavKey, string>> = {
   search: 'Use the Command Palette below to search across all data. Try /scan followed by a keyword.',
   settings: 'Terminal configuration and operator preferences. Feature coming in V2.',
-  wallet: undefined,
-  reflections: 'Agent reflection logs and cross-system annotations. Displaying active agents below.',
+  wallet: 'MIC wallet, MFS shards, and blockchain explorer. Integrity economics in real time.',
+  reflections: 'Agent reflection logs and cross-system annotations.',
 };
+
+function chamberStatus(nav: NavKey, gi: number, tripwireCount: number, epiconCount: number, alertCount: number) {
+  if (CHAMBER_DESCRIPTIONS[nav]) return CHAMBER_DESCRIPTIONS[nav] as string;
+
+  const giLabel = gi >= 0.85 ? 'GI stable' : gi >= 0.7 ? 'GI under pressure' : 'GI critical';
+  const tripwireLabel = tripwireCount === 0 ? 'No active tripwires' : `${tripwireCount} tripwire${tripwireCount === 1 ? '' : 's'} active`;
+  const feedLabel = `${epiconCount} signal${epiconCount === 1 ? '' : 's'} in feed`;
+
+  switch (nav) {
+    case 'pulse':
+      return `${giLabel}. ${tripwireLabel}. ${feedLabel}. ${alertCount} alert${alertCount === 1 ? '' : 's'}.`;
+    case 'geopolitics':
+      return `Geopolitical signals filtered. ${feedLabel}. ${tripwireLabel}.`;
+    case 'markets':
+      return `Market signals filtered. ${feedLabel}.`;
+    case 'governance':
+      return `Governance view. ${giLabel}. Signal Engine scoring active.`;
+    case 'infrastructure':
+      return `Infrastructure watch. ${tripwireLabel}.`;
+    case 'agents':
+      return 'Agent cortex. All sentinels reporting.';
+    default:
+      return `${giLabel}. ${tripwireLabel}.`;
+  }
+}
 
 const NAV_LABEL_MAP = new Map(navItems.map((item) => [item.key, item.label]));
 
@@ -105,6 +131,8 @@ function TerminalPage() {
   const showIntegrity = ['pulse', 'governance', 'agents'].includes(selectedNav);
   const showWallet = selectedNav === 'wallet';
   const showSignal = ['pulse', 'governance', 'geopolitics', 'markets'].includes(selectedNav);
+  const showConsensus = showCreateEpicon || inspectorTarget.kind === 'epicon';
+  const criticalAlertCount = mergedAlerts.filter((alert) => alert.severity === 'critical' || alert.severity === 'high').length;
 
   const consensusAgents = (() => {
     if (showCreateEpicon) {
@@ -130,14 +158,7 @@ function TerminalPage() {
       ];
     }
 
-    return [
-      { name: 'ZEUS', verdict: 'approve' as const, note: 'Verification fabric nominal.' },
-      { name: 'EVE', verdict: 'approve' as const, note: 'Ethics observer online.' },
-      { name: 'AUREA', verdict: 'approve' as const, note: 'Synthesis layer stable.' },
-      { name: 'HERMES', verdict: streamStatus === 'offline' ? 'caution' as const : 'approve' as const, note: 'Routing follows stream posture.' },
-      { name: 'JADE', verdict: 'pending' as const, note: 'Annotation opens when operator context is supplied.' },
-      { name: 'ATLAS', verdict: dominantTripwireState === 'degraded' ? 'caution' as const : 'approve' as const, note: 'Risk preview mirrors active tripwires.' },
-    ];
+    return [];
   })();
 
   const suggestedActions: SuggestedAction[] = (() => {
@@ -220,7 +241,7 @@ function TerminalPage() {
     <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
       <TopStatusBar
         gi={gi.score}
-        alertCount={allTripwires.length + mergedAlerts.filter((alert) => alert.severity === 'critical' || alert.severity === 'high').length}
+        alertCount={allTripwires.length + criticalAlertCount}
         cycleId={currentCycleId()}
         streamStatus={streamStatus}
         onNavigate={setSelectedNav}
@@ -242,16 +263,18 @@ function TerminalPage() {
         streamLabel={streamStatus === 'live' ? 'LIVE' : streamStatus === 'reconnecting' ? 'RECONNECTING' : 'OFFLINE'}
       />
 
-      <ConsensusPreviewStrip
-        title={showCreateEpicon ? 'Consensus Preview · Submission Lane' : 'Consensus Preview · Operator Lane'}
-        subtitle={operatorMessage}
-        agents={consensusAgents}
-      />
+      {showConsensus && (
+        <ConsensusPreviewStrip
+          title={showCreateEpicon ? 'Consensus Preview · Submission Lane' : 'Consensus Preview · Operator Lane'}
+          subtitle={operatorMessage}
+          agents={consensusAgents}
+        />
+      )}
 
       <div className="grid flex-1 grid-cols-12 max-md:grid-cols-1">
         <SidebarNav items={navItems} selected={selectedNav} onSelect={setSelectedNav} />
 
-        <main className="col-span-7 max-lg:col-span-9 max-md:col-span-1 border-r border-slate-800 max-md:border-r-0 bg-slate-950">
+        <main className="col-span-7 border-r border-slate-800 bg-slate-950 max-lg:col-span-9 max-md:col-span-1 max-md:border-r-0">
           <div className="grid h-full grid-rows-[auto_auto_auto_1fr] gap-4 p-4">
             <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-4">
               <div className="flex flex-wrap items-start justify-between gap-3">
@@ -260,7 +283,7 @@ function TerminalPage() {
                     {NAV_LABEL_MAP.get(selectedNav)} Chamber
                   </div>
                   <div className="mt-2 text-sm font-sans text-slate-400">
-                    {CHAMBER_DESCRIPTIONS[selectedNav] ?? 'Operational state is visible before command entry. Use the live ribbon, replay rail, and consensus strip to inspect trust, freshness, and next actions from first paint.'}
+                    {chamberStatus(selectedNav, gi.score, allTripwires.length, filteredEpicon.length, criticalAlertCount)}
                   </div>
                 </div>
                 <div className="max-w-md text-xs font-mono uppercase tracking-[0.15em] text-slate-500">
@@ -418,9 +441,16 @@ function TerminalPage() {
       <footer className="flex items-center justify-between border-t border-slate-800 bg-slate-950 px-4 py-2 text-xs font-mono text-slate-500">
         <span className="shrink-0">MOBIUS TERMINAL V1</span>
         <div className="flex items-center gap-2">
-          <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400" />
-          <span className="hidden sm:inline">Substrate Connected · Browser Shell OK · Ledger Live · Sentinel Council Active</span>
-          <span className="sm:hidden">All Systems OK</span>
+          <span
+            className={cn(
+              'inline-block h-1.5 w-1.5 shrink-0 rounded-full',
+              streamStatus === 'live' ? 'bg-emerald-400' : streamStatus === 'reconnecting' ? 'bg-amber-400' : 'bg-slate-500',
+            )}
+          />
+          <span className="hidden sm:inline">
+            {currentCycleId()} · {allTripwires.length} tripwire{allTripwires.length === 1 ? '' : 's'} · GI {gi.score.toFixed(2)} · {filteredEpicon.length} signals · {streamStatus === 'live' ? 'Stream live' : streamStatus === 'reconnecting' ? 'Reconnecting' : 'Local mode'}
+          </span>
+          <span className="sm:hidden">{currentCycleId()} · GI {gi.score.toFixed(2)}</span>
         </div>
       </footer>
     </div>

--- a/components/terminal/ConsensusPreviewStrip.tsx
+++ b/components/terminal/ConsensusPreviewStrip.tsx
@@ -1,11 +1,26 @@
 'use client';
 
+/**
+ * ConsensusPreviewStrip — Compact agent consensus bar.
+ *
+ * Defaults to a row of verdict dots and expands on click to show
+ * detailed agent notes only when the operator needs them.
+ */
+
+import { useState } from 'react';
 import { cn } from '@/lib/terminal/utils';
 
 export type ConsensusAgentState = {
   name: string;
   verdict: 'approve' | 'caution' | 'block' | 'pending';
   note: string;
+};
+
+const VERDICT_DOT: Record<ConsensusAgentState['verdict'], string> = {
+  approve: 'bg-emerald-400',
+  caution: 'bg-amber-400',
+  block: 'bg-red-400',
+  pending: 'bg-slate-500',
 };
 
 const VERDICT_TONE: Record<ConsensusAgentState['verdict'], string> = {
@@ -24,27 +39,66 @@ export default function ConsensusPreviewStrip({
   subtitle?: string;
   agents: ConsensusAgentState[];
 }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const approveCount = agents.filter((agent) => agent.verdict === 'approve').length;
+  const cautionCount = agents.filter((agent) => agent.verdict === 'caution').length;
+  const blockCount = agents.filter((agent) => agent.verdict === 'block').length;
+
   return (
-    <section className="border-b border-slate-800 bg-slate-950/80 px-4 py-3">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <div className="text-xs font-mono font-semibold uppercase tracking-[0.2em] text-sky-300">
-            {title ?? 'Consensus Preview'}
-          </div>
-          <div className="mt-1 text-xs font-sans text-slate-500">
-            {subtitle ?? 'ZEUS, EVE, AUREA, HERMES, JADE, and ATLAS posture before major operator actions.'}
-          </div>
-        </div>
-        <div className="flex flex-wrap gap-2">
+    <button
+      onClick={() => setExpanded((value) => !value)}
+      className="w-full border-b border-slate-800 bg-slate-950/80 text-left transition-all duration-300"
+    >
+      <div className="flex items-center gap-3 px-4 py-1.5">
+        <span className="text-[10px] font-mono font-semibold uppercase tracking-[0.2em] text-slate-500">
+          Consensus
+        </span>
+
+        <div className="flex items-center gap-1">
           {agents.map((agent) => (
-            <div key={agent.name} className={cn('min-w-[122px] rounded-md border px-3 py-2', VERDICT_TONE[agent.verdict])}>
-              <div className="text-[11px] font-mono uppercase tracking-[0.15em]">{agent.name}</div>
-              <div className="mt-1 text-[11px] font-mono uppercase tracking-[0.15em] opacity-90">{agent.verdict}</div>
-              <div className="mt-1 text-xs font-sans text-current/80">{agent.note}</div>
-            </div>
+            <span key={agent.name} className={cn('h-2 w-2 rounded-full transition-all', VERDICT_DOT[agent.verdict])} />
           ))}
         </div>
+
+        <span className="text-[10px] font-mono text-slate-500">
+          {approveCount > 0 && <span className="text-emerald-400">{approveCount}✓</span>}
+          {cautionCount > 0 && <span className="ml-1 text-amber-400">{cautionCount}⚠</span>}
+          {blockCount > 0 && <span className="ml-1 text-red-400">{blockCount}✕</span>}
+        </span>
+
+        {subtitle && (
+          <span className="hidden max-w-xs truncate text-[10px] font-mono text-slate-600 sm:inline">
+            {subtitle}
+          </span>
+        )}
+
+        <span className={cn('ml-auto text-[10px] font-mono text-slate-600 transition-transform duration-300', expanded && 'rotate-180')}>
+          ▾
+        </span>
       </div>
-    </section>
+
+      <div
+        className={cn(
+          'overflow-hidden transition-all duration-300 ease-out',
+          expanded ? 'max-h-64 opacity-100' : 'max-h-0 opacity-0',
+        )}
+      >
+        <div className="px-4 pb-3">
+          {title && <div className="mb-2 text-[10px] font-mono uppercase tracking-[0.15em] text-sky-300">{title}</div>}
+          <div className="flex flex-wrap gap-2">
+            {agents.map((agent) => (
+              <div key={agent.name} className={cn('min-w-[110px] rounded-md border px-2.5 py-1.5', VERDICT_TONE[agent.verdict])}>
+                <div className="flex items-center gap-1.5">
+                  <span className={cn('h-1.5 w-1.5 rounded-full', VERDICT_DOT[agent.verdict])} />
+                  <span className="text-[10px] font-mono uppercase tracking-[0.12em]">{agent.name}</span>
+                </div>
+                <div className="mt-1 text-[10px] leading-tight text-current/80">{agent.note}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </button>
   );
 }

--- a/components/terminal/IntegrityMonitorCard.tsx
+++ b/components/terminal/IntegrityMonitorCard.tsx
@@ -1,22 +1,60 @@
+'use client';
+
+/**
+ * IntegrityMonitorCard — Radial GI gauge with animated arcs.
+ *
+ * Replaces flat progress bars with a radial gauge that makes the
+ * system feel alive. The core pulse speeds up as GI degrades,
+ * sub-metrics render as concentric arcs, and the weekly trend is
+ * shown as a lightweight SVG sparkline.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
 import type { GISnapshot } from '@/lib/terminal/types';
-import { giScoreColor, metricBarColor, cn } from '@/lib/terminal/utils';
+import { cn, giScoreColor } from '@/lib/terminal/utils';
 import SectionLabel from './SectionLabel';
 
-function MetricRow({ label, value }: { label: string; value: number }) {
-  const pct = Math.round(value * 100);
+function polarToCartesian(cx: number, cy: number, r: number, angleDeg: number) {
+  const rad = ((angleDeg - 90) * Math.PI) / 180;
+  return {
+    x: cx + r * Math.cos(rad),
+    y: cy + r * Math.sin(rad),
+  };
+}
 
+function describeArc(cx: number, cy: number, r: number, startAngle: number, endAngle: number) {
+  const start = polarToCartesian(cx, cy, r, endAngle);
+  const end = polarToCartesian(cx, cy, r, startAngle);
+  const largeArcFlag = endAngle - startAngle > 180 ? 1 : 0;
+
+  return `M ${start.x} ${start.y} A ${r} ${r} 0 ${largeArcFlag} 0 ${end.x} ${end.y}`;
+}
+
+function sparklinePath(points: number[], width: number, height: number) {
+  if (points.length < 2) return '';
+
+  const min = Math.min(...points) - 0.02;
+  const max = Math.max(...points) + 0.02;
+  const range = max - min || 1;
+  const step = width / (points.length - 1);
+
+  return points
+    .map((value, index) => {
+      const x = index * step;
+      const y = height - ((value - min) / range) * height;
+      return `${index === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`;
+    })
+    .join(' ');
+}
+
+function MetricLabel({ label, value, color }: { label: string; value: number; color: string }) {
   return (
-    <div>
-      <div className="mb-1 flex items-center justify-between text-sm font-sans">
-        <span className="text-slate-300">{label}</span>
-        <span className="text-slate-400 font-mono">{pct}%</span>
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex items-center gap-1.5">
+        <span className={cn('h-1.5 w-1.5 rounded-full', color)} />
+        <span className="text-[11px] font-mono text-slate-400">{label}</span>
       </div>
-      <div className="h-2 rounded-full bg-slate-800">
-        <div
-          className={cn('h-2 rounded-full transition-all duration-500', metricBarColor(value))}
-          style={{ width: `${pct}%` }}
-        />
-      </div>
+      <span className="text-[11px] font-mono text-slate-300">{Math.round(value * 100)}%</span>
     </div>
   );
 }
@@ -28,46 +66,136 @@ export default function IntegrityMonitorCard({
   gi: GISnapshot;
   onClick?: () => void;
 }) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const colors = giScoreColor(gi.score);
+  const cx = 80;
+  const cy = 80;
+  const arcStart = -135;
+  const arcEnd = 135;
+  const arcRange = arcEnd - arcStart;
+
+  const giAngle = arcStart + gi.score * arcRange;
+  const trustAngle = arcStart + gi.institutionalTrust * arcRange;
+  const reliabilityAngle = arcStart + gi.infoReliability * arcRange;
+  const consensusAngle = arcStart + gi.consensusStability * arcRange;
+
+  const giArc = describeArc(cx, cy, 62, arcStart, mounted ? giAngle : arcStart);
+  const bgArc = describeArc(cx, cy, 62, arcStart, arcEnd);
+  const trustArc = describeArc(cx, cy, 52, arcStart, mounted ? trustAngle : arcStart);
+  const reliabilityArc = describeArc(cx, cy, 44, arcStart, mounted ? reliabilityAngle : arcStart);
+  const consensusArc = describeArc(cx, cy, 36, arcStart, mounted ? consensusAngle : arcStart);
+
+  const zone = colors.bar === 'bg-emerald-500' ? 'healthy' : colors.bar === 'bg-amber-500' ? 'watch' : 'critical';
+  const mainStroke = zone === 'healthy' ? 'rgb(52 211 153)' : zone === 'watch' ? 'rgb(251 191 36)' : 'rgb(248 113 113)';
+  const coreRingStroke = zone === 'healthy' ? 'rgb(16 185 129 / 0.3)' : zone === 'watch' ? 'rgb(245 158 11 / 0.3)' : 'rgb(239 68 68 / 0.3)';
+  const pulseSpeed = gi.score >= 0.85 ? '3s' : gi.score >= 0.7 ? '1.8s' : '0.9s';
+
+  const sparkW = 120;
+  const sparkH = 32;
+  const spark = useMemo(() => sparklinePath(gi.weekly, sparkW, sparkH), [gi.weekly]);
+  const sparkFill = zone === 'healthy' ? 'rgb(52 211 153)' : zone === 'watch' ? 'rgb(251 191 36)' : 'rgb(248 113 113)';
+  const sparkStroke = sparkFill;
+  const sparkDot = sparkFill;
+
+  const lastPoint = useMemo(() => {
+    if (gi.weekly.length < 2) return null;
+
+    const min = Math.min(...gi.weekly) - 0.02;
+    const max = Math.max(...gi.weekly) + 0.02;
+    const range = max - min || 1;
+    const x = sparkW - 1;
+    const y = sparkH - ((gi.weekly[gi.weekly.length - 1] - min) / range) * sparkH;
+
+    return { x, y };
+  }, [gi.weekly]);
+
   return (
     <button
       onClick={onClick}
-      className="w-full rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-left transition hover:border-slate-700 hover:bg-slate-900/80"
+      className="group w-full rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-left transition hover:border-slate-700 hover:bg-slate-900/80"
     >
       <SectionLabel title="GI Monitor" subtitle="Civic integrity signal" />
-      <div className="mt-4 flex items-end gap-3">
-        <div className={cn('text-4xl font-mono font-semibold transition-colors duration-700', giScoreColor(gi.score).text)}>
-          {gi.score.toFixed(2)}
-        </div>
-        <div className={cn('pb-1 text-sm font-mono', gi.delta > 0 ? 'text-emerald-300' : gi.delta < 0 ? 'text-red-300' : 'text-slate-400')}>
-          {gi.delta > 0
-            ? `▲ +${gi.delta.toFixed(2)}`
-            : gi.delta < 0
-              ? `▼ ${gi.delta.toFixed(2)}`
-              : `${gi.delta.toFixed(2)}`}
-        </div>
-      </div>
 
-      <div className="mt-4 space-y-3">
-        <MetricRow label="Institutional Trust" value={gi.institutionalTrust} />
-        <MetricRow label="Info Reliability" value={gi.infoReliability} />
-        <MetricRow
-          label="Consensus Stability"
-          value={gi.consensusStability}
-        />
-      </div>
+      <div className="mt-3 flex flex-col gap-4 sm:flex-row sm:items-start">
+        <div className="relative shrink-0 self-center sm:self-start" style={{ width: 160, height: 160 }}>
+          <svg viewBox="0 0 160 160" className="h-full w-full">
+            <defs>
+              <filter id="gi-glow">
+                <feGaussianBlur stdDeviation="3" result="blur" />
+                <feMerge>
+                  <feMergeNode in="blur" />
+                  <feMergeNode in="SourceGraphic" />
+                </feMerge>
+              </filter>
+            </defs>
 
-      <div className="mt-4">
-        <div className="mb-2 text-[11px] font-mono uppercase tracking-[0.18em] text-slate-500">
-          Weekly Trend
+            <path d={bgArc} fill="none" stroke="rgb(30 41 59 / 0.8)" strokeWidth="8" strokeLinecap="round" />
+            <path d={describeArc(cx, cy, 52, arcStart, arcEnd)} fill="none" stroke="rgb(30 41 59 / 0.4)" strokeWidth="4" strokeLinecap="round" />
+            <path d={describeArc(cx, cy, 44, arcStart, arcEnd)} fill="none" stroke="rgb(30 41 59 / 0.3)" strokeWidth="3" strokeLinecap="round" />
+            <path d={describeArc(cx, cy, 36, arcStart, arcEnd)} fill="none" stroke="rgb(30 41 59 / 0.2)" strokeWidth="2.5" strokeLinecap="round" />
+
+            <path d={trustArc} fill="none" stroke="rgb(56 189 248 / 0.6)" strokeWidth="4" strokeLinecap="round" className="transition-all duration-1000 ease-out" />
+            <path d={reliabilityArc} fill="none" stroke="rgb(168 85 247 / 0.6)" strokeWidth="3" strokeLinecap="round" className="transition-all duration-1000 ease-out" />
+            <path d={consensusArc} fill="none" stroke="rgb(251 191 36 / 0.5)" strokeWidth="2.5" strokeLinecap="round" className="transition-all duration-1000 ease-out" />
+            <path d={giArc} fill="none" stroke={mainStroke} strokeWidth="8" strokeLinecap="round" className="transition-all duration-1000 ease-out" />
+
+            <circle cx={cx} cy={cy} r="22" fill="rgb(15 23 42 / 0.9)" />
+            <circle cx={cx} cy={cy} r="18" fill="none" stroke={coreRingStroke} strokeWidth="1" filter="url(#gi-glow)">
+              <animate attributeName="opacity" values="0.3;0.8;0.3" dur={pulseSpeed} repeatCount="indefinite" />
+              <animate attributeName="r" values="18;20;18" dur={pulseSpeed} repeatCount="indefinite" />
+            </circle>
+
+            <text x={cx} y={cy - 2} textAnchor="middle" className="fill-white font-mono font-bold" fontSize="18">
+              {gi.score.toFixed(2)}
+            </text>
+            <text x={cx} y={cy + 12} textAnchor="middle" className="fill-slate-500 font-mono uppercase" fontSize="7" letterSpacing="0.12em">
+              GI SCORE
+            </text>
+            <text
+              x={cx}
+              y="148"
+              textAnchor="middle"
+              className={cn(
+                'font-mono',
+                gi.delta > 0 ? 'fill-emerald-400' : gi.delta < 0 ? 'fill-red-400' : 'fill-slate-500',
+              )}
+              fontSize="10"
+            >
+              {gi.delta > 0 ? `▲ +${gi.delta.toFixed(2)}` : gi.delta < 0 ? `▼ ${gi.delta.toFixed(2)}` : `${gi.delta.toFixed(2)}`}
+            </text>
+          </svg>
         </div>
-        <div className="flex h-16 items-end gap-2 rounded-lg border border-slate-800 bg-slate-950/60 p-3">
-          {gi.weekly.map((v, i) => (
-            <div
-              key={i}
-              className={cn('flex-1 rounded-t opacity-80 transition-all duration-500', metricBarColor(v))}
-              style={{ height: `${Math.max(12, v * 60)}px` }}
-            />
-          ))}
+
+        <div className="min-w-0 flex-1 pt-1">
+          <div className="space-y-2">
+            <MetricLabel label="Institutional Trust" value={gi.institutionalTrust} color="bg-sky-400" />
+            <MetricLabel label="Info Reliability" value={gi.infoReliability} color="bg-violet-400" />
+            <MetricLabel label="Consensus Stability" value={gi.consensusStability} color="bg-amber-400" />
+          </div>
+
+          <div className="mt-4 rounded-lg border border-slate-800/60 bg-slate-950/50 p-2">
+            <div className="mb-1.5 text-[10px] font-mono uppercase tracking-[0.15em] text-slate-600">7-day trend</div>
+            <svg viewBox={`0 0 ${sparkW} ${sparkH}`} className="h-8 w-full" preserveAspectRatio="none">
+              <defs>
+                <linearGradient id="spark-grad" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor={sparkFill} stopOpacity="0.25" />
+                  <stop offset="100%" stopColor="transparent" stopOpacity="0" />
+                </linearGradient>
+              </defs>
+              {spark && (
+                <>
+                  <path d={`${spark} L ${sparkW} ${sparkH} L 0 ${sparkH} Z`} fill="url(#spark-grad)" />
+                  <path d={spark} fill="none" stroke={sparkStroke} strokeWidth="1.5" strokeLinejoin="round" className="transition-all duration-700" />
+                </>
+              )}
+              {lastPoint && <circle cx={lastPoint.x} cy={lastPoint.y} r="2.5" fill={sparkDot} />}
+            </svg>
+          </div>
         </div>
       </div>
     </button>

--- a/components/terminal/LiveIntegrityRibbon.tsx
+++ b/components/terminal/LiveIntegrityRibbon.tsx
@@ -1,5 +1,14 @@
 'use client';
 
+/**
+ * LiveIntegrityRibbon — Collapsible integrity status bar.
+ *
+ * Defaults to a compact summary and expands on click to reveal the
+ * full metric chip set, reducing first-paint chrome while preserving
+ * access to the detailed health/freshness signals.
+ */
+
+import { useState } from 'react';
 import { cn } from '@/lib/terminal/utils';
 
 export type IntegrityTone = 'stable' | 'watch' | 'degraded';
@@ -16,10 +25,11 @@ export type LiveIntegrityRibbonProps = {
   streamLabel: string;
 };
 
-function formatScore(value: number) {
-  if (Number.isNaN(value)) return '--';
-  return value.toFixed(2);
-}
+const TONE_DOT: Record<IntegrityTone, string> = {
+  stable: 'bg-emerald-400',
+  watch: 'bg-amber-400',
+  degraded: 'bg-red-400',
+};
 
 const TONE_STYLES: Record<IntegrityTone, string> = {
   stable: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-300',
@@ -41,6 +51,11 @@ function MetricChip({ label, value, tone }: { label: string; value: string; tone
   );
 }
 
+function formatScore(value: number) {
+  if (Number.isNaN(value)) return '--';
+  return value.toFixed(2);
+}
+
 export default function LiveIntegrityRibbon({
   gi,
   mii,
@@ -52,39 +67,64 @@ export default function LiveIntegrityRibbon({
   cycleId,
   streamLabel,
 }: LiveIntegrityRibbonProps) {
+  const [expanded, setExpanded] = useState(false);
   const micLabel = `${micDelta >= 0 ? '+' : ''}${micDelta.toFixed(1)}`;
+  const giTone: IntegrityTone = gi >= 0.9 ? 'stable' : gi >= 0.78 ? 'watch' : 'degraded';
 
   return (
-    <section className="ribbon-sweep ribbon-border-glow relative overflow-hidden border-b border-sky-500/10 bg-slate-950/90 backdrop-blur">
-      {/* Cycling sweep highlight overlay */}
-      <div className="relative z-10 px-4 py-2">
-        {/* Title – always visible */}
-        <div className="mb-1.5 flex items-center gap-2 md:mb-0">
-          <div className="shrink-0 text-[11px] font-mono font-semibold uppercase tracking-[0.22em] text-sky-300">
-            Live Integrity Ribbon
-          </div>
-          {/* Animated dot indicator */}
-          <span className="relative flex h-2 w-2 shrink-0">
-            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-sky-400 opacity-75" />
-            <span className="relative inline-flex h-2 w-2 rounded-full bg-sky-500" />
+    <button
+      onClick={() => setExpanded((value) => !value)}
+      className="w-full border-b border-sky-500/10 bg-slate-950/90 text-left backdrop-blur transition-all duration-300"
+    >
+      <div className="flex items-center gap-3 px-4 py-1.5">
+        <span className="relative flex h-2 w-2 shrink-0">
+          <span className={cn('absolute inline-flex h-full w-full animate-ping rounded-full opacity-75', TONE_DOT[tripwireState])} />
+          <span className={cn('relative inline-flex h-2 w-2 rounded-full', TONE_DOT[tripwireState])} />
+        </span>
+
+        <span className="text-[10px] font-mono font-semibold uppercase tracking-[0.2em] text-sky-300">
+          Integrity
+        </span>
+
+        <div className="flex min-w-0 items-center gap-2 overflow-hidden text-[10px] font-mono">
+          <span className={cn(giTone === 'stable' ? 'text-emerald-300' : giTone === 'watch' ? 'text-amber-300' : 'text-red-300')}>
+            GI {formatScore(gi)}
+          </span>
+          <span className="text-slate-600">·</span>
+          <span className={cn(tripwireState === 'stable' ? 'text-emerald-300' : tripwireState === 'watch' ? 'text-amber-300' : 'text-red-300')}>
+            {tripwireState.toUpperCase()}
+          </span>
+          <span className="text-slate-600">·</span>
+          <span className="truncate text-slate-400">{cycleId}</span>
+          <span className="text-slate-600">·</span>
+          <span className={cn(streamLabel === 'LIVE' ? 'text-emerald-300' : streamLabel === 'OFFLINE' ? 'text-slate-500' : 'text-amber-300')}>
+            {streamLabel}
           </span>
         </div>
 
-        {/* Metric chips – horizontal scroll on mobile, flex wrap on desktop */}
-        <div className="ribbon-scroll-container overflow-x-auto md:overflow-x-visible">
-          <div className="flex items-center gap-2 md:flex-wrap">
-            <MetricChip label="cycle" value={cycleId} />
-            <MetricChip label="gi" value={formatScore(gi)} tone={gi >= 0.9 ? 'stable' : gi >= 0.78 ? 'watch' : 'degraded'} />
-            <MetricChip label="mii" value={formatScore(mii)} tone={mii >= 0.9 ? 'stable' : mii >= 0.78 ? 'watch' : 'degraded'} />
-            <MetricChip label="mic" value={micLabel} tone={micDelta >= 0 ? 'stable' : 'degraded'} />
-            <MetricChip label="tripwire" value={tripwireState.toUpperCase()} tone={tripwireState} />
-            <MetricChip label="ledger" value={lastLedgerSyncLabel} />
-            <MetricChip label="ingest" value={lastIngestLabel} />
-            <MetricChip label="cycle advance" value={lastCycleAdvanceLabel} />
-            <MetricChip label="stream" value={streamLabel} />
-          </div>
+        <span className={cn('ml-auto text-[10px] font-mono text-slate-600 transition-transform duration-300', expanded && 'rotate-180')}>
+          ▾
+        </span>
+      </div>
+
+      <div
+        className={cn(
+          'overflow-hidden transition-all duration-300 ease-out',
+          expanded ? 'max-h-20 opacity-100' : 'max-h-0 opacity-0',
+        )}
+      >
+        <div className="flex flex-wrap items-center gap-2 px-4 pb-2">
+          <MetricChip label="cycle" value={cycleId} />
+          <MetricChip label="gi" value={formatScore(gi)} tone={giTone} />
+          <MetricChip label="mii" value={formatScore(mii)} tone={mii >= 0.9 ? 'stable' : mii >= 0.78 ? 'watch' : 'degraded'} />
+          <MetricChip label="mic" value={micLabel} tone={micDelta >= 0 ? 'stable' : 'degraded'} />
+          <MetricChip label="tripwire" value={tripwireState.toUpperCase()} tone={tripwireState} />
+          <MetricChip label="ledger" value={lastLedgerSyncLabel} />
+          <MetricChip label="ingest" value={lastIngestLabel} />
+          <MetricChip label="cycle advance" value={lastCycleAdvanceLabel} />
+          <MetricChip label="stream" value={streamLabel} />
         </div>
       </div>
-    </section>
+    </button>
   );
 }

--- a/components/terminal/SuggestedNextActions.tsx
+++ b/components/terminal/SuggestedNextActions.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+/**
+ * SuggestedNextActions — Compact horizontal action pills.
+ */
+
 export type SuggestedAction = {
   id: string;
   label: string;
@@ -16,26 +20,24 @@ export default function SuggestedNextActions({
   onSelect?: (actionId: string) => void;
 }) {
   return (
-    <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-      <div className="text-xs font-mono font-semibold uppercase tracking-[0.2em] text-sky-300">
-        {title}
+    <div className="rounded-lg border border-slate-800/60 bg-slate-900/40 px-3 py-2">
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="shrink-0 text-[10px] font-mono uppercase tracking-[0.15em] text-slate-500">
+          {title}
+        </span>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {actions.map((action) => (
+            <button
+              key={action.id}
+              onClick={() => onSelect?.(action.id)}
+              title={action.description}
+              className="rounded-md border border-slate-700/60 bg-slate-950/80 px-2.5 py-1 text-[11px] font-mono text-slate-300 transition hover:border-sky-500/30 hover:bg-sky-500/5 hover:text-sky-300"
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
       </div>
-      <div className="mt-1 text-sm font-sans text-slate-400">
-        Keep operators in motion with the most likely follow-on steps.
-      </div>
-
-      <div className="mt-4 grid gap-2">
-        {actions.map((action) => (
-          <button
-            key={action.id}
-            onClick={() => onSelect?.(action.id)}
-            className="rounded-lg border border-slate-800 bg-slate-950 px-3 py-3 text-left transition hover:border-slate-700 hover:bg-slate-900"
-          >
-            <div className="text-sm font-sans font-medium text-white">{action.label}</div>
-            <div className="mt-1 text-xs font-sans text-slate-400">{action.description}</div>
-          </button>
-        ))}
-      </div>
-    </section>
+    </div>
   );
 }


### PR DESCRIPTION
### Motivation

- Reduce first-paint chrome and visual noise so operators see critical state at a glance.  
- Replace the static, hard-to-read GI card with a living, animated signal that communicates health and trends.  
- Keep detailed signals accessible while reclaiming vertical space for content and inspection flows.

### Description

- Replace the flat progress-bar monitor with an animated radial SVG gauge in `components/terminal/IntegrityMonitorCard.tsx`, including a 270° main arc, concentric sub-metric rings, a health-adaptive pulsing core, and a 7-day SVG sparkline.  
- Convert the live ribbon into a compact, collapsible summary with expandable metric chips in `components/terminal/LiveIntegrityRibbon.tsx` to save vertical space on first paint.  
- Make the consensus strip a collapsed verdict-dot row that expands to full agent cards and only renders during EPICON inspection or submission flows in `components/terminal/ConsensusPreviewStrip.tsx` and conditionally on `app/terminal/page.tsx`.  
- Compress suggested actions into a horizontal pill bar in `components/terminal/SuggestedNextActions.tsx`, and update `app/terminal/page.tsx` to provide dynamic chamber status copy and a footer that reflects live cycle/stream/tripwire state.

### Testing

- Ran the production build with `npm run build`, which completed successfully with pages generated and no build errors.  
- The build included type/lint checks as part of the Next.js build and reported the terminal route as generated (no runtime compile errors observed).  
- Verified the repository diff shows the five UI files updated: `IntegrityMonitorCard.tsx`, `LiveIntegrityRibbon.tsx`, `ConsensusPreviewStrip.tsx`, `SuggestedNextActions.tsx`, and `app/terminal/page.tsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc9f33b7c8832d832b748fba6f3cd8)