### PR TITLE
feat(epicon): add publish-from-query modal and stake flow

### DIFF
--- a/app/api/epicon/publish/route.ts
+++ b/app/api/epicon/publish/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+
+  const record = {
+    id: `EPICON-${Math.random().toString(36).slice(2, 10).toUpperCase()}`,
+    status: 'pending',
+    title: body.title,
+    summary: body.summary,
+    sources: body.sources || [],
+    tags: body.tags || [],
+    confidence_tier: body.confidence >= 0.7 ? 2 : 1,
+    publication_mode: body.publication_mode,
+    mic_stake: body.publication_mode === 'public' ? body.mic_stake || 0 : 0,
+    agents_used: body.agents_used || [],
+    created_at: new Date().toISOString(),
+    trace: [
+      'Query result transformed into EPICON candidate',
+      'Publication flow completed',
+      'Awaiting ZEUS review / later settlement layer',
+    ],
+  };
+
+  return NextResponse.json({
+    ok: true,
+    record,
+  });
+}

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -20,6 +20,7 @@ import TripwirePanel from '@/components/tripwire/TripwirePanel';
 import DetailInspectorRail from '@/components/terminal/DetailInspectorRail';
 import type { ZeusVerifyPayload, ZeusVerifyResult } from '@/components/terminal/DetailInspectorRail';
 import CommandPalette from '@/components/terminal/CommandPalette';
+import QueryResultCard from '@/components/query/QueryResultCard';
 import LedgerPanel from '@/components/terminal/LedgerPanel';
 import SubstrateStatusCard from '@/components/terminal/SubstrateStatusCard';
 import CivicRadarPanel from '@/components/terminal/CivicRadarPanel';
@@ -29,6 +30,7 @@ import { WalletProvider } from '@/contexts/WalletContext';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { navItems, mockCivicAlerts, mockSentinels } from '@/lib/terminal/mock';
 import type { NavKey } from '@/lib/terminal/types';
+import { mockQueryResult } from '@/lib/mock/queryResult';
 import { cn } from '@/lib/terminal/utils';
 import { useTerminalCommands } from '@/hooks/useTerminalCommands';
 import { useTerminalData } from '@/hooks/useTerminalData';
@@ -380,6 +382,10 @@ function TerminalPage() {
                 <MFSShardPanel integrity={echoIntegrity} />
                 <MICBlockchainExplorer />
               </>
+            )}
+
+            {selectedNav === 'search' && (
+              <QueryResultCard result={mockQueryResult} />
             )}
 
             {showMetrics && (

--- a/components/query/PublishEpiconModal.tsx
+++ b/components/query/PublishEpiconModal.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useState } from 'react';
+
+type QueryResult = {
+  id: string;
+  query: string;
+  title: string;
+  summary: string;
+  sources: readonly string[];
+  tags: readonly string[];
+  confidence: number;
+  agents_used: readonly string[];
+  created_at: string;
+};
+
+export default function PublishEpiconModal({
+  open,
+  onClose,
+  result,
+}: {
+  open: boolean;
+  onClose: () => void;
+  result: QueryResult;
+}) {
+  const [publicationMode, setPublicationMode] = useState<'public' | 'private_draft'>('private_draft');
+  const [stake, setStake] = useState<number>(0);
+  const [loading, setLoading] = useState(false);
+
+  if (!open) return null;
+
+  async function handleSubmit() {
+    try {
+      setLoading(true);
+
+      const res = await fetch('/api/epicon/publish', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query_result_id: result.id,
+          title: result.title,
+          summary: result.summary,
+          sources: result.sources,
+          tags: result.tags,
+          confidence: result.confidence,
+          agents_used: result.agents_used,
+          publication_mode: publicationMode,
+          mic_stake: publicationMode === 'public' ? stake : 0,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error('Publish failed');
+      }
+
+      onClose();
+      alert(
+        publicationMode === 'public'
+          ? 'EPICON published in pending state'
+          : 'Private draft saved',
+      );
+    } catch (err) {
+      console.error(err);
+      alert('Unable to complete publish flow');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 p-4">
+      <div className="w-full max-w-2xl rounded-2xl border border-slate-800 bg-slate-900 p-5 text-slate-100">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-xs uppercase tracking-[0.24em] text-slate-400">
+              Publish to EPICON
+            </div>
+            <div className="mt-1 text-sm text-slate-500">
+              Turn this result into a public Mobius ledger entry or save it privately.
+            </div>
+          </div>
+
+          <button
+            onClick={onClose}
+            className="rounded-md border border-slate-700 px-3 py-1 text-sm text-slate-300 hover:bg-slate-800"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="mt-5 rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+          <div className="text-sm font-semibold text-white">{result.title}</div>
+          <div className="mt-2 text-sm text-slate-300">{result.summary}</div>
+          <div className="mt-3 text-xs text-slate-500">
+            Confidence: {result.confidence.toFixed(2)} · Agents: {result.agents_used.join(', ')}
+          </div>
+        </div>
+
+        <div className="mt-5">
+          <div className="text-xs uppercase tracking-[0.18em] text-slate-400">
+            Publication Mode
+          </div>
+          <div className="mt-3 flex gap-2">
+            <button
+              onClick={() => setPublicationMode('private_draft')}
+              className={`rounded-lg border px-3 py-2 text-sm ${
+                publicationMode === 'private_draft'
+                  ? 'border-sky-500/30 bg-sky-500/10 text-sky-300'
+                  : 'border-slate-700 bg-slate-950 text-slate-300'
+              }`}
+            >
+              Private Draft
+            </button>
+            <button
+              onClick={() => setPublicationMode('public')}
+              className={`rounded-lg border px-3 py-2 text-sm ${
+                publicationMode === 'public'
+                  ? 'border-violet-500/30 bg-violet-500/10 text-violet-300'
+                  : 'border-slate-700 bg-slate-950 text-slate-300'
+              }`}
+            >
+              Public EPICON
+            </button>
+          </div>
+        </div>
+
+        {publicationMode === 'public' ? (
+          <div className="mt-5">
+            <div className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              MIC Stake
+            </div>
+            <div className="mt-3 flex gap-2">
+              {[0, 1, 3, 5].map((value) => (
+                <button
+                  key={value}
+                  onClick={() => setStake(value)}
+                  className={`rounded-lg border px-3 py-2 text-sm ${
+                    stake === value
+                      ? 'border-amber-500/30 bg-amber-500/10 text-amber-300'
+                      : 'border-slate-700 bg-slate-950 text-slate-300'
+                  }`}
+                >
+                  {value} MIC
+                </button>
+              ))}
+            </div>
+
+            <div className="mt-3 text-xs text-slate-500">
+              Verified → stake returned + future reward layer
+              <br />
+              Inconclusive → stake returned
+              <br />
+              Contradicted → stake eligible for burn in later settlement layer
+            </div>
+          </div>
+        ) : null}
+
+        <div className="mt-5 rounded-xl border border-dashed border-slate-700 p-4 text-sm text-slate-400">
+          Asking questions is free. Staking only applies when making a public claim.
+        </div>
+
+        <div className="mt-5 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="rounded-lg border border-slate-700 px-4 py-2 text-sm text-slate-300 hover:bg-slate-800"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={loading}
+            className="rounded-lg border border-sky-500/30 bg-sky-500/10 px-4 py-2 text-sm text-sky-300 hover:bg-sky-500/20 disabled:opacity-50"
+          >
+            {loading ? 'Publishing...' : 'Confirm'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/query/QueryResultCard.tsx
+++ b/components/query/QueryResultCard.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import PublishEpiconModal from './PublishEpiconModal';
+
+type QueryResult = {
+  id: string;
+  query: string;
+  title: string;
+  summary: string;
+  sources: readonly string[];
+  tags: readonly string[];
+  confidence: number;
+  agents_used: readonly string[];
+  created_at: string;
+};
+
+export default function QueryResultCard({
+  result,
+}: {
+  result: QueryResult;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-4 text-slate-100">
+        <div className="text-xs uppercase tracking-[0.14em] text-slate-500">
+          Query Result
+        </div>
+
+        <div className="mt-2 text-lg font-semibold text-white">{result.title}</div>
+        <div className="mt-2 text-sm text-slate-300">{result.summary}</div>
+
+        <div className="mt-3 flex flex-wrap gap-2">
+          {result.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-md bg-slate-800 px-2 py-1 text-[10px] uppercase tracking-[0.12em] text-slate-300"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+
+        <div className="mt-3 text-xs text-slate-500">
+          Confidence: {result.confidence.toFixed(2)} · Agents: {result.agents_used.join(', ')}
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-2">
+          <button
+            className="rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 hover:bg-slate-800"
+            onClick={() => alert('Saved to dashboard')}
+          >
+            Save to Dashboard
+          </button>
+
+          <button
+            className="rounded-lg border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-sm text-sky-300 hover:bg-sky-500/20"
+            onClick={() => setOpen(true)}
+          >
+            Publish to EPICON
+          </button>
+
+          <button
+            className="rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 hover:bg-slate-800"
+            onClick={() => alert('Follow-up flow next')}
+          >
+            Ask Follow-Up
+          </button>
+        </div>
+      </div>
+
+      <PublishEpiconModal
+        open={open}
+        onClose={() => setOpen(false)}
+        result={result}
+      />
+    </>
+  );
+}

--- a/lib/mock/queryResult.ts
+++ b/lib/mock/queryResult.ts
@@ -1,0 +1,12 @@
+export const mockQueryResult = {
+  id: 'query-c256-001',
+  query: 'ZEUS give me a volatility report on BTC and comparing it to Oil',
+  title: 'BTC vs Oil volatility snapshot',
+  summary:
+    'BTC remains high-beta and sentiment-sensitive, while oil is currently driven more directly by geopolitical supply risk. Correlation is unstable and regime-dependent.',
+  sources: ['Coinbase', 'Macro feed', 'Energy feed'],
+  tags: ['btc', 'oil', 'volatility', 'macro'],
+  confidence: 0.74,
+  agents_used: ['ECHO', 'ZEUS', 'ATLAS'],
+  created_at: '2026-03-20T12:00:00Z',
+} as const;


### PR DESCRIPTION
### Motivation
- Provide a first Query → EPICON publication path so analysts can turn useful terminal query results into ledger-native artifacts.
- Support deliberate public publication with optional MIC staking while preserving free querying and private-draft workflows.
- Seed the UI and API surface with a mock result so the flow can be tested prior to backend persistence and settlement logic.

### Description
- Add a query result card UI with Save / Publish / Ask Follow-Up actions in `components/query/QueryResultCard.tsx` and a claim preview + publication modal in `components/query/PublishEpiconModal.tsx`.
- Implement a lightweight publish API at `app/api/epicon/publish/route.ts` that returns a pending EPICON record including `publication_mode`, optional `mic_stake`, `confidence_tier`, and a starter `trace`.
- Add mock seed data in `lib/mock/queryResult.ts` and wire the `QueryResultCard` into the Terminal search chamber in `app/terminal/page.tsx` for manual validation.
- Keep economic and settlement logic out of scope (no MIC settlement, MII mutations, or database persistence in this change).

### Testing
- Ran `npm run build` which completed successfully and performed TypeScript checks and page generation without errors.
- The build output lists the new route `ƒ /api/epicon/publish`, confirming the API is included in the app manifest.
- Addressed a TypeScript readonly-array mismatch during the rollout and re-ran the build to verify the fix and successful compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdabed2910832d8e71478c1e722f60)