### PR TITLE
feat(mic): add settlement logic for verified, inconclusive, and contradicted EPICON claims

### DIFF
--- a/app/api/epicon/publish/route.ts
+++ b/app/api/epicon/publish/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { lockStake } from '@/lib/mic/store';
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
@@ -14,6 +15,7 @@ export async function POST(req: NextRequest) {
     publication_mode: body.publication_mode,
     mic_stake: body.publication_mode === 'public' ? body.mic_stake || 0 : 0,
     agents_used: body.agents_used || [],
+    submitted_by_login: body.submitted_by_login || 'anonymous',
     created_at: new Date().toISOString(),
     trace: [
       'Query result transformed into EPICON candidate',
@@ -22,8 +24,19 @@ export async function POST(req: NextRequest) {
     ],
   };
 
+  let stake_lock = null;
+
+  if (record.publication_mode === 'public' && record.mic_stake > 0) {
+    stake_lock = lockStake({
+      epicon_id: record.id,
+      login: record.submitted_by_login,
+      stake: record.mic_stake,
+    });
+  }
+
   return NextResponse.json({
     ok: true,
     record,
+    stake_lock,
   });
 }

--- a/app/api/mic/settle/route.ts
+++ b/app/api/mic/settle/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { settleEpiconClaim } from '@/lib/mic/settle';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+
+    const result = settleEpiconClaim({
+      epicon_id: body.epicon_id,
+      outcome: body.outcome,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      settlement: result,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : 'Settlement failed',
+      },
+      { status: 400 },
+    );
+  }
+}

--- a/lib/mic/settle.ts
+++ b/lib/mic/settle.ts
@@ -1,0 +1,54 @@
+import {
+  creditMic,
+  getMicAccount,
+  getStakeLock,
+  settleStakeLock,
+} from './store';
+
+export type SettlementOutcome = 'verified' | 'inconclusive' | 'contradicted';
+
+export function settleEpiconClaim(input: {
+  epicon_id: string;
+  outcome: SettlementOutcome;
+}) {
+  const lock = getStakeLock(input.epicon_id);
+
+  if (!lock) {
+    throw new Error('No stake lock found for EPICON');
+  }
+
+  if (lock.status === 'settled') {
+    throw new Error('Stake lock already settled');
+  }
+
+  const login = lock.login;
+  const stake = lock.stake;
+
+  let returned_stake = 0;
+  let reward = 0;
+  let burned = 0;
+
+  if (input.outcome === 'verified') {
+    returned_stake = stake;
+    reward = 3;
+    creditMic(login, returned_stake + reward);
+  } else if (input.outcome === 'inconclusive') {
+    returned_stake = stake;
+    creditMic(login, returned_stake);
+  } else if (input.outcome === 'contradicted') {
+    burned = stake;
+  }
+
+  settleStakeLock(input.epicon_id);
+
+  return {
+    epicon_id: input.epicon_id,
+    login,
+    outcome: input.outcome,
+    returned_stake,
+    reward,
+    burned,
+    balance: getMicAccount(login).balance,
+    settled_at: new Date().toISOString(),
+  };
+}

--- a/lib/mic/store.ts
+++ b/lib/mic/store.ts
@@ -1,0 +1,81 @@
+export type MicAccount = {
+  login: string;
+  balance: number;
+};
+
+export type StakeLock = {
+  epicon_id: string;
+  login: string;
+  stake: number;
+  status: 'locked' | 'settled';
+  created_at: string;
+};
+
+const balances = new Map<string, MicAccount>();
+const stakeLocks = new Map<string, StakeLock>();
+
+export function ensureMicAccount(login: string) {
+  if (!balances.has(login)) {
+    balances.set(login, {
+      login,
+      balance: 100,
+    });
+  }
+
+  return balances.get(login)!;
+}
+
+export function getMicAccount(login: string) {
+  return ensureMicAccount(login);
+}
+
+export function lockStake(input: {
+  epicon_id: string;
+  login: string;
+  stake: number;
+}) {
+  const account = ensureMicAccount(input.login);
+
+  if (input.stake > account.balance) {
+    throw new Error('Insufficient MIC balance');
+  }
+
+  account.balance -= input.stake;
+
+  const lock: StakeLock = {
+    epicon_id: input.epicon_id,
+    login: input.login,
+    stake: input.stake,
+    status: 'locked',
+    created_at: new Date().toISOString(),
+  };
+
+  stakeLocks.set(input.epicon_id, lock);
+  return lock;
+}
+
+export function getStakeLock(epicon_id: string) {
+  return stakeLocks.get(epicon_id) || null;
+}
+
+export function settleStakeLock(epicon_id: string) {
+  const lock = stakeLocks.get(epicon_id);
+  if (!lock) {
+    return null;
+  }
+
+  lock.status = 'settled';
+  return lock;
+}
+
+export function creditMic(login: string, amount: number) {
+  const account = ensureMicAccount(login);
+  account.balance += amount;
+  return account;
+}
+
+export function debitMic(login: string, amount: number) {
+  const account = ensureMicAccount(login);
+  account.balance -= amount;
+  return account;
+}


### PR DESCRIPTION
### Motivation

- Introduce a minimal MIC settlement layer so public EPICON publications carry economic consequences and enable a simple claim → review → settlement loop.  
- Provide in-memory tooling for staking, balance updates, and a manual settlement endpoint without adding persistence, MII changes, or wallet integration.

### Description

- Added an in-memory MIC ledger and stake lock store with starter balances and credit/debit helpers in `lib/mic/store.ts`.  
- Implemented the settlement engine `settleEpiconClaim` with `verified`, `inconclusive`, and `contradicted` rules in `lib/mic/settle.ts` (verified returns stake + fixed reward, inconclusive returns stake, contradicted burns stake).  
- Added a manual settlement API `POST /api/mic/settle` in `app/api/mic/settle/route.ts` which returns structured settlement responses or errors.  
- Updated `POST /api/epicon/publish` in `app/api/epicon/publish/route.ts` to lock stake on public publishes and return the created `stake_lock` alongside the pending EPICON record.

### Testing

- Ran TypeScript checks with `npx tsc --noEmit`, which completed successfully.  
- Built the app with `npm run build`, which compiled and produced a successful build.  
- Ran `npm run lint` which triggered Next.js/ESLint interactive setup in this repo (did not complete automated lint resolution).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdf79ff264832d939b538a7a68429e)