### PR TITLE
feat(themis): add layered data.gov fallback and source-state model for C-261

### DIFF
--- a/components/signals/PulseTimeline.tsx
+++ b/components/signals/PulseTimeline.tsx
@@ -23,6 +23,29 @@ type RuntimeStatus = {
   };
 };
 
+type AgentMode = 'nominal' | 'degraded' | 'critical';
+type SourceHealth = 'ok' | 'degraded' | 'failed' | 'cached';
+
+type MicroAgent = {
+  agentName: string;
+  healthy: boolean;
+  polledAt: string;
+  errors: string[];
+  mode?: AgentMode;
+  sourceStatus?: Record<string, SourceHealth>;
+  fallbackUsed?: string | null;
+  lastGoodAt?: string | null;
+};
+
+type MicroSweepResponse = {
+  ok: boolean;
+  cached?: boolean;
+  timestamp: string;
+  agents: MicroAgent[];
+  composite: number;
+  healthy: boolean;
+};
+
 function freshnessLabel(runtime: RuntimeStatus | null) {
   if (runtime?.freshness.status === 'fresh') return 'System live';
   if (runtime?.freshness.status === 'degraded') return 'System degraded';
@@ -37,17 +60,57 @@ function freshnessTone(runtime: RuntimeStatus | null) {
   return 'text-slate-500';
 }
 
+function modeTone(mode?: AgentMode, healthy = true) {
+  if (mode === 'critical') return 'border-rose-500/30 bg-rose-500/10 text-rose-200';
+  if (mode === 'degraded') return 'border-amber-500/30 bg-amber-500/10 text-amber-200';
+  if (mode === 'nominal') return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200';
+  return healthy
+    ? 'border-emerald-500/20 bg-emerald-500/5 text-emerald-200'
+    : 'border-amber-500/20 bg-amber-500/5 text-amber-200';
+}
+
+function sourceTone(status: SourceHealth) {
+  switch (status) {
+    case 'ok':
+      return 'bg-emerald-500/10 text-emerald-300 border-emerald-500/20';
+    case 'degraded':
+      return 'bg-amber-500/10 text-amber-300 border-amber-500/20';
+    case 'cached':
+      return 'bg-sky-500/10 text-sky-300 border-sky-500/20';
+    case 'failed':
+    default:
+      return 'bg-rose-500/10 text-rose-300 border-rose-500/20';
+  }
+}
+
+function formatMode(agent: MicroAgent) {
+  if (agent.mode) return agent.mode.toUpperCase();
+  return agent.healthy ? 'NOMINAL' : 'DEGRADED';
+}
+
 export default function PulseTimeline() {
   const [signals, setSignals] = useState<Signal[]>([]);
   const [runtime, setRuntime] = useState<RuntimeStatus | null>(null);
+  const [micro, setMicro] = useState<MicroSweepResponse | null>(null);
 
   async function load() {
-    const pulseRes = await fetch('/api/signals/pulse', { cache: 'no-store' });
-    const pulseJson = await pulseRes.json();
-    const runtimeRes = await fetch('/api/runtime/status', { cache: 'no-store' });
-    const runtimeJson: RuntimeStatus = await runtimeRes.json();
-    setSignals(pulseJson.signals || []);
-    setRuntime(runtimeJson);
+    try {
+      const [pulseRes, runtimeRes, microRes] = await Promise.all([
+        fetch('/api/signals/pulse', { cache: 'no-store' }),
+        fetch('/api/runtime/status', { cache: 'no-store' }),
+        fetch('/api/signals/micro', { cache: 'no-store' }),
+      ]);
+
+      const pulseJson = await pulseRes.json();
+      const runtimeJson: RuntimeStatus = await runtimeRes.json();
+      const microJson: MicroSweepResponse = await microRes.json();
+
+      setSignals(pulseJson.signals || []);
+      setRuntime(runtimeJson);
+      setMicro(microJson.ok ? microJson : null);
+    } catch {
+      // Preserve previous state if a refresh fails.
+    }
   }
 
   useEffect(() => {
@@ -55,6 +118,9 @@ export default function PulseTimeline() {
     const interval = setInterval(load, 15000);
     return () => clearInterval(interval);
   }, []);
+
+  const themis = micro?.agents.find((agent) => agent.agentName === 'THEMIS');
+  const visibleAgents = micro?.agents ?? [];
 
   return (
     <div>
@@ -69,8 +135,92 @@ export default function PulseTimeline() {
         <div className="text-right text-xs text-slate-500">
           <div>{runtime?.last_run ? `Updated ${new Date(runtime.last_run).toLocaleString()}` : 'Awaiting heartbeat'}</div>
           <div>{signals.length} active signals</div>
+          <div>{micro ? `${visibleAgents.length} micro agents · composite ${micro.composite.toFixed(3)}` : 'Micro sweep pending'}</div>
         </div>
       </div>
+
+      {micro ? (
+        <div className="mt-4 rounded-xl border border-slate-800 bg-slate-950/40 p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="text-[11px] uppercase tracking-[0.14em] text-slate-500">
+                Micro Agent Health
+              </div>
+              <div className="mt-1 text-sm text-slate-300">
+                Live runtime posture for governance, routing, climate, and build micro-agents.
+              </div>
+            </div>
+
+            <div className="text-right text-xs text-slate-500">
+              <div>{micro.cached ? 'Cached sweep' : 'Live sweep'}</div>
+              <div>{new Date(micro.timestamp).toLocaleString()}</div>
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-3 xl:grid-cols-2">
+            {visibleAgents.map((agent) => (
+              <div
+                key={agent.agentName}
+                className="rounded-xl border border-slate-800 bg-slate-950/60 p-4"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-[11px] uppercase tracking-[0.14em] text-slate-500">
+                      {agent.agentName}
+                    </div>
+                    <div className="mt-1 text-sm text-white">
+                      {agent.agentName === 'THEMIS'
+                        ? 'Governance transparency posture'
+                        : 'Micro-agent runtime posture'}
+                    </div>
+                  </div>
+
+                  <div className={`rounded-md border px-2 py-1 text-[10px] uppercase tracking-[0.12em] ${modeTone(agent.mode, agent.healthy)}`}>
+                    {formatMode(agent)}
+                  </div>
+                </div>
+
+                {agent.fallbackUsed ? (
+                  <div className="mt-3 text-xs text-amber-300">
+                    Fallback active: {agent.fallbackUsed}
+                    {agent.lastGoodAt ? ` · last good ${new Date(agent.lastGoodAt).toLocaleString()}` : ''}
+                  </div>
+                ) : null}
+
+                {agent.sourceStatus ? (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {Object.entries(agent.sourceStatus).map(([source, status]) => (
+                      <span
+                        key={`${agent.agentName}-${source}`}
+                        className={`rounded-md border px-2 py-1 text-[10px] uppercase tracking-[0.12em] ${sourceTone(status)}`}
+                      >
+                        {source}: {status}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+
+                {agent.errors.length > 0 ? (
+                  <div className="mt-3 text-xs text-slate-400">
+                    {agent.errors.length} issue{agent.errors.length === 1 ? '' : 's'} · {agent.errors[0]}
+                  </div>
+                ) : (
+                  <div className="mt-3 text-xs text-slate-500">
+                    No active source errors · polled {new Date(agent.polledAt).toLocaleString()}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {themis?.sourceStatus ? (
+            <div className="mt-4 rounded-xl border border-slate-800 bg-slate-950/50 p-3 text-xs text-slate-400">
+              <span className="font-medium text-slate-200">THEMIS readout:</span>{' '}
+              Governance transparency is now rendered with explicit source-state visibility, so catalog failures, keyed fallbacks, and cached snapshots become operator-visible instead of silent.
+            </div>
+          ) : null}
+        </div>
+      ) : null}
 
       <div className="mt-4 space-y-3">
         {signals.length === 0 ? (

--- a/components/terminal/AgentCortexPanel.tsx
+++ b/components/terminal/AgentCortexPanel.tsx
@@ -1,9 +1,31 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import type { Agent } from '@/lib/terminal/types';
 import { useMobiusIdentity } from '@/hooks/useMobiusIdentity';
 import { statusColor, cn } from '@/lib/terminal/utils';
 import SectionLabel from './SectionLabel';
+
+type AgentMode = 'nominal' | 'degraded' | 'critical';
+type SourceHealth = 'ok' | 'degraded' | 'failed' | 'cached';
+
+type MicroAgent = {
+  agentName: string;
+  healthy: boolean;
+  polledAt: string;
+  errors: string[];
+  mode?: AgentMode;
+  sourceStatus?: Record<string, SourceHealth>;
+  fallbackUsed?: string | null;
+  lastGoodAt?: string | null;
+};
+
+type MicroSweepResponse = {
+  ok: boolean;
+  cached?: boolean;
+  timestamp: string;
+  agents: MicroAgent[];
+};
 
 export default function AgentCortexPanel({
   agents,
@@ -15,10 +37,60 @@ export default function AgentCortexPanel({
   onSelect?: (agent: Agent) => void;
 }) {
   const { identity, hasPermission, loading } = useMobiusIdentity();
+  const [themis, setThemis] = useState<MicroAgent | null>(null);
+  const [microCached, setMicroCached] = useState(false);
   const canInvoke = hasPermission('agents:invoke');
   const visibleAgents = identity
     ? agents.filter((agent) => identity.agent_permissions.includes(agent.name.toUpperCase()))
     : agents;
+
+  useEffect(() => {
+    let alive = true;
+
+    async function loadMicroState() {
+      try {
+        const res = await fetch('/api/signals/micro', { cache: 'no-store' });
+        const json: MicroSweepResponse = await res.json();
+        if (!alive || !json.ok) return;
+
+        const nextThemis = json.agents.find((agent) => agent.agentName === 'THEMIS') ?? null;
+        setThemis(nextThemis);
+        setMicroCached(Boolean(json.cached));
+      } catch {
+        // Keep prior THEMIS state if refresh fails.
+      }
+    }
+
+    loadMicroState();
+    const interval = setInterval(loadMicroState, 30000);
+    return () => {
+      alive = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  function themisTone(mode?: AgentMode, healthy = true) {
+    if (mode === 'critical') return 'border-rose-500/30 bg-rose-500/10 text-rose-200';
+    if (mode === 'degraded') return 'border-amber-500/30 bg-amber-500/10 text-amber-200';
+    if (mode === 'nominal') return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200';
+    return healthy
+      ? 'border-emerald-500/20 bg-emerald-500/5 text-emerald-200'
+      : 'border-amber-500/20 bg-amber-500/5 text-amber-200';
+  }
+
+  function sourceTone(status: SourceHealth) {
+    switch (status) {
+      case 'ok':
+        return 'border-emerald-500/20 bg-emerald-500/10 text-emerald-300';
+      case 'degraded':
+        return 'border-amber-500/20 bg-amber-500/10 text-amber-300';
+      case 'cached':
+        return 'border-sky-500/20 bg-sky-500/10 text-sky-300';
+      case 'failed':
+      default:
+        return 'border-rose-500/20 bg-rose-500/10 text-rose-300';
+    }
+  }
 
   return (
     <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
@@ -38,6 +110,63 @@ export default function AgentCortexPanel({
             : 'Agent invocation unavailable for current role. Read-only status view only.'}
         </div>
       ) : null}
+
+      {themis ? (
+        <div className="mt-3 rounded-lg border border-slate-800 bg-slate-950 px-3 py-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="text-[11px] font-mono uppercase tracking-[0.14em] text-slate-500">
+                Micro Watch
+              </div>
+              <div className="mt-1 text-sm text-slate-300">
+                THEMIS governance transparency posture
+              </div>
+            </div>
+
+            <div
+              className={cn(
+                'rounded-md border px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em]',
+                themisTone(themis.mode, themis.healthy),
+              )}
+            >
+              THEMIS {themis.mode ? themis.mode.toUpperCase() : themis.healthy ? 'NOMINAL' : 'DEGRADED'}
+            </div>
+          </div>
+
+          <div className="mt-3 flex flex-wrap gap-2">
+            {themis.fallbackUsed ? (
+              <span className="rounded-md border border-amber-500/20 bg-amber-500/10 px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em] text-amber-300">
+                fallback · {themis.fallbackUsed}
+              </span>
+            ) : null}
+            {microCached ? (
+              <span className="rounded-md border border-sky-500/20 bg-sky-500/10 px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em] text-sky-300">
+                cached sweep
+              </span>
+            ) : null}
+            <span className="rounded-md border border-slate-800 bg-slate-900 px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em] text-slate-400">
+              polled · {new Date(themis.polledAt).toLocaleTimeString()}
+            </span>
+          </div>
+
+          {themis.sourceStatus ? (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {Object.entries(themis.sourceStatus).map(([source, status]) => (
+                <span
+                  key={`themis-${source}`}
+                  className={cn(
+                    'rounded-md border px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em]',
+                    sourceTone(status),
+                  )}
+                >
+                  {source}: {status}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
       <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3 xl:grid-cols-4">
         {visibleAgents.map((agent) => (
           <button

--- a/lib/agents/micro/core.ts
+++ b/lib/agents/micro/core.ts
@@ -21,6 +21,9 @@ export interface MicroSignal {
   raw?: unknown;
 }
 
+export type AgentMode = 'nominal' | 'degraded' | 'critical';
+export type SourceHealth = 'ok' | 'degraded' | 'failed' | 'cached';
+
 /** Result of a full agent poll cycle */
 export interface AgentPollResult {
   agentName: string;
@@ -28,6 +31,14 @@ export interface AgentPollResult {
   polledAt: string;
   errors: string[];
   healthy: boolean;
+  /**
+   * Optional runtime posture for richer agent-state UIs.
+   * Existing consumers can ignore these fields safely.
+   */
+  mode?: AgentMode;
+  sourceStatus?: Record<string, SourceHealth>;
+  fallbackUsed?: string | null;
+  lastGoodAt?: string | null;
 }
 
 /** Configuration for a micro sub-agent */

--- a/lib/agents/micro/themis.ts
+++ b/lib/agents/micro/themis.ts
@@ -1,12 +1,13 @@
 // ============================================================================
 // THEMIS — Government/Civic Transparency Micro Sub-Agent
 //
-// Polls Federal Register API and data.gov metadata.
-// Free, no API key required.
+// Polls Federal Register API and layered transparency sources.
+// C-261 · THEMIS fallback hardening
 // CC0 Public Domain
 // ============================================================================
 
 import {
+  type AgentMode,
   type AgentPollResult,
   type MicroSignal,
   type MicroAgentConfig,
@@ -18,7 +19,7 @@ import {
 export const THEMIS_CONFIG: MicroAgentConfig = {
   name: 'THEMIS',
   description: 'Governance transparency — federal register activity, open data health',
-  pollIntervalMs: 15 * 60 * 1000, // 15 minutes (gov data updates slowly)
+  pollIntervalMs: 15 * 60 * 1000,
   sources: ['Federal Register', 'data.gov'],
 };
 
@@ -28,7 +29,7 @@ type FRResponse = {
   results?: Array<{
     title: string;
     type: string;
-    publication_date: string;
+    publication_date?: string;
     agencies: Array<{ name: string }>;
   }>;
 };
@@ -71,31 +72,57 @@ async function pollFederalRegister(): Promise<MicroSignal | null> {
   };
 }
 
-// ── data.gov: dataset freshness check ─────────────────────────────────────
-type DataGovResponse = {
-  total?: number;
-  dataset?: Array<{
-    title: string;
-    modified: string;
-    publisher?: { name: string };
-  }>;
+// ── Transparency sources: data.gov + fallback paths ────────────────────────
+type DataGovDataset = {
+  title?: string;
+  modified?: string;
+  metadata_modified?: string;
+  publisher?: { name?: string };
 };
 
-async function pollDataGov(): Promise<MicroSignal | null> {
-  // Recently modified datasets
-  const url =
-    'https://catalog.data.gov/api/3/action/package_search?sort=metadata_modified+desc&rows=10';
+type DataGovResult = {
+  count?: number;
+  total?: number;
+  results?: DataGovDataset[];
+  dataset?: DataGovDataset[];
+};
 
-  const data = await safeFetch<{ result?: DataGovResponse }>(url);
-  const result = data?.result;
-  if (!result?.dataset || result.dataset.length === 0) return null;
+type DataGovEnvelope = {
+  result?: DataGovResult;
+};
+
+const DATAGOV_CATALOG_URL =
+  'https://catalog.data.gov/api/3/action/package_search?sort=metadata_modified+desc&rows=10';
+
+const THEMIS_DATA_GOV_API_KEY =
+  process.env.THEMIS_DATA_GOV_API_KEY ?? process.env.API_DATA_GOV_KEY ?? '';
+
+function getOfficialDataGovUrl(apiKey: string): string {
+  return `https://api.gsa.gov/technology/datagov/v3/action/package_search?api_key=${encodeURIComponent(apiKey)}&sort=metadata_modified+desc&rows=10`;
+}
+
+let lastGoodTransparencySignal: MicroSignal | null = null;
+let lastGoodTransparencyAt: string | null = null;
+
+function extractDatasets(result?: DataGovResult): DataGovDataset[] {
+  if (!result) return [];
+  if (Array.isArray(result.results) && result.results.length > 0) return result.results;
+  if (Array.isArray(result.dataset) && result.dataset.length > 0) return result.dataset;
+  return [];
+}
+
+function buildTransparencySignal(
+  source: string,
+  datasets: DataGovDataset[],
+  total?: number,
+): MicroSignal | null {
+  if (!datasets.length) return null;
 
   const now = Date.now();
   const dayMs = 24 * 60 * 60 * 1000;
 
-  // How recently were datasets updated?
-  const modifiedTimes = result.dataset
-    .map((d) => new Date(d.modified).getTime())
+  const modifiedTimes = datasets
+    .map((d) => new Date(d.modified ?? d.metadata_modified ?? '').getTime())
     .filter((t) => !isNaN(t));
 
   if (modifiedTimes.length === 0) return null;
@@ -110,35 +137,150 @@ async function pollDataGov(): Promise<MicroSignal | null> {
       ? Number((0.6 + normalizeDirect(30 - avgAgeDays, 0, 23) * 0.4).toFixed(3))
       : Number(Math.max(0.1, normalizeDirect(90 - avgAgeDays, 0, 60)).toFixed(3));
 
-  return {
+  const signal: MicroSignal = {
     agentName: 'THEMIS',
-    source: 'data.gov',
+    source,
     timestamp: new Date().toISOString(),
     value,
-    label: `data.gov: top 10 datasets avg ${Math.round(avgAgeDays)}d old, ${result.total ?? '?'} total`,
+    label: `${source}: top ${datasets.length} datasets avg ${Math.round(avgAgeDays)}d old${typeof total === 'number' ? `, ${total} total` : ''}`,
     severity: classifySeverity(value, { watch: 0.5, elevated: 0.3, critical: 0.1 }),
-    raw: { avgAgeDays: Math.round(avgAgeDays), total: result.total, sampleSize: result.dataset.length },
+    raw: {
+      avgAgeDays: Math.round(avgAgeDays),
+      total,
+      sampleSize: datasets.length,
+    },
   };
+
+  lastGoodTransparencySignal = signal;
+  lastGoodTransparencyAt = signal.timestamp;
+
+  return signal;
+}
+
+function buildCachedTransparencySignal(): MicroSignal | null {
+  if (!lastGoodTransparencySignal) return null;
+
+  const previousRaw =
+    lastGoodTransparencySignal.raw &&
+    typeof lastGoodTransparencySignal.raw === 'object' &&
+    !Array.isArray(lastGoodTransparencySignal.raw)
+      ? (lastGoodTransparencySignal.raw as Record<string, unknown>)
+      : {};
+
+  return {
+    ...lastGoodTransparencySignal,
+    timestamp: new Date().toISOString(),
+    source: `${lastGoodTransparencySignal.source} (cached)`,
+    label: `${lastGoodTransparencySignal.label} [cached snapshot]`,
+    raw: {
+      ...previousRaw,
+      cached: true,
+      cachedFrom: lastGoodTransparencyAt,
+    },
+  };
+}
+
+async function pollDataGovCatalog(): Promise<MicroSignal | null> {
+  const data = await safeFetch<DataGovEnvelope>(DATAGOV_CATALOG_URL);
+  const result = data?.result;
+  if (!result) return null;
+  return buildTransparencySignal('data.gov catalog', extractDatasets(result), result.total ?? result.count);
+}
+
+async function pollDataGovOfficial(): Promise<MicroSignal | null> {
+  if (!THEMIS_DATA_GOV_API_KEY) return null;
+
+  const url = getOfficialDataGovUrl(THEMIS_DATA_GOV_API_KEY);
+  const data = await safeFetch<DataGovEnvelope>(url);
+  const result = data?.result;
+  if (!result) return null;
+
+  return buildTransparencySignal('data.gov official', extractDatasets(result), result.total ?? result.count);
+}
+
+// Optional C-261 extension point:
+// add a third-party transparency heartbeat later (e.g. fiscal/disclosure API)
+// without changing the THEMIS contract again.
+
+type SourceStatus = 'ok' | 'degraded' | 'failed' | 'cached';
+
+function deriveMode(
+  regulatoryOk: boolean,
+  transparencyOk: boolean,
+  fallbackUsed: string | null,
+): AgentMode {
+  if (regulatoryOk && transparencyOk && !fallbackUsed) return 'nominal';
+  if (regulatoryOk || transparencyOk) return 'degraded';
+  return 'critical';
 }
 
 // ── Poll all THEMIS sources ───────────────────────────────────────────────
 export async function pollThemis(): Promise<AgentPollResult> {
   const errors: string[] = [];
   const signals: MicroSignal[] = [];
+  const sourceStatus: Record<string, SourceStatus> = {
+    'Federal Register': 'failed',
+    'data.gov catalog': 'failed',
+    'data.gov official': 'failed',
+    'last-good-cache': 'failed',
+  };
 
   const fr = await pollFederalRegister();
-  if (fr) signals.push(fr);
-  else errors.push('Federal Register API fetch failed');
+  if (fr) {
+    signals.push(fr);
+    sourceStatus['Federal Register'] = 'ok';
+  } else {
+    errors.push('Federal Register API fetch failed');
+  }
 
-  const dg = await pollDataGov();
-  if (dg) signals.push(dg);
-  else errors.push('data.gov API fetch failed');
+  let transparencySignal: MicroSignal | null = null;
+  let fallbackUsed: string | null = null;
+
+  const dgCatalog = await pollDataGovCatalog();
+  if (dgCatalog) {
+    transparencySignal = dgCatalog;
+    sourceStatus['data.gov catalog'] = 'ok';
+  } else {
+    errors.push('data.gov catalog API fetch failed');
+
+    const dgOfficial = await pollDataGovOfficial();
+    if (dgOfficial) {
+      transparencySignal = dgOfficial;
+      sourceStatus['data.gov official'] = 'degraded';
+      fallbackUsed = 'data.gov official';
+    } else {
+      if (THEMIS_DATA_GOV_API_KEY) {
+        errors.push('data.gov official API fetch failed');
+      }
+
+      const cached = buildCachedTransparencySignal();
+      if (cached) {
+        transparencySignal = cached;
+        sourceStatus['last-good-cache'] = 'cached';
+        fallbackUsed = 'last-good-cache';
+      } else {
+        errors.push('No THEMIS transparency fallback available');
+      }
+    }
+  }
+
+  if (transparencySignal) {
+    signals.push(transparencySignal);
+  }
+
+  const regulatoryOk = !!fr;
+  const transparencyOk = !!transparencySignal;
+  const mode = deriveMode(regulatoryOk, transparencyOk, fallbackUsed);
 
   return {
     agentName: 'THEMIS',
     signals,
     polledAt: new Date().toISOString(),
     errors,
-    healthy: signals.length > 0,
+    healthy: regulatoryOk && transparencyOk,
+    mode,
+    sourceStatus,
+    fallbackUsed,
+    lastGoodAt: lastGoodTransparencyAt,
   };
 }


### PR DESCRIPTION
### Motivation

- THEMIS previously treated any returned signal as healthy and had a brittle dependency on the data.gov catalog, which caused unreliable governance transparency signals (C-261).
- The change aims to make THEMIS resilient to data.gov outages by adding fallback sources and explicit runtime state so downstream consumers (ZEUS/EVE/ATLAS) can reason about source reliability.
- The goal is to improve integrity of the transparency signal by surfacing mode/fallback metadata and tightening the health contract between regulatory and transparency heartbeats.

### Description

- Added new types `AgentMode` and `SourceHealth` and extended `AgentPollResult` with optional fields `mode`, `sourceStatus`, `fallbackUsed`, and `lastGoodAt` in `lib/agents/micro/core.ts` so consumers can opt into richer agent-state metadata without breaking existing callers.
- Reworked `lib/agents/micro/themis.ts` to implement a layered transparency polling flow that preserves `Federal Register` as the regulatory heartbeat and uses `data.gov` catalog as primary transparency source, then falls back to the official `api.gsa.gov` Data.gov endpoint when a key exists, and finally to an in-memory last-good cached snapshot.
- Added helper functions: `pollDataGovCatalog`, `pollDataGovOfficial`, `buildTransparencySignal`, `buildCachedTransparencySignal`, and `deriveMode`, plus in-memory `lastGoodTransparencySignal` tracking to support caching and fallback behavior.
- Implemented explicit `sourceStatus` tracking and `mode` derivation (`nominal` | `degraded` | `critical`) and tightened `healthy` semantics to require both a regulatory signal and a transparency signal before reporting healthy; existing signal shape is preserved for compatibility.

### Testing

- Ran TypeScript type-check with `npx tsc --noEmit`, which completed successfully and reported no type errors.
- Attempted `npm run lint` (Next.js ESLint bootstrap) but it launched an interactive ESLint configuration prompt in this non-interactive environment, so linting did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c402b7b254832d8be2e7c14e6ddcb4)