### PR TITLE
Add C-255 terminal close seal and refresh mock runtime state

### DIFF
--- a/docs/epicon/cycles/C-255/EPICON_C-255_PRODUCT_terminal-close-seal_v1.md
+++ b/docs/epicon/cycles/C-255/EPICON_C-255_PRODUCT_terminal-close-seal_v1.md
@@ -1,0 +1,126 @@
+---
+epicon_id: EPICON_C-255_PRODUCT_terminal-close-seal_v1
+title: "Terminal Close Seal — C-255 War-Energy Market Snapshot"
+author_name: "AUREA Agent"
+author_wallet: ""
+cycle: "C-255"
+epoch: ""
+tier: "PRODUCT"
+scope:
+  domain: "product"
+  system: "civic-ai-terminal"
+  environment: "mainnet"
+epicon_type: "closeout"
+status: "active"
+related_prs: []
+related_commits: []
+related_epicons:
+  - "EPICON_C-253_PRODUCT_signal-engine-v1_v1"
+  - "EPICON_C-249_PRODUCT_civic-ai-terminal-scaffold_v1"
+tags:
+  - "terminal"
+  - "close-seal"
+  - "iran"
+  - "hormuz"
+  - "energy"
+  - "inflation"
+  - "markets"
+  - "strategy"
+integrity_index_baseline: 0.79
+risk_level: "high"
+created_at: "2026-03-19T22:05:00Z"
+updated_at: "2026-03-19T22:05:00Z"
+version: 1
+hash_hint: ""
+summary: "Sealed C-255 in the terminal with one EPICON pulse per core agent, capturing the March 19, 2026 close as an energy-inflation-war day centered on the Iran war / Hormuz shock rather than a full financial-break event."
+---
+
+# EPICON C-255: Terminal Close Seal
+
+- **Layer:** PRODUCT > civic-ai-terminal > close-out
+- **Author:** AUREA Agent (+Michael)
+- **Date:** 2026-03-19
+- **Status:** Active
+
+## Context
+
+March 19, 2026 closed with the Iran war / Hormuz energy shock still acting as the dominant macro fact. The terminal close needed a concise but structured seal: one EPICON pulse per core agent, preserving the market read, macro routing, sentiment judgment, strategic watchpoints, and final synthesis inside the terminal memory.
+
+The key design constraint for this close-out was clarity under noise. The market had not moved into a clean recession script. Instead, the world was repricing physical energy disruption, imported inflation risk, and the possibility that Hormuz would again function as a leverage instrument rather than just a shipping corridor.
+
+## Core Agent Pulses
+
+### ECHO — Market pulse
+
+- Reuters close coverage showed a war-in-energy repricing.
+- Brent settled at **$108.65** after touching **$119.13**.
+- WTI settled at **$96.14**.
+- The Brent-WTI spread widened to an **11-year high**.
+- U.S. equities finished lower while European equities sold off more sharply.
+
+**Terminal interpretation:** oil was the day’s cleanest truth asset because it priced direct physical disruption.
+
+### HERMES — Global economy pulse
+
+- Citi’s global economic surprise index remained positive for **14 months**, showing that growth had continued outperforming prior forecasts.
+- The war introduced a new transmission channel: higher oil and gas prices feeding inflation risk, rate repricing, and slower future growth.
+- The Fed, ECB, and BoE all held policy steady, but their messaging shifted toward concern that energy could reaccelerate inflation.
+
+**Routing judgment:** the macro regime moved from resilient growth with disinflation hopes toward resilient growth threatened by imported energy inflation.
+
+### ZEUS — Global sentiment pulse
+
+- The dominant fear signal was inflation fear, not pure collapse fear.
+- Traders increasingly behaved as if expected rate cuts were being pushed far out rather than immediately replaced by financial panic.
+- Allied statements condemned attacks on shipping and infrastructure while backing stabilization of passage and energy markets.
+
+**Verification judgment:** sentiment was anxious, but still institutionally channeled and rule-seeking.
+
+### ATLAS — Strategic pulse
+
+- The most important structural shift was not an immediate currency reset.
+- The more important shift was that Hormuz was again being treated as a **pricing weapon**.
+- Iran’s consideration of transit fees, the effective blockade response, alternative route planning, and importer stockpiling all pointed to strategic adaptation rather than a one-day market spasm.
+
+**Watchpoints for the next cycle:**
+1. Whether transit fees become formal policy.
+2. Whether bilateral passage arrangements expand.
+3. Whether panic-zone oil pricing lasts long enough to hit activity data.
+4. Whether external ecosystems over-amplify “system reset” narratives beyond the evidence.
+
+### AUREA — Synthesis
+
+The close seal judged March 19 as an **energy-inflation-war day**, not yet a full financial-break day.
+
+The center of gravity was the energy system:
+- shipping,
+- gas,
+- oil,
+- inflation expectations,
+- and rate expectations.
+
+These channels were all being rewritten by the war, but markets and states were still operating through institutions, diplomacy, and coordinated stabilization responses.
+
+## Terminal Snapshot at Seal
+
+- **SPY:** 659.8
+- **QQQ:** 593.0
+- **BTC:** 70,531
+- **GLD:** 426.4
+
+These values were recorded as the latest feed available to the terminal at seal time.
+
+## Impact
+
+- Updated the terminal’s mock close state from the earlier C-253 Hormuz escalation frame to a C-255 close-seal frame.
+- Added a durable cycle artifact for the March 19, 2026 close-out.
+- Preserved a five-agent summary structure that is compact enough for terminal use but still strategic enough for later audit.
+- Clarified that the dominant live regime is energy-driven inflation risk under geopolitical disruption, not indiscriminate collapse.
+
+## Integrity Notes
+
+- **MII impact:** Positive — the close-out reduces narrative sprawl by pinning the day to a structured five-agent pulse set.
+- **GI impact:** Negative near-term — shipping risk and energy inflation remain active system stressors.
+- **Risk:** High — the physical energy channel remains live, and narrative overreach can still outrun verified policy change.
+
+> "Reality is not everything breaks tonight; reality is the energy order just got more expensive, and everyone now has to recalculate."

--- a/lib/terminal/mock.ts
+++ b/lib/terminal/mock.ts
@@ -24,8 +24,8 @@ export const navItems = [
   { key: 'settings' as const, label: 'Settings' },
 ];
 
-// ── C-253 Agent States (March 17, 2026 · 10:06 ET) ──────────
-// Iran–Hormuz crisis active. All agents engaged. Maximum alert posture.
+// ── C-255 Agent States (March 19, 2026 · close seal) ────────
+// Iran war / Hormuz energy shock remains the dominant macro driver.
 
 export const mockAgents: Agent[] = [
   {
@@ -35,7 +35,7 @@ export const mockAgents: Agent[] = [
     color: 'bg-sky-500',
     status: 'alert',
     heartbeatOk: true,
-    lastAction: 'Elevated monitoring — Hormuz chokepoint disruption, energy supply chain stress',
+    lastAction: 'Tracking Hormuz transit-fee risk, bypass-route adaptation, and shipping-security escalation',
   },
   {
     id: 'zeus',
@@ -44,7 +44,7 @@ export const mockAgents: Agent[] = [
     color: 'bg-amber-500',
     status: 'verifying',
     heartbeatOk: true,
-    lastAction: 'Verifying yuan-passage claims — no high-confidence source found, marked UNVERIFIED',
+    lastAction: 'Verifying Reuters war-energy pricing stack — Brent $108.65 settle, S&P 500 and Nasdaq both closed lower',
   },
   {
     id: 'hermes',
@@ -53,7 +53,7 @@ export const mockAgents: Agent[] = [
     color: 'bg-rose-500',
     status: 'routing',
     heartbeatOk: true,
-    lastAction: 'Routing Hormuz energy signals — throttling alarmist narratives, prioritizing verified feeds',
+    lastAction: 'Routing resilient-growth signals through the imported-energy inflation lane after ECB/BoE hold decisions',
   },
   {
     id: 'echo',
@@ -62,7 +62,7 @@ export const mockAgents: Agent[] = [
     color: 'bg-slate-400',
     status: 'listening',
     heartbeatOk: true,
-    lastAction: 'Recording C-253-E001 through E003 — Hormuz, markets, narrative layers committed',
+    lastAction: 'Recording C-255 close-out — market pulse, macro reroute, sentiment posture, and strategic adaptation sealed',
   },
   {
     id: 'aurea',
@@ -71,7 +71,7 @@ export const mockAgents: Agent[] = [
     color: 'bg-orange-500',
     status: 'analyzing',
     heartbeatOk: true,
-    lastAction: 'Synthesizing petrodollar structural analysis — energy→currency→military cascade model',
+    lastAction: 'Synthesizing the day as an energy-inflation-war close, not yet a full financial-break event',
   },
   {
     id: 'jade',
@@ -80,7 +80,7 @@ export const mockAgents: Agent[] = [
     color: 'bg-emerald-500',
     status: 'analyzing',
     heartbeatOk: true,
-    lastAction: 'Elevated civic anxiety detected — sentiment feeds show fear amplification in financial channels',
+    lastAction: 'Fear-heavy sentiment mapped as inflation anxiety rather than pure collapse psychology',
   },
   {
     id: 'eve',
@@ -89,7 +89,7 @@ export const mockAgents: Agent[] = [
     color: 'bg-fuchsia-500',
     status: 'verifying',
     heartbeatOk: true,
-    lastAction: 'Ethics review on narrative distortion vectors — flagging manipulation risk in governance channels',
+    lastAction: 'Reviewing containment narratives to keep allied stabilization language distinct from panic amplification',
   },
   {
     id: 'daedalus',
@@ -98,286 +98,304 @@ export const mockAgents: Agent[] = [
     color: 'bg-yellow-700',
     status: 'analyzing',
     heartbeatOk: true,
-    lastAction: 'Signal Engine V1 deployed — scoring pipeline active for C-253 events',
+    lastAction: 'Refreshing terminal mock surfaces for C-255 with close-seal market, macro, and strategic snapshots',
   },
 ];
 
-// ── C-253 EPICON Feed ────────────────────────────────────────
-// Iran–Hormuz crisis. Three-layer analysis: Event → Market → Narrative.
+// ── C-255 EPICON Feed ───────────────────────────────────────
+// One EPICON pulse per core agent for the March 19 close-out.
 
 export const mockEpicon: EpiconItem[] = [
   {
-    id: 'EPICON-C253-003',
-    title: 'Narrative war: multi-layer perception divergence across Hormuz crisis',
-    category: 'geopolitical',
+    id: 'EPICON-C255-004',
+    title: 'AUREA close seal: energy-inflation-war day, not yet a full financial-break day',
+    category: 'governance',
     status: 'verified',
-    confidenceTier: 3,
+    confidenceTier: 4,
     ownerAgent: 'AUREA',
-    timestamp: '2026-03-17 10:48 ET',
-    sources: ['ECHO Threat Intelligence', 'Social media analysis', 'State media monitoring', 'Independent analysts'],
+    timestamp: '2026-03-19 18:05 ET',
+    sources: ['AUREA synthesis', 'Reuters macro wrap', 'Terminal close feed'],
     summary:
-      'Multi-layer narrative divergence forming: mainstream media cautious ("regional instability"), social platforms extreme ("WW3 imminent"), state messaging strategic. Self-reinforcing feedback loop detected: narrative → market → price confirms fear → more narrative. GII delta -0.06.',
+      'C-255 closes with the energy system as the center of gravity. Shipping, oil, gas, inflation expectations, and rate expectations all rerouted through the Iran war / Hormuz shock. Terminal snapshot at seal: SPY 659.8, QQQ 593.0, BTC 70,531, GLD 426.4.',
     trace: [
-      'ECHO detected narrative divergence across 4 information layers',
-      'AUREA classified perception field structure — 4 actor types identified',
-      'JADE flagged cognitive impact — numbness and fear amplification patterns',
-      'EVE opened ethics review on manipulation vectors in governance channels',
-      'ZEUS confirmed core signal stable but distortion field extreme',
+      'ECHO sealed the day\'s four core agent pulses into the close ledger',
+      'HERMES routed growth resilience into an imported-energy inflation framework',
+      'ZEUS confirmed the cleanest fear signal is inflation persistence, not immediate collapse',
+      'ATLAS elevated strategic watchpoints around transit fees, bypass routes, and stockpiling',
+      'AUREA classified the close as structured danger rather than systemic financial breakage',
     ],
   },
   {
-    id: 'EPICON-C253-002',
-    title: 'Market cascade: oil spike, BTC volatile, gold safe-haven flows, DXY mixed',
+    id: 'EPICON-C255-003',
+    title: 'ATLAS: Hormuz is being repriced as a leverage weapon, not just a shipping lane',
+    category: 'geopolitical',
+    status: 'verified',
+    confidenceTier: 3,
+    ownerAgent: 'ATLAS',
+    timestamp: '2026-03-19 17:42 ET',
+    sources: ['Reuters shipping coverage', 'Gulf producer statements', 'Terminal strategy notes'],
+    summary:
+      'Iran considering transit fees and the effective blockade response have turned Hormuz back into a pricing weapon. Gulf producers are accelerating bypass routes, Qatar has halted LNG production, and importers are revisiting diversification and stockpiling assumptions.',
+    trace: [
+      'ATLAS flagged transit fees as the highest-consequence unresolved policy variable',
+      'ECHO logged alternative pipeline and port adaptation as structural rather than temporary behavior',
+      'HERMES routed shipping-security and reserve-release scenarios into the strategy lane',
+      'ZEUS marked currency-reset narratives as over-amplified relative to the evidence',
+      'AUREA converted the signal into a watchlist for the next cycle',
+    ],
+  },
+  {
+    id: 'EPICON-C255-002',
+    title: 'HERMES: resilient global growth is being rerouted through the energy inflation channel',
     category: 'market',
     status: 'verified',
     confidenceTier: 3,
     ownerAgent: 'HERMES',
-    timestamp: '2026-03-17 10:32 ET',
-    sources: ['Bloomberg Terminal', 'CoinGecko', 'On-chain analytics', 'Reuters Markets'],
+    timestamp: '2026-03-19 17:18 ET',
+    sources: ['Reuters economies coverage', 'ECB decision', 'BoE decision'],
     summary:
-      'Global markets reacting to Hormuz disruption. Brent ~$102, gold up (fear hedge), BTC volatile (competing "digital gold" vs "risk asset" narratives), DXY mixed (safe-haven short-term vs structural pressure long-term), equities pressured. Classic macro cascade: energy shock → cost increase → margin compression → risk repricing. GII delta -0.04.',
+      'Citi’s global surprise index stayed positive for 14 months, but the war is now the transmission channel. The Fed, ECB, and BoE held rates steady while warning that higher oil and gas prices could reverse inflation progress. BoE guidance now allows inflation to re-approach 3.5% if the shock persists.',
     trace: [
-      'HERMES routed overnight market signals for C-253 intake',
-      'ZEUS verified oil/gold/BTC/DXY moves across 3+ independent feeds',
-      'JADE assessed civic anxiety signal — elevated in financial sentiment channels',
-      'ATLAS confirmed no infrastructure systemic risk — monitoring continues',
-      'AUREA synthesized structural insight: narrative competition amplifying market reflexivity',
+      'HERMES routed the surprise-index resilience signal into a downside energy filter',
+      'ZEUS confirmed all three central-bank holds and their inflation concern language',
+      'ATLAS tagged imported energy inflation as the current macro transmission mechanism',
+      'JADE noted that policy anxiety is outrunning recession anxiety in operator sentiment',
+      'AUREA shifted the macro frame from disinflation hope to inflation-risk reroute',
     ],
   },
   {
-    id: 'EPICON-C253-001',
-    title: 'Strait of Hormuz under severe disruption — selective passage negotiated',
-    category: 'geopolitical',
+    id: 'EPICON-C255-001',
+    title: 'ECHO: energy shock remains the cleanest truth asset in cross-market pricing',
+    category: 'market',
     status: 'verified',
     confidenceTier: 3,
-    ownerAgent: 'ZEUS',
-    timestamp: '2026-03-17 10:18 ET',
-    sources: ['Reuters', 'AP', 'IMO advisory', 'UN Security Council briefing'],
+    ownerAgent: 'ECHO',
+    timestamp: '2026-03-19 16:28 ET',
+    sources: ['Reuters markets wrap', 'Terminal close feed'],
     summary:
-      'Iran conflict has disrupted Hormuz — ~20% of global oil/LNG transit. Verified: severe strain, selective bilateral passage (Pakistan, Iraq negotiating with Iran), Brent ~$102, Gulf exports down 60%. UNVERIFIED: formal yuan-only passage policy. Structural analysis: even partial non-USD energy settlement pressures petrodollar system at margin. Military-energy logistics stress elevated.',
+      'Brent settled at $108.65 after touching $119.13, WTI settled at $96.14, and the Brent-WTI spread widened to an 11-year high. U.S. equities closed lower, the STOXX 600 fell 2.4%, and traders increasingly priced out Fed cuts before 2027. Inflation fear led the tape more cleanly than recession fear.',
     trace: [
-      'ECHO captured initial Hormuz disruption signal from multiple feeds',
-      'ZEUS cross-verified across Reuters, AP, IMO — confirmed disruption, rejected yuan-only claim',
-      'HERMES routed to geopolitical + market verification lanes',
-      'ATLAS elevated monitoring — chokepoint risk to global energy system',
-      'AUREA synthesized petrodollar structural analysis — 3-stage cascade model',
+      'ECHO ranked oil as the day\'s clearest direct-pricing signal because it reflects physical disruption',
+      'ZEUS confirmed S&P 500 -0.27%, Nasdaq -0.28%, and STOXX 600 -2.4% from the close coverage',
+      'HERMES routed the move as risk-off with inflation pressure rather than clean recession pricing',
+      'JADE logged heightened fear, but still within institutional-response channels',
+      'AUREA used the cross-asset stack as the close seal foundation',
     ],
   },
   {
-    id: 'EPICON-C253-000',
-    title: 'C-253 cycle initialized — Signal Engine V1 deployed',
+    id: 'EPICON-C255-000',
+    title: 'C-255 cycle seal — Reuters war-energy close synchronized into terminal memory',
     category: 'infrastructure',
     status: 'verified',
     confidenceTier: 4,
     ownerAgent: 'ECHO',
-    timestamp: '2026-03-17 10:06 ET',
-    sources: ['ECHO ledger system', 'DAEDALUS build report'],
+    timestamp: '2026-03-19 16:05 ET',
+    sources: ['ECHO ledger system', 'Terminal operator seal'],
     summary:
-      'Cycle C-253 opened at operator clock-in. Signal Engine V1 deployed — every EPICON event now scored across signal/narrative/volatility dimensions with SIGNAL/EMERGING/DISTORTION classification. Cycle health monitoring active.',
+      'Cycle C-255 close-out staged with one EPICON pulse per core agent: ECHO market pulse, HERMES macro routing, ZEUS sentiment read, ATLAS strategic posture, and AUREA synthesis.',
     trace: [
-      'ECHO committed C-253 genesis entry at operator clock-in',
-      'DAEDALUS deployed Signal Engine V1 scoring pipeline',
-      'ZENITH confirmed cycle transition quorum',
-      'ATLAS verified substrate integrity — all systems nominal',
+      'ECHO initialized the close-seal bundle for C-255',
+      'ZENITH confirmed the core-agent pulse set was complete',
+      'ATLAS verified no missing strategic watchpoints before seal',
+      'AUREA approved the cycle summary language for terminal display',
     ],
   },
 ];
 
-// ── C-253 Tripwires ──────────────────────────────────────────
-// Major geopolitical crisis — multiple active tripwires.
+// ── C-255 Tripwires ─────────────────────────────────────────
+// Energy shock remains live; inflation and shipping tripwires elevated.
 
 export const mockTripwires: Tripwire[] = [
   {
-    id: 'TW-120',
-    label: 'Hormuz Chokepoint Disruption',
+    id: 'TW-130',
+    label: 'Hormuz Transit Fee Risk',
     severity: 'high',
     owner: 'ATLAS',
-    openedAt: '10:18 ET',
-    action: 'Elevated monitoring — 20% global oil transit affected, supply chain stress active',
+    openedAt: '17:40 ET',
+    action: 'Monitoring whether Iran formalizes transit fees and turns passage into an overt leverage instrument',
   },
   {
-    id: 'TW-121',
-    label: 'Narrative Distortion Field',
+    id: 'TW-129',
+    label: 'Energy Inflation Repricing',
     severity: 'high',
-    owner: 'ZEUS',
-    openedAt: '10:48 ET',
-    action: 'Extreme narrative noise — "WW3", "petrodollar collapse" claims circulating without verification',
-  },
-  {
-    id: 'TW-119',
-    label: 'Energy Market Volatility',
-    severity: 'medium',
     owner: 'HERMES',
-    openedAt: '10:32 ET',
-    action: 'Brent ~$102, cross-asset volatility elevated — monitoring for systemic contagion',
+    openedAt: '16:28 ET',
+    action: 'Oil shock is delaying expected rate cuts and reopening inflation risk across developed markets',
   },
   {
-    id: 'TW-118',
-    label: 'Yuan-Passage Claim',
+    id: 'TW-128',
+    label: 'Narrative Overreach: System Reset Claims',
     severity: 'medium',
     owner: 'ZEUS',
-    openedAt: '10:20 ET',
-    action: 'Unverified claim — no high-confidence source confirms yuan-only Hormuz passage policy',
+    openedAt: '17:48 ET',
+    action: 'Watching for over-amplified currency-reset narratives that move faster than the verified evidence',
+  },
+  {
+    id: 'TW-127',
+    label: 'Allied Stabilization Coordination',
+    severity: 'medium',
+    owner: 'EVE',
+    openedAt: '17:05 ET',
+    action: 'Joint diplomatic statements and energy-stabilization actions remain active; escalation risk persists if shipping deteriorates',
   },
 ];
 
-// ── C-253 GI Snapshot ────────────────────────────────────────
-// GI dropped: Hormuz crisis introduces real geopolitical stress,
-// narrative noise extreme, market volatility elevated.
+// ── C-255 GI Snapshot ───────────────────────────────────────
+// Growth is still resilient, but energy-driven inflation and shipping
+// disorder pulled integrity lower again.
 
 export const mockGI: GISnapshot = {
-  score: 0.83,
-  delta: -0.13,
-  institutionalTrust: 0.82,
-  infoReliability: 0.74,
-  consensusStability: 0.78,
-  weekly: [0.94, 0.96, 0.95, 0.93, 0.91, 0.88, 0.83],
+  score: 0.79,
+  delta: -0.04,
+  institutionalTrust: 0.81,
+  infoReliability: 0.72,
+  consensusStability: 0.75,
+  weekly: [0.92, 0.9, 0.88, 0.85, 0.83, 0.81, 0.79],
 };
 
-// ── C-253 Ledger Entries ─────────────────────────────────────
+// ── C-255 Ledger Entries ────────────────────────────────────
 
 export const mockLedger: LedgerEntry[] = [
   {
-    id: 'LE-C253-006',
-    cycleId: 'C-253',
+    id: 'LE-C255-006',
+    cycleId: 'C-255',
     type: 'epicon',
-    agentOrigin: 'ECHO',
-    timestamp: '2026-03-17 10:48 ET',
-    summary: 'EPICON-C253-003 committed — narrative war layer analysis, multi-platform distortion field mapped',
-    integrityDelta: -0.06,
+    agentOrigin: 'AUREA',
+    timestamp: '2026-03-19 18:05 ET',
+    summary: 'EPICON-C255-004 committed — AUREA close seal classifies the day as energy-inflation-war, not financial-break',
+    integrityDelta: -0.01,
     status: 'committed',
   },
   {
-    id: 'LE-C253-005',
-    cycleId: 'C-253',
-    type: 'attestation',
-    agentOrigin: 'EVE',
-    timestamp: '2026-03-17 10:45 ET',
-    summary: 'Ethics attestation — manipulation vectors flagged in governance channels, deepfake audio detected',
+    id: 'LE-C255-005',
+    cycleId: 'C-255',
+    type: 'epicon',
+    agentOrigin: 'ATLAS',
+    timestamp: '2026-03-19 17:42 ET',
+    summary: 'EPICON-C255-003 committed — Hormuz transit fees and bypass-route adaptation elevated to strategic watch',
     integrityDelta: -0.02,
     status: 'committed',
   },
   {
-    id: 'LE-C253-004',
-    cycleId: 'C-253',
+    id: 'LE-C255-004',
+    cycleId: 'C-255',
     type: 'epicon',
-    agentOrigin: 'ECHO',
-    timestamp: '2026-03-17 10:32 ET',
-    summary: 'EPICON-C253-002 committed — market cascade verified: oil, gold, BTC, DXY, equities',
-    integrityDelta: -0.04,
+    agentOrigin: 'HERMES',
+    timestamp: '2026-03-19 17:18 ET',
+    summary: 'EPICON-C255-002 committed — resilient growth rerouted through imported-energy inflation risk',
+    integrityDelta: -0.02,
     status: 'committed',
   },
   {
-    id: 'LE-C253-003',
-    cycleId: 'C-253',
+    id: 'LE-C255-003',
+    cycleId: 'C-255',
     type: 'epicon',
     agentOrigin: 'ECHO',
-    timestamp: '2026-03-17 10:18 ET',
-    summary: 'EPICON-C253-001 committed — Hormuz disruption verified, yuan-passage claim marked UNVERIFIED',
+    timestamp: '2026-03-19 16:28 ET',
+    summary: 'EPICON-C255-001 committed — Brent $108.65, WTI $96.14, equities lower, inflation fear dominant',
     integrityDelta: -0.03,
     status: 'committed',
   },
   {
-    id: 'LE-C253-002',
-    cycleId: 'C-253',
+    id: 'LE-C255-002',
+    cycleId: 'C-255',
     type: 'shard',
     agentOrigin: 'JADE',
-    timestamp: '2026-03-17 10:15 ET',
-    summary: 'MFS-7730 protection shard created — civic anxiety monitoring during Hormuz crisis',
-    integrityDelta: 0.005,
+    timestamp: '2026-03-19 16:40 ET',
+    summary: 'MFS-7762 protection shard created — fear-heavy but rule-seeking public mood logged for the close',
+    integrityDelta: 0.004,
     status: 'committed',
   },
   {
-    id: 'LE-C253-001',
-    cycleId: 'C-253',
+    id: 'LE-C255-001',
+    cycleId: 'C-255',
     type: 'settlement',
     agentOrigin: 'ECHO',
-    timestamp: '2026-03-17 10:06 ET',
-    summary: 'C-253 genesis — operator clock-in, Signal Engine V1 deployed, crisis monitoring activated',
-    integrityDelta: 0.0,
+    timestamp: '2026-03-19 16:05 ET',
+    summary: 'C-255 close seal initialized — five core agent pulses staged for terminal memory',
+    integrityDelta: 0,
     status: 'committed',
   },
   {
-    id: 'LE-C252-014',
-    cycleId: 'C-252',
+    id: 'LE-C254-011',
+    cycleId: 'C-254',
     type: 'ubi',
     agentOrigin: 'DAEDALUS',
-    timestamp: '2026-03-16 23:58 ET',
-    summary: 'C-252 UBI distribution finalized — 358 citizens, 13,200 MIC distributed',
-    integrityDelta: 0.0,
+    timestamp: '2026-03-18 23:58 ET',
+    summary: 'C-254 UBI distribution finalized — resilience buffers carried forward into the C-255 war-energy close',
+    integrityDelta: 0,
     status: 'committed',
   },
 ];
 
-// ── C-253 MFS Shards ────────────────────────────────────────
+// ── C-255 MFS Shards ────────────────────────────────────────
 
 export const mockShards: MFSShard[] = [
   {
-    id: 'MFS-7730',
+    id: 'MFS-7762',
     citizenId: 'CZ-1042',
     archetype: 'protection',
-    weight: 0.92,
-    qualityScore: 0.95,
-    integrityCoefficient: 0.91,
-    miiDelta: 0.018,
-    timestamp: '2026-03-17 10:48 ET',
+    weight: 0.91,
+    qualityScore: 0.94,
+    integrityCoefficient: 0.9,
+    miiDelta: 0.016,
+    timestamp: '2026-03-19 18:05 ET',
   },
   {
-    id: 'MFS-7729',
+    id: 'MFS-7761',
     citizenId: 'CZ-0891',
     archetype: 'verification',
-    weight: 0.97,
-    qualityScore: 0.99,
-    integrityCoefficient: 0.96,
-    miiDelta: 0.022,
-    timestamp: '2026-03-17 10:18 ET',
+    weight: 0.96,
+    qualityScore: 0.98,
+    integrityCoefficient: 0.95,
+    miiDelta: 0.021,
+    timestamp: '2026-03-19 16:28 ET',
   },
   {
-    id: 'MFS-7728',
-    citizenId: 'CZ-1042',
+    id: 'MFS-7760',
+    citizenId: 'CZ-1277',
     archetype: 'governance',
-    weight: 0.88,
-    qualityScore: 0.91,
-    integrityCoefficient: 0.87,
-    miiDelta: 0.014,
-    timestamp: '2026-03-17 10:06 ET',
+    weight: 0.87,
+    qualityScore: 0.9,
+    integrityCoefficient: 0.88,
+    miiDelta: 0.013,
+    timestamp: '2026-03-19 17:18 ET',
   },
 ];
 
-// ── C-253 Attestations ──────────────────────────────────────
+// ── C-255 Attestations ──────────────────────────────────────
 
 export const mockAttestations: Attestation[] = [
   {
-    id: 'ATT-455',
+    id: 'ATT-462',
     citizenId: 'CZ-1042',
     type: 'mint',
-    reason: 'Signal Engine contribution — civic infrastructure expansion verified by DAEDALUS',
-    miiImpact: 0.03,
-    validatorAgent: 'DAEDALUS',
-    timestamp: '2026-03-17 10:06 ET',
+    reason: 'C-255 close synthesis contribution — structured-risk framing validated by AUREA',
+    miiImpact: 0.028,
+    validatorAgent: 'AUREA',
+    timestamp: '2026-03-19 18:05 ET',
   },
   {
-    id: 'ATT-454',
+    id: 'ATT-461',
     citizenId: 'CZ-0891',
     type: 'mint',
-    reason: 'Hormuz crisis verification — cross-source chain accuracy under pressure',
-    miiImpact: 0.025,
+    reason: 'Cross-market verification during war-energy repricing — Reuters close stack confirmed by ZEUS',
+    miiImpact: 0.024,
     validatorAgent: 'ZEUS',
-    timestamp: '2026-03-17 10:20 ET',
+    timestamp: '2026-03-19 16:30 ET',
   },
   {
-    id: 'ATT-453',
-    citizenId: 'CZ-1042',
+    id: 'ATT-460',
+    citizenId: 'CZ-1277',
     type: 'mint',
-    reason: 'Narrative distortion mapping — structural analysis contribution',
-    miiImpact: 0.02,
-    validatorAgent: 'EVE',
-    timestamp: '2026-03-17 10:50 ET',
+    reason: 'Strategic watchpoint formalization — Hormuz leverage pathways mapped by ATLAS',
+    miiImpact: 0.019,
+    validatorAgent: 'ATLAS',
+    timestamp: '2026-03-19 17:45 ET',
   },
 ];
 
-// ── C-253 Sentinel Council ───────────────────────────────────
-// Crisis posture. Most sentinels active. URIEL elevated.
+// ── C-255 Sentinel Council ──────────────────────────────────
 
 export const mockSentinels: Sentinel[] = [
   {
@@ -387,7 +405,7 @@ export const mockSentinels: Sentinel[] = [
     status: 'active',
     integrity: 0.95,
     provider: 'anthropic',
-    lastAction: 'Elevated monitoring — Hormuz chokepoint risk to global energy infrastructure',
+    lastAction: 'Strategic watchpoints set: transit fees, passage deals, panic-zone oil duration, and narrative overreach',
     domains: ['integrity', 'monitoring', 'escalation'],
   },
   {
@@ -397,7 +415,7 @@ export const mockSentinels: Sentinel[] = [
     status: 'active',
     integrity: 0.97,
     provider: 'openai',
-    lastAction: 'Hormuz verification: disruption CONFIRMED, yuan-only REJECTED, bilateral passage CONFIRMED',
+    lastAction: 'Verified close stack: Brent $108.65, WTI $96.14, S&P 500 -0.27%, Nasdaq -0.28%, STOXX 600 -2.4%',
     domains: ['verification', 'source-chain', 'confidence'],
   },
   {
@@ -407,7 +425,7 @@ export const mockSentinels: Sentinel[] = [
     status: 'active',
     integrity: 0.98,
     provider: 'anthropic',
-    lastAction: 'Flagging narrative manipulation vectors — deepfake audio + astroturfing patterns active',
+    lastAction: 'Monitoring diplomatic containment language to reduce panic while preserving operational clarity',
     domains: ['ethics', 'bias', 'governance'],
   },
   {
@@ -417,7 +435,7 @@ export const mockSentinels: Sentinel[] = [
     status: 'active',
     integrity: 0.94,
     provider: 'google',
-    lastAction: 'Throttling alarmist market narratives — prioritizing verified Reuters/AP/IMO feeds',
+    lastAction: 'Rerouting macro interpretation from disinflation optimism toward imported-energy inflation risk',
     domains: ['routing', 'prioritization', 'throttling'],
   },
   {
@@ -427,7 +445,7 @@ export const mockSentinels: Sentinel[] = [
     status: 'active',
     integrity: 0.99,
     provider: 'anthropic',
-    lastAction: 'C-253 crisis ledger active — 6 entries committed, 3 EPICON events archived',
+    lastAction: 'C-255 close ledger active — five pulses committed, market snapshot sealed for terminal recall',
     domains: ['memory', 'archival', 'ledger'],
   },
   {
@@ -437,7 +455,7 @@ export const mockSentinels: Sentinel[] = [
     status: 'active',
     integrity: 0.95,
     provider: 'openai',
-    lastAction: 'Petrodollar structural analysis: 3-stage cascade model (shipping→bilateral→reserve diversification)',
+    lastAction: 'Close verdict issued: more dangerous than a headline day, more structured than a collapse day',
     domains: ['strategy', 'synthesis', 'architecture'],
   },
   {
@@ -447,7 +465,7 @@ export const mockSentinels: Sentinel[] = [
     status: 'active',
     integrity: 0.93,
     provider: 'google',
-    lastAction: 'Civic anxiety elevated — fear amplification in financial sentiment feeds, cognitive impact flagged',
+    lastAction: 'Mapped public mood as anxious but still rule-seeking — inflation fear dominates collapse fear',
     domains: ['annotation', 'patterns', 'morale'],
   },
   {
@@ -457,7 +475,7 @@ export const mockSentinels: Sentinel[] = [
     status: 'active',
     integrity: 0.94,
     provider: 'meta',
-    lastAction: 'Signal Engine V1 deployed — scoring pipeline active, cycle health monitoring operational',
+    lastAction: 'Updated terminal mock state to reflect March 19 close seal and cross-market snapshot values',
     domains: ['research', 'building', 'ubi'],
   },
   {
@@ -467,7 +485,7 @@ export const mockSentinels: Sentinel[] = [
     status: 'active',
     integrity: 0.99,
     provider: 'anthropic',
-    lastAction: 'Safety protocol ELEVATED — monitoring escalation paths during Hormuz crisis',
+    lastAction: 'Safety posture elevated for shipping escalation and inflation-shock civic stress transmission',
     domains: ['safety', 'escalation', 'veto'],
   },
   {
@@ -477,84 +495,69 @@ export const mockSentinels: Sentinel[] = [
     status: 'consensus',
     integrity: 0.96,
     provider: 'google',
-    lastAction: 'C-253 crisis quorum maintained — 9-of-10 sentinels active, consensus holding',
+    lastAction: 'C-255 quorum maintained — core-agent pulse set complete and internally coherent at seal',
     domains: ['consensus', 'quorum', 'coordination'],
   },
 ];
 
-// ── C-253 Civic Radar Alerts ─────────────────────────────────
-// Major crisis cycle. Multiple high-severity alerts.
+// ── C-255 Civic Radar Alerts ────────────────────────────────
 
 export const mockCivicAlerts: CivicRadarAlert[] = [
   {
-    id: 'CRA-2055',
-    title: 'Narrative feedback loop: Hormuz rumor → market spike → fear confirmation → more rumor',
+    id: 'CRA-2064',
+    title: 'Transit fee scenario emerging in Hormuz shipping lanes',
     severity: 'critical',
-    category: 'misinformation',
-    source: 'AUREA Synthesis Engine',
-    timestamp: '2026-03-17 10:50 ET',
-    impact: 'Self-reinforcing belief system detected: unverified claims amplified by market reactions create false confirmation',
+    category: 'infrastructure',
+    source: 'ATLAS Strategic Monitor',
+    timestamp: '2026-03-19 17:42 ET',
+    impact: 'If formalized, transit fees would shift Hormuz from a chokepoint headline into an overt pricing and leverage regime for energy trade',
     actions: [
-      'ZEUS maintaining continuous verification on yuan-passage claims',
-      'HERMES throttling alarmist propagation across all channels',
-      'JADE monitoring cognitive impact — numbness and inevitability patterns',
-      'EVE ethics review on narrative manipulation vectors',
+      'ATLAS tracking formal policy language and bilateral exceptions',
+      'HERMES mapping implications for shipping costs, reserve releases, and rerouting',
+      'ZEUS filtering out premature system-reset narratives until policy is explicit',
+      'AUREA preparing scenario branches for the next cycle',
     ],
   },
   {
-    id: 'CRA-2054',
-    title: 'Deepfake audio targeting civic governance proceedings',
-    severity: 'high',
-    category: 'manipulation',
-    source: 'ECHO Threat Intelligence',
-    timestamp: '2026-03-17 10:40 ET',
-    impact: 'Synthetic audio clips impersonating municipal officials detected in 2 forums during crisis chaos',
-    actions: [
-      'ZEUS opened verification lane for audio provenance',
-      'EVE flagged for ethics review — democratic harm potential elevated during crisis',
-      'ATLAS increased monitoring on governance channels',
-    ],
-  },
-  {
-    id: 'CRA-2053',
-    title: 'Energy market shock — Brent $102, Gulf exports down 60%',
+    id: 'CRA-2063',
+    title: 'Oil shock reprices central-bank path across the U.S. and Europe',
     severity: 'high',
     category: 'infrastructure',
     source: 'HERMES Market Router',
-    timestamp: '2026-03-17 10:32 ET',
-    impact: 'Hormuz disruption causing real energy supply shock — 20% of global oil/LNG transit affected',
+    timestamp: '2026-03-19 16:28 ET',
+    impact: 'Brent at $108.65 settlement and an 11-year-high Brent-WTI spread are pushing markets to postpone rate-cut expectations while growth remains only partially impaired',
     actions: [
-      'ATLAS monitoring for systemic infrastructure contagion',
-      'DAEDALUS reviewing UBI buffer adequacy under energy price stress',
-      'HERMES prioritizing verified market data over narrative feeds',
+      'ZEUS maintaining verification of close-market and rate-pricing data',
+      'JADE monitoring inflation-fear amplification in public channels',
+      'EVE tracking policy communication for panic-control integrity',
     ],
   },
   {
-    id: 'CRA-2052',
-    title: 'Elevated civic anxiety — financial sentiment feeds showing fear amplification',
+    id: 'CRA-2062',
+    title: 'Allied energy-stabilization bloc hardens around Hormuz passage security',
+    severity: 'high',
+    category: 'governance',
+    source: 'EVE Diplomatic Watch',
+    timestamp: '2026-03-19 17:05 ET',
+    impact: 'Britain, France, Germany, Italy, the Netherlands, and Japan have converged on a containment-and-stabilization posture rather than accepting blockade normalization',
+    actions: [
+      'EVE distinguishing stabilization efforts from escalation rhetoric',
+      'ATLAS watching for shipping-security implementation moves',
+      'AUREA incorporating allied coordination into the strategic baseline',
+    ],
+  },
+  {
+    id: 'CRA-2061',
+    title: 'Inflation fear dominates public mood as equities slide and gold firms',
     severity: 'medium',
     category: 'manipulation',
     source: 'JADE Morale Assessment',
-    timestamp: '2026-03-17 10:25 ET',
-    impact: 'Citizen financial sentiment elevated by crisis — information overload → fear → belief anchoring → polarization',
+    timestamp: '2026-03-19 16:45 ET',
+    impact: 'The dominant fear signal is persistent inflation and delayed relief, not immediate systemic collapse; this keeps institutional channels intact but stressed',
     actions: [
-      'JADE monitoring sentiment trajectory for inflection points',
-      'EVE assessing ethical implications of fear amplification patterns',
-      'AUREA preparing civic resilience synthesis',
-    ],
-  },
-  {
-    id: 'CRA-2051',
-    title: 'Unverified yuan-only passage claim circulating at scale',
-    severity: 'medium',
-    category: 'misinformation',
-    source: 'ZEUS Verification Engine',
-    timestamp: '2026-03-17 10:20 ET',
-    impact: 'Claim that Hormuz only accepts yuan for passage spreading without high-confidence sourcing',
-    actions: [
-      'ZEUS actively monitoring for official policy announcement from Iran',
-      'HERMES throttling propagation of unverified claim',
-      'ECHO tracking claim provenance across platforms',
+      'JADE tracking whether anxiety mutates into collapse narratives',
+      'ZEUS checking sensational claims against the verified close stack',
+      'HERMES keeping the operator view centered on energy transmission mechanics',
     ],
   },
 ];


### PR DESCRIPTION
### Motivation
- Capture and seal the March 19, 2026 close (C-255) for the Terminal as a structured five-agent pulse set reflecting the Iran war / Hormuz energy shock rather than the earlier C-253 escalation snapshot.
- Provide an auditable, in-repo artifact for the cycle close so the terminal can present a consistent market/macro/sentiment/strategy snapshot for operator recall and downstream flows.

### Description
- Updated the runtime mock state in `lib/terminal/mock.ts` to C-255, replacing C-253 content with new agent `lastAction` entries, a five-item EPICON feed, tripwires, GI snapshot, ledger entries, MFS shards, attestations, sentinel summaries, and civic alerts aligned to the March 19 close.
- Added a new EPICON close-out document at `docs/epicon/cycles/C-255/EPICON_C-255_PRODUCT_terminal-close-seal_v1.md` that records the five core agent pulses, terminal snapshot (SPY/QQQ/BTC/GLD), strategic watchpoints, and AUREA synthesis.
- Adjusted identifiers and timestamps in the mock ledger/shard/attestation entries to reflect the C-255 cycle and to keep the mock runtime internally consistent.

### Testing
- Ran `npx tsc --noEmit` and the type check completed successfully with no errors.
- Ran `npm run build` and the Next.js production build completed successfully and produced prerendered and dynamic routes without build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bca83f14cc832d94c18fff6e1e9edf)