### PR TITLE
docs(boot): add Mobius boot profiles and align cycle/state docs for C-261

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The system tracks a **Global Integrity Score (GI)** that measures information he
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────────┐
-│ MOBIUS TERMINAL                                      C-249 | 07:46 | GI .94 │
+│ MOBIUS TERMINAL                           C-XXX (runtime cycle) | ET | GI .94 │
 │ Alerts 2 | ATLAS OK | ZEUS ACTIVE | ECHO LIVE | HERMES ROUTING | TRIPWIRE N │
 ├──────────────┬───────────────────────────────────────────────┬───────────────┤
 │              │                                               │               │
@@ -198,7 +198,65 @@ Without a configured API, the terminal falls back to mock data automatically.
 
 ---
 
+## Boot Modes
+
+Mobius should not be understood as a single boot path.
+
+The terminal is the entry surface, but the full Mobius stack can be mounted at different depths depending on the operator.
+
+### Visitor
+Open the deployed terminal in the browser.
+
+```bash
+open https://mobius-civic-ai-terminal.vercel.app/terminal
+```
+
+Best for:
+- first-time users
+- public observers
+- read-only exploration
+
+### Operator
+Use the terminal as a working command surface connected to hosted APIs and hosted inference.
+
+```bash
+npx mobius-terminal
+```
+
+Best for:
+- daily terminal usage
+- civic operators
+- high-context contributors
+
+### Builder
+Run the repo locally for development, testing, and hybrid integration work.
+
+```bash
+npm install
+npm run dev
+```
+
+Best for:
+- contributors
+- local testing
+- terminal and API iteration
+
+### Sovereign
+Run Mobius as private or self-hosted infrastructure.
+
+```bash
+mobius up --profile sovereign
+```
+
+This mode is the long-term full-node / private-stack direction.
+
+For the canonical boot matrix, see [docs/BOOT_PROFILES.md](docs/BOOT_PROFILES.md).
+
+---
+
 ## Local Development
+
+The current repo-local development flow is closest to **Builder Mode**.
 
 ### Frontend
 
@@ -262,6 +320,8 @@ The terminal includes a keyboard-first command interface:
 ## Project Status
 
 Experimental civic infrastructure project. The Mobius Civic AI Terminal is a prototype interface exploring how AI systems and humans might collaboratively monitor information integrity.
+
+The runtime cycle is derived from the terminal's deterministic cycle engine rather than from static documentation examples.
 
 **Live deployment:** [mobius-civic-ai-terminal.vercel.app/terminal](https://mobius-civic-ai-terminal.vercel.app/terminal)
 

--- a/docs/BOOT_PROFILES.md
+++ b/docs/BOOT_PROFILES.md
@@ -1,0 +1,166 @@
+# Mobius Boot Profiles
+
+**Status:** Canonical boot model  
+**Cycle:** C-261
+
+Mobius should not have a single boot path.
+
+It should boot in layers, with the operator choosing how much of the stack to mount.
+
+## Core Principle
+
+Mobius boots in three layers:
+
+1. **Surface Layer**  
+   Terminal UI, chambers, dashboards, command palette
+
+2. **Control Layer**  
+   Auth, memory, ledger, policies, routing, orchestration
+
+3. **Inference Layer**  
+   Model providers, local models, verification engines, enrichment pipelines
+
+That means “booting Mobius” should not always mean “boot every service.”
+
+It should mean:
+
+> boot the appropriate Mobius depth for the current operator.
+
+---
+
+## Visitor Mode
+
+**Who it is for:**  
+Curious users, readers, public observers, first-time visitors
+
+**How it boots:**
+
+```bash
+open https://mobius-civic-ai-terminal.vercel.app/terminal
+```
+
+**What loads:**
+- terminal surface
+- public cycle state
+- public signals and feeds
+- read-only or low-permission interaction
+- remote/shared inference only
+
+**Purpose:**  
+Experience Mobius without setup friction.
+
+---
+
+## Operator Mode
+
+**Who it is for:**  
+Daily users, civic operators, high-context contributors
+
+**How it boots:**
+
+```bash
+npx mobius-terminal
+```
+
+**What loads:**
+- terminal shell
+- command system
+- chamber memory
+- role-aware session
+- connection to hosted APIs
+- connection to hosted control/state
+- hosted inference attachment
+
+**Purpose:**  
+Use Mobius as a working terminal without needing to self-host the substrate.
+
+---
+
+## Builder Mode
+
+**Who it is for:**  
+Developers, repo contributors, chamber architects, local testers
+
+**How it boots today:**
+
+```bash
+git clone https://github.com/kaizencycle/mobius-civic-ai-terminal
+cd mobius-civic-ai-terminal
+npm install
+npm run dev
+```
+
+**How it may boot later:**
+
+```bash
+mobius up --profile builder
+```
+
+**What loads:**
+- local terminal app
+- local dev server
+- mock/live toggles
+- selected API services
+- debug surfaces
+- hybrid inference and provider routing
+
+**Purpose:**  
+Build and test Mobius locally without requiring full sovereignty.
+
+**Current repo note:**  
+The existing local development flow in this repository is closest to **Builder Mode**.
+
+---
+
+## Sovereign Mode
+
+**Who it is for:**  
+Institutions, research labs, serious operators, private deployments, self-hosters
+
+**How it may boot:**
+
+```bash
+mobius up --profile sovereign
+```
+
+**What loads:**
+- terminal UI
+- local control plane
+- local memory and ledger services
+- policy engine
+- agent orchestration
+- automation workers
+- observability stack
+- local/private inference routing
+
+**Purpose:**  
+Run Mobius as durable infrastructure, not just a terminal surface.
+
+---
+
+## Boot Matrix
+
+| Mode | Entry | Surface | Control | Inference |
+|---|---|---|---|---|
+| **Visitor** | URL | Hosted | Hosted/public | Remote/shared |
+| **Operator** | `npx mobius-terminal` | Local shell | Hosted | Remote |
+| **Builder** | `npm run dev` | Local | Partial local / partial hosted | Hybrid |
+| **Sovereign** | `mobius up --profile sovereign` | Local/private | Local/private | Local/private |
+
+---
+
+## Recommended Build Order
+
+For the current Mobius Terminal era, the clean progression is:
+
+1. **Operator Mode**
+2. **Builder Mode**
+3. **Sovereign Mode**
+
+That order keeps adoption easy, development fast, and sovereignty expandable.
+
+---
+
+## Canon Line
+
+**Mobius should boot like a terminal, attach like a substrate, and deepen into inference only to the degree the operator needs sovereignty.**

--- a/docs/cycles/C-261.md
+++ b/docs/cycles/C-261.md
@@ -1,0 +1,18 @@
+# C-261 — Boot Profiles and Cycle/State Doc Alignment
+
+## Summary
+- added canonical Mobius boot profiles
+- aligned README language with runtime-derived cycle behavior
+- removed stale static cycle example from terminal mock
+- clarified current local dev flow as Builder Mode
+
+## Why
+The terminal runtime already derives its cycle from the deterministic cycle engine, but repo-facing docs still included stale static examples. This created avoidable confusion for contributors and first-time operators.
+
+## Outcome
+Mobius now reads more clearly as:
+- a terminal surface first
+- a substrate second
+- an inference stack only as deeply mounted as the operator requires
+
+Signed: ATLAS


### PR DESCRIPTION
### Motivation
- The README included a stale static terminal cycle example while the runtime already derives cycle state from a deterministic cycle engine, causing contributor confusion.
- The repository lacks a clear canonical explanation of how Mobius should boot at different operator depths, which hinders onboarding.
- This is a low-risk, docs-only change intended to clarify boot modes and align documentation with runtime behavior.

### Description
- Add `docs/BOOT_PROFILES.md` which defines Visitor, Operator, Builder, and Sovereign modes, the Surface/Control/Inference layers, a boot matrix, and recommended build order.
- Update `README.md` to replace the static `C-249` mock with runtime-safe wording, add a new `Boot Modes` section linking to `docs/BOOT_PROFILES.md`, and mark local development as closest to `Builder Mode`.
- Add `docs/cycles/C-261.md` as a short cycle note summarizing the change and intent for C-261. 
- Changes were committed on branch `c261/boot-profiles-cycle-state` with message `docs(boot): add Mobius boot profiles and align cycle/state docs for C-261`.

### Testing
- No automated test suite or CI was executed for this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3f4174be4832d869d30d7068e1288)