### PR TITLE
feat(gi): make Global Integrity reactive to signal engine and tripwire state

### DIFF
--- a/app/api/epicon/feed/route.ts
+++ b/app/api/epicon/feed/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { getPublicEpiconFeed } from '@/lib/epicon/feedStore';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const items = getPublicEpiconFeed();
+
+  return NextResponse.json({
+    ok: true,
+    count: items.length,
+    items,
+  });
+}

--- a/app/api/epicon/publish/route.ts
+++ b/app/api/epicon/publish/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { addPublicEpicon } from '@/lib/epicon/feedStore';
 import { lockStake } from '@/lib/mic/store';
 
 export async function POST(req: NextRequest) {
@@ -6,7 +7,7 @@ export async function POST(req: NextRequest) {
 
   const record = {
     id: `EPICON-${Math.random().toString(36).slice(2, 10).toUpperCase()}`,
-    status: 'pending',
+    status: 'pending' as const,
     title: body.title,
     summary: body.summary,
     sources: body.sources || [],
@@ -15,7 +16,7 @@ export async function POST(req: NextRequest) {
     publication_mode: body.publication_mode,
     mic_stake: body.publication_mode === 'public' ? body.mic_stake || 0 : 0,
     agents_used: body.agents_used || [],
-    submitted_by_login: body.submitted_by_login || 'anonymous',
+    submitted_by_login: body.submitted_by_login || 'kaizencycle',
     created_at: new Date().toISOString(),
     trace: [
       'Query result transformed into EPICON candidate',
@@ -32,6 +33,10 @@ export async function POST(req: NextRequest) {
       login: record.submitted_by_login,
       stake: record.mic_stake,
     });
+  }
+
+  if (record.publication_mode === 'public') {
+    addPublicEpicon(record);
   }
 
   return NextResponse.json({

--- a/app/api/integrity-status/route.ts
+++ b/app/api/integrity-status/route.ts
@@ -1,6 +1,53 @@
 import { NextResponse } from 'next/server';
+import { computeGI } from '@/lib/gi/compute';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
+import { getEchoEpicon } from '@/lib/echo/store';
 import { integrityStatus } from '@/lib/mock/integrityStatus';
+import { getHeartbeat } from '@/lib/runtime/heartbeat';
+import { getStalenessStatus } from '@/lib/runtime/staleness';
+import { scoreBatch } from '@/lib/echo/signal-engine';
+import { mockAgents, mockEpicon } from '@/lib/terminal/mock';
+import { getTripwireState } from '@/lib/tripwire/store';
+
+export const dynamic = 'force-dynamic';
+
+function resolveSignalQuality() {
+  const epicon = getEchoEpicon();
+  const items = epicon.length > 0 ? epicon : mockEpicon;
+  return scoreBatch(items).map((score) => score.signal);
+}
+
+function resolveActiveAgentCount() {
+  return mockAgents.filter((agent) => agent.heartbeatOk && agent.status !== 'idle').length;
+}
 
 export async function GET() {
-  return NextResponse.json(integrityStatus);
+  const freshness = getStalenessStatus(getHeartbeat());
+  const tripwire = getTripwireState();
+  const computed = computeGI({
+    zeusScores: resolveSignalQuality(),
+    freshness: freshness.status,
+    tripwire: tripwire.level,
+    activeAgents: resolveActiveAgentCount(),
+  });
+
+  return NextResponse.json({
+    ok: true,
+    cycle: currentCycleId(),
+    timestamp: computed.timestamp,
+    global_integrity: computed.global_integrity,
+    mode: computed.mode,
+    mii_baseline: integrityStatus.mii_baseline,
+    mic_supply: integrityStatus.mic_supply,
+    terminal_status: computed.terminal_status,
+    primary_driver: computed.primary_driver,
+    summary: computed.summary,
+    signals: {
+      ...computed.signals,
+      geopolitics: computed.signals.quality,
+      economy: computed.signals.system,
+      sentiment: computed.signals.stability,
+      information: computed.signals.freshness,
+    },
+  });
 }

--- a/app/api/mic/account/route.ts
+++ b/app/api/mic/account/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getMicAccount } from '@/lib/mic/store';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const login = req.nextUrl.searchParams.get('login') || 'kaizencycle';
+  const account = getMicAccount(login);
+
+  return NextResponse.json({
+    ok: true,
+    account: {
+      login: account.login,
+      balance: account.balance,
+      locked: 0,
+      rewards_earned: 0,
+      mic_burned: 0,
+      updated_at: new Date().toISOString(),
+    },
+  });
+}

--- a/app/epicon/page.tsx
+++ b/app/epicon/page.tsx
@@ -1,0 +1,9 @@
+import EpiconFeedPage from '@/components/epicon/EpiconFeedPage';
+
+export default function EpiconPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 p-6 text-slate-100">
+      <EpiconFeedPage />
+    </main>
+  );
+}

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -258,6 +258,7 @@ function TerminalPage() {
         primaryDriver={primaryDriver}
         cycleId={cycleId}
         streamStatus={streamStatus}
+        giMode={gi.mode}
         onNavigate={setSelectedNav}
         onShowGI={() => {
           setSelectedNav('governance');

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -18,6 +18,7 @@ import PulseTimeline from '@/components/signals/PulseTimeline';
 import TripwireWatchCard from '@/components/terminal/TripwireWatchCard';
 import TripwirePanel from '@/components/tripwire/TripwirePanel';
 import DetailInspectorRail from '@/components/terminal/DetailInspectorRail';
+import MicAccountPanel from '@/components/mic/MicAccountPanel';
 import type { ZeusVerifyPayload, ZeusVerifyResult } from '@/components/terminal/DetailInspectorRail';
 import CommandPalette from '@/components/terminal/CommandPalette';
 import QueryResultCard from '@/components/query/QueryResultCard';
@@ -250,7 +251,6 @@ function TerminalPage() {
   return (
     <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
       <TopStatusBar
-        gi={gi.score}
         alertCount={allTripwires.length + criticalAlertCount}
         mii={liveRibbonMii}
         micSupply={micSupply}
@@ -258,12 +258,7 @@ function TerminalPage() {
         primaryDriver={primaryDriver}
         cycleId={cycleId}
         streamStatus={streamStatus}
-        giMode={gi.mode}
         onNavigate={setSelectedNav}
-        onShowGI={() => {
-          setSelectedNav('governance');
-          setInspectorTarget({ kind: 'gi', data: gi });
-        }}
       />
 
       <LiveIntegrityRibbon
@@ -418,18 +413,23 @@ function TerminalPage() {
 
         <DetailInspectorRail
           target={inspectorTarget}
-          prependContent={inspectorTarget.kind === 'epicon' ? (
-            <AttestationReplayRail
-              event={inspectorTarget.data}
-              relatedLedger={relatedLedgerEntry}
-              onAction={(actionId) => {
-                setOperatorMessage(`Replay rail action queued: ${actionId}`);
-                if (actionId === 'compare') {
-                  setSelectedNav('governance');
-                }
-              }}
-            />
-          ) : null}
+          prependContent={
+            <>
+              <MicAccountPanel />
+              {inspectorTarget.kind === 'epicon' ? (
+                <AttestationReplayRail
+                  event={inspectorTarget.data}
+                  relatedLedger={relatedLedgerEntry}
+                  onAction={(actionId) => {
+                    setOperatorMessage(`Replay rail action queued: ${actionId}`);
+                    if (actionId === 'compare') {
+                      setSelectedNav('governance');
+                    }
+                  }}
+                />
+              ) : null}
+            </>
+          }
           onZeusVerify={async (payload: ZeusVerifyPayload): Promise<ZeusVerifyResult> => {
             try {
               const response = await fetch('/api/zeus/verify', {

--- a/components/epicon/EpiconFeedCard.tsx
+++ b/components/epicon/EpiconFeedCard.tsx
@@ -1,0 +1,76 @@
+import type { PublicEpiconRecord } from '@/lib/epicon/feedStore';
+
+function statusTone(status: PublicEpiconRecord['status']) {
+  switch (status) {
+    case 'verified':
+      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300';
+    case 'contradicted':
+      return 'border-rose-500/30 bg-rose-500/10 text-rose-300';
+    case 'developing':
+      return 'border-sky-500/30 bg-sky-500/10 text-sky-300';
+    default:
+      return 'border-amber-500/30 bg-amber-500/10 text-amber-300';
+  }
+}
+
+export default function EpiconFeedCard({
+  item,
+}: {
+  item: PublicEpiconRecord;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-[11px] uppercase tracking-[0.14em] text-slate-500">
+            {item.id}
+          </div>
+          <div className="mt-1 text-sm font-semibold text-white">{item.title}</div>
+        </div>
+
+        <div
+          className={`rounded-md border px-2 py-1 text-[10px] uppercase tracking-[0.14em] ${statusTone(
+            item.status,
+          )}`}
+        >
+          {item.status}
+        </div>
+      </div>
+
+      <div className="mt-3 text-sm text-slate-300">{item.summary}</div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {item.tags.map((tag) => (
+          <span
+            key={tag}
+            className="rounded-md bg-slate-800 px-2 py-1 text-[10px] uppercase tracking-[0.12em] text-slate-300"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-3 text-xs text-slate-400">
+        <div>
+          <span className="text-slate-500">Confidence:</span>{' '}
+          {item.confidence_tier}
+        </div>
+        <div>
+          <span className="text-slate-500">Stake:</span> {item.mic_stake} MIC
+        </div>
+        <div>
+          <span className="text-slate-500">By:</span>{' '}
+          @{item.submitted_by_login || 'unknown'}
+        </div>
+        <div>
+          <span className="text-slate-500">Agents:</span>{' '}
+          {item.agents_used.join(', ')}
+        </div>
+      </div>
+
+      <div className="mt-3 text-xs text-slate-500">
+        {new Date(item.created_at).toLocaleString()}
+      </div>
+    </div>
+  );
+}

--- a/components/epicon/EpiconFeedPage.tsx
+++ b/components/epicon/EpiconFeedPage.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { PublicEpiconRecord } from '@/lib/epicon/feedStore';
+import EpiconFeedCard from './EpiconFeedCard';
+
+export default function EpiconFeedPage() {
+  const [items, setItems] = useState<PublicEpiconRecord[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function load() {
+      const res = await fetch('/api/epicon/feed', { cache: 'no-store' });
+      const json = await res.json();
+      if (mounted) setItems(json.items || []);
+    }
+
+    load();
+    const interval = setInterval(load, 5000);
+    return () => {
+      mounted = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-4">
+      <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-4">
+        <div className="text-xs uppercase tracking-[0.2em] text-slate-400">
+          EPICON Feed
+        </div>
+        <div className="mt-2 text-lg font-semibold text-white">
+          Public Mobius Memory
+        </div>
+        <div className="mt-1 text-sm text-slate-400">
+          Pending, developing, verified, and contradicted public knowledge artifacts.
+        </div>
+      </div>
+
+      {items.length === 0 ? (
+        <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 text-slate-400">
+          No public EPICON entries yet.
+        </div>
+      ) : (
+        items.map((item) => <EpiconFeedCard key={item.id} item={item} />)
+      )}
+    </div>
+  );
+}

--- a/components/gi/GIMonitorBadge.tsx
+++ b/components/gi/GIMonitorBadge.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { IntegrityStatusResponse } from '@/lib/mock/integrityStatus';
+import GIMonitorOverlay from './GIMonitorOverlay';
+
+type GIData = Pick<
+  IntegrityStatusResponse,
+  'cycle' | 'global_integrity' | 'mode' | 'terminal_status' | 'primary_driver' | 'summary' | 'timestamp'
+> & {
+  signals: Pick<IntegrityStatusResponse['signals'], 'quality' | 'freshness' | 'stability' | 'system'>;
+};
+
+function statusTone(status: GIData['terminal_status']) {
+  switch (status) {
+    case 'nominal':
+      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300';
+    case 'stressed':
+      return 'border-amber-500/30 bg-amber-500/10 text-amber-300';
+    case 'critical':
+      return 'border-rose-500/30 bg-rose-500/10 text-rose-300';
+    default:
+      return 'border-slate-700 bg-slate-900 text-slate-300';
+  }
+}
+
+function normalizeGIData(json: IntegrityStatusResponse): GIData {
+  return {
+    cycle: json.cycle,
+    global_integrity: json.global_integrity,
+    mode: json.mode,
+    terminal_status: json.terminal_status,
+    primary_driver: json.primary_driver,
+    summary: json.summary,
+    timestamp: json.timestamp,
+    signals: {
+      quality: json.signals.quality,
+      freshness: json.signals.freshness,
+      stability: json.signals.stability,
+      system: json.signals.system,
+    },
+  };
+}
+
+export default function GIMonitorBadge() {
+  const [data, setData] = useState<GIData | null>(null);
+  const [hovered, setHovered] = useState(false);
+  const [open, setOpen] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function load() {
+      try {
+        const res = await fetch('/api/integrity-status', { cache: 'no-store' });
+        const json = await res.json();
+        if (mounted) setData(normalizeGIData(json));
+      } catch {
+        if (mounted) setData(null);
+      }
+    }
+
+    load();
+    const interval = window.setInterval(load, 15000);
+
+    return () => {
+      mounted = false;
+      window.clearInterval(interval);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  if (!data) {
+    return (
+      <div className="rounded-md border border-slate-700 bg-slate-900 px-3 py-1.5 text-xs text-slate-400">
+        GI loading...
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="relative"
+      onMouseEnter={() => {
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        setHovered(true);
+      }}
+      onMouseLeave={() => {
+        timeoutRef.current = setTimeout(() => setHovered(false), 120);
+      }}
+    >
+      <button
+        onClick={() => setOpen((value) => !value)}
+        className={`rounded-md border px-3 py-1.5 text-xs uppercase tracking-[0.14em] ${statusTone(
+          data.terminal_status,
+        )}`}
+      >
+        GI {(data.global_integrity * 100).toFixed(0)}%
+      </button>
+
+      {hovered && !open ? (
+        <div className="absolute right-0 top-10 z-40 w-[260px] rounded-xl border border-slate-800 bg-slate-900 p-3 shadow-xl">
+          <div className="text-xs uppercase tracking-[0.18em] text-slate-400">
+            GI Preview
+          </div>
+          <div className="mt-2 text-lg font-semibold text-white">
+            {(data.global_integrity * 100).toFixed(0)}% · {data.terminal_status}
+          </div>
+          <div className="mt-2 text-sm text-slate-300">{data.primary_driver}</div>
+          <div className="mt-2 text-xs text-slate-500">
+            Updated {new Date(data.timestamp).toLocaleString()}
+          </div>
+        </div>
+      ) : null}
+
+      {open ? <GIMonitorOverlay data={data} onClose={() => setOpen(false)} /> : null}
+    </div>
+  );
+}

--- a/components/gi/GIMonitorOverlay.tsx
+++ b/components/gi/GIMonitorOverlay.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import type { IntegrityStatusResponse } from '@/lib/mock/integrityStatus';
+
+type GIData = Pick<
+  IntegrityStatusResponse,
+  'cycle' | 'global_integrity' | 'mode' | 'terminal_status' | 'primary_driver' | 'summary' | 'timestamp'
+> & {
+  signals: Pick<IntegrityStatusResponse['signals'], 'quality' | 'freshness' | 'stability' | 'system'>;
+};
+
+function barWidth(value: number) {
+  return `${Math.max(6, Math.round(value * 100))}%`;
+}
+
+export default function GIMonitorOverlay({
+  data,
+  onClose,
+}: {
+  data: GIData;
+  onClose: () => void;
+}) {
+  return (
+    <div className="absolute right-0 top-10 z-50 w-[360px] rounded-2xl border border-slate-800 bg-slate-900 p-4 shadow-2xl">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-xs uppercase tracking-[0.2em] text-slate-400">
+            Global Integrity Monitor
+          </div>
+          <div className="mt-2 text-2xl font-bold text-white">
+            {(data.global_integrity * 100).toFixed(0)}%
+          </div>
+        </div>
+
+        <button
+          onClick={onClose}
+          className="rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-300 hover:bg-slate-800"
+        >
+          Close
+        </button>
+      </div>
+
+      <div className="mt-2 text-sm text-slate-400">
+        Mode: <span className="text-white">{data.mode}</span>
+      </div>
+      <div className="mt-1 text-sm text-slate-400">
+        Status: <span className="text-white">{data.terminal_status}</span>
+      </div>
+      <div className="mt-1 text-sm text-slate-400">
+        Driver: <span className="text-white">{data.primary_driver}</span>
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {Object.entries(data.signals).map(([key, value]) => (
+          <div key={key}>
+            <div className="mb-1 flex items-center justify-between text-xs uppercase tracking-[0.12em] text-slate-400">
+              <span>{key}</span>
+              <span>{value.toFixed(2)}</span>
+            </div>
+            <div className="h-2 rounded-full bg-slate-800">
+              <div
+                className="h-2 rounded-full bg-sky-400"
+                style={{ width: barWidth(value) }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 rounded-lg border border-slate-800 bg-slate-950 p-3 text-sm text-slate-300">
+        {data.summary}
+      </div>
+
+      <div className="mt-3 text-xs text-slate-500">
+        {data.cycle} · Updated {new Date(data.timestamp).toLocaleString()}
+      </div>
+    </div>
+  );
+}

--- a/components/mic/MicAccountPanel.tsx
+++ b/components/mic/MicAccountPanel.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type MicAccount = {
+  login: string;
+  balance: number;
+  locked: number;
+  rewards_earned: number;
+  mic_burned: number;
+  updated_at: string;
+};
+
+function MiniStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-950 p-3">
+      <div className="text-[11px] uppercase tracking-[0.14em] text-slate-500">
+        {label}
+      </div>
+      <div className="mt-1 text-sm font-semibold text-white">{value}</div>
+    </div>
+  );
+}
+
+export default function MicAccountPanel() {
+  const [account, setAccount] = useState<MicAccount | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function load() {
+      try {
+        const res = await fetch('/api/mic/account?login=kaizencycle', {
+          cache: 'no-store',
+        });
+        const json = await res.json();
+        if (mounted) setAccount(json.account || null);
+      } catch {
+        if (mounted) setAccount(null);
+      }
+    }
+
+    load();
+    const interval = window.setInterval(load, 15000);
+
+    return () => {
+      mounted = false;
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  if (!account) {
+    return (
+      <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-4 text-slate-400">
+        Loading MIC account...
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-4">
+      <div className="text-xs uppercase tracking-[0.2em] text-slate-400">
+        MIC Account
+      </div>
+
+      <div className="mt-2 text-lg font-semibold text-white">
+        @{account.login}
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <MiniStat label="Balance" value={String(account.balance)} />
+        <MiniStat label="Locked" value={String(account.locked)} />
+        <MiniStat label="Rewards" value={String(account.rewards_earned)} />
+        <MiniStat label="Burned" value={String(account.mic_burned)} />
+      </div>
+
+      <div className="mt-3 text-xs text-slate-500">
+        Updated: {new Date(account.updated_at).toLocaleString()}
+      </div>
+    </div>
+  );
+}

--- a/components/query/PublishEpiconModal.tsx
+++ b/components/query/PublishEpiconModal.tsx
@@ -46,6 +46,7 @@ export default function PublishEpiconModal({
           agents_used: result.agents_used,
           publication_mode: publicationMode,
           mic_stake: publicationMode === 'public' ? stake : 0,
+          submitted_by_login: 'kaizencycle',
         }),
       });
 
@@ -56,7 +57,7 @@ export default function PublishEpiconModal({
       onClose();
       alert(
         publicationMode === 'public'
-          ? 'EPICON published in pending state'
+          ? 'EPICON published in pending state and added to the public feed'
           : 'Private draft saved',
       );
     } catch (err) {

--- a/components/query/QueryResultCard.tsx
+++ b/components/query/QueryResultCard.tsx
@@ -68,6 +68,13 @@ export default function QueryResultCard({
           >
             Ask Follow-Up
           </button>
+
+          <a
+            href="/epicon"
+            className="rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 hover:bg-slate-800"
+          >
+            Open EPICON Feed
+          </a>
         </div>
       </div>
 

--- a/components/terminal/DetailInspectorRail.tsx
+++ b/components/terminal/DetailInspectorRail.tsx
@@ -454,16 +454,16 @@ function GIView({ data }: { data: InspectorTarget & { kind: 'gi' } }) {
 
       <div className="grid grid-cols-2 gap-3">
         <InspectorStat
-          label="Institutional Trust"
-          value={`${Math.round(gi.institutionalTrust * 100)}%`}
+          label="GI Mode"
+          value={(gi.mode ?? 'yellow').toUpperCase()}
         />
         <InspectorStat
-          label="Info Reliability"
-          value={`${Math.round(gi.infoReliability * 100)}%`}
+          label="Terminal Status"
+          value={(gi.terminalStatus ?? 'stressed').toUpperCase()}
         />
         <InspectorStat
-          label="Consensus Stability"
-          value={`${Math.round(gi.consensusStability * 100)}%`}
+          label="Primary Driver"
+          value={gi.primaryDriver ?? 'No primary driver available'}
         />
         <InspectorStat
           label="Weekly Avg"
@@ -477,9 +477,10 @@ function GIView({ data }: { data: InspectorTarget & { kind: 'gi' } }) {
         <SmallLabel>Score Breakdown</SmallLabel>
         <div className="mt-2 space-y-3">
           {[
-            { label: 'Institutional Trust', value: gi.institutionalTrust },
-            { label: 'Info Reliability', value: gi.infoReliability },
-            { label: 'Consensus Stability', value: gi.consensusStability },
+            { label: 'Signal Quality', value: gi.signalBreakdown?.quality ?? gi.institutionalTrust },
+            { label: 'Signal Freshness', value: gi.signalBreakdown?.freshness ?? gi.infoReliability },
+            { label: 'Tripwire Stability', value: gi.signalBreakdown?.stability ?? gi.consensusStability },
+            { label: 'System Health', value: gi.signalBreakdown?.system ?? gi.score },
           ].map((m) => {
             const pct = Math.round(m.value * 100);
             return (

--- a/components/terminal/IntegrityMonitorCard.tsx
+++ b/components/terminal/IntegrityMonitorCard.tsx
@@ -119,7 +119,10 @@ export default function IntegrityMonitorCard({
       onClick={onClick}
       className="group w-full rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-left transition hover:border-slate-700 hover:bg-slate-900/80"
     >
-      <SectionLabel title="GI Monitor" subtitle="Civic integrity signal" />
+      <SectionLabel
+        title="GI Monitor"
+        subtitle={gi.summary ?? `Civic integrity signal${gi.mode ? ` · ${gi.mode.toUpperCase()}` : ''}`}
+      />
 
       <div className="mt-3 flex flex-col gap-4 sm:flex-row sm:items-start">
         <div className="relative shrink-0 self-center sm:self-start" style={{ width: 160, height: 160 }}>
@@ -173,9 +176,10 @@ export default function IntegrityMonitorCard({
 
         <div className="min-w-0 flex-1 pt-1">
           <div className="space-y-2">
-            <MetricLabel label="Institutional Trust" value={gi.institutionalTrust} color="bg-sky-400" />
-            <MetricLabel label="Info Reliability" value={gi.infoReliability} color="bg-violet-400" />
-            <MetricLabel label="Consensus Stability" value={gi.consensusStability} color="bg-amber-400" />
+            <MetricLabel label="Signal Quality" value={gi.signalBreakdown?.quality ?? gi.institutionalTrust} color="bg-sky-400" />
+            <MetricLabel label="Signal Freshness" value={gi.signalBreakdown?.freshness ?? gi.infoReliability} color="bg-violet-400" />
+            <MetricLabel label="Tripwire Stability" value={gi.signalBreakdown?.stability ?? gi.consensusStability} color="bg-amber-400" />
+            <MetricLabel label="System Health" value={gi.signalBreakdown?.system ?? gi.score} color="bg-emerald-400" />
           </div>
 
           <div className="mt-4 rounded-lg border border-slate-800/60 bg-slate-950/50 p-2">

--- a/components/terminal/TopStatusBar.tsx
+++ b/components/terminal/TopStatusBar.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import GIMonitorBadge from '@/components/gi/GIMonitorBadge';
 import type { NavKey } from '@/lib/terminal/types';
-import { cn, giScoreColor } from '@/lib/terminal/utils';
+import { cn } from '@/lib/terminal/utils';
 
 function Chip({
   label,
@@ -74,7 +75,6 @@ const clockFormatter = new Intl.DateTimeFormat('en-US', {
 export type StreamStatus = 'live' | 'reconnecting' | 'offline';
 
 export default function TopStatusBar({
-  gi,
   mii,
   micSupply,
   terminalStatus,
@@ -82,11 +82,8 @@ export default function TopStatusBar({
   alertCount,
   cycleId = 'C-253',
   streamStatus = 'offline',
-  giMode,
   onNavigate,
-  onShowGI,
 }: {
-  gi: number;
   mii: number;
   micSupply: number;
   terminalStatus: 'nominal' | 'stressed' | 'critical';
@@ -94,9 +91,7 @@ export default function TopStatusBar({
   alertCount: number;
   cycleId?: string;
   streamStatus?: StreamStatus;
-  giMode?: 'green' | 'yellow' | 'red';
   onNavigate: (key: NavKey) => void;
-  onShowGI: () => void;
 }) {
   const [clock, setClock] = useState('');
 
@@ -131,7 +126,7 @@ export default function TopStatusBar({
         <div className="hidden sm:flex flex-wrap items-center justify-end gap-2">
           <Chip label={cycleId} onClick={() => onNavigate('pulse')} />
           <Chip label={clock || 'Loading...'} />
-          <Chip label={`GI ${gi.toFixed(2)}${giMode ? ` · ${giMode.toUpperCase()}` : ''}`} tone={giScoreColor(gi).chip} onClick={onShowGI} />
+          <GIMonitorBadge />
           <Chip label={`MII ${mii.toFixed(2)}`} tone={mii >= 0.7 ? 'text-cyan-300 border-cyan-500/30 bg-cyan-500/10' : 'text-amber-300 border-amber-500/30 bg-amber-500/10'} onClick={() => onNavigate('wallet')} />
           <Chip label={`MIC ${micSupply.toLocaleString()}`} tone="text-violet-300 border-violet-500/30 bg-violet-500/10" onClick={() => onNavigate('wallet')} />
           <Chip label={terminalStatus} tone={statusTone} onClick={() => onNavigate('governance')} />
@@ -164,7 +159,7 @@ export default function TopStatusBar({
 
         <div className="flex sm:hidden items-center gap-2">
           <Chip label={cycleId} onClick={() => onNavigate('pulse')} />
-          <Chip label={`GI ${gi.toFixed(2)}${giMode ? ` · ${giMode.toUpperCase()}` : ''}`} tone={giScoreColor(gi).chip} onClick={onShowGI} />
+          <GIMonitorBadge />
           <Chip label={`MII ${mii.toFixed(2)}`} tone="text-cyan-300 border-cyan-500/30 bg-cyan-500/10" onClick={() => onNavigate('wallet')} />
           <Chip label={`${alertCount}`} tone="text-amber-300 border-amber-500/30 bg-amber-500/10" onClick={() => onNavigate('infrastructure')} />
         </div>

--- a/components/terminal/TopStatusBar.tsx
+++ b/components/terminal/TopStatusBar.tsx
@@ -82,6 +82,7 @@ export default function TopStatusBar({
   alertCount,
   cycleId = 'C-253',
   streamStatus = 'offline',
+  giMode,
   onNavigate,
   onShowGI,
 }: {
@@ -93,6 +94,7 @@ export default function TopStatusBar({
   alertCount: number;
   cycleId?: string;
   streamStatus?: StreamStatus;
+  giMode?: 'green' | 'yellow' | 'red';
   onNavigate: (key: NavKey) => void;
   onShowGI: () => void;
 }) {
@@ -129,7 +131,7 @@ export default function TopStatusBar({
         <div className="hidden sm:flex flex-wrap items-center justify-end gap-2">
           <Chip label={cycleId} onClick={() => onNavigate('pulse')} />
           <Chip label={clock || 'Loading...'} />
-          <Chip label={`GI ${gi.toFixed(2)}`} tone={giScoreColor(gi).chip} onClick={onShowGI} />
+          <Chip label={`GI ${gi.toFixed(2)}${giMode ? ` · ${giMode.toUpperCase()}` : ''}`} tone={giScoreColor(gi).chip} onClick={onShowGI} />
           <Chip label={`MII ${mii.toFixed(2)}`} tone={mii >= 0.7 ? 'text-cyan-300 border-cyan-500/30 bg-cyan-500/10' : 'text-amber-300 border-amber-500/30 bg-amber-500/10'} onClick={() => onNavigate('wallet')} />
           <Chip label={`MIC ${micSupply.toLocaleString()}`} tone="text-violet-300 border-violet-500/30 bg-violet-500/10" onClick={() => onNavigate('wallet')} />
           <Chip label={terminalStatus} tone={statusTone} onClick={() => onNavigate('governance')} />
@@ -162,7 +164,7 @@ export default function TopStatusBar({
 
         <div className="flex sm:hidden items-center gap-2">
           <Chip label={cycleId} onClick={() => onNavigate('pulse')} />
-          <Chip label={`GI ${gi.toFixed(2)}`} tone={giScoreColor(gi).chip} onClick={onShowGI} />
+          <Chip label={`GI ${gi.toFixed(2)}${giMode ? ` · ${giMode.toUpperCase()}` : ''}`} tone={giScoreColor(gi).chip} onClick={onShowGI} />
           <Chip label={`MII ${mii.toFixed(2)}`} tone="text-cyan-300 border-cyan-500/30 bg-cyan-500/10" onClick={() => onNavigate('wallet')} />
           <Chip label={`${alertCount}`} tone="text-amber-300 border-amber-500/30 bg-amber-500/10" onClick={() => onNavigate('infrastructure')} />
         </div>

--- a/hooks/useTerminalData.ts
+++ b/hooks/useTerminalData.ts
@@ -94,7 +94,7 @@ export function useTerminalData(selectedNav: NavKey) {
       setAgents(agentsData);
       setEpicon(epiconData);
       setIntegrityStatus(integrityData);
-      setGi(integrityStatusToGISnapshot(integrityData));
+      setGi((prev) => integrityStatusToGISnapshot(integrityData, prev?.score));
       setTripwires(tripwireData);
       setBackfillLedger(ledgerBackfillData);
       setInspectorTarget((prev) => prev ?? (epiconData[0] ? { kind: 'epicon', data: epiconData[0] } : null));

--- a/lib/epicon/feedStore.ts
+++ b/lib/epicon/feedStore.ts
@@ -1,0 +1,31 @@
+export type PublicEpiconRecord = {
+  id: string;
+  status: 'pending' | 'developing' | 'verified' | 'contradicted';
+  title: string;
+  summary: string;
+  sources: string[];
+  tags: string[];
+  confidence_tier: number;
+  publication_mode: 'public' | 'private_draft';
+  mic_stake: number;
+  agents_used: string[];
+  submitted_by_login?: string;
+  created_at: string;
+  trace: string[];
+};
+
+const publicFeed: PublicEpiconRecord[] = [];
+
+export function addPublicEpicon(record: PublicEpiconRecord) {
+  publicFeed.unshift(record);
+
+  if (publicFeed.length > 200) {
+    publicFeed.length = 200;
+  }
+
+  return record;
+}
+
+export function getPublicEpiconFeed() {
+  return publicFeed.slice();
+}

--- a/lib/gi/compute.ts
+++ b/lib/gi/compute.ts
@@ -1,0 +1,72 @@
+import { getGiMode } from './mode';
+
+type GIInput = {
+  zeusScores: number[];
+  freshness: 'fresh' | 'degraded' | 'stale';
+  tripwire: 'none' | 'watch' | 'elevated';
+  activeAgents: number;
+};
+
+function avg(values: number[]) {
+  if (!values.length) return 0.5;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+export function computeGI(input: GIInput) {
+  const quality = avg(input.zeusScores);
+
+  const freshnessMap = {
+    fresh: 1,
+    degraded: 0.6,
+    stale: 0.3,
+  } as const;
+
+  const tripwireMap = {
+    none: 1,
+    watch: 0.6,
+    elevated: 0.3,
+  } as const;
+
+  const system =
+    input.activeAgents >= 4 ? 1 :
+    input.activeAgents >= 2 ? 0.6 :
+    0.3;
+
+  const freshness = freshnessMap[input.freshness];
+  const stability = tripwireMap[input.tripwire];
+
+  const global_integrity =
+    0.35 * quality +
+    0.25 * freshness +
+    0.20 * stability +
+    0.20 * system;
+
+  const mode = getGiMode(global_integrity);
+
+  const terminal_status =
+    mode === 'green' ? 'nominal' :
+    mode === 'yellow' ? 'stressed' :
+    'critical';
+
+  const primary_driver =
+    mode === 'red'
+      ? 'System instability detected'
+      : mode === 'yellow'
+        ? 'Moderate signal degradation'
+        : 'System operating within normal parameters';
+
+  return {
+    global_integrity: Number(global_integrity.toFixed(2)),
+    mode,
+    terminal_status,
+    primary_driver,
+    summary: 'GI reflects signal quality, freshness, tripwire stability, and active system health.',
+    signals: {
+      quality: Number(quality.toFixed(2)),
+      freshness: Number(freshness.toFixed(2)),
+      stability: Number(stability.toFixed(2)),
+      system: Number(system.toFixed(2)),
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/gi/mode.ts
+++ b/lib/gi/mode.ts
@@ -1,0 +1,31 @@
+export type GIMode = 'green' | 'yellow' | 'red';
+
+export function getGiMode(gi: number): GIMode {
+  if (gi >= 0.8) return 'green';
+  if (gi >= 0.6) return 'yellow';
+  return 'red';
+}
+
+export const giModeConfig = {
+  green: {
+    label: 'Expansion',
+    rewardMultiplier: 1.0,
+    burnMultiplier: 1.0,
+    minStakeOptions: [0, 1, 3],
+    visibilityThreshold: 0.35,
+  },
+  yellow: {
+    label: 'Stabilization',
+    rewardMultiplier: 1.5,
+    burnMultiplier: 1.0,
+    minStakeOptions: [1, 3, 5],
+    visibilityThreshold: 0.5,
+  },
+  red: {
+    label: 'Defense',
+    rewardMultiplier: 2.0,
+    burnMultiplier: 1.5,
+    minStakeOptions: [3, 5, 8],
+    visibilityThreshold: 0.7,
+  },
+} as const;

--- a/lib/mock/integrityStatus.ts
+++ b/lib/mock/integrityStatus.ts
@@ -1,19 +1,28 @@
+import type { GIMode } from '@/lib/gi/mode';
+
+export type IntegritySignals = {
+  quality: number;
+  freshness: number;
+  stability: number;
+  system: number;
+  geopolitics: number;
+  economy: number;
+  sentiment: number;
+  information: number;
+};
+
 export type IntegrityStatusResponse = {
   ok: true;
   cycle: string;
   timestamp: string;
   global_integrity: number;
+  mode: GIMode;
   mii_baseline: number;
   mic_supply: number;
   terminal_status: 'nominal' | 'stressed' | 'critical';
   primary_driver: string;
   summary: string;
-  signals: {
-    geopolitics: number;
-    economy: number;
-    sentiment: number;
-    information: number;
-  };
+  signals: IntegritySignals;
 };
 
 export const integrityStatus: IntegrityStatusResponse = {
@@ -21,16 +30,21 @@ export const integrityStatus: IntegrityStatusResponse = {
   cycle: 'C-256',
   timestamp: '2026-03-20T11:34:00Z',
   global_integrity: 0.78,
+  mode: 'yellow',
   mii_baseline: 0.5,
   mic_supply: 1000000,
   terminal_status: 'stressed',
   primary_driver: 'Middle East energy instability',
   summary:
-    'Global system stable but stressed. Energy markets continue to drive macro uncertainty.',
+    'GI reflects signal quality, freshness, tripwire stability, and active system health.',
   signals: {
-    geopolitics: 0.65,
-    economy: 0.75,
+    quality: 0.8,
+    freshness: 0.6,
+    stability: 0.72,
+    system: 1,
+    geopolitics: 0.8,
+    economy: 1,
     sentiment: 0.72,
-    information: 0.8,
+    information: 0.6,
   },
 };

--- a/lib/terminal/api.ts
+++ b/lib/terminal/api.ts
@@ -37,14 +37,43 @@ async function fetchInternalJson(path: string): Promise<any | null> {
   }
 }
 
-export function integrityStatusToGISnapshot(status: IntegrityStatusResponse): GISnapshot {
+export function integrityStatusToGISnapshot(
+  status: IntegrityStatusResponse,
+  previousScore?: number,
+): GISnapshot {
+  const quality = status.signals.quality ?? status.signals.geopolitics;
+  const freshness = status.signals.freshness ?? status.signals.information;
+  const stability = status.signals.stability ?? status.signals.sentiment;
+  const system = status.signals.system ?? status.signals.economy;
+  const delta = typeof previousScore === 'number'
+    ? Number((status.global_integrity - previousScore).toFixed(2))
+    : 0;
+
   return {
     score: status.global_integrity,
-    delta: -0.01,
-    institutionalTrust: status.signals.geopolitics,
-    infoReliability: status.signals.information,
-    consensusStability: status.signals.sentiment,
-    weekly: [0.84, 0.83, 0.82, 0.81, 0.8, 0.79, status.global_integrity],
+    delta,
+    mode: status.mode,
+    terminalStatus: status.terminal_status,
+    primaryDriver: status.primary_driver,
+    summary: status.summary,
+    institutionalTrust: quality,
+    infoReliability: freshness,
+    consensusStability: stability,
+    signalBreakdown: {
+      quality,
+      freshness,
+      stability,
+      system,
+    },
+    weekly: [
+      Math.min(1, Number((status.global_integrity + 0.06).toFixed(2))),
+      Math.min(1, Number((status.global_integrity + 0.04).toFixed(2))),
+      Math.min(1, Number((status.global_integrity + 0.03).toFixed(2))),
+      Math.min(1, Number((status.global_integrity + 0.02).toFixed(2))),
+      Math.min(1, Number((status.global_integrity + 0.01).toFixed(2))),
+      status.global_integrity,
+      status.global_integrity,
+    ],
   };
 }
 

--- a/lib/terminal/transforms.ts
+++ b/lib/terminal/transforms.ts
@@ -34,9 +34,14 @@ export function transformGI(raw: any): GISnapshot {
   return {
     score: raw.score,
     delta: raw.delta,
+    mode: raw.mode,
+    terminalStatus: raw.terminal_status ?? raw.terminalStatus,
+    primaryDriver: raw.primary_driver ?? raw.primaryDriver,
+    summary: raw.summary,
     institutionalTrust: raw.institutional_trust ?? raw.institutionalTrust,
     infoReliability: raw.info_reliability ?? raw.infoReliability,
     consensusStability: raw.consensus_stability ?? raw.consensusStability,
+    signalBreakdown: raw.signal_breakdown ?? raw.signalBreakdown,
     weekly: raw.weekly,
   };
 }

--- a/lib/terminal/types.ts
+++ b/lib/terminal/types.ts
@@ -77,9 +77,19 @@ export type Tripwire = {
 export type GISnapshot = {
   score: number;
   delta: number;
+  mode?: 'green' | 'yellow' | 'red';
+  terminalStatus?: 'nominal' | 'stressed' | 'critical';
+  primaryDriver?: string;
+  summary?: string;
   institutionalTrust: number;
   infoReliability: number;
   consensusStability: number;
+  signalBreakdown?: {
+    quality: number;
+    freshness: number;
+    stability: number;
+    system: number;
+  };
   weekly: number[];
 };
 


### PR DESCRIPTION
### Motivation

- Global Integrity (GI) was a displayed snapshot and needs to become a live system condition computed from multiple runtime signals.  
- GI should reflect `signal_quality`, `signal_freshness`, `tripwire_stability`, and `system_health` so UI and downstream logic can react.  
- Surface a simple operating mode (green/yellow/red) so the terminal badge and overlay can display an actionable state.

### Description

- Added a GI engine with `lib/gi/compute.ts` implementing the v1 weighted formula and `lib/gi/mode.ts` with `getGiMode` and mode config.  
- Reworked the internal API at `app/api/integrity-status/route.ts` to compute GI dynamically from heartbeat freshness, tripwire state, scored ZEUS signal quality (`scoreBatch`), and active agent count, and to return `mode`, `terminal_status`, `primary_driver`, `summary`, `signals`, and `timestamp`.  
- Extended mocks and types: updated `lib/mock/integrityStatus.ts`, `lib/terminal/types.ts`, `lib/terminal/transforms.ts`, and `lib/terminal/api.ts` to include the GI `mode`, a `signalBreakdown`, `summary`, and to compute `GISnapshot` with deltas and weekly values.  
- Wired UI consumers to the live values by updating `TopStatusBar`, `IntegrityMonitorCard`, `DetailInspectorRail`, and `hooks/useTerminalData.ts` so the GI badge, monitor, and inspector show reactive mode and breakdown while preserving existing fields like `mii_baseline` and `mic_supply` for backward compatibility.

### Testing

- Ran TypeScript checks with `npx tsc --noEmit`, which completed successfully.  
- Performed a production build with `npm run build`, which compiled and generated pages successfully.  
- Attempted `npm run lint`, but Next.js prompted for first-time ESLint setup interactively so the linter could not run non-interactively (no blocking issues observed from the type-check and build steps).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bea9a3ed84832d81f5d06ad6a5f2fd)