### PR TITLE
feat(ui): Sentinel Pulse + EVE Global News panels in Pulse chamber

### DIFF
--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -31,6 +31,8 @@ import SubstrateStatusCard from '@/components/terminal/SubstrateStatusCard';
 import CivicRadarPanel from '@/components/terminal/CivicRadarPanel';
 import SignalEnginePanel from '@/components/terminal/SignalEnginePanel';
 import IntegrityRatingPanel from '@/components/terminal/IntegrityRatingPanel';
+import SentinelPulsePanel from '@/components/terminal/SentinelPulsePanel';
+import EveGlobalNewsPanel from '@/components/terminal/EveGlobalNewsPanel';
 import { WalletProvider } from '@/contexts/WalletContext';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { navItems, mockCivicAlerts, mockSentinels } from '@/lib/terminal/mock';
@@ -381,32 +383,39 @@ function TerminalPage() {
             )}
 
             {selectedNav === 'pulse' && (
-              <div className="grid gap-4 xl:grid-cols-[1.3fr_0.9fr]">
-                <TerminalSection
-                  eyebrow="Live Intake"
-                  title="Pulse Timeline"
-                  description="Incoming micro-agent signals and current intake state."
-                >
-                  <PulseTimeline />
-                </TerminalSection>
+              <div className="space-y-4">
+                <div className="grid gap-4 xl:grid-cols-[1.3fr_0.9fr]">
+                  <TerminalSection
+                    eyebrow="Live Intake"
+                    title="Pulse Timeline"
+                    description="Incoming micro-agent signals and current intake state."
+                  >
+                    <PulseTimeline />
+                  </TerminalSection>
 
-                <TerminalSection
-                  eyebrow="System State"
-                  title="Global Integrity"
-                  description="Reactive integrity, tripwire, and system state."
-                >
-                  <div className="space-y-4">
-                    <TripwirePanel />
-                    <div className="grid gap-4 sm:grid-cols-2">
-                      <IntegrityMonitorCard gi={gi} onClick={() => setInspectorTarget({ kind: 'gi', data: gi })} />
-                      <TripwireWatchCard
-                        tripwires={allTripwires}
-                        selectedId={inspectorTarget.kind === 'tripwire' ? inspectorTarget.data.id : undefined}
-                        onSelect={(tripwire) => setInspectorTarget({ kind: 'tripwire', data: tripwire })}
-                      />
+                  <TerminalSection
+                    eyebrow="System State"
+                    title="Global Integrity"
+                    description="Reactive integrity, tripwire, and system state."
+                  >
+                    <div className="space-y-4">
+                      <TripwirePanel />
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        <IntegrityMonitorCard gi={gi} onClick={() => setInspectorTarget({ kind: 'gi', data: gi })} />
+                        <TripwireWatchCard
+                          tripwires={allTripwires}
+                          selectedId={inspectorTarget.kind === 'tripwire' ? inspectorTarget.data.id : undefined}
+                          onSelect={(tripwire) => setInspectorTarget({ kind: 'tripwire', data: tripwire })}
+                        />
+                      </div>
                     </div>
-                  </div>
-                </TerminalSection>
+                  </TerminalSection>
+                </div>
+
+                <div className="grid gap-4 xl:grid-cols-2">
+                  <SentinelPulsePanel />
+                  <EveGlobalNewsPanel />
+                </div>
               </div>
             )}
 

--- a/components/terminal/EveGlobalNewsPanel.tsx
+++ b/components/terminal/EveGlobalNewsPanel.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type Tension = 'low' | 'moderate' | 'elevated' | 'high';
+
+type EveItem = {
+  id: string;
+  title: string;
+  url: string;
+  source: string;
+  region: string;
+  category: string;
+  severity: 'low' | 'medium' | 'high';
+  eve_tag: string;
+};
+
+type EveResponse = {
+  ok: boolean;
+  global_tension: Tension;
+  pattern_notes: string[];
+  items: EveItem[];
+};
+
+const REFRESH_MS = 3 * 60 * 1000;
+
+function tensionClass(tension: Tension): string {
+  if (tension === 'high') return 'border-rose-500/60 bg-rose-500/15 text-rose-200';
+  if (tension === 'elevated') return 'border-amber-500/60 bg-amber-500/15 text-amber-200';
+  if (tension === 'moderate') return 'border-yellow-500/50 bg-yellow-500/10 text-yellow-200';
+  return 'border-emerald-500/60 bg-emerald-500/15 text-emerald-200';
+}
+
+function severityDot(severity: EveItem['severity']): string {
+  if (severity === 'high') return 'bg-rose-400';
+  if (severity === 'medium') return 'bg-amber-400';
+  return 'bg-emerald-400';
+}
+
+export default function EveGlobalNewsPanel() {
+  const [data, setData] = useState<EveResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const res = await fetch('/api/eve/global-news', { cache: 'no-store' });
+        if (!res.ok) throw new Error(`EVE feed failed (${res.status})`);
+        const json = (await res.json()) as EveResponse;
+        if (!json.ok) throw new Error('EVE feed unavailable');
+
+        if (!cancelled) {
+          setData(json);
+          setError(null);
+          setLoading(false);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Unable to load EVE feed');
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+    const interval = setInterval(() => {
+      void load();
+    }, REFRESH_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  return (
+    <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div className="text-xs uppercase tracking-[0.18em] text-slate-400">EVE Global News</div>
+        {data && (
+          <span className={`rounded-md border px-2 py-1 text-[10px] font-mono uppercase tracking-[0.14em] ${tensionClass(data.global_tension)}`}>
+            {data.global_tension}
+          </span>
+        )}
+      </div>
+
+      {loading && <div className="text-sm text-slate-400">Loading EVE synthesis…</div>}
+      {error && <div className="text-sm text-rose-300">{error}</div>}
+
+      {!loading && !error && data && (
+        <div className="space-y-3">
+          {data.pattern_notes.slice(0, 2).map((note) => (
+            <div key={note} className="rounded-lg border border-slate-800 bg-slate-950/70 p-3 text-xs text-slate-300">
+              {note}
+            </div>
+          ))}
+
+          <ul className="space-y-2">
+            {data.items.slice(0, 8).map((item) => (
+              <li key={item.id} className="rounded-lg border border-slate-800 bg-slate-950/70 p-3">
+                <a href={item.url} target="_blank" rel="noreferrer" className="text-sm font-medium text-slate-100 hover:text-cyan-300">
+                  {item.title}
+                </a>
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-[0.12em] text-slate-400">
+                  <span className={`inline-block h-2 w-2 rounded-full ${severityDot(item.severity)}`} />
+                  <span>{item.category}</span>
+                  <span>·</span>
+                  <span>{item.region}</span>
+                  <span>·</span>
+                  <span>{item.source}</span>
+                </div>
+                <div className="mt-1 text-xs text-slate-500">{item.eve_tag}</div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/components/terminal/SentinelPulsePanel.tsx
+++ b/components/terminal/SentinelPulsePanel.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+type AtlasHeartbeat = {
+  timestamp?: string;
+  health?: string;
+  signals?: {
+    gi?: number;
+    anomalies?: number;
+    mode?: string;
+  };
+  eve?: {
+    global_tension?: string;
+  };
+};
+
+type ZeusVerification = {
+  timestamp?: string;
+  verification_status?: string;
+  findings?: Array<{ result?: string }>;
+  gi_verified?: boolean;
+};
+
+type AureaReportResponse = {
+  ok?: boolean;
+  report?: {
+    timestamp?: string;
+    summary?: string;
+    pending_epicon_backlog?: {
+      count?: number;
+      status?: string;
+    };
+    adapter_health?: {
+      degraded?: number;
+      total?: number;
+    };
+  };
+};
+
+type PulseEvent = {
+  id: string;
+  agent: 'ATLAS' | 'ZEUS' | 'AUREA';
+  timestamp: string;
+  title: string;
+  detail: string;
+};
+
+const HEARTBEAT_INDEX_URL =
+  'https://api.github.com/repos/kaizencycle/mobius-civic-ai-terminal/contents/docs/catalog/heartbeats';
+const ZEUS_FILE_URL =
+  'https://raw.githubusercontent.com/kaizencycle/mobius-civic-ai-terminal/main/docs/catalog/zeus/20260324T211630Z-verification.json';
+const REFRESH_MS = 2 * 60 * 1000;
+
+function formatTimestamp(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString();
+}
+
+function badgeClass(agent: PulseEvent['agent']): string {
+  if (agent === 'ATLAS') return 'border-cyan-500/50 bg-cyan-500/15 text-cyan-200';
+  if (agent === 'ZEUS') return 'border-amber-500/50 bg-amber-500/15 text-amber-200';
+  return 'border-orange-500/50 bg-orange-500/15 text-orange-200';
+}
+
+export default function SentinelPulsePanel() {
+  const [events, setEvents] = useState<PulseEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        setError(null);
+
+        const heartbeatListRes = await fetch(HEARTBEAT_INDEX_URL, { cache: 'no-store' });
+        if (!heartbeatListRes.ok) throw new Error(`Heartbeat index failed (${heartbeatListRes.status})`);
+        const heartbeatList = (await heartbeatListRes.json()) as Array<{ name?: string; download_url?: string }>;
+
+        const latestHeartbeat = heartbeatList
+          .filter((item) => item.name?.endsWith('.json') && item.download_url)
+          .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''))
+          .at(-1);
+
+        if (!latestHeartbeat?.download_url) throw new Error('No ATLAS heartbeat found');
+
+        const [atlasRes, zeusRes, aureaRes] = await Promise.all([
+          fetch(latestHeartbeat.download_url, { cache: 'no-store' }),
+          fetch(ZEUS_FILE_URL, { cache: 'no-store' }),
+          fetch('/api/aurea/oversee', { cache: 'no-store' }),
+        ]);
+
+        if (!atlasRes.ok) throw new Error(`ATLAS heartbeat fetch failed (${atlasRes.status})`);
+        if (!zeusRes.ok) throw new Error(`ZEUS report fetch failed (${zeusRes.status})`);
+        if (!aureaRes.ok) throw new Error(`AUREA report fetch failed (${aureaRes.status})`);
+
+        const [atlas, zeus, aurea] = (await Promise.all([
+          atlasRes.json(),
+          zeusRes.json(),
+          aureaRes.json(),
+        ])) as [AtlasHeartbeat, ZeusVerification, AureaReportResponse];
+
+        const nextEvents: PulseEvent[] = [
+          {
+            id: 'atlas',
+            agent: 'ATLAS' as const,
+            timestamp: atlas.timestamp ?? new Date().toISOString(),
+            title: `Heartbeat ${String(atlas.health ?? 'unknown').toUpperCase()}`,
+            detail: `GI ${(atlas.signals?.gi ?? 0).toFixed(2)} · anomalies ${atlas.signals?.anomalies ?? 0} · EVE ${String(atlas.eve?.global_tension ?? 'n/a').toUpperCase()}`,
+          },
+          {
+            id: 'zeus',
+            agent: 'ZEUS' as const,
+            timestamp: zeus.timestamp ?? new Date().toISOString(),
+            title: `Verification ${String(zeus.verification_status ?? 'unknown').toUpperCase()}`,
+            detail: `${zeus.findings?.length ?? 0} checks · GI ${zeus.gi_verified ? 'verified' : 'unverified'}`,
+          },
+          {
+            id: 'aurea',
+            agent: 'AUREA' as const,
+            timestamp: aurea.report?.timestamp ?? new Date().toISOString(),
+            title: `Oversight ${String(aurea.report?.pending_epicon_backlog?.status ?? 'nominal').toUpperCase()}`,
+            detail: `Pending ${aurea.report?.pending_epicon_backlog?.count ?? 0} · degraded adapters ${aurea.report?.adapter_health?.degraded ?? 0}/${aurea.report?.adapter_health?.total ?? 0}`,
+          },
+        ].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+        if (!cancelled) {
+          setEvents(nextEvents);
+          setLoading(false);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Unable to load sentinel timeline');
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+    const interval = setInterval(() => {
+      void load();
+    }, REFRESH_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  const content = useMemo(() => {
+    if (loading) return <div className="text-sm text-slate-400">Loading sentinel timeline…</div>;
+    if (error) return <div className="text-sm text-rose-300">{error}</div>;
+    if (events.length === 0) return <div className="text-sm text-slate-400">No sentinel events found.</div>;
+
+    return (
+      <ul className="space-y-3">
+        {events.map((event) => (
+          <li key={event.id} className="rounded-lg border border-slate-800 bg-slate-950/70 p-3">
+            <div className="mb-1 flex items-center justify-between gap-2">
+              <span className={`rounded-md border px-2 py-1 text-[10px] font-mono uppercase tracking-[0.14em] ${badgeClass(event.agent)}`}>
+                {event.agent}
+              </span>
+              <span className="text-xs text-slate-500">{formatTimestamp(event.timestamp)}</span>
+            </div>
+            <div className="text-sm font-semibold text-slate-100">{event.title}</div>
+            <div className="mt-1 text-xs text-slate-400">{event.detail}</div>
+          </li>
+        ))}
+      </ul>
+    );
+  }, [error, events, loading]);
+
+  return (
+    <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+      <div className="mb-3 text-xs uppercase tracking-[0.18em] text-slate-400">Sentinel Pulse</div>
+      {content}
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation

- Surface the currently-available sentinel pipeline and EVE synthesis data in the terminal UI so operators see ATLAS heartbeats, ZEUS verification status, and AUREA oversight without digging into docs/catalog files.
- Provide an inline EVE news panel to surface global tension, pattern notes, and top items so the operator can correlate news-driven tension with system integrity.

### Description

- Added `components/terminal/SentinelPulsePanel.tsx` which fetches the heartbeat index from the repository catalog, the ZEUS verification JSON, and the AUREA oversight report and renders a unified, timestamped timeline with agent-colored badges (ATLAS=cerulean, ZEUS=amber, AUREA=orange) and summary details; the panel auto-refreshes every 2 minutes.
- Added `components/terminal/EveGlobalNewsPanel.tsx` which fetches `/api/eve/global-news`, shows a global tension badge (LOW/MODERATE/ELEVATED/HIGH), pattern notes, and up to 8 news items with severity dots, category/region/source metadata, and EVE tags; the panel auto-refreshes every 3 minutes.
- Wired both panels into the Pulse chamber layout in `app/terminal/page.tsx` so they appear beneath the existing Pulse Timeline and Global Integrity sections in a 1:1 grid.
- Implemented lightweight client-side error/loading states and conservative cache-control usage (`cache: 'no-store'`) for live operator visibility.

### Testing

- Ran the TypeScript type-check with `npx tsc --noEmit` and it completed successfully.
- No other automated UI or end-to-end tests were run in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c33cd25190832da05cfe5252a9512a)