### PR TITLE
Expose role permissions and simplify profile UI to fetch identity and permissions

### DIFF
--- a/app/api/epicon/publish/route.ts
+++ b/app/api/epicon/publish/route.ts
@@ -1,52 +1,68 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { addPublicEpicon } from '@/lib/epicon/feedStore';
+import { requirePermission } from '@/lib/identity/guards';
 import { lockStake } from '@/lib/mic/store';
 import { incrementEpiconCount } from '@/lib/identity/store';
 
 export async function POST(req: NextRequest) {
-  const body = await req.json();
+  try {
+    const body = await req.json();
+    const submitted_by_login = body.submitted_by_login || 'kaizencycle';
 
-  const record = {
-    id: `EPICON-${Math.random().toString(36).slice(2, 10).toUpperCase()}`,
-    status: 'pending' as const,
-    title: body.title,
-    summary: body.summary,
-    sources: body.sources || [],
-    tags: body.tags || [],
-    confidence_tier: body.confidence >= 0.7 ? 2 : 1,
-    publication_mode: body.publication_mode,
-    mic_stake: body.publication_mode === 'public' ? body.mic_stake || 0 : 0,
-    agents_used: body.agents_used || [],
-    submitted_by_login: body.submitted_by_login || 'kaizencycle',
-    created_at: new Date().toISOString(),
-    trace: [
-      'Query result transformed into EPICON candidate',
-      'Publication flow completed',
-      'Awaiting ZEUS review / later settlement layer',
-    ],
-  };
-
-  let stake_lock = null;
-
-  if (record.publication_mode === 'public' && record.mic_stake > 0) {
-    stake_lock = lockStake({
-      epicon_id: record.id,
-      login: record.submitted_by_login,
-      stake: record.mic_stake,
-    });
-  }
-
-  if (record.publication_mode === 'public') {
-    addPublicEpicon(record);
-
-    if (record.submitted_by_login) {
-      incrementEpiconCount(record.submitted_by_login);
+    if (body.publication_mode === 'public') {
+      requirePermission(submitted_by_login, 'epicon:publish');
     }
-  }
 
-  return NextResponse.json({
-    ok: true,
-    record,
-    stake_lock,
-  });
+    const record = {
+      id: `EPICON-${Math.random().toString(36).slice(2, 10).toUpperCase()}`,
+      status: 'pending' as const,
+      title: body.title,
+      summary: body.summary,
+      sources: body.sources || [],
+      tags: body.tags || [],
+      confidence_tier: body.confidence >= 0.7 ? 2 : 1,
+      publication_mode: body.publication_mode,
+      mic_stake: body.publication_mode === 'public' ? body.mic_stake || 0 : 0,
+      agents_used: body.agents_used || [],
+      submitted_by_login,
+      created_at: new Date().toISOString(),
+      trace: [
+        'Query result transformed into EPICON candidate',
+        'Publication flow completed',
+        'Awaiting ZEUS review / later settlement layer',
+      ],
+    };
+
+    let stake_lock = null;
+
+    if (record.publication_mode === 'public' && record.mic_stake > 0) {
+      stake_lock = lockStake({
+        epicon_id: record.id,
+        login: record.submitted_by_login,
+        stake: record.mic_stake,
+      });
+    }
+
+    if (record.publication_mode === 'public') {
+      addPublicEpicon(record);
+
+      if (record.submitted_by_login) {
+        incrementEpiconCount(record.submitted_by_login);
+      }
+    }
+
+    return NextResponse.json({
+      ok: true,
+      record,
+      stake_lock,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to publish EPICON';
+    const status = message.startsWith('Permission denied:') ? 403 : 400;
+
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status },
+    );
+  }
 }

--- a/app/api/epicon/verify/route.ts
+++ b/app/api/epicon/verify/route.ts
@@ -1,25 +1,40 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { requirePermission } from '@/lib/identity/guards';
 import { verifyCandidate } from '@/lib/epicon/store';
 
 export async function POST(req: NextRequest) {
-  const body = await req.json();
+  try {
+    const body = await req.json();
+    const reviewer = body.reviewer || 'kaizencycle';
+    const permission = body.outcome === 'contradicted' ? 'epicon:contradict' : 'epicon:verify';
 
-  const updated = verifyCandidate({
-    id: body.id,
-    outcome: body.outcome,
-    confidence_tier: body.confidence_tier,
-    zeus_note: body.zeus_note,
-  });
+    requirePermission(reviewer, permission);
 
-  if (!updated) {
+    const updated = verifyCandidate({
+      id: body.id,
+      outcome: body.outcome,
+      confidence_tier: body.confidence_tier,
+      zeus_note: body.zeus_note,
+    });
+
+    if (!updated) {
+      return NextResponse.json(
+        { ok: false, error: 'Candidate not found' },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      candidate: updated,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to verify candidate';
+    const status = message.startsWith('Permission denied:') ? 403 : 400;
+
     return NextResponse.json(
-      { ok: false, error: 'Candidate not found' },
-      { status: 404 },
+      { ok: false, error: message },
+      { status },
     );
   }
-
-  return NextResponse.json({
-    ok: true,
-    candidate: updated,
-  });
 }

--- a/app/api/identity/me/route.ts
+++ b/app/api/identity/me/route.ts
@@ -1,14 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { touchIdentity } from '@/lib/identity/store';
+import { getIdentity, getIdentityPermissions } from '@/lib/identity/store';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
   const username = req.nextUrl.searchParams.get('username') || 'kaizencycle';
-  const identity = touchIdentity(username);
+  const identity = getIdentity(username);
 
   return NextResponse.json({
     ok: true,
     identity,
+    permissions: getIdentityPermissions(username),
   });
 }

--- a/app/api/zeus/verify/route.ts
+++ b/app/api/zeus/verify/route.ts
@@ -15,6 +15,7 @@
  */
 
 import { NextResponse } from 'next/server';
+import { requirePermission } from '@/lib/identity/guards';
 import {
   getStoredEpicon,
   updateEpicon,
@@ -34,6 +35,10 @@ type VerifyRequest = {
 export async function POST(request: Request) {
   try {
     const body = (await request.json()) as VerifyRequest;
+    const reviewer = ((body as VerifyRequest & { reviewer?: string }).reviewer) || 'kaizencycle';
+    const permission = body.finalStatus === 'contradicted' || body.outcome === 'miss'
+      ? 'epicon:contradict'
+      : 'epicon:verify';
 
     if (!body.epiconId) {
       return NextResponse.json({ ok: false, error: 'epiconId is required' }, { status: 400 });
@@ -44,6 +49,8 @@ export async function POST(request: Request) {
     if (!body.finalStatus || !['verified', 'contradicted'].includes(body.finalStatus)) {
       return NextResponse.json({ ok: false, error: 'finalStatus must be "verified" or "contradicted"' }, { status: 400 });
     }
+
+    requirePermission(reviewer, permission);
 
     const epicon = getStoredEpicon(body.epiconId);
     if (!epicon) {
@@ -94,10 +101,13 @@ export async function POST(request: Request) {
           }
         : null,
     });
-  } catch {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid request body';
+    const status = message.startsWith('Permission denied:') ? 403 : 400;
+
     return NextResponse.json(
-      { ok: false, error: 'Invalid request body' },
-      { status: 400 },
+      { ok: false, error: message },
+      { status },
     );
   }
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,355 +1,62 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
 import MobiusIdentityCard from '@/components/identity/MobiusIdentityCard';
 import type { MobiusIdentity } from '@/lib/identity/types';
-import type { MobiusProfile, MIIHistoryPoint, StoredEpicon } from '@/lib/mobius/stores';
-
-type ProfileResponse = {
-  ok: boolean;
-  profile: MobiusProfile;
-  epicons: StoredEpicon[];
-};
-
-function tierColor(tier: string): string {
-  switch (tier) {
-    case 'signal-node': return 'text-emerald-300 border-emerald-500/30 bg-emerald-500/10';
-    case 'node-2': return 'text-violet-300 border-violet-500/30 bg-violet-500/10';
-    case 'node-1': return 'text-sky-300 border-sky-500/30 bg-sky-500/10';
-    case 'participant': return 'text-amber-300 border-amber-500/30 bg-amber-500/10';
-    default: return 'text-slate-300 border-slate-700 bg-slate-900';
-  }
-}
-
-function statusColor(status: string): string {
-  switch (status) {
-    case 'verified': return 'text-emerald-300 border-emerald-500/30 bg-emerald-500/10';
-    case 'contradicted': return 'text-red-300 border-red-500/30 bg-red-500/10';
-    default: return 'text-amber-300 border-amber-500/30 bg-amber-500/10';
-  }
-}
-
-function outcomeColor(outcome?: string | null): string {
-  switch (outcome) {
-    case 'hit': return 'text-emerald-300';
-    case 'miss': return 'text-red-300';
-    default: return 'text-slate-500';
-  }
-}
-
-function miiBarColor(score: number): string {
-  if (score >= 0.80) return 'bg-emerald-500';
-  if (score >= 0.65) return 'bg-sky-500';
-  if (score >= 0.50) return 'bg-amber-500';
-  return 'bg-red-500';
-}
-
-function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
-  return (
-    <div className="rounded-lg border border-slate-800 bg-slate-950 p-4">
-      <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500">{label}</div>
-      <div className="mt-1 text-xl font-mono font-semibold text-white">{value}</div>
-      {sub && <div className="mt-1 text-xs text-slate-500">{sub}</div>}
-    </div>
-  );
-}
-
-function MIISparkline({ history }: { history: MIIHistoryPoint[] }) {
-  if (history.length === 0) return null;
-  const maxScore = Math.max(...history.map((h) => h.score), 0.6);
-
-  return (
-    <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4">
-      <div className="mb-3 text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500">
-        MII Trend
-      </div>
-      <div className="flex h-24 items-end gap-1.5">
-        {history.map((point, i) => {
-          const height = Math.max(8, (point.score / maxScore) * 80);
-          return (
-            <div key={`${point.timestamp}-${i}`} className="group relative flex-1">
-              <div
-                className={`rounded-t ${miiBarColor(point.score)} transition-all duration-300`}
-                style={{ height: `${height}px` }}
-              />
-              <div className="absolute bottom-full left-1/2 z-10 mb-2 hidden -translate-x-1/2 group-hover:block">
-                <div className="whitespace-nowrap rounded-md border border-slate-700 bg-slate-900 px-2 py-1.5 text-[10px] font-mono text-slate-300 shadow-lg">
-                  <div className="text-sky-300">{point.score.toFixed(2)}</div>
-                  <div className="text-slate-500">{new Date(point.timestamp).toLocaleDateString()}</div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-      <div className="mt-2 flex justify-between text-[10px] font-mono text-slate-600">
-        <span>{history.length > 0 ? new Date(history[0].timestamp).toLocaleDateString() : ''}</span>
-        <span>{history.length > 1 ? new Date(history[history.length - 1].timestamp).toLocaleDateString() : ''}</span>
-      </div>
-    </div>
-  );
-}
-
-function TierProgressBar({ currentTier, mii }: { currentTier: string; mii: number }) {
-  const tiers = [
-    { key: 'observer', label: 'Observer', threshold: 0 },
-    { key: 'participant', label: 'Participant', threshold: 0.50 },
-    { key: 'node-1', label: 'Node-1', threshold: 0.65 },
-    { key: 'node-2', label: 'Node-2', threshold: 0.80 },
-    { key: 'signal-node', label: 'Signal Node', threshold: 0.90 },
-  ];
-
-  return (
-    <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4">
-      <div className="mb-3 text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500">
-        Tier Progression
-      </div>
-      <div className="space-y-2">
-        {tiers.map((tier) => {
-          const active = tier.key === currentTier;
-          const reached = mii >= tier.threshold;
-          return (
-            <div key={tier.key} className="flex items-center gap-3">
-              <div className={`h-2.5 w-2.5 shrink-0 rounded-full ${
-                active ? 'bg-sky-400 shadow-[0_0_6px_rgba(56,189,248,0.4)]' :
-                reached ? 'bg-emerald-500/60' : 'bg-slate-700'
-              }`} />
-              <div className={`flex-1 text-sm font-mono ${active ? 'font-medium text-sky-300' : reached ? 'text-slate-300' : 'text-slate-600'}`}>
-                {tier.label}
-              </div>
-              <div className={`text-xs font-mono ${active ? 'text-sky-400' : 'text-slate-600'}`}>
-                {tier.threshold > 0 ? `≥ ${tier.threshold.toFixed(2)}` : '—'}
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function HistoryTimeline({ history }: { history: MIIHistoryPoint[] }) {
-  const reversed = [...history].reverse();
-
-  return (
-    <div className="space-y-2">
-      {reversed.map((point, i) => (
-        <div key={`${point.timestamp}-${i}`} className="flex items-start gap-3 rounded-lg border border-slate-800 bg-slate-950/60 p-3">
-          <div className={`mt-0.5 shrink-0 rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-xs font-mono ${miiBarColor(point.score).replace('bg-', 'text-').replace('500', '300')}`}>
-            {point.score.toFixed(2)}
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="text-sm text-slate-200">{point.reason}</div>
-            <div className="mt-1 text-[11px] font-mono text-slate-500">
-              {new Date(point.timestamp).toLocaleString()}
-            </div>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function EpiconList({ epicons }: { epicons: StoredEpicon[] }) {
-  if (epicons.length === 0) {
-    return (
-      <div className="rounded-lg border border-dashed border-slate-800 bg-slate-950/40 p-6 text-center text-sm text-slate-500">
-        No EPICONs submitted yet. Use /submit in the terminal to create your first signal.
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-2">
-      {epicons.map((e) => (
-        <div key={e.id} className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0 flex-1">
-              <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500">{e.id}</div>
-              <div className="mt-1 text-sm font-medium text-slate-200">{e.title}</div>
-              <div className="mt-1 line-clamp-2 text-xs text-slate-400">{e.summary}</div>
-            </div>
-            <div className="flex shrink-0 flex-col items-end gap-1.5">
-              <span className={`rounded-md border px-2 py-0.5 text-[10px] font-mono uppercase tracking-[0.1em] ${statusColor(e.status)}`}>
-                {e.status}
-              </span>
-              {e.verificationOutcome && (
-                <span className={`text-[10px] font-mono uppercase ${outcomeColor(e.verificationOutcome)}`}>
-                  {e.verificationOutcome}
-                </span>
-              )}
-            </div>
-          </div>
-          <div className="mt-2 flex flex-wrap items-center gap-2">
-            <span className="rounded-md bg-slate-800 px-2 py-0.5 text-[10px] font-mono uppercase tracking-[0.1em] text-slate-400">
-              {e.category}
-            </span>
-            <span className="rounded-md bg-slate-800 px-2 py-0.5 text-[10px] font-mono uppercase tracking-[0.1em] text-slate-400">
-              T{e.confidenceTier}
-            </span>
-            <span className="text-[10px] font-mono text-slate-500">
-              {new Date(e.createdAt).toLocaleDateString()}
-            </span>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
 
 export default function ProfilePage() {
-  const [data, setData] = useState<ProfileResponse | null>(null);
   const [identity, setIdentity] = useState<MobiusIdentity | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [loginInput, setLoginInput] = useState('kaizencycle');
-
-  async function loadProfile(login: string) {
-    setLoading(true);
-    try {
-      const [profileRes, identityRes] = await Promise.all([
-        fetch(`/api/profile?login=${encodeURIComponent(login)}`, { cache: 'no-store' }),
-        fetch(`/api/identity/me?username=${encodeURIComponent(login)}`, { cache: 'no-store' }),
-      ]);
-      const [profileJson, identityJson] = await Promise.all([profileRes.json(), identityRes.json()]);
-      setData(profileJson);
-      setIdentity(identityJson.identity || null);
-    } catch {
-      setData(null);
-      setIdentity(null);
-    } finally {
-      setLoading(false);
-    }
-  }
 
   useEffect(() => {
-    loadProfile('kaizencycle');
+    let mounted = true;
+
+    async function load() {
+      try {
+        const res = await fetch('/api/identity/me?username=kaizencycle', {
+          cache: 'no-store',
+        });
+        const json = await res.json();
+
+        if (mounted) {
+          setIdentity(json.identity || null);
+        }
+      } catch {
+        if (mounted) {
+          setIdentity(null);
+        }
+      }
+    }
+
+    load();
+
+    return () => {
+      mounted = false;
+    };
   }, []);
 
-  const profile = data?.profile;
-  const epicons = data?.epicons ?? [];
-  const totalReviewed = (profile?.verificationHits ?? 0) + (profile?.verificationMisses ?? 0);
-  const accuracy = totalReviewed > 0
-    ? ((profile?.verificationHits ?? 0) / totalReviewed * 100).toFixed(0)
-    : '—';
-
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
-      <header className="border-b border-slate-800 bg-slate-950/95 px-6 py-4 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4">
+    <main className="min-h-screen bg-slate-950 p-6 text-slate-100">
+      <div className="mx-auto max-w-5xl">
+        <div className="mb-6">
           <div>
-            <Link href="/terminal" className="text-xs font-mono uppercase tracking-[0.25em] text-sky-300 transition hover:text-sky-200">
-              &larr; Mobius Terminal
-            </Link>
-            <h1 className="mt-2 text-2xl font-semibold">Mobius Profile</h1>
+            <div className="text-sm uppercase tracking-[0.3em] text-sky-300">
+              Mobius Identity Layer
+            </div>
+            <h1 className="mt-3 text-3xl font-semibold">Profile &amp; Role Surface</h1>
             <p className="mt-1 text-sm text-slate-400">
-              Identity, permissions, reputation, and contribution history for the active Mobius operator.
+              Identity, permissions, integrity score, and contribution state for the current Mobius node.
             </p>
           </div>
-          <div className="flex items-center gap-2">
-            <input
-              value={loginInput}
-              onChange={(e) => setLoginInput(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && loadProfile(loginInput)}
-              placeholder="github login"
-              className="w-40 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm font-mono text-white outline-none placeholder:text-slate-600 focus:border-sky-500/40"
-            />
-            <button
-              onClick={() => loadProfile(loginInput)}
-              className="rounded-lg border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-xs font-mono uppercase tracking-[0.14em] text-sky-300 transition hover:bg-sky-500/15"
-            >
-              Load
-            </button>
-          </div>
         </div>
-      </header>
 
-      <main className="mx-auto max-w-6xl px-6 py-6">
-        {loading ? (
-          <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 text-slate-400">
-            Loading Mobius profile surfaces…
-          </div>
-        ) : !profile ? (
-          <div className="rounded-xl border border-rose-500/20 bg-rose-500/10 p-6 text-rose-200">
-            Unable to load this profile right now.
-          </div>
+        {identity ? (
+          <MobiusIdentityCard identity={identity} />
         ) : (
-          <div className="space-y-6">
-            {identity ? <MobiusIdentityCard identity={identity} /> : null}
-
-            <div className="grid gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.65fr)]">
-              <div className="space-y-6">
-                <section className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
-                  <div className="flex flex-wrap items-start justify-between gap-4">
-                    <div>
-                      <div className="text-xs font-mono uppercase tracking-[0.2em] text-slate-500">Mobius Reputation</div>
-                      <h2 className="mt-2 text-xl font-semibold text-white">{profile.displayName}</h2>
-                      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs font-mono uppercase tracking-[0.14em]">
-                        <span className={`rounded-md border px-2 py-1 ${tierColor(profile.nodeTier)}`}>
-                          {profile.nodeTier}
-                        </span>
-                        <span className="rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-300">
-                          @{profile.login}
-                        </span>
-                        <span className="rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-300">
-                          {identity?.status || 'active'}
-                        </span>
-                      </div>
-                    </div>
-                    <div className="min-w-[180px] rounded-xl border border-slate-800 bg-slate-950/70 p-4">
-                      <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500">Current MII</div>
-                      <div className="mt-2 text-3xl font-semibold text-white">{profile.miiScore.toFixed(2)}</div>
-                      <div className="mt-2 h-2 overflow-hidden rounded-full bg-slate-800">
-                        <div className={`h-full ${miiBarColor(profile.miiScore)}`} style={{ width: `${Math.min(profile.miiScore * 100, 100)}%` }} />
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                    <Stat label="Signals Submitted" value={String(profile.epiconCount)} />
-                    <Stat label="Verification Hits" value={String(profile.verificationHits)} />
-                    <Stat label="Verification Misses" value={String(profile.verificationMisses)} />
-                    <Stat label="Accuracy" value={accuracy === '—' ? accuracy : `${accuracy}%`} sub={`${totalReviewed} reviewed`} />
-                  </div>
-                </section>
-
-                <section className="grid gap-6 xl:grid-cols-2">
-                  <MIISparkline history={profile.miiHistory} />
-                  <TierProgressBar currentTier={profile.nodeTier} mii={profile.miiScore} />
-                </section>
-
-                <section className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
-                  <div className="text-xs font-mono uppercase tracking-[0.2em] text-slate-500">Recent EPICONs</div>
-                  <div className="mt-4">
-                    <EpiconList epicons={epicons} />
-                  </div>
-                </section>
-              </div>
-
-              <div className="space-y-6">
-                <section className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
-                  <div className="text-xs font-mono uppercase tracking-[0.2em] text-slate-500">Integrity History</div>
-                  <div className="mt-4">
-                    <HistoryTimeline history={profile.miiHistory} />
-                  </div>
-                </section>
-
-                <section className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
-                  <div className="text-xs font-mono uppercase tracking-[0.2em] text-slate-500">Identity Layer Notes</div>
-                  <div className="mt-3 space-y-3 text-sm text-slate-400">
-                    <p>
-                      Mobius Identity now binds role visibility, MIC state, and EPICON contribution count into a single operator surface.
-                    </p>
-                    <p>
-                      This scaffold keeps storage in memory so the terminal can evolve toward real auth, wallet linkage, and role-based permissions without changing the UI contract.
-                    </p>
-                  </div>
-                </section>
-              </div>
-            </div>
+          <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 text-slate-400">
+            Loading identity...
           </div>
         )}
-      </main>
-    </div>
+      </div>
+    </main>
   );
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,38 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import MobiusIdentityCard from '@/components/identity/MobiusIdentityCard';
-import type { MobiusIdentity } from '@/lib/identity/types';
+import { useMobiusIdentity } from '@/hooks/useMobiusIdentity';
 
 export default function ProfilePage() {
-  const [identity, setIdentity] = useState<MobiusIdentity | null>(null);
-
-  useEffect(() => {
-    let mounted = true;
-
-    async function load() {
-      try {
-        const res = await fetch('/api/identity/me?username=kaizencycle', {
-          cache: 'no-store',
-        });
-        const json = await res.json();
-
-        if (mounted) {
-          setIdentity(json.identity || null);
-        }
-      } catch {
-        if (mounted) {
-          setIdentity(null);
-        }
-      }
-    }
-
-    load();
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
+  const { identity, loading, permissions } = useMobiusIdentity();
 
   return (
     <main className="min-h-screen bg-slate-950 p-6 text-slate-100">
@@ -46,6 +18,18 @@ export default function ProfilePage() {
             <p className="mt-1 text-sm text-slate-400">
               Identity, permissions, integrity score, and contribution state for the current Mobius node.
             </p>
+            {!loading && permissions.length > 0 ? (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {permissions.map((permission) => (
+                  <span
+                    key={permission}
+                    className="rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em] text-slate-300"
+                  >
+                    {permission}
+                  </span>
+                ))}
+              </div>
+            ) : null}
           </div>
         </div>
 
@@ -53,7 +37,7 @@ export default function ProfilePage() {
           <MobiusIdentityCard identity={identity} />
         ) : (
           <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 text-slate-400">
-            Loading identity...
+            {loading ? 'Loading identity...' : 'Identity unavailable.'}
           </div>
         )}
       </div>

--- a/components/epicon/CandidateCard.tsx
+++ b/components/epicon/CandidateCard.tsx
@@ -14,6 +14,8 @@ type Candidate = {
 type Props = {
   item: Candidate;
   onVerify: (id: string, outcome: 'verified' | 'contradicted') => Promise<void>;
+  canVerify: boolean;
+  canContradict: boolean;
 };
 
 function tone(status: Candidate['status']) {
@@ -27,7 +29,7 @@ function tone(status: Candidate['status']) {
   }
 }
 
-export default function CandidateCard({ item, onVerify }: Props) {
+export default function CandidateCard({ item, onVerify, canVerify, canContradict }: Props) {
   return (
     <div className="rounded-xl border border-slate-800 bg-black/40 p-4 text-white">
       <div className="flex items-start justify-between gap-3">
@@ -60,17 +62,33 @@ export default function CandidateCard({ item, onVerify }: Props) {
       {item.status === 'pending' ? (
         <div className="mt-4 flex gap-2">
           <button
+            disabled={!canVerify}
             onClick={() => onVerify(item.id, 'verified')}
-            className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-300 hover:bg-emerald-500/20"
+            className={`rounded-lg border px-3 py-2 text-xs transition ${
+              canVerify
+                ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300 hover:bg-emerald-500/20'
+                : 'cursor-not-allowed border-slate-800 bg-slate-950 text-slate-600'
+            }`}
           >
             ZEUS Verify
           </button>
           <button
+            disabled={!canContradict}
             onClick={() => onVerify(item.id, 'contradicted')}
-            className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-300 hover:bg-rose-500/20"
+            className={`rounded-lg border px-3 py-2 text-xs transition ${
+              canContradict
+                ? 'border-rose-500/30 bg-rose-500/10 text-rose-300 hover:bg-rose-500/20'
+                : 'cursor-not-allowed border-slate-800 bg-slate-950 text-slate-600'
+            }`}
           >
             ZEUS Contradict
           </button>
+        </div>
+      ) : null}
+
+      {item.status === 'pending' && !canVerify && !canContradict ? (
+        <div className="mt-3 text-xs text-slate-500">
+          Verification unavailable for current role
         </div>
       ) : null}
     </div>

--- a/components/epicon/CandidateFeed.tsx
+++ b/components/epicon/CandidateFeed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useMobiusIdentity } from '@/hooks/useMobiusIdentity';
 import CandidateCard from './CandidateCard';
 
 type Candidate = {
@@ -16,26 +17,12 @@ type Candidate = {
 
 export default function CandidateFeed() {
   const [data, setData] = useState<Candidate[]>([]);
-  const [canVerify, setCanVerify] = useState(false);
-  const [canContradict, setCanContradict] = useState(false);
+  const { hasPermission } = useMobiusIdentity();
 
   async function load() {
     const res = await fetch('/api/epicon/candidates', { cache: 'no-store' });
     const json = await res.json();
     setData(json.candidates || []);
-  }
-
-  async function loadPermissions() {
-    try {
-      const res = await fetch('/api/identity/me?username=kaizencycle', { cache: 'no-store' });
-      const json = await res.json();
-      const permissions = json.permissions || [];
-      setCanVerify(permissions.includes('epicon:verify'));
-      setCanContradict(permissions.includes('epicon:contradict'));
-    } catch {
-      setCanVerify(false);
-      setCanContradict(false);
-    }
   }
 
   async function onVerify(id: string, outcome: 'verified' | 'contradicted') {
@@ -65,7 +52,6 @@ export default function CandidateFeed() {
 
   useEffect(() => {
     load();
-    loadPermissions();
     const interval = setInterval(load, 5000);
     return () => clearInterval(interval);
   }, []);
@@ -83,8 +69,8 @@ export default function CandidateFeed() {
           key={item.id}
           item={item}
           onVerify={onVerify}
-          canVerify={canVerify}
-          canContradict={canContradict}
+          canVerify={hasPermission('epicon:verify')}
+          canContradict={hasPermission('epicon:contradict')}
         />
       ))}
     </div>

--- a/components/epicon/CandidateFeed.tsx
+++ b/components/epicon/CandidateFeed.tsx
@@ -16,11 +16,26 @@ type Candidate = {
 
 export default function CandidateFeed() {
   const [data, setData] = useState<Candidate[]>([]);
+  const [canVerify, setCanVerify] = useState(false);
+  const [canContradict, setCanContradict] = useState(false);
 
   async function load() {
     const res = await fetch('/api/epicon/candidates', { cache: 'no-store' });
     const json = await res.json();
     setData(json.candidates || []);
+  }
+
+  async function loadPermissions() {
+    try {
+      const res = await fetch('/api/identity/me?username=kaizencycle', { cache: 'no-store' });
+      const json = await res.json();
+      const permissions = json.permissions || [];
+      setCanVerify(permissions.includes('epicon:verify'));
+      setCanContradict(permissions.includes('epicon:contradict'));
+    } catch {
+      setCanVerify(false);
+      setCanContradict(false);
+    }
   }
 
   async function onVerify(id: string, outcome: 'verified' | 'contradicted') {
@@ -35,11 +50,13 @@ export default function CandidateFeed() {
           outcome === 'verified'
             ? 'Cross-source alignment sufficient for verified candidate status.'
             : 'Contradiction or insufficient support detected by ZEUS.',
+        reviewer: 'kaizencycle',
       }),
     });
 
     if (!res.ok) {
-      console.error('ZEUS verification failed');
+      const json = await res.json().catch(() => null);
+      console.error(json?.error || 'ZEUS verification failed');
       return;
     }
 
@@ -48,6 +65,7 @@ export default function CandidateFeed() {
 
   useEffect(() => {
     load();
+    loadPermissions();
     const interval = setInterval(load, 5000);
     return () => clearInterval(interval);
   }, []);
@@ -61,7 +79,13 @@ export default function CandidateFeed() {
       ) : null}
 
       {data.map((item) => (
-        <CandidateCard key={item.id} item={item} onVerify={onVerify} />
+        <CandidateCard
+          key={item.id}
+          item={item}
+          onVerify={onVerify}
+          canVerify={canVerify}
+          canContradict={canContradict}
+        />
       ))}
     </div>
   );

--- a/components/identity/MobiusIdentityBadge.tsx
+++ b/components/identity/MobiusIdentityBadge.tsx
@@ -1,39 +1,16 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
-import type { MobiusIdentity } from '@/lib/identity/types';
+import { useMobiusIdentity } from '@/hooks/useMobiusIdentity';
+
+function formatRole(role: string) {
+  return role.charAt(0).toUpperCase() + role.slice(1);
+}
 
 export default function MobiusIdentityBadge() {
-  const [identity, setIdentity] = useState<MobiusIdentity | null>(null);
+  const { identity, loading } = useMobiusIdentity();
 
-  useEffect(() => {
-    let mounted = true;
-
-    async function load() {
-      try {
-        const res = await fetch('/api/identity/me?username=kaizencycle', {
-          cache: 'no-store',
-        });
-        const json = await res.json();
-        if (mounted) {
-          setIdentity(json.identity || null);
-        }
-      } catch {
-        if (mounted) {
-          setIdentity(null);
-        }
-      }
-    }
-
-    load();
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  if (!identity) {
+  if (loading || !identity) {
     return (
       <div className="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-[11px] font-mono uppercase tracking-[0.15em] text-slate-400">
         Identity loading…
@@ -46,7 +23,7 @@ export default function MobiusIdentityBadge() {
       href="/profile"
       className="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-[11px] font-mono uppercase tracking-[0.15em] text-slate-300 transition hover:border-sky-500/30 hover:bg-slate-800 hover:text-sky-200"
     >
-      @{identity.username} · {identity.role} · MII {identity.mii_score.toFixed(2)}
+      @{identity.username} · {formatRole(identity.role)} · MII {identity.mii_score.toFixed(2)} · MIC {identity.mic_balance}
     </Link>
   );
 }

--- a/components/query/PublishEpiconModal.tsx
+++ b/components/query/PublishEpiconModal.tsx
@@ -126,9 +126,10 @@ export default function PublishEpiconModal({
           submitted_by_login: 'kaizencycle',
         }),
       });
+      const json = await res.json();
 
       if (!res.ok) {
-        throw new Error('Publish failed');
+        throw new Error(json.error || 'Publish failed');
       }
 
       onClose();
@@ -139,7 +140,7 @@ export default function PublishEpiconModal({
       );
     } catch (err) {
       console.error(err);
-      alert('Unable to complete publish flow');
+      alert(err instanceof Error ? err.message : 'Unable to complete publish flow');
     } finally {
       setLoading(false);
     }

--- a/components/query/QueryResultCard.tsx
+++ b/components/query/QueryResultCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useMobiusIdentity } from '@/hooks/useMobiusIdentity';
 import PublishEpiconModal from './PublishEpiconModal';
 
 type QueryResult = {
@@ -21,30 +22,8 @@ export default function QueryResultCard({
   result: QueryResult;
 }) {
   const [open, setOpen] = useState(false);
-  const [canPublish, setCanPublish] = useState(false);
-
-  useEffect(() => {
-    let active = true;
-
-    async function loadPermissions() {
-      try {
-        const res = await fetch('/api/identity/me?username=kaizencycle', { cache: 'no-store' });
-        const json = await res.json();
-        if (!active) return;
-        setCanPublish(Boolean(json.permissions?.includes('epicon:publish')));
-      } catch {
-        if (active) {
-          setCanPublish(false);
-        }
-      }
-    }
-
-    loadPermissions();
-
-    return () => {
-      active = false;
-    };
-  }, []);
+  const { hasPermission, loading } = useMobiusIdentity();
+  const canPublish = hasPermission('epicon:publish');
 
   return (
     <>
@@ -81,7 +60,7 @@ export default function QueryResultCard({
 
           <div className="flex flex-col gap-1">
             <button
-              disabled={!canPublish}
+              disabled={loading || !canPublish}
               className={`rounded-lg border px-3 py-2 text-sm transition ${
                 canPublish
                   ? 'border-sky-500/30 bg-sky-500/10 text-sky-300 hover:bg-sky-500/20'
@@ -91,7 +70,7 @@ export default function QueryResultCard({
             >
               Publish to EPICON
             </button>
-            {!canPublish ? (
+            {!loading && !canPublish ? (
               <div className="text-[11px] text-slate-500">
                 Publish unavailable for current role
               </div>

--- a/components/query/QueryResultCard.tsx
+++ b/components/query/QueryResultCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import PublishEpiconModal from './PublishEpiconModal';
 
 type QueryResult = {
@@ -21,6 +21,30 @@ export default function QueryResultCard({
   result: QueryResult;
 }) {
   const [open, setOpen] = useState(false);
+  const [canPublish, setCanPublish] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadPermissions() {
+      try {
+        const res = await fetch('/api/identity/me?username=kaizencycle', { cache: 'no-store' });
+        const json = await res.json();
+        if (!active) return;
+        setCanPublish(Boolean(json.permissions?.includes('epicon:publish')));
+      } catch {
+        if (active) {
+          setCanPublish(false);
+        }
+      }
+    }
+
+    loadPermissions();
+
+    return () => {
+      active = false;
+    };
+  }, []);
 
   return (
     <>
@@ -55,12 +79,24 @@ export default function QueryResultCard({
             Save to Dashboard
           </button>
 
-          <button
-            className="rounded-lg border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-sm text-sky-300 hover:bg-sky-500/20"
-            onClick={() => setOpen(true)}
-          >
-            Publish to EPICON
-          </button>
+          <div className="flex flex-col gap-1">
+            <button
+              disabled={!canPublish}
+              className={`rounded-lg border px-3 py-2 text-sm transition ${
+                canPublish
+                  ? 'border-sky-500/30 bg-sky-500/10 text-sky-300 hover:bg-sky-500/20'
+                  : 'cursor-not-allowed border-slate-800 bg-slate-950 text-slate-600'
+              }`}
+              onClick={() => canPublish && setOpen(true)}
+            >
+              Publish to EPICON
+            </button>
+            {!canPublish ? (
+              <div className="text-[11px] text-slate-500">
+                Publish unavailable for current role
+              </div>
+            ) : null}
+          </div>
 
           <button
             className="rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 hover:bg-slate-800"

--- a/components/terminal/AgentCortexPanel.tsx
+++ b/components/terminal/AgentCortexPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import type { Agent } from '@/lib/terminal/types';
+import { useMobiusIdentity } from '@/hooks/useMobiusIdentity';
 import { statusColor, cn } from '@/lib/terminal/utils';
 import SectionLabel from './SectionLabel';
 
@@ -14,30 +14,11 @@ export default function AgentCortexPanel({
   selectedId?: string;
   onSelect?: (agent: Agent) => void;
 }) {
-  const [canInvoke, setCanInvoke] = useState(false);
-
-  useEffect(() => {
-    let active = true;
-
-    async function loadPermissions() {
-      try {
-        const res = await fetch('/api/identity/me?username=kaizencycle', { cache: 'no-store' });
-        const json = await res.json();
-        if (!active) return;
-        setCanInvoke(Boolean(json.permissions?.includes('agents:invoke')));
-      } catch {
-        if (active) {
-          setCanInvoke(false);
-        }
-      }
-    }
-
-    loadPermissions();
-
-    return () => {
-      active = false;
-    };
-  }, []);
+  const { identity, hasPermission, loading } = useMobiusIdentity();
+  const canInvoke = hasPermission('agents:invoke');
+  const visibleAgents = identity
+    ? agents.filter((agent) => identity.agent_permissions.includes(agent.name.toUpperCase()))
+    : agents;
 
   return (
     <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
@@ -45,13 +26,20 @@ export default function AgentCortexPanel({
         title="Agent Cortex"
         subtitle="Live substrate operator map"
       />
+      {identity ? (
+        <div className="mt-3 text-[11px] font-mono uppercase tracking-[0.14em] text-slate-500">
+          @{identity.username} · {identity.role} · agent access {identity.agent_permissions.join(', ')}
+        </div>
+      ) : null}
       {!canInvoke ? (
         <div className="mt-3 rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-xs font-mono text-slate-500">
-          Agent invocation unavailable for current role. Read-only status view only.
+          {loading
+            ? 'Loading agent access…'
+            : 'Agent invocation unavailable for current role. Read-only status view only.'}
         </div>
       ) : null}
       <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3 xl:grid-cols-4">
-        {agents.map((agent) => (
+        {visibleAgents.map((agent) => (
           <button
             key={agent.id}
             onClick={() => onSelect?.(agent)}

--- a/components/terminal/AgentCortexPanel.tsx
+++ b/components/terminal/AgentCortexPanel.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import type { Agent } from '@/lib/terminal/types';
 import { statusColor, cn } from '@/lib/terminal/utils';
 import SectionLabel from './SectionLabel';
@@ -11,12 +14,42 @@ export default function AgentCortexPanel({
   selectedId?: string;
   onSelect?: (agent: Agent) => void;
 }) {
+  const [canInvoke, setCanInvoke] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadPermissions() {
+      try {
+        const res = await fetch('/api/identity/me?username=kaizencycle', { cache: 'no-store' });
+        const json = await res.json();
+        if (!active) return;
+        setCanInvoke(Boolean(json.permissions?.includes('agents:invoke')));
+      } catch {
+        if (active) {
+          setCanInvoke(false);
+        }
+      }
+    }
+
+    loadPermissions();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
   return (
     <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
       <SectionLabel
         title="Agent Cortex"
         subtitle="Live substrate operator map"
       />
+      {!canInvoke ? (
+        <div className="mt-3 rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-xs font-mono text-slate-500">
+          Agent invocation unavailable for current role. Read-only status view only.
+        </div>
+      ) : null}
       <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3 xl:grid-cols-4">
         {agents.map((agent) => (
           <button

--- a/components/terminal/DetailInspectorRail.tsx
+++ b/components/terminal/DetailInspectorRail.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState, type ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
+import { useMobiusIdentity } from '@/hooks/useMobiusIdentity';
 import type { InspectorTarget, Tripwire } from '@/lib/terminal/types';
 import { confidenceLabel, statusColor, tripwireStyle, giScoreColor, metricBarColor, cn } from '@/lib/terminal/utils';
 import SectionLabel from './SectionLabel';
@@ -133,36 +134,11 @@ function ZeusVerifyControls({
   const [tier, setTier] = useState(3);
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<ZeusVerifyResult | null>(null);
-  const [canVerify, setCanVerify] = useState(false);
-  const [canContradict, setCanContradict] = useState(false);
+  const { hasPermission } = useMobiusIdentity();
+  const canVerify = hasPermission('epicon:verify');
+  const canContradict = hasPermission('epicon:contradict');
 
   if (!onVerify) return null;
-
-  useEffect(() => {
-    let active = true;
-
-    async function loadPermissions() {
-      try {
-        const res = await fetch('/api/identity/me?username=kaizencycle', { cache: 'no-store' });
-        const json = await res.json();
-        const permissions = json.permissions || [];
-        if (!active) return;
-        setCanVerify(permissions.includes('epicon:verify'));
-        setCanContradict(permissions.includes('epicon:contradict'));
-      } catch {
-        if (active) {
-          setCanVerify(false);
-          setCanContradict(false);
-        }
-      }
-    }
-
-    loadPermissions();
-
-    return () => {
-      active = false;
-    };
-  }, []);
 
   // Only show for user-submitted pending EPICONs
   const isUserSubmitted = epiconId.includes('-USR-');

--- a/components/terminal/DetailInspectorRail.tsx
+++ b/components/terminal/DetailInspectorRail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import type { InspectorTarget, Tripwire } from '@/lib/terminal/types';
 import { confidenceLabel, statusColor, tripwireStyle, giScoreColor, metricBarColor, cn } from '@/lib/terminal/utils';
 import SectionLabel from './SectionLabel';
@@ -11,6 +11,7 @@ export type ZeusVerifyPayload = {
   finalStatus: 'verified' | 'contradicted';
   finalConfidenceTier: number;
   zeusNote: string;
+  reviewer?: string;
 };
 
 export type ZeusVerifyResult = {
@@ -132,8 +133,36 @@ function ZeusVerifyControls({
   const [tier, setTier] = useState(3);
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<ZeusVerifyResult | null>(null);
+  const [canVerify, setCanVerify] = useState(false);
+  const [canContradict, setCanContradict] = useState(false);
 
   if (!onVerify) return null;
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadPermissions() {
+      try {
+        const res = await fetch('/api/identity/me?username=kaizencycle', { cache: 'no-store' });
+        const json = await res.json();
+        const permissions = json.permissions || [];
+        if (!active) return;
+        setCanVerify(permissions.includes('epicon:verify'));
+        setCanContradict(permissions.includes('epicon:contradict'));
+      } catch {
+        if (active) {
+          setCanVerify(false);
+          setCanContradict(false);
+        }
+      }
+    }
+
+    loadPermissions();
+
+    return () => {
+      active = false;
+    };
+  }, []);
 
   // Only show for user-submitted pending EPICONs
   const isUserSubmitted = epiconId.includes('-USR-');
@@ -157,6 +186,7 @@ function ZeusVerifyControls({
         finalStatus: outcome === 'hit' ? 'verified' : 'contradicted',
         finalConfidenceTier: tier,
         zeusNote: note,
+        reviewer: 'kaizencycle',
       });
       setResult(res);
     } catch {
@@ -183,6 +213,12 @@ function ZeusVerifyControls({
 
   return (
     <div className="space-y-3">
+      {!canVerify && !canContradict ? (
+        <div className="rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-xs font-mono text-slate-500">
+          ZEUS verification unavailable for current role.
+        </div>
+      ) : null}
+
       <div className="flex items-center gap-2">
         <span className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-500">
           Final Tier
@@ -214,16 +250,16 @@ function ZeusVerifyControls({
 
       <div className="flex gap-2">
         <button
-          disabled={busy}
+          disabled={busy || !canVerify}
           onClick={() => handleVerify('hit')}
-          className="flex-1 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs font-mono uppercase tracking-[0.12em] text-emerald-300 transition hover:bg-emerald-500/20 disabled:opacity-50"
+          className="flex-1 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs font-mono uppercase tracking-[0.12em] text-emerald-300 transition hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-30"
         >
           {busy ? '...' : 'Verify (Hit)'}
         </button>
         <button
-          disabled={busy}
+          disabled={busy || !canContradict}
           onClick={() => handleVerify('miss')}
-          className="flex-1 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs font-mono uppercase tracking-[0.12em] text-rose-300 transition hover:bg-rose-500/20 disabled:opacity-50"
+          className="flex-1 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs font-mono uppercase tracking-[0.12em] text-rose-300 transition hover:bg-rose-500/20 disabled:cursor-not-allowed disabled:opacity-30"
         >
           {busy ? '...' : 'Contradict (Miss)'}
         </button>

--- a/hooks/useMobiusIdentity.ts
+++ b/hooks/useMobiusIdentity.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { MobiusIdentity } from '@/lib/identity/types';
+import type { MobiusPermission } from '@/lib/identity/permissions';
+
+export function useMobiusIdentity() {
+  const [identity, setIdentity] = useState<MobiusIdentity | null>(null);
+  const [permissions, setPermissions] = useState<MobiusPermission[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        const res = await fetch('/api/identity/me?username=kaizencycle', {
+          cache: 'no-store',
+        });
+        const json = await res.json();
+
+        if (!active) return;
+
+        setIdentity(json.identity || null);
+        setPermissions(json.permissions || []);
+      } catch {
+        if (active) {
+          setIdentity(null);
+          setPermissions([]);
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    load();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return {
+    identity,
+    permissions,
+    loading,
+    hasPermission: (permission: MobiusPermission) => permissions.includes(permission),
+  };
+}

--- a/lib/identity/guards.ts
+++ b/lib/identity/guards.ts
@@ -1,0 +1,17 @@
+import type { MobiusPermission } from '@/lib/identity/permissions';
+import { getIdentityPermissions } from '@/lib/identity/store';
+
+export function hasPermission(username: string, permission: MobiusPermission) {
+  const permissions = getIdentityPermissions(username);
+  return permissions.includes(permission);
+}
+
+export function requirePermission(username: string, permission: MobiusPermission) {
+  const allowed = hasPermission(username, permission);
+
+  if (!allowed) {
+    throw new Error(`Permission denied: ${permission}`);
+  }
+
+  return true;
+}

--- a/lib/identity/permissions.ts
+++ b/lib/identity/permissions.ts
@@ -1,0 +1,30 @@
+import type { MobiusRole } from '@/lib/identity/types';
+
+export type MobiusPermission =
+  | 'query:run'
+  | 'query:save'
+  | 'epicon:publish'
+  | 'epicon:verify'
+  | 'epicon:contradict'
+  | 'agents:invoke'
+  | 'terminal:admin';
+
+export const rolePermissions: Record<MobiusRole, MobiusPermission[]> = {
+  observer: ['query:run', 'query:save'],
+  citizen: ['query:run', 'query:save', 'epicon:publish'],
+  analyst: ['query:run', 'query:save', 'epicon:publish', 'epicon:contradict'],
+  journalist: ['query:run', 'query:save', 'epicon:publish'],
+  developer: ['query:run', 'query:save', 'epicon:publish', 'agents:invoke'],
+  steward: [
+    'query:run',
+    'query:save',
+    'epicon:publish',
+    'epicon:verify',
+    'epicon:contradict',
+    'terminal:admin',
+  ],
+};
+
+export function getPermissionsForRole(role: MobiusRole): MobiusPermission[] {
+  return [...rolePermissions[role]];
+}

--- a/lib/identity/store.ts
+++ b/lib/identity/store.ts
@@ -1,10 +1,8 @@
 import { getMicAccount } from '@/lib/mic/store';
 import type { MobiusIdentity, MobiusRole } from '@/lib/identity/types';
+import { rolePermissions } from '@/lib/identity/permissions';
 
 const DEFAULT_USERNAME = 'kaizencycle';
-const DEFAULT_ROLE: MobiusRole = 'developer';
-const DEFAULT_AGENTS = ['ECHO', 'ZEUS', 'ATLAS'];
-
 const identities = new Map<string, MobiusIdentity>();
 
 function randomId(prefix: string) {
@@ -15,21 +13,41 @@ function normalizeUsername(username?: string | null) {
   return (username || DEFAULT_USERNAME).trim() || DEFAULT_USERNAME;
 }
 
+function defaultRoleFor(username: string): MobiusRole {
+  return username === DEFAULT_USERNAME ? 'developer' : 'citizen';
+}
+
+function defaultAgentPermissions(role: MobiusRole): string[] {
+  if (role === 'developer') {
+    return ['ECHO', 'ZEUS', 'ATLAS', 'AUREA'];
+  }
+
+  return ['ECHO', 'ZEUS'];
+}
+
+function displayNameFor(username: string) {
+  if (username === DEFAULT_USERNAME) {
+    return 'Michael';
+  }
+
+  return username;
+}
+
 function buildIdentity(username: string): MobiusIdentity {
   const now = new Date().toISOString();
-  const account = getMicAccount(username);
+  const role = defaultRoleFor(username);
 
   return {
     mobius_id: randomId('mbx'),
     ledger_id: randomId('ldr'),
     username,
-    display_name: username === DEFAULT_USERNAME ? 'Michael' : username,
-    role: DEFAULT_ROLE,
+    display_name: displayNameFor(username),
+    role,
     status: 'active',
     mii_score: 0.5,
-    mic_balance: account.balance,
+    mic_balance: getMicAccount(username).balance,
     epicon_count: 0,
-    agent_permissions: [...DEFAULT_AGENTS],
+    agent_permissions: defaultAgentPermissions(role),
     joined_at: now,
     last_active_at: now,
   };
@@ -55,7 +73,6 @@ export function getIdentity(username?: string | null) {
 
 export function listIdentities() {
   ensureIdentity(DEFAULT_USERNAME);
-
   return Array.from(identities.values()).map((identity) => ({
     ...identity,
     mic_balance: getMicAccount(identity.username).balance,
@@ -75,4 +92,9 @@ export function incrementEpiconCount(username?: string | null) {
   identity.last_active_at = new Date().toISOString();
   identity.mic_balance = getMicAccount(identity.username).balance;
   return identity;
+}
+
+export function getIdentityPermissions(username?: string | null) {
+  const identity = ensureIdentity(username);
+  return rolePermissions[identity.role];
 }


### PR DESCRIPTION
### Motivation

- Surface role-based permissions from the identity layer via the API so callers can make authorization decisions without inferring roles. 
- Centralize role→permission mappings to avoid scattered hard-coded permission lists. 
- Simplify the profile page to only fetch and render the identity and its permissions, removing an older multi-request profile scaffold. 

### Description

- Added `lib/identity/permissions.ts` which defines the `MobiusPermission` type, a `rolePermissions` mapping, and `getPermissionsForRole`. 
- Introduced default role and agent logic in `lib/identity/store.ts`, moved display name logic into a helper, and updated `buildIdentity` to use the new defaults and the MIC balance lookup. 
- Added `getIdentityPermissions` to `lib/identity/store.ts` to return permissions for an identity's role and updated identity helper functions accordingly. 
- Updated `app/api/identity/me/route.ts` to use `getIdentity` and include `permissions: getIdentityPermissions(username)` in the JSON response. 
- Simplified `app/profile/page.tsx` to only fetch `/api/identity/me`, render `MobiusIdentityCard` when available, and remove the previous detailed profile/epicon UI and controls. 

### Testing

- Built and type-checked the project using `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec676a0c4832d898f8bcb28cbd8be)