### PR TITLE
feat(identity): add Mobius Identity spine, profile surface, and EPICON linkage

### DIFF
--- a/app/api/epicon/publish/route.ts
+++ b/app/api/epicon/publish/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { addPublicEpicon } from '@/lib/epicon/feedStore';
 import { lockStake } from '@/lib/mic/store';
+import { incrementEpiconCount } from '@/lib/identity/store';
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
@@ -37,6 +38,10 @@ export async function POST(req: NextRequest) {
 
   if (record.publication_mode === 'public') {
     addPublicEpicon(record);
+
+    if (record.submitted_by_login) {
+      incrementEpiconCount(record.submitted_by_login);
+    }
   }
 
   return NextResponse.json({

--- a/app/api/identity/list/route.ts
+++ b/app/api/identity/list/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { listIdentities } from '@/lib/identity/store';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    identities: listIdentities(),
+  });
+}

--- a/app/api/identity/me/route.ts
+++ b/app/api/identity/me/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { touchIdentity } from '@/lib/identity/store';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const username = req.nextUrl.searchParams.get('username') || 'kaizencycle';
+  const identity = touchIdentity(username);
+
+  return NextResponse.json({
+    ok: true,
+    identity,
+  });
+}

--- a/app/api/mic/account/route.ts
+++ b/app/api/mic/account/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getMicAccount } from '@/lib/mic/store';
+import { getIdentity } from '@/lib/identity/store';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
   const login = req.nextUrl.searchParams.get('login') || 'kaizencycle';
+  const identity = getIdentity(login);
   const account = getMicAccount(login);
 
   return NextResponse.json({
@@ -12,6 +14,8 @@ export async function GET(req: NextRequest) {
     account: {
       login: account.login,
       balance: account.balance,
+      mobius_id: identity.mobius_id,
+      role: identity.role,
       locked: 0,
       rewards_earned: 0,
       mic_burned: 0,

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -2,17 +2,15 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import MobiusIdentityCard from '@/components/identity/MobiusIdentityCard';
+import type { MobiusIdentity } from '@/lib/identity/types';
 import type { MobiusProfile, MIIHistoryPoint, StoredEpicon } from '@/lib/mobius/stores';
-
-// ── Types for API response ───────────────────────────────────
 
 type ProfileResponse = {
   ok: boolean;
   profile: MobiusProfile;
   epicons: StoredEpicon[];
 };
-
-// ── Helpers ──────────────────────────────────────────────────
 
 function tierColor(tier: string): string {
   switch (tier) {
@@ -47,8 +45,6 @@ function miiBarColor(score: number): string {
   return 'bg-red-500';
 }
 
-// ── Components ───────────────────────────────────────────────
-
 function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-950 p-4">
@@ -65,23 +61,20 @@ function MIISparkline({ history }: { history: MIIHistoryPoint[] }) {
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4">
-      <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500 mb-3">
+      <div className="mb-3 text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500">
         MII Trend
       </div>
-      <div className="flex items-end gap-1.5 h-24">
+      <div className="flex h-24 items-end gap-1.5">
         {history.map((point, i) => {
           const height = Math.max(8, (point.score / maxScore) * 80);
           return (
-            <div
-              key={`${point.timestamp}-${i}`}
-              className="group relative flex-1"
-            >
+            <div key={`${point.timestamp}-${i}`} className="group relative flex-1">
               <div
                 className={`rounded-t ${miiBarColor(point.score)} transition-all duration-300`}
                 style={{ height: `${height}px` }}
               />
-              <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block z-10">
-                <div className="rounded-md border border-slate-700 bg-slate-900 px-2 py-1.5 text-[10px] font-mono text-slate-300 whitespace-nowrap shadow-lg">
+              <div className="absolute bottom-full left-1/2 z-10 mb-2 hidden -translate-x-1/2 group-hover:block">
+                <div className="whitespace-nowrap rounded-md border border-slate-700 bg-slate-900 px-2 py-1.5 text-[10px] font-mono text-slate-300 shadow-lg">
                   <div className="text-sky-300">{point.score.toFixed(2)}</div>
                   <div className="text-slate-500">{new Date(point.timestamp).toLocaleDateString()}</div>
                 </div>
@@ -109,7 +102,7 @@ function TierProgressBar({ currentTier, mii }: { currentTier: string; mii: numbe
 
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4">
-      <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500 mb-3">
+      <div className="mb-3 text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500">
         Tier Progression
       </div>
       <div className="space-y-2">
@@ -118,11 +111,11 @@ function TierProgressBar({ currentTier, mii }: { currentTier: string; mii: numbe
           const reached = mii >= tier.threshold;
           return (
             <div key={tier.key} className="flex items-center gap-3">
-              <div className={`w-2.5 h-2.5 rounded-full shrink-0 ${
+              <div className={`h-2.5 w-2.5 shrink-0 rounded-full ${
                 active ? 'bg-sky-400 shadow-[0_0_6px_rgba(56,189,248,0.4)]' :
                 reached ? 'bg-emerald-500/60' : 'bg-slate-700'
               }`} />
-              <div className={`flex-1 text-sm font-mono ${active ? 'text-sky-300 font-medium' : reached ? 'text-slate-300' : 'text-slate-600'}`}>
+              <div className={`flex-1 text-sm font-mono ${active ? 'font-medium text-sky-300' : reached ? 'text-slate-300' : 'text-slate-600'}`}>
                 {tier.label}
               </div>
               <div className={`text-xs font-mono ${active ? 'text-sky-400' : 'text-slate-600'}`}>
@@ -143,7 +136,7 @@ function HistoryTimeline({ history }: { history: MIIHistoryPoint[] }) {
     <div className="space-y-2">
       {reversed.map((point, i) => (
         <div key={`${point.timestamp}-${i}`} className="flex items-start gap-3 rounded-lg border border-slate-800 bg-slate-950/60 p-3">
-          <div className={`mt-0.5 shrink-0 rounded-md border px-2 py-1 text-xs font-mono ${miiBarColor(point.score).replace('bg-', 'text-').replace('500', '300')} border-slate-700 bg-slate-900`}>
+          <div className={`mt-0.5 shrink-0 rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-xs font-mono ${miiBarColor(point.score).replace('bg-', 'text-').replace('500', '300')}`}>
             {point.score.toFixed(2)}
           </div>
           <div className="min-w-0 flex-1">
@@ -175,9 +168,9 @@ function EpiconList({ epicons }: { epicons: StoredEpicon[] }) {
             <div className="min-w-0 flex-1">
               <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500">{e.id}</div>
               <div className="mt-1 text-sm font-medium text-slate-200">{e.title}</div>
-              <div className="mt-1 text-xs text-slate-400 line-clamp-2">{e.summary}</div>
+              <div className="mt-1 line-clamp-2 text-xs text-slate-400">{e.summary}</div>
             </div>
-            <div className="flex flex-col items-end gap-1.5 shrink-0">
+            <div className="flex shrink-0 flex-col items-end gap-1.5">
               <span className={`rounded-md border px-2 py-0.5 text-[10px] font-mono uppercase tracking-[0.1em] ${statusColor(e.status)}`}>
                 {e.status}
               </span>
@@ -188,7 +181,7 @@ function EpiconList({ epicons }: { epicons: StoredEpicon[] }) {
               )}
             </div>
           </div>
-          <div className="mt-2 flex items-center gap-2 flex-wrap">
+          <div className="mt-2 flex flex-wrap items-center gap-2">
             <span className="rounded-md bg-slate-800 px-2 py-0.5 text-[10px] font-mono uppercase tracking-[0.1em] text-slate-400">
               {e.category}
             </span>
@@ -205,21 +198,25 @@ function EpiconList({ epicons }: { epicons: StoredEpicon[] }) {
   );
 }
 
-// ── Main Page ────────────────────────────────────────────────
-
 export default function ProfilePage() {
   const [data, setData] = useState<ProfileResponse | null>(null);
+  const [identity, setIdentity] = useState<MobiusIdentity | null>(null);
   const [loading, setLoading] = useState(true);
   const [loginInput, setLoginInput] = useState('kaizencycle');
 
   async function loadProfile(login: string) {
     setLoading(true);
     try {
-      const res = await fetch(`/api/profile?login=${encodeURIComponent(login)}`);
-      const json = await res.json();
-      setData(json);
+      const [profileRes, identityRes] = await Promise.all([
+        fetch(`/api/profile?login=${encodeURIComponent(login)}`, { cache: 'no-store' }),
+        fetch(`/api/identity/me?username=${encodeURIComponent(login)}`, { cache: 'no-store' }),
+      ]);
+      const [profileJson, identityJson] = await Promise.all([profileRes.json(), identityRes.json()]);
+      setData(profileJson);
+      setIdentity(identityJson.identity || null);
     } catch {
       setData(null);
+      setIdentity(null);
     } finally {
       setLoading(false);
     }
@@ -238,30 +235,28 @@ export default function ProfilePage() {
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
-      {/* Header */}
-      <header className="border-b border-slate-800 bg-slate-950/95 backdrop-blur px-6 py-4">
-        <div className="mx-auto max-w-6xl flex items-center justify-between">
+      <header className="border-b border-slate-800 bg-slate-950/95 px-6 py-4 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4">
           <div>
-            <Link href="/terminal" className="text-xs font-mono uppercase tracking-[0.25em] text-sky-300 hover:text-sky-200 transition">
+            <Link href="/terminal" className="text-xs font-mono uppercase tracking-[0.25em] text-sky-300 transition hover:text-sky-200">
               &larr; Mobius Terminal
             </Link>
             <h1 className="mt-2 text-2xl font-semibold">Mobius Profile</h1>
             <p className="mt-1 text-sm text-slate-400">
-              Reputation is earned through contribution, verification, and consistency.
+              Identity, permissions, reputation, and contribution history for the active Mobius operator.
             </p>
           </div>
-          {/* Login lookup */}
           <div className="flex items-center gap-2">
             <input
               value={loginInput}
               onChange={(e) => setLoginInput(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && loadProfile(loginInput)}
               placeholder="github login"
-              className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm font-mono text-white outline-none placeholder:text-slate-600 focus:border-sky-500/40 w-40"
+              className="w-40 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm font-mono text-white outline-none placeholder:text-slate-600 focus:border-sky-500/40"
             />
             <button
               onClick={() => loadProfile(loginInput)}
-              className="rounded-lg border border-sky-500/30 bg-sky-500/10 px-4 py-2 text-sm font-mono text-sky-300 hover:bg-sky-500/20 transition"
+              className="rounded-lg border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-xs font-mono uppercase tracking-[0.14em] text-sky-300 transition hover:bg-sky-500/15"
             >
               Load
             </button>
@@ -269,67 +264,87 @@ export default function ProfilePage() {
         </div>
       </header>
 
-      <main className="mx-auto max-w-6xl p-6">
+      <main className="mx-auto max-w-6xl px-6 py-6">
         {loading ? (
-          <div className="text-center text-slate-400 py-20">Loading profile...</div>
+          <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 text-slate-400">
+            Loading Mobius profile surfaces…
+          </div>
         ) : !profile ? (
-          <div className="text-center text-slate-400 py-20">No profile found. Try a different login.</div>
+          <div className="rounded-xl border border-rose-500/20 bg-rose-500/10 p-6 text-rose-200">
+            Unable to load this profile right now.
+          </div>
         ) : (
           <div className="space-y-6">
-            {/* Identity card */}
-            <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-6">
-              <div className="flex items-start justify-between gap-4 flex-wrap">
-                <div>
-                  <div className="text-2xl font-semibold text-white">{profile.displayName}</div>
-                  <div className="mt-1 text-sm font-mono text-slate-400">@{profile.login}</div>
-                  <div className="mt-1 text-xs font-mono text-slate-500">
-                    Member since {new Date(profile.createdAt).toLocaleDateString()}
-                  </div>
-                </div>
-                <div className="flex items-center gap-3">
-                  <div className="text-right">
-                    <div className="text-3xl font-mono font-bold text-white">{profile.miiScore.toFixed(2)}</div>
-                    <div className="text-[10px] font-mono uppercase tracking-[0.12em] text-slate-500">MII Score</div>
-                  </div>
-                  <span className={`rounded-lg border px-3 py-1.5 text-xs font-mono uppercase tracking-[0.12em] ${tierColor(profile.nodeTier)}`}>
-                    {profile.nodeTier}
-                  </span>
-                </div>
-              </div>
-              <div className="mt-6 grid grid-cols-2 sm:grid-cols-4 gap-3">
-                <Stat label="EPICONs" value={String(profile.epiconCount)} />
-                <Stat
-                  label="Accuracy"
-                  value={accuracy === '—' ? '—' : `${accuracy}%`}
-                  sub={`${profile.verificationHits} hits / ${profile.verificationMisses} misses`}
-                />
-                <Stat label="Hits" value={String(profile.verificationHits)} />
-                <Stat label="Misses" value={String(profile.verificationMisses)} />
-              </div>
-            </div>
+            {identity ? <MobiusIdentityCard identity={identity} /> : null}
 
-            {/* Two-column layout */}
-            <div className="grid gap-6 lg:grid-cols-[1fr_340px]">
-              {/* Left: MII trend + EPICON history */}
+            <div className="grid gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.65fr)]">
               <div className="space-y-6">
-                <MIISparkline history={profile.miiHistory ?? []} />
-                <div>
-                  <div className="text-xs font-mono uppercase tracking-[0.2em] text-slate-400 mb-3">
-                    EPICON Submissions ({epicons.length})
+                <section className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
+                  <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div>
+                      <div className="text-xs font-mono uppercase tracking-[0.2em] text-slate-500">Mobius Reputation</div>
+                      <h2 className="mt-2 text-xl font-semibold text-white">{profile.displayName}</h2>
+                      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs font-mono uppercase tracking-[0.14em]">
+                        <span className={`rounded-md border px-2 py-1 ${tierColor(profile.nodeTier)}`}>
+                          {profile.nodeTier}
+                        </span>
+                        <span className="rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-300">
+                          @{profile.login}
+                        </span>
+                        <span className="rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-300">
+                          {identity?.status || 'active'}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="min-w-[180px] rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+                      <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500">Current MII</div>
+                      <div className="mt-2 text-3xl font-semibold text-white">{profile.miiScore.toFixed(2)}</div>
+                      <div className="mt-2 h-2 overflow-hidden rounded-full bg-slate-800">
+                        <div className={`h-full ${miiBarColor(profile.miiScore)}`} style={{ width: `${Math.min(profile.miiScore * 100, 100)}%` }} />
+                      </div>
+                    </div>
                   </div>
-                  <EpiconList epicons={epicons} />
-                </div>
+
+                  <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                    <Stat label="Signals Submitted" value={String(profile.epiconCount)} />
+                    <Stat label="Verification Hits" value={String(profile.verificationHits)} />
+                    <Stat label="Verification Misses" value={String(profile.verificationMisses)} />
+                    <Stat label="Accuracy" value={accuracy === '—' ? accuracy : `${accuracy}%`} sub={`${totalReviewed} reviewed`} />
+                  </div>
+                </section>
+
+                <section className="grid gap-6 xl:grid-cols-2">
+                  <MIISparkline history={profile.miiHistory} />
+                  <TierProgressBar currentTier={profile.nodeTier} mii={profile.miiScore} />
+                </section>
+
+                <section className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
+                  <div className="text-xs font-mono uppercase tracking-[0.2em] text-slate-500">Recent EPICONs</div>
+                  <div className="mt-4">
+                    <EpiconList epicons={epicons} />
+                  </div>
+                </section>
               </div>
 
-              {/* Right: Tier progression + MII history log */}
               <div className="space-y-6">
-                <TierProgressBar currentTier={profile.nodeTier} mii={profile.miiScore} />
-                <div>
-                  <div className="text-xs font-mono uppercase tracking-[0.2em] text-slate-400 mb-3">
-                    MII History ({(profile.miiHistory ?? []).length} events)
+                <section className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
+                  <div className="text-xs font-mono uppercase tracking-[0.2em] text-slate-500">Integrity History</div>
+                  <div className="mt-4">
+                    <HistoryTimeline history={profile.miiHistory} />
                   </div>
-                  <HistoryTimeline history={profile.miiHistory ?? []} />
-                </div>
+                </section>
+
+                <section className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
+                  <div className="text-xs font-mono uppercase tracking-[0.2em] text-slate-500">Identity Layer Notes</div>
+                  <div className="mt-3 space-y-3 text-sm text-slate-400">
+                    <p>
+                      Mobius Identity now binds role visibility, MIC state, and EPICON contribution count into a single operator surface.
+                    </p>
+                    <p>
+                      This scaffold keeps storage in memory so the terminal can evolve toward real auth, wallet linkage, and role-based permissions without changing the UI contract.
+                    </p>
+                  </div>
+                </section>
               </div>
             </div>
           </div>

--- a/components/epicon/EpiconFeedCard.tsx
+++ b/components/epicon/EpiconFeedCard.tsx
@@ -59,8 +59,8 @@ export default function EpiconFeedCard({
           <span className="text-slate-500">Stake:</span> {item.mic_stake} MIC
         </div>
         <div>
-          <span className="text-slate-500">By:</span>{' '}
-          @{item.submitted_by_login || 'unknown'}
+          <span className="text-slate-500">Identity:</span>{' '}
+          <span className="text-slate-200">@{item.submitted_by_login || 'unknown'}</span>
         </div>
         <div>
           <span className="text-slate-500">Agents:</span>{' '}

--- a/components/identity/MobiusIdentityBadge.tsx
+++ b/components/identity/MobiusIdentityBadge.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import type { MobiusIdentity } from '@/lib/identity/types';
+
+export default function MobiusIdentityBadge() {
+  const [identity, setIdentity] = useState<MobiusIdentity | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function load() {
+      try {
+        const res = await fetch('/api/identity/me?username=kaizencycle', {
+          cache: 'no-store',
+        });
+        const json = await res.json();
+        if (mounted) {
+          setIdentity(json.identity || null);
+        }
+      } catch {
+        if (mounted) {
+          setIdentity(null);
+        }
+      }
+    }
+
+    load();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (!identity) {
+    return (
+      <div className="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-[11px] font-mono uppercase tracking-[0.15em] text-slate-400">
+        Identity loading…
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      href="/profile"
+      className="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-[11px] font-mono uppercase tracking-[0.15em] text-slate-300 transition hover:border-sky-500/30 hover:bg-slate-800 hover:text-sky-200"
+    >
+      @{identity.username} · {identity.role} · MII {identity.mii_score.toFixed(2)}
+    </Link>
+  );
+}

--- a/components/identity/MobiusIdentityCard.tsx
+++ b/components/identity/MobiusIdentityCard.tsx
@@ -1,0 +1,50 @@
+import type { MobiusIdentity } from '@/lib/identity/types';
+
+function MiniStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-950 p-3">
+      <div className="text-[11px] uppercase tracking-[0.14em] text-slate-500">{label}</div>
+      <div className="mt-1 text-sm font-semibold text-white">{value}</div>
+    </div>
+  );
+}
+
+export default function MobiusIdentityCard({ identity }: { identity: MobiusIdentity }) {
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/50 p-4">
+      <div className="text-xs uppercase tracking-[0.2em] text-slate-400">Mobius Identity</div>
+      <div className="mt-2 text-xl font-semibold text-white">{identity.display_name}</div>
+      <div className="mt-1 text-sm text-slate-400">@{identity.username}</div>
+
+      <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <MiniStat label="MobiusID" value={identity.mobius_id} />
+        <MiniStat label="LedgerID" value={identity.ledger_id} />
+        <MiniStat label="Role" value={identity.role} />
+        <MiniStat label="Status" value={identity.status} />
+        <MiniStat label="MII" value={identity.mii_score.toFixed(2)} />
+        <MiniStat label="MIC" value={String(identity.mic_balance)} />
+        <MiniStat label="EPICONs" value={String(identity.epicon_count)} />
+        <MiniStat label="Agents" value={String(identity.agent_permissions.length)} />
+      </div>
+
+      <div className="mt-4 rounded-xl border border-slate-800 bg-slate-950 p-3">
+        <div className="text-xs uppercase tracking-[0.14em] text-slate-500">Agent Permissions</div>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {identity.agent_permissions.map((agent) => (
+            <span
+              key={agent}
+              className="rounded-md bg-slate-800 px-2 py-1 text-[10px] uppercase tracking-[0.12em] text-slate-300"
+            >
+              {agent}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 text-xs text-slate-500">
+        Joined {new Date(identity.joined_at).toLocaleString()} · Last active{' '}
+        {new Date(identity.last_active_at).toLocaleString()}
+      </div>
+    </div>
+  );
+}

--- a/components/mic/MicAccountPanel.tsx
+++ b/components/mic/MicAccountPanel.tsx
@@ -5,6 +5,8 @@ import { useEffect, useState } from 'react';
 type MicAccount = {
   login: string;
   balance: number;
+  mobius_id: string;
+  role: string;
   locked: number;
   rewards_earned: number;
   mic_burned: number;
@@ -63,6 +65,9 @@ export default function MicAccountPanel() {
       <div className="text-xs uppercase tracking-[0.2em] text-slate-400">MIC Account</div>
 
       <div className="mt-2 text-lg font-semibold text-white">@{account.login}</div>
+      <div className="mt-1 text-xs uppercase tracking-[0.14em] text-slate-500">
+        {account.mobius_id} · {account.role}
+      </div>
 
       <div className="mt-4 grid grid-cols-2 gap-3">
         <MiniStat label="Balance" value={String(account.balance)} />

--- a/components/terminal/TopStatusBar.tsx
+++ b/components/terminal/TopStatusBar.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import TerminalNav from '@/components/layout/TerminalNav';
 import GIMonitorBadge from '@/components/gi/GIMonitorBadge';
+import MobiusIdentityBadge from '@/components/identity/MobiusIdentityBadge';
 import type { NavKey } from '@/lib/terminal/types';
 import { cn } from '@/lib/terminal/utils';
 
@@ -132,6 +133,7 @@ export default function TopStatusBar({
             <Chip label={cycleId} onClick={() => onNavigate('pulse')} />
             <Chip label={clock || 'Loading...'} />
             <GIMonitorBadge />
+            <MobiusIdentityBadge />
             <Chip
               label={`MII ${mii.toFixed(2)}`}
               tone={mii >= 0.7 ? 'text-cyan-300 border-cyan-500/30 bg-cyan-500/10' : 'text-amber-300 border-amber-500/30 bg-amber-500/10'}

--- a/lib/identity/store.ts
+++ b/lib/identity/store.ts
@@ -1,0 +1,78 @@
+import { getMicAccount } from '@/lib/mic/store';
+import type { MobiusIdentity, MobiusRole } from '@/lib/identity/types';
+
+const DEFAULT_USERNAME = 'kaizencycle';
+const DEFAULT_ROLE: MobiusRole = 'developer';
+const DEFAULT_AGENTS = ['ECHO', 'ZEUS', 'ATLAS'];
+
+const identities = new Map<string, MobiusIdentity>();
+
+function randomId(prefix: string) {
+  return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function normalizeUsername(username?: string | null) {
+  return (username || DEFAULT_USERNAME).trim() || DEFAULT_USERNAME;
+}
+
+function buildIdentity(username: string): MobiusIdentity {
+  const now = new Date().toISOString();
+  const account = getMicAccount(username);
+
+  return {
+    mobius_id: randomId('mbx'),
+    ledger_id: randomId('ldr'),
+    username,
+    display_name: username === DEFAULT_USERNAME ? 'Michael' : username,
+    role: DEFAULT_ROLE,
+    status: 'active',
+    mii_score: 0.5,
+    mic_balance: account.balance,
+    epicon_count: 0,
+    agent_permissions: [...DEFAULT_AGENTS],
+    joined_at: now,
+    last_active_at: now,
+  };
+}
+
+export function ensureIdentity(username?: string | null): MobiusIdentity {
+  const normalized = normalizeUsername(username);
+  const existing = identities.get(normalized);
+
+  if (existing) {
+    existing.mic_balance = getMicAccount(normalized).balance;
+    return existing;
+  }
+
+  const created = buildIdentity(normalized);
+  identities.set(normalized, created);
+  return created;
+}
+
+export function getIdentity(username?: string | null) {
+  return ensureIdentity(username);
+}
+
+export function listIdentities() {
+  ensureIdentity(DEFAULT_USERNAME);
+
+  return Array.from(identities.values()).map((identity) => ({
+    ...identity,
+    mic_balance: getMicAccount(identity.username).balance,
+  }));
+}
+
+export function touchIdentity(username?: string | null) {
+  const identity = ensureIdentity(username);
+  identity.last_active_at = new Date().toISOString();
+  identity.mic_balance = getMicAccount(identity.username).balance;
+  return identity;
+}
+
+export function incrementEpiconCount(username?: string | null) {
+  const identity = ensureIdentity(username);
+  identity.epicon_count += 1;
+  identity.last_active_at = new Date().toISOString();
+  identity.mic_balance = getMicAccount(identity.username).balance;
+  return identity;
+}

--- a/lib/identity/types.ts
+++ b/lib/identity/types.ts
@@ -1,0 +1,24 @@
+export type MobiusRole =
+  | 'observer'
+  | 'citizen'
+  | 'analyst'
+  | 'journalist'
+  | 'developer'
+  | 'steward';
+
+export type MobiusIdentityStatus = 'active' | 'restricted' | 'suspended';
+
+export type MobiusIdentity = {
+  mobius_id: string;
+  ledger_id: string;
+  username: string;
+  display_name: string;
+  role: MobiusRole;
+  status: MobiusIdentityStatus;
+  mii_score: number;
+  mic_balance: number;
+  epicon_count: number;
+  agent_permissions: string[];
+  joined_at: string;
+  last_active_at: string;
+};


### PR DESCRIPTION
### Motivation

- Add a minimal, in-memory Mobius identity layer so operator actions are attributable and the terminal can surface role, MIC, and contribution state. 
- Bind identity to existing EPICON and MIC flows so publication and account views reflect who submitted signals without introducing auth or persistence yet.

### Description

- Added core types and an in-memory store in `lib/identity/types.ts` and `lib/identity/store.ts` with a default username of `kaizencycle` and MIC balance alignment via `getMicAccount`. 
- Exposed API endpoints `GET /api/identity/me` and `GET /api/identity/list` in `app/api/identity/me/route.ts` and `app/api/identity/list/route.ts` that return and touch identity state. 
- Introduced UI components `components/identity/MobiusIdentityBadge.tsx` and `components/identity/MobiusIdentityCard.tsx`, wired the badge into the terminal top bar (`components/terminal/TopStatusBar.tsx`) and added the identity card into the profile page (`app/profile/page.tsx`). 
- Integrated identity with workflows by attaching `submitted_by_login` to EPICON publish (`app/api/epicon/publish/route.ts`) and calling `incrementEpiconCount`, and by enriching MIC account responses and panel with `mobius_id` and `role` (`app/api/mic/account/route.ts`, `components/mic/MicAccountPanel.tsx`); EPICON feed cards now show submitting identity cleanly (`components/epicon/EpiconFeedCard.tsx`). 
- Intentionally kept this a scaffold: no auth provider, no database persistence, no MII mutation UI, no wallet or enforcement logic were added.

### Testing

- Ran a production build with `npm run build` (`next build`) and the project compiled successfully and generated pages and routes including the new identity APIs. 
- Type checking ran as part of the build and passed for the introduced changes. 
- `npm run lint` triggered Next.js/ESLint interactive setup in this environment and could not complete non-interactively, so linting was not fully exercised here. 
- Changes were committed and a PR was prepared titled `feat(identity): add Mobius Identity spine, profile surface, and EPICON-linked identity flow`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bebf379a30832daeb332e9d63706d0)