### PR TITLE
perf: content-visibility rendering optimization for feed lists

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -128,3 +128,13 @@ body {
 ::-webkit-scrollbar-thumb:hover {
   background: #475569;
 }
+
+/* ── Rendering performance ─────────────────────────────────── */
+/* content-visibility: auto skips rendering for off-screen items.
+   The browser only paints items as they scroll into view.
+   contain-intrinsic-block-size gives the browser a height estimate
+   so scroll position calculations stay accurate. */
+.cv-auto {
+  content-visibility: auto;
+  contain-intrinsic-block-size: auto 80px;
+}

--- a/components/signals/PulseTimeline.tsx
+++ b/components/signals/PulseTimeline.tsx
@@ -161,7 +161,7 @@ export default function PulseTimeline() {
             {visibleAgents.map((agent) => (
               <div
                 key={agent.agentName}
-                className="rounded-xl border border-slate-800 bg-slate-950/60 p-4"
+                className="cv-auto rounded-xl border border-slate-800 bg-slate-950/60 p-4"
               >
                 <div className="flex items-start justify-between gap-3">
                   <div>

--- a/components/terminal/EpiconFeedPanel.tsx
+++ b/components/terminal/EpiconFeedPanel.tsx
@@ -72,9 +72,8 @@ export default function EpiconFeedPanel({
           <button
             key={item.id}
             onClick={() => onSelect(item)}
-            style={{ contentVisibility: 'auto', containIntrinsicSize: '0 160px' }}
             className={cn(
-              'w-full rounded-lg border p-4 text-left transition',
+              'cv-auto w-full rounded-lg border p-4 text-left transition',
               selectedId === item.id
                 ? 'border-sky-500/40 bg-sky-500/10'
                 : 'border-slate-800 bg-slate-950/60 hover:border-slate-700 hover:bg-slate-900',

--- a/components/terminal/EveGlobalNewsPanel.tsx
+++ b/components/terminal/EveGlobalNewsPanel.tsx
@@ -100,7 +100,7 @@ export default function EveGlobalNewsPanel() {
 
           <ul className="space-y-2">
             {data.items.slice(0, 8).map((item) => (
-              <li key={item.id} className="rounded-lg border border-slate-800 bg-slate-950/70 p-3">
+              <li key={item.id} className="cv-auto rounded-lg border border-slate-800 bg-slate-950/70 p-3">
                 <a href={item.url} target="_blank" rel="noreferrer" className="text-sm font-medium text-slate-100 hover:text-cyan-300">
                   {item.title}
                 </a>

--- a/components/terminal/LedgerPanel.tsx
+++ b/components/terminal/LedgerPanel.tsx
@@ -83,7 +83,7 @@ export default function LedgerPanel({
             key={entry.id}
             onClick={() => onSelect?.(entry)}
             className={cn(
-              'w-full rounded-lg border p-3 text-left transition',
+              'cv-auto w-full rounded-lg border p-3 text-left transition',
               selectedId === entry.id
                 ? 'border-sky-500/40 bg-sky-500/10'
                 : 'border-slate-800 bg-slate-950/60 hover:border-slate-700 hover:bg-slate-900',

--- a/components/terminal/SentinelPulsePanel.tsx
+++ b/components/terminal/SentinelPulsePanel.tsx
@@ -158,7 +158,7 @@ export default function SentinelPulsePanel() {
     return (
       <ul className="space-y-3">
         {events.map((event) => (
-          <li key={event.id} className="rounded-lg border border-slate-800 bg-slate-950/70 p-3">
+          <li key={event.id} className="cv-auto rounded-lg border border-slate-800 bg-slate-950/70 p-3">
             <div className="mb-1 flex items-center justify-between gap-2">
               <span className={`rounded-md border px-2 py-1 text-[10px] font-mono uppercase tracking-[0.14em] ${badgeClass(event.agent)}`}>
                 {event.agent}


### PR DESCRIPTION
### Motivation
- Reduce browser paint/layout work for long, scrollable lists in the terminal UI by using native `content-visibility` so off-screen items are not rendered until needed.
- Provide a single reusable utility so the optimization is consistent across multiple feed/list components without adding JS or a virtualization library.

### Description
- Added a shared utility class `.cv-auto` in `app/globals.css` that applies `content-visibility: auto` and `contain-intrinsic-block-size: auto 80px` for height estimation.
- Applied `.cv-auto` to list items/cards in the following feed components: `components/terminal/EpiconFeedPanel.tsx`, `components/signals/PulseTimeline.tsx`, `components/terminal/SentinelPulsePanel.tsx`, `components/terminal/EveGlobalNewsPanel.tsx`, and `components/terminal/LedgerPanel.tsx`.
- Removed the one-off inline `contentVisibility` style from `EpiconFeedPanel` in favor of the shared CSS utility.
- Commit message: `perf: content-visibility rendering optimization for feed lists` (changes limited to CSS and component class updates).

### Testing
- Ran TypeScript check with `npx tsc --noEmit`, which failed in this environment due to a missing `@upstash/redis` module triggered by existing KV integration files (type-check error): failed.
- Attempted `npm install` to restore dependencies and resolve types, but installation failed due to a registry access policy error fetching a transitive dependency (`uncrypto@0.1.3`): failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c49019f614832d9fd09689f492d645)