### PR TITLE
feat: add C-261 hard halt modal and signal noise suppression

### DIFF
--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -30,7 +30,9 @@ import LedgerPanel from '@/components/terminal/LedgerPanel';
 import SubstrateStatusCard from '@/components/terminal/SubstrateStatusCard';
 import CivicRadarPanel from '@/components/terminal/CivicRadarPanel';
 import SignalEnginePanel from '@/components/terminal/SignalEnginePanel';
+import IntegrityFilter from '@/components/terminal/IntegrityFilter';
 import IntegrityRatingPanel from '@/components/terminal/IntegrityRatingPanel';
+import HardHalt from '@/components/modals/HardHalt';
 import SentinelPulsePanel from '@/components/terminal/SentinelPulsePanel';
 import EveGlobalNewsPanel from '@/components/terminal/EveGlobalNewsPanel';
 import MacroIntegrityPulseCard from '@/components/markets/MacroIntegrityPulseCard';
@@ -45,6 +47,7 @@ import { navItems, mockCivicAlerts, mockSentinels } from '@/lib/terminal/mock';
 import type { NavKey } from '@/lib/terminal/types';
 import { mockQueryResult } from '@/lib/mock/queryResult';
 import { cn } from '@/lib/terminal/utils';
+import { checkCovenantCompliance } from '@/lib/integrity-check';
 import { useTerminalCommands } from '@/hooks/useTerminalCommands';
 import { useTerminalData } from '@/hooks/useTerminalData';
 
@@ -98,6 +101,7 @@ export default function TerminalPageWrapper() {
 function TerminalPage() {
   const [selectedNav, setSelectedNav] = useState<NavKey>('pulse');
   const [commandResult, setCommandResult] = useState<TerminalCommandResult | null>(null);
+  const [noiseThreshold, setNoiseThreshold] = useState(0.7);
   const {
     agents,
     allTripwires,
@@ -153,6 +157,8 @@ function TerminalPage() {
   const showSignal = ['pulse', 'governance', 'geopolitics', 'markets'].includes(selectedNav);
   const showConsensus = showCreateEpicon || inspectorTarget.kind === 'epicon';
   const criticalAlertCount = mergedAlerts.filter((alert) => alert.severity === 'critical' || alert.severity === 'high').length;
+  const filteredSignals = filteredEpicon.filter((item) => item.confidenceTier / 4 >= noiseThreshold);
+  const covenantStatus = checkCovenantCompliance(gi.score);
 
   const consensusAgents = (() => {
     if (showCreateEpicon) {
@@ -263,6 +269,11 @@ function TerminalPage() {
 
   return (
     <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
+      <HardHalt
+        isOpen={covenantStatus.status === 'HALT'}
+        giScore={gi.score}
+        reason="Semantic drift detected in active civic signal lanes."
+      />
       <TopStatusBar
         alertCount={allTripwires.length + criticalAlertCount}
         mii={liveRibbonMii}
@@ -308,11 +319,13 @@ function TerminalPage() {
             >
               <div className="flex flex-wrap items-center gap-2 text-[11px] uppercase tracking-[0.14em] text-slate-500">
                 <span className="rounded-md border border-slate-700 bg-slate-950 px-2 py-1">Driver · {primaryDriver}</span>
-                <span className="rounded-md border border-slate-700 bg-slate-950 px-2 py-1">Signals · {filteredEpicon.length}</span>
+                <span className="rounded-md border border-slate-700 bg-slate-950 px-2 py-1">Signals · {filteredSignals.length}</span>
                 <span className="rounded-md border border-slate-700 bg-slate-950 px-2 py-1">Tripwires · {allTripwires.length}</span>
                 <span className="rounded-md border border-slate-700 bg-slate-950 px-2 py-1">Alerts · {criticalAlertCount}</span>
               </div>
             </TerminalSection>
+
+            <IntegrityFilter onFilterChange={setNoiseThreshold} defaultThreshold={noiseThreshold} />
 
             {showLedger && (
               <LedgerPanel
@@ -331,9 +344,10 @@ function TerminalPage() {
               >
                 <div className="space-y-4">
                   <EpiconFeedPanel
-                    items={filteredEpicon}
+                    items={filteredSignals}
                     selectedId={inspectorTarget.kind === 'epicon' ? inspectorTarget.data.id : ''}
                     onSelect={(item) => setInspectorTarget({ kind: 'epicon', data: item })}
+                    noiseThreshold={noiseThreshold}
                   />
 
                   <div className="rounded-xl border border-slate-800 bg-slate-950/50 p-4">

--- a/components/modals/HardHalt.tsx
+++ b/components/modals/HardHalt.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { C261_COVENANT } from '@/lib/constants/covenants';
+
+export default function HardHalt({
+  isOpen,
+  giScore,
+  reason,
+}: {
+  isOpen: boolean;
+  giScore: number;
+  reason: string;
+}) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[999] flex items-center justify-center bg-black/90 p-6 backdrop-blur-sm">
+      <div className="w-full max-w-2xl border-2 border-orange-500 bg-slate-950 p-8 font-mono shadow-[0_0_50px_rgba(249,115,22,0.28)]">
+        <div className="mb-6 flex items-center gap-4 border-b border-orange-500/30 pb-4 text-orange-400">
+          <span className="text-3xl">⚠️</span>
+          <h1 className="text-xl font-bold uppercase tracking-[0.08em]">Hard Halt: C-261 Circuit Breaker</h1>
+        </div>
+
+        <div className="space-y-5 text-slate-200">
+          <p className="text-lg">System integrity breach detected.</p>
+
+          <div className="rounded border border-orange-500/50 bg-orange-500/10 p-4">
+            <div className="mb-2 flex items-center justify-between">
+              <span className="uppercase tracking-[0.08em]">Current GI Score</span>
+              <span className="font-bold text-red-400">{giScore.toFixed(3)}</span>
+            </div>
+            <div className="flex items-center justify-between text-xs text-slate-400">
+              <span>Minimum Threshold</span>
+              <span>{C261_COVENANT.GI_THRESHOLD} (C-261)</span>
+            </div>
+          </div>
+
+          <div className="space-y-2 text-sm">
+            <p><span className="text-slate-400">Issue:</span> {reason}</p>
+            <p><span className="text-slate-400">Status:</span> Read-only mode recommended until recovery.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/terminal/EpiconFeedPanel.tsx
+++ b/components/terminal/EpiconFeedPanel.tsx
@@ -39,10 +39,12 @@ export default function EpiconFeedPanel({
   items,
   selectedId,
   onSelect,
+  noiseThreshold,
 }: {
   items: EpiconItem[];
   selectedId: string;
   onSelect: (item: EpiconItem) => void;
+  noiseThreshold?: number;
 }) {
   const [sortKey, setSortKey] = useState<EpiconSortKey>('time');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
@@ -70,6 +72,7 @@ export default function EpiconFeedPanel({
           <button
             key={item.id}
             onClick={() => onSelect(item)}
+            style={{ contentVisibility: 'auto', containIntrinsicSize: '0 160px' }}
             className={cn(
               'w-full rounded-lg border p-4 text-left transition',
               selectedId === item.id
@@ -115,6 +118,11 @@ export default function EpiconFeedPanel({
               <span className="rounded-md bg-slate-800 px-2 py-1 text-[10px] font-mono uppercase tracking-[0.15em] text-slate-300">
                 {item.ownerAgent}
               </span>
+              {typeof noiseThreshold === 'number' && item.confidenceTier / 4 < noiseThreshold && (
+                <span className="rounded-md border border-orange-500/40 bg-orange-500/10 px-2 py-1 text-[10px] font-mono uppercase tracking-[0.15em] text-orange-300">
+                  C-261 Breach Risk
+                </span>
+              )}
               {item.id.includes('-USR-') && (
                 <span className="rounded-md border border-violet-500/20 bg-violet-500/10 px-2 py-1 text-[10px] font-mono uppercase tracking-[0.15em] text-violet-300">
                   participant

--- a/components/terminal/IntegrityFilter.tsx
+++ b/components/terminal/IntegrityFilter.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function IntegrityFilter({
+  onFilterChange,
+  defaultThreshold = 0.7,
+}: {
+  onFilterChange: (val: number) => void;
+  defaultThreshold?: number;
+}) {
+  const [threshold, setThreshold] = useState(defaultThreshold);
+
+  return (
+    <div className="flex flex-wrap items-center gap-4 rounded-xl border border-slate-800 bg-slate-900/60 px-4 py-3">
+      <span className="text-xs font-mono uppercase tracking-[0.18em] text-emerald-300">
+        Noise Suppression: {Math.round(threshold * 100)}%
+      </span>
+      <input
+        type="range"
+        min="0"
+        max="1"
+        step="0.01"
+        value={threshold}
+        onChange={(e) => {
+          const val = Number.parseFloat(e.target.value);
+          setThreshold(val);
+          onFilterChange(val);
+        }}
+        className="h-1 w-40 cursor-pointer appearance-none rounded-lg bg-slate-700 accent-emerald-400"
+      />
+      <div
+        className={`rounded border px-2 py-1 text-[10px] font-mono uppercase tracking-[0.16em] ${threshold > 0.8 ? 'border-sky-500 text-sky-300' : 'border-slate-700 text-slate-300'}`}
+      >
+        {threshold > 0.8 ? 'Ultra-Pure Signal' : 'Standard Audit'}
+      </div>
+    </div>
+  );
+}

--- a/lib/constants/covenants.ts
+++ b/lib/constants/covenants.ts
@@ -1,0 +1,10 @@
+export const C261_COVENANT = {
+  VERSION: '1.0.4',
+  GI_THRESHOLD: 0.61,
+  IDEAL_SIGNAL: 0.85,
+  SENTINELS: {
+    JADE: 'Semantic Auditor',
+    AUREA: 'Ethical Arbiter',
+    ATLAS: 'Substrate Guardian',
+  },
+} as const;

--- a/lib/integrity-check.ts
+++ b/lib/integrity-check.ts
@@ -1,0 +1,13 @@
+import { C261_COVENANT } from '@/lib/constants/covenants';
+
+export function checkCovenantCompliance(miiScore: number) {
+  if (miiScore < C261_COVENANT.GI_THRESHOLD) {
+    return {
+      status: 'HALT' as const,
+      message: 'System integrity below C-261 threshold',
+      threshold: C261_COVENANT.GI_THRESHOLD,
+    };
+  }
+
+  return { status: 'OK' as const, threshold: C261_COVENANT.GI_THRESHOLD };
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,8 @@
 import type { NextConfig } from 'next';
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  bundlePagesRouterDependencies: true,
+  serverExternalPackages: ['@mobius/integrity-core'],
+};
 
 export default nextConfig;


### PR DESCRIPTION
### Motivation
- Introduce an operator-facing circuit breaker (C-261) and per-feed noise-suppression to protect the terminal from low-integrity signals and reduce UI jank during high-velocity streams. 
- Improve client-side rendering efficiency for long feeds using a lightweight `content-visibility` strategy and reduce unnecessary rendering overhead.

### Description
- Add C-261 constants and helper: new `lib/constants/covenants.ts` and `lib/integrity-check.ts` with `C261_COVENANT` and `checkCovenantCompliance` to centralize threshold logic. 
- Hard halt modal: new `components/modals/HardHalt.tsx` renders a blocking overlay when `checkCovenantCompliance` returns `HALT` and displays GI vs C-261 details. 
- Noise suppression UI: new `components/terminal/IntegrityFilter.tsx` slider that emits an operator `noiseThreshold` for the EPICON feed. 
- Feed performance + UX: update `components/terminal/EpiconFeedPanel.tsx` to apply `style={{ contentVisibility: 'auto', containIntrinsicSize: '0 160px' }}` to feed items and show a `C-261 Breach Risk` badge for items below the threshold. 
- Integration: wire the filter and halt logic into `app/terminal/page.tsx` by tracking `noiseThreshold`, filtering `filteredEpicon` to `filteredSignals`, computing covenant status via `checkCovenantCompliance`, and rendering the `HardHalt` modal and `IntegrityFilter`. 
- Next.js config: update `next.config.ts` to set `bundlePagesRouterDependencies` and declare `serverExternalPackages: ['@mobius/integrity-core']` for downstream integration.

### Testing
- Ran `npm run build`, which produced a successful production build after adjustments; static and dynamic routes were generated and the build completed. 
- Attempted to install `babel-plugin-react-compiler` to re-enable the React Compiler, but `npm i -D babel-plugin-react-compiler` failed with a registry `403`, so the `reactCompiler` experiment was not enabled in this environment. 
- All changes were committed and a PR was created; the build step is the primary automated validation (`npm run build` succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c480d5efd0832d95da343b881e01c1)