### PR TITLE
feat(commands): add terminal command registry and weekly digest scaffold

### DIFF
--- a/app/api/digest/weekly/route.ts
+++ b/app/api/digest/weekly/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { buildWeeklyDigest } from '@/lib/digest/weekly';
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    digest: buildWeeklyDigest(),
+  });
+}

--- a/app/api/terminal/command/route.ts
+++ b/app/api/terminal/command/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { runTerminalCommand } from '@/lib/commands/run';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const result = await runTerminalCommand(body.input || '');
+
+  return NextResponse.json({
+    ok: true,
+    result,
+  });
+}

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import { useState } from 'react';
+import type { TerminalCommandResult } from '@/lib/commands/types';
 import TopStatusBar from '@/components/terminal/TopStatusBar';
 import TerminalSection from '@/components/layout/TerminalSection';
 import LiveIntegrityRibbon from '@/components/terminal/LiveIntegrityRibbon';
@@ -22,6 +23,8 @@ import DetailInspectorRail from '@/components/terminal/DetailInspectorRail';
 import MicAccountPanel from '@/components/mic/MicAccountPanel';
 import type { ZeusVerifyPayload, ZeusVerifyResult } from '@/components/terminal/DetailInspectorRail';
 import CommandPalette from '@/components/terminal/CommandPalette';
+import CommandInput from '@/components/terminal/CommandInput';
+import CommandResult from '@/components/terminal/CommandResult';
 import QueryResultCard from '@/components/query/QueryResultCard';
 import LedgerPanel from '@/components/terminal/LedgerPanel';
 import SubstrateStatusCard from '@/components/terminal/SubstrateStatusCard';
@@ -86,6 +89,7 @@ export default function TerminalPageWrapper() {
 
 function TerminalPage() {
   const [selectedNav, setSelectedNav] = useState<NavKey>('pulse');
+  const [commandResult, setCommandResult] = useState<TerminalCommandResult | null>(null);
   const {
     agents,
     allTripwires,
@@ -449,6 +453,17 @@ function TerminalPage() {
                 </section>
               </TerminalSection>
             )}
+
+            <TerminalSection
+              eyebrow="Command Surface"
+              title="Terminal Commands"
+              description="Exact command matching for weekly digest, GI status, and agent status."
+            >
+              <div className="space-y-4">
+                <CommandInput onResult={setCommandResult} />
+                <CommandResult result={commandResult} />
+              </div>
+            </TerminalSection>
 
             <CommandPalette
               onExecute={(command) => {

--- a/components/terminal/CommandInput.tsx
+++ b/components/terminal/CommandInput.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState } from 'react';
+import { commandRegistry } from '@/lib/commands/registry';
+import type { TerminalCommandResult } from '@/lib/commands/types';
+
+export default function CommandInput({
+  onResult,
+}: {
+  onResult: (result: TerminalCommandResult) => void;
+}) {
+  const [value, setValue] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleRun() {
+    if (!value.trim()) return;
+
+    try {
+      setLoading(true);
+
+      const res = await fetch('/api/terminal/command', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ input: value }),
+      });
+
+      const json = await res.json();
+      onResult(json.result);
+      setValue('');
+    } catch {
+      onResult({
+        command: value,
+        ok: false,
+        title: 'Command Failure',
+        error: 'Unable to execute command.',
+        timestamp: new Date().toISOString(),
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/50 p-4">
+      <div className="text-[11px] uppercase tracking-[0.2em] text-slate-500">
+        Command Interface
+      </div>
+
+      <div className="mt-3 flex gap-2 max-sm:flex-col">
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleRun();
+          }}
+          placeholder="Enter command: weekly_digest"
+          className="flex-1 rounded-xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-white outline-none placeholder:text-slate-500"
+        />
+
+        <button
+          onClick={handleRun}
+          disabled={loading}
+          className="rounded-xl border border-sky-500/30 bg-sky-500/10 px-4 py-3 text-sm text-sky-300 transition hover:bg-sky-500/20 disabled:opacity-50"
+        >
+          {loading ? 'Running...' : 'Run'}
+        </button>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-500">
+        <span>Available:</span>
+        {commandRegistry.map((command) => (
+          <span
+            key={command.name}
+            className="rounded-md border border-slate-800 bg-slate-950 px-2 py-1 font-mono text-slate-400"
+          >
+            {command.name}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/terminal/CommandResult.tsx
+++ b/components/terminal/CommandResult.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import type { TerminalCommandResult } from '@/lib/commands/types';
+
+export default function CommandResult({
+  result,
+}: {
+  result: TerminalCommandResult | null;
+}) {
+  if (!result) {
+    return (
+      <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-4 text-slate-400">
+        No command executed yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-4">
+      <div className="text-[11px] uppercase tracking-[0.2em] text-slate-500">
+        Command Result
+      </div>
+
+      <div className="mt-2 text-lg font-semibold text-white">{result.title}</div>
+
+      {result.summary ? (
+        <div className="mt-2 text-sm text-slate-300">{result.summary}</div>
+      ) : null}
+
+      {result.error ? (
+        <div className="mt-3 rounded-xl border border-rose-500/20 bg-rose-500/10 p-3 text-sm text-rose-300">
+          {result.error}
+        </div>
+      ) : null}
+
+      {result.data ? (
+        <pre className="mt-4 overflow-x-auto rounded-xl border border-slate-800 bg-slate-950 p-4 text-xs text-slate-300">
+          {JSON.stringify(result.data, null, 2)}
+        </pre>
+      ) : null}
+
+      <div className="mt-3 text-xs text-slate-500">
+        {new Date(result.timestamp).toLocaleString()}
+      </div>
+    </div>
+  );
+}

--- a/lib/commands/registry.ts
+++ b/lib/commands/registry.ts
@@ -1,0 +1,22 @@
+import type { TerminalCommandDefinition, TerminalCommandName } from './types';
+
+export const commandRegistry: TerminalCommandDefinition[] = [
+  {
+    name: 'weekly_digest',
+    description: 'Generate the Mobius weekly global situation digest.',
+  },
+  {
+    name: 'gi_status',
+    description: 'Return current Global Integrity system state.',
+  },
+  {
+    name: 'agent_status',
+    description: 'Return current Mobius agent status grid data.',
+  },
+];
+
+export const commandRegistryByName: Record<TerminalCommandName, TerminalCommandDefinition> =
+  commandRegistry.reduce((acc, command) => {
+    acc[command.name] = command;
+    return acc;
+  }, {} as Record<TerminalCommandName, TerminalCommandDefinition>);

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -1,0 +1,67 @@
+import { agentStatus } from '@/lib/mock/agentStatus';
+import { integrityStatus } from '@/lib/mock/integrityStatus';
+import { buildWeeklyDigest } from '@/lib/digest/weekly';
+import { commandRegistryByName } from './registry';
+import type { TerminalCommandName, TerminalCommandResult } from './types';
+
+function isTerminalCommandName(value: string): value is TerminalCommandName {
+  return value in commandRegistryByName;
+}
+
+export async function runTerminalCommand(
+  rawInput: string,
+): Promise<TerminalCommandResult> {
+  const input = rawInput.trim();
+
+  if (!input) {
+    return {
+      command: input,
+      ok: false,
+      title: 'Command Required',
+      error: 'Enter a command to execute.',
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  if (!isTerminalCommandName(input)) {
+    return {
+      command: input,
+      ok: false,
+      title: 'Unknown Command',
+      error: `Command not recognized: ${input}`,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  switch (input) {
+    case 'weekly_digest': {
+      const digest = buildWeeklyDigest();
+      return {
+        command: input,
+        ok: true,
+        title: 'Mobius Weekly Situation Digest',
+        summary: digest.summary,
+        data: digest,
+        timestamp: new Date().toISOString(),
+      };
+    }
+    case 'gi_status':
+      return {
+        command: input,
+        ok: true,
+        title: 'Global Integrity Status',
+        summary: integrityStatus.summary,
+        data: integrityStatus,
+        timestamp: new Date().toISOString(),
+      };
+    case 'agent_status':
+      return {
+        command: input,
+        ok: true,
+        title: 'Mobius Agent Status',
+        summary: 'Canonical agent role and state surface.',
+        data: agentStatus,
+        timestamp: new Date().toISOString(),
+      };
+  }
+}

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -1,0 +1,19 @@
+export type TerminalCommandName =
+  | 'weekly_digest'
+  | 'gi_status'
+  | 'agent_status';
+
+export type TerminalCommandResult = {
+  command: TerminalCommandName | string;
+  ok: boolean;
+  title: string;
+  summary?: string;
+  data?: unknown;
+  error?: string;
+  timestamp: string;
+};
+
+export type TerminalCommandDefinition = {
+  name: TerminalCommandName;
+  description: string;
+};

--- a/lib/digest/weekly.ts
+++ b/lib/digest/weekly.ts
@@ -1,0 +1,89 @@
+export type WeeklyDigest = {
+  week: string;
+  cycle_range: string;
+  gi_status: 'stable' | 'guarded' | 'stressed';
+  global_risk: 'low' | 'guarded' | 'elevated';
+  macro: {
+    inflation: string;
+    rates: string;
+    liquidity: string;
+    summary: string;
+  };
+  geopolitics: {
+    middle_east: string;
+    asia_pacific: string;
+    europe: string;
+    summary: string;
+  };
+  technology: {
+    ai: string;
+    semiconductors: string;
+    cyber: string;
+    summary: string;
+  };
+  climate: {
+    extreme_weather: string;
+    energy_grid: string;
+    summary: string;
+  };
+  risk_dashboard: {
+    financial: 'low' | 'medium' | 'high';
+    geopolitical: 'low' | 'medium' | 'high';
+    cyber: 'low' | 'medium' | 'high';
+    energy: 'low' | 'medium' | 'high';
+    civil: 'low' | 'medium' | 'high';
+  };
+  weekly_changes: string[];
+  summary: string;
+};
+
+export function buildWeeklyDigest(): WeeklyDigest {
+  return {
+    week: '2026-W13',
+    cycle_range: 'C-257-C-258',
+    gi_status: 'stable',
+    global_risk: 'guarded',
+    macro: {
+      inflation: 'elevated',
+      rates: 'high',
+      liquidity: 'tight',
+      summary:
+        'Financial conditions remain restrictive, but broad system stability remains intact.',
+    },
+    geopolitics: {
+      middle_east: 'elevated',
+      asia_pacific: 'guarded',
+      europe: 'stable',
+      summary:
+        'Middle East tensions remain the most immediate external risk driver.',
+    },
+    technology: {
+      ai: 'accelerating',
+      semiconductors: 'strategic',
+      cyber: 'elevated',
+      summary:
+        'AI and compute remain strategic growth vectors while cyber risk stays elevated.',
+    },
+    climate: {
+      extreme_weather: 'increasing',
+      energy_grid: 'stable',
+      summary:
+        'Environmental pressure is rising but not yet producing system-wide grid stress.',
+    },
+    risk_dashboard: {
+      financial: 'medium',
+      geopolitical: 'medium',
+      cyber: 'high',
+      energy: 'medium',
+      civil: 'low',
+    },
+    weekly_changes: [
+      'Mobius Terminal identity spine advanced',
+      'GI became more visible and interactive',
+      'EPICON public memory surface expanded',
+      'Global risk remained concentrated in geopolitics and cyber',
+    ],
+    summary:
+      'The global system remains guarded but stable. Geopolitical and cyber risks remain the primary watch areas while AI and infrastructure continue to accelerate.',
+  };
+}


### PR DESCRIPTION
### Motivation

- Provide the Terminal with a simple, operator-facing command surface so operators can run explicit commands instead of only using panels and palettes.
- Ship an initial, minimal command set to make the Terminal feel operational: `weekly_digest`, `gi_status`, and `agent_status` with exact-match parsing.

### Description

- Add typed command domain with `lib/commands/types.ts`, an exact-match `commandRegistry` in `lib/commands/registry.ts`, and a runner `runTerminalCommand` in `lib/commands/run.ts` that supports the three initial commands.
- Implement a structured weekly digest builder in `lib/digest/weekly.ts` and expose it via `GET /api/digest/weekly` at `app/api/digest/weekly/route.ts`.
- Add a terminal command API endpoint `POST /api/terminal/command` at `app/api/terminal/command/route.ts` that delegates to `runTerminalCommand`.
- Add UI components `components/terminal/CommandInput.tsx` and `components/terminal/CommandResult.tsx` and wire them into the terminal page so command input and structured results render in the operator flow.
- Keep v1 scope intentionally small: exact command matching only, no persistence/auth, and no advanced NLP parsing.

### Testing

- Ran a full production build with `npm run build` (Next.js `next build`) and the build completed successfully with pages and API routes generated.
- Attempted `npm run lint` but the linter prompted for interactive ESLint setup in this environment so it could not complete non-interactively.
- Verified the new API route `app/api/terminal/command` is present in the build output and the terminal page compiles with the new command surface components included.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c188db974c832d881fd9ffba932cc0)