### PR TITLE
feat(kv): Upstash Redis persistence — GI survives cold starts

### DIFF
--- a/app/api/integrity-status/route.ts
+++ b/app/api/integrity-status/route.ts
@@ -8,6 +8,7 @@ import { getStalenessStatus } from '@/lib/runtime/staleness';
 import { scoreBatch } from '@/lib/echo/signal-engine';
 import { mockAgents, mockEpicon } from '@/lib/terminal/mock';
 import { getTripwireState } from '@/lib/tripwire/store';
+import { saveGIState, loadGIState, isRedisAvailable, type GIState } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,7 +18,6 @@ function resolveSignalQuality() {
   const items = isLive ? epicon : mockEpicon;
   const scores = scoreBatch(items).map((score) => score.signal);
 
-  // If using mock data, apply a 20% penalty — mock perfection is not real integrity
   if (!isLive) {
     return { scores: scores.map((s) => s * 0.8), source: 'mock' as const };
   }
@@ -33,7 +33,6 @@ export async function GET() {
   const tripwire = getTripwireState();
   const signalData = resolveSignalQuality();
 
-  // If running on mock data with no real heartbeat, degrade freshness
   const effectiveFreshness =
     signalData.source === 'mock' && freshness.status === 'fresh'
       ? ('degraded' as const)
@@ -46,6 +45,57 @@ export async function GET() {
     activeAgents: resolveActiveAgentCount(),
   });
 
+  let source: 'live' | 'mock' | 'cached' = signalData.source;
+
+  // If running on mock data AND Redis has a cached GI state, use the cached version
+  // This is the cold-start recovery: Redis remembers the last real GI computation
+  if (signalData.source === 'mock' && isRedisAvailable()) {
+    const cached = await loadGIState();
+    if (cached && cached.source !== 'mock') {
+      // Redis has a recent live computation — use it instead of mock
+      const age = Date.now() - new Date(cached.timestamp).getTime();
+      if (age < 15 * 60 * 1000) {
+        // Less than 15 min old — serve the cached live state
+        return NextResponse.json({
+          ok: true,
+          cycle: currentCycleId(),
+          timestamp: cached.timestamp,
+          global_integrity: cached.global_integrity,
+          mode: cached.mode,
+          mii_baseline: integrityStatus.mii_baseline,
+          mic_supply: integrityStatus.mic_supply,
+          terminal_status: cached.terminal_status,
+          primary_driver: cached.primary_driver,
+          summary: 'GI reflects signal quality, freshness, tripwire stability, and active system health.',
+          source: 'cached' as const,
+          kv: true,
+          signals: {
+            ...cached.signals,
+            geopolitics: cached.signals.quality,
+            economy: cached.signals.system,
+            sentiment: cached.signals.stability,
+            information: cached.signals.freshness,
+          },
+        });
+      }
+    }
+  }
+
+  // Save current computation to Redis for future cold-start recovery
+  if (isRedisAvailable()) {
+    const giState: GIState = {
+      global_integrity: computed.global_integrity,
+      mode: computed.mode,
+      terminal_status: computed.terminal_status,
+      primary_driver: computed.primary_driver,
+      source,
+      signals: computed.signals,
+      timestamp: computed.timestamp,
+    };
+    // Fire and forget — don't block the response
+    saveGIState(giState).catch(() => {});
+  }
+
   return NextResponse.json({
     ok: true,
     cycle: currentCycleId(),
@@ -57,7 +107,8 @@ export async function GET() {
     terminal_status: computed.terminal_status,
     primary_driver: computed.primary_driver,
     summary: computed.summary,
-    source: signalData.source,
+    source,
+    kv: isRedisAvailable(),
     signals: {
       ...computed.signals,
       geopolitics: computed.signals.quality,

--- a/app/api/kv/health/route.ts
+++ b/app/api/kv/health/route.ts
@@ -1,0 +1,37 @@
+/**
+ * GET /api/kv/health
+ *
+ * Returns Upstash Redis health status and diagnostic info.
+ * Used by sentinel agents to verify KV persistence is operational.
+ *
+ * CC0 Public Domain
+ */
+
+import { NextResponse } from 'next/server';
+import { kvHealth, isRedisAvailable, KV_KEYS, kvGet } from '@/lib/kv/store';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const health = await kvHealth();
+
+  // Check what keys are populated
+  const keys: Record<string, boolean> = {};
+  if (health.available) {
+    for (const [name, key] of Object.entries(KV_KEYS)) {
+      const val = await kvGet(key);
+      keys[name] = val !== null;
+    }
+  }
+
+  return NextResponse.json({
+    ok: health.available,
+    ...health,
+    keys,
+    timestamp: new Date().toISOString(),
+  }, {
+    headers: {
+      'X-Mobius-Source': 'kv-health',
+    },
+  });
+}

--- a/app/api/signals/micro/route.ts
+++ b/app/api/signals/micro/route.ts
@@ -1,12 +1,13 @@
 // ============================================================================
 // GET /api/signals/micro
 // Runs all four micro sub-agents and returns aggregated signal data.
-// C-258 · Micro Sub-Agent Scaffold
+// C-261 · KV persistence for cold-start recovery
 // CC0 Public Domain
 // ============================================================================
 
 import { NextResponse } from 'next/server';
 import { pollAllMicroAgents } from '@/lib/agents/micro';
+import { saveSignalSnapshot, loadSignalSnapshot, isRedisAvailable } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,7 +18,7 @@ const CACHE_TTL_MS = 60_000; // 1 minute
 export async function GET() {
   const now = Date.now();
 
-  // Return cache if fresh
+  // Return in-memory cache if fresh
   if (cached && now - cached.timestamp < CACHE_TTL_MS) {
     return NextResponse.json({
       ok: true,
@@ -35,9 +36,27 @@ export async function GET() {
     const result = await pollAllMicroAgents();
     cached = { data: result, timestamp: now };
 
+    // Persist signal snapshot to Redis for cold-start recovery
+    if (isRedisAvailable()) {
+      saveSignalSnapshot({
+        composite: result.composite,
+        anomalies: result.anomalies?.length ?? 0,
+        allSignals: (result.allSignals ?? []).map((s: { agentName: string; source: string; value: number; label: string; severity: string }) => ({
+          agentName: s.agentName,
+          source: s.source,
+          value: s.value,
+          label: s.label,
+          severity: s.severity,
+        })),
+        timestamp: result.timestamp,
+        healthy: result.healthy,
+      }).catch(() => {});
+    }
+
     return NextResponse.json({
       ok: true,
       cached: false,
+      kv: isRedisAvailable(),
       ...result,
     }, {
       headers: {
@@ -46,6 +65,27 @@ export async function GET() {
       },
     });
   } catch (err) {
+    // On failure, try to serve last-known state from Redis
+    if (isRedisAvailable()) {
+      const snapshot = await loadSignalSnapshot();
+      if (snapshot) {
+        return NextResponse.json({
+          ok: true,
+          cached: true,
+          source: 'kv-fallback',
+          composite: snapshot.composite,
+          anomalies: snapshot.allSignals.filter((s) => s.severity === 'elevated' || s.severity === 'critical'),
+          allSignals: snapshot.allSignals,
+          timestamp: snapshot.timestamp,
+          healthy: snapshot.healthy,
+        }, {
+          headers: {
+            'X-Mobius-Source': 'micro-agents-kv-fallback',
+          },
+        });
+      }
+    }
+
     return NextResponse.json(
       { ok: false, error: err instanceof Error ? err.message : 'Unknown error' },
       { status: 500 },

--- a/lib/kv/store.ts
+++ b/lib/kv/store.ts
@@ -1,0 +1,305 @@
+/**
+ * Mobius KV — Upstash Redis Persistence Layer
+ *
+ * Provides durable key-value storage that survives Vercel cold starts.
+ * Uses Upstash Redis via HTTP REST (no TCP connections needed).
+ *
+ * Design:
+ *   - Cache-through: read from Redis first, fall back to in-memory
+ *   - Write-through: write to both Redis and in-memory simultaneously
+ *   - Graceful degradation: if Redis is unavailable, system continues
+ *     with in-memory-only behavior (same as before this integration)
+ *   - All values are JSON-serialized automatically
+ *   - TTL support for automatic expiration
+ *
+ * Required env vars (set in Vercel project settings):
+ *   UPSTASH_REDIS_REST_URL   — Upstash REST endpoint
+ *   UPSTASH_REDIS_REST_TOKEN — Upstash REST auth token
+ *
+ * Free tier: 500K commands/month, more than enough for this project.
+ *
+ * CC0 Public Domain
+ */
+
+import { Redis } from '@upstash/redis';
+
+// ── Redis client (lazy singleton) ────────────────────────────
+
+let _redis: Redis | null = null;
+let _redisAvailable: boolean | null = null;
+
+function getRedis(): Redis | null {
+  if (_redis) return _redis;
+
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  if (!url || !token) {
+    _redisAvailable = false;
+    return null;
+  }
+
+  try {
+    _redis = new Redis({ url, token });
+    _redisAvailable = true;
+    return _redis;
+  } catch {
+    _redisAvailable = false;
+    return null;
+  }
+}
+
+/**
+ * Check if Redis is configured and available.
+ */
+export function isRedisAvailable(): boolean {
+  if (_redisAvailable !== null) return _redisAvailable;
+  getRedis();
+  return _redisAvailable ?? false;
+}
+
+// ── Key prefix (namespace all Mobius keys) ───────────────────
+
+const PREFIX = 'mobius:';
+
+function prefixKey(key: string): string {
+  return `${PREFIX}${key}`;
+}
+
+// ── Core operations ──────────────────────────────────────────
+
+/**
+ * Get a value from Redis. Returns null if not found or Redis unavailable.
+ */
+export async function kvGet<T>(key: string): Promise<T | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+
+  try {
+    const value = await redis.get<T>(prefixKey(key));
+    return value;
+  } catch (err) {
+    console.warn(`[mobius-kv] GET ${key} failed:`, err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+/**
+ * Set a value in Redis.
+ * @param ttlSeconds — optional TTL in seconds (default: no expiry)
+ */
+export async function kvSet<T>(key: string, value: T, ttlSeconds?: number): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+
+  try {
+    if (ttlSeconds) {
+      await redis.set(prefixKey(key), value, { ex: ttlSeconds });
+    } else {
+      await redis.set(prefixKey(key), value);
+    }
+    return true;
+  } catch (err) {
+    console.warn(`[mobius-kv] SET ${key} failed:`, err instanceof Error ? err.message : err);
+    return false;
+  }
+}
+
+/**
+ * Delete a key from Redis.
+ */
+export async function kvDel(key: string): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+
+  try {
+    await redis.del(prefixKey(key));
+    return true;
+  } catch (err) {
+    console.warn(`[mobius-kv] DEL ${key} failed:`, err instanceof Error ? err.message : err);
+    return false;
+  }
+}
+
+/**
+ * Check if a key exists in Redis.
+ */
+export async function kvExists(key: string): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+
+  try {
+    const result = await redis.exists(prefixKey(key));
+    return result === 1;
+  } catch {
+    return false;
+  }
+}
+
+// ── Mobius-specific compound operations ──────────────────────
+
+/**
+ * Key constants for Mobius state
+ */
+export const KV_KEYS = {
+  /** Last signal snapshot from micro-agents */
+  SIGNAL_SNAPSHOT: 'signals:latest',
+  /** Last GI computation result */
+  GI_STATE: 'gi:latest',
+  /** ECHO store state (epicon, ledger, alerts) */
+  ECHO_STATE: 'echo:state',
+  /** Tripwire state */
+  TRIPWIRE_STATE: 'tripwire:state',
+  /** Last heartbeat timestamp */
+  HEARTBEAT: 'heartbeat:last',
+  /** Last ingest timestamp */
+  LAST_INGEST: 'ingest:last',
+} as const;
+
+// ── Signal snapshot persistence ──────────────────────────────
+
+export type SignalSnapshot = {
+  composite: number;
+  anomalies: number;
+  allSignals: Array<{
+    agentName: string;
+    source: string;
+    value: number;
+    label: string;
+    severity: string;
+  }>;
+  timestamp: string;
+  healthy: boolean;
+};
+
+/**
+ * Save the latest signal snapshot to Redis.
+ * TTL: 10 minutes (signals older than this are stale).
+ */
+export async function saveSignalSnapshot(snapshot: SignalSnapshot): Promise<void> {
+  await kvSet(KV_KEYS.SIGNAL_SNAPSHOT, snapshot, 600);
+}
+
+/**
+ * Load the latest signal snapshot from Redis.
+ */
+export async function loadSignalSnapshot(): Promise<SignalSnapshot | null> {
+  return kvGet<SignalSnapshot>(KV_KEYS.SIGNAL_SNAPSHOT);
+}
+
+// ── GI state persistence ─────────────────────────────────────
+
+export type GIState = {
+  global_integrity: number;
+  mode: string;
+  terminal_status: string;
+  primary_driver: string;
+  source: 'live' | 'mock' | 'cached';
+  signals: {
+    quality: number;
+    freshness: number;
+    stability: number;
+    system: number;
+  };
+  timestamp: string;
+};
+
+/**
+ * Save the latest GI state. TTL: 15 minutes.
+ */
+export async function saveGIState(state: GIState): Promise<void> {
+  await kvSet(KV_KEYS.GI_STATE, state, 900);
+}
+
+/**
+ * Load the last-known GI state from Redis.
+ */
+export async function loadGIState(): Promise<GIState | null> {
+  return kvGet<GIState>(KV_KEYS.GI_STATE);
+}
+
+// ── ECHO state persistence ───────────────────────────────────
+
+export type EchoKVState = {
+  lastIngest: string | null;
+  cycleId: string;
+  totalIngested: number;
+  epiconCount: number;
+  ledgerCount: number;
+  alertCount: number;
+  timestamp: string;
+};
+
+/**
+ * Save ECHO store summary. TTL: 30 minutes.
+ */
+export async function saveEchoState(state: EchoKVState): Promise<void> {
+  await kvSet(KV_KEYS.ECHO_STATE, state, 1800);
+}
+
+/**
+ * Load ECHO store summary.
+ */
+export async function loadEchoState(): Promise<EchoKVState | null> {
+  return kvGet<EchoKVState>(KV_KEYS.ECHO_STATE);
+}
+
+// ── Tripwire state persistence ───────────────────────────────
+
+export type TripwireKVState = {
+  active: boolean;
+  level: 'none' | 'watch' | 'elevated';
+  reason: string;
+  last_updated: string;
+};
+
+/**
+ * Save tripwire state. TTL: 30 minutes.
+ */
+export async function saveTripwireState(state: TripwireKVState): Promise<void> {
+  await kvSet(KV_KEYS.TRIPWIRE_STATE, state, 1800);
+}
+
+/**
+ * Load tripwire state.
+ */
+export async function loadTripwireState(): Promise<TripwireKVState | null> {
+  return kvGet<TripwireKVState>(KV_KEYS.TRIPWIRE_STATE);
+}
+
+// ── Health check ─────────────────────────────────────────────
+
+/**
+ * Check Redis health and return diagnostic info.
+ */
+export async function kvHealth(): Promise<{
+  available: boolean;
+  configured: boolean;
+  latencyMs: number | null;
+  error: string | null;
+}> {
+  const configured = !!(process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN);
+
+  if (!configured) {
+    return { available: false, configured: false, latencyMs: null, error: 'Env vars not set' };
+  }
+
+  const redis = getRedis();
+  if (!redis) {
+    return { available: false, configured: true, latencyMs: null, error: 'Redis client init failed' };
+  }
+
+  try {
+    const start = Date.now();
+    await redis.ping();
+    const latencyMs = Date.now() - start;
+    return { available: true, configured: true, latencyMs, error: null };
+  } catch (err) {
+    return {
+      available: false,
+      configured: true,
+      latencyMs: null,
+      error: err instanceof Error ? err.message : 'Unknown error',
+    };
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mobius-civic-ai-terminal",
       "version": "0.1.0",
       "dependencies": {
+        "@upstash/redis": "^1.37.0",
         "next": "^15.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -759,6 +760,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+      "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/any-promise": {
@@ -2035,6 +2045,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@upstash/redis": "^1.37.0",
     "next": "^15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"


### PR DESCRIPTION
### Motivation
- Vercel serverless cold starts reset in-memory state causing GI to flip between live and mock; durable persistence is needed to stabilize GI responses across cold starts. 
- Use a lightweight, free Upstash Redis REST-backed KV layer to persist recent GI computations and micro-agent snapshots for cold-start recovery. 
- The integration must gracefully degrade to the existing in-memory behavior if Redis is not configured or reachable.

### Description
- Add a new persistence layer in `lib/kv/store.ts` with namespaced keys, TTL-backed helpers and public functions such as `kvGet`, `kvSet`, `saveGIState`, `loadGIState`, `saveSignalSnapshot`, `loadSignalSnapshot`, and `kvHealth` for diagnostics. 
- Add a KV diagnostic endpoint `GET /api/kv/health` implemented in `app/api/kv/health/route.ts` that reports Redis availability, configuration, latency, and which Mobius keys are populated. 
- Update `app/api/integrity-status/route.ts` to attempt `loadGIState` on cold starts (serving `source: "cached"` when appropriate), and asynchronously persist the current GI via `saveGIState` while exposing `kv` availability in responses. 
- Update `app/api/signals/micro/route.ts` to persist micro-agent snapshots with `saveSignalSnapshot`, expose `kv` in live responses, and fall back to `loadSignalSnapshot` on polling failures. 
- Add `@upstash/redis` to `package.json` and update `package-lock.json` to include the dependency and its transitive entries.

### Testing
- Ran `npm run lint`, but it could not complete non-interactively because Next.js triggered an interactive ESLint setup prompt. 
- Ran `npm run build`, which failed with `Module not found: Can't resolve '@upstash/redis'` prior to installing dependencies. 
- Ran `npm install`, which failed in this environment with a `403 Forbidden` when fetching the transitive `uncrypto@0.1.3` package, preventing a successful install and build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c481457218832d9752c8d1fc776ad1)