### PR TITLE
feat(epicon): source feed from GitHub commits and add ledger backfill seeding

### DIFF
--- a/app/api/epicon/feed/route.ts
+++ b/app/api/epicon/feed/route.ts
@@ -1,14 +1,315 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { Redis } from '@upstash/redis';
 import { getPublicEpiconFeed } from '@/lib/epicon/feedStore';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
-  const items = getPublicEpiconFeed();
+type EpiconType = 'heartbeat' | 'catalog' | 'zeus-verify' | 'zeus-report' | 'epicon' | 'merge' | 'unknown';
+type EpiconSeverity = 'nominal' | 'degraded' | 'elevated' | 'critical' | 'info';
+type EpiconSource = 'github-commit' | 'kv-ledger' | 'memory-feed' | 'backfill';
 
-  return NextResponse.json({
-    ok: true,
-    count: items.length,
-    items,
-  });
+type EpiconEntry = {
+  id: string;
+  cycle?: string;
+  timestamp: string;
+  author: string;
+  title: string;
+  body?: string;
+  type: EpiconType;
+  severity: EpiconSeverity;
+  gi?: number;
+  anomalies?: string[];
+  sha?: string;
+  source: EpiconSource;
+  tags: string[];
+  verified: boolean;
+  verifiedBy?: string;
+};
+
+type GitHubCommit = {
+  sha: string;
+  commit: {
+    message: string;
+    author: {
+      name: string;
+      email: string;
+      date: string;
+    };
+  };
+};
+
+function getRedisClient(): Redis | null {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  try {
+    return new Redis({ url, token });
+  } catch {
+    return null;
+  }
+}
+
+async function fetchGitHubCommits(limit = 80): Promise<GitHubCommit[]> {
+  const url = `https://api.github.com/repos/kaizencycle/mobius-civic-ai-terminal/commits?per_page=${limit}&sha=main`;
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  const res = await fetch(url, { headers, next: { revalidate: 120 } });
+  if (!res.ok) {
+    return [];
+  }
+
+  const data: unknown = await res.json();
+  return Array.isArray(data) ? (data as GitHubCommit[]) : [];
+}
+
+function parseHeartbeat(message: string): Partial<EpiconEntry> | null {
+  const base = /^heartbeat:\s*(nominal|degraded|elevated|critical)/i.exec(message);
+  if (!base) return null;
+
+  const state = base[1].toLowerCase() as Exclude<EpiconSeverity, 'info'>;
+  const giMatch = /GI\s+([\d.]+)/i.exec(message);
+  const gi = giMatch ? Number.parseFloat(giMatch[1]) : undefined;
+  const anomaliesMatch = /(\d+)\s+anomal/i.exec(message);
+  const anomalyCount = anomaliesMatch ? Number.parseInt(anomaliesMatch[1], 10) : 0;
+
+  const anomalyLines = message
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('⚠'))
+    .map((line) => line.replace(/^⚠\s*(ELEVATED|CRITICAL|WARNING):\s*/i, '').trim())
+    .filter(Boolean);
+
+  return {
+    type: 'heartbeat',
+    severity: state,
+    gi,
+    anomalies: anomalyLines.length > 0 ? anomalyLines : undefined,
+    title: `Heartbeat: ${state.toUpperCase()} · GI ${gi ?? '–'} · ${anomalyCount} anomalies`,
+    tags: ['heartbeat', 'gaia', state],
+    verified: false,
+  };
+}
+
+function parseZeus(message: string): Partial<EpiconEntry> | null {
+  if (!/^zeus:/i.test(message)) return null;
+
+  if (/verification confirmed/i.test(message)) {
+    const fileMatch = /reviewed\s+([\w.-]+)/i.exec(message);
+    return {
+      type: 'zeus-verify',
+      severity: 'nominal',
+      title: `ZEUS: Verification confirmed${fileMatch ? ` · ${fileMatch[1]}` : ''}`,
+      tags: ['zeus', 'verification', 'confirmed'],
+      verified: true,
+      verifiedBy: 'ZEUS',
+    };
+  }
+
+  if (/verification report/i.test(message)) {
+    const dateMatch = /report\s+(\S+)/i.exec(message);
+    return {
+      type: 'zeus-report',
+      severity: 'info',
+      title: `ZEUS: Verification report${dateMatch ? ` · ${dateMatch[1]}` : ''}`,
+      tags: ['zeus', 'report'],
+      verified: true,
+      verifiedBy: 'ZEUS',
+    };
+  }
+
+  return {
+    type: 'zeus-verify',
+    severity: 'info',
+    title: message.split('\n')[0]?.trim() ?? 'ZEUS event',
+    tags: ['zeus'],
+    verified: false,
+  };
+}
+
+function parseCatalog(message: string): Partial<EpiconEntry> | null {
+  if (!/chore\(catalog\)/i.test(message)) return null;
+  return {
+    type: 'catalog',
+    severity: 'info',
+    title: 'Catalog snapshot updated',
+    tags: ['catalog', 'mobius-bot', 'automated'],
+    author: 'mobius-bot',
+    verified: false,
+  };
+}
+
+function parseEpicon(message: string): Partial<EpiconEntry> | null {
+  const m = /^EPICON\s+(C-\d+):\s+(.+)/i.exec(message);
+  if (!m) return null;
+
+  return {
+    type: 'epicon',
+    cycle: m[1].toUpperCase(),
+    severity: 'info',
+    title: m[2].split('\n')[0]?.trim() ?? 'EPICON event',
+    tags: ['epicon', 'backfill', m[1].toLowerCase()],
+    verified: false,
+    source: 'backfill',
+  };
+}
+
+function parseMerge(message: string): Partial<EpiconEntry> | null {
+  if (!/^Merge pull request/i.test(message)) return null;
+  const lines = message.split('\n');
+  const fallback = lines[0]?.trim() ?? 'Merge pull request';
+  const firstNonBlank = lines.find((line, idx) => idx > 0 && line.trim().length > 0)?.trim();
+
+  return {
+    type: 'merge',
+    severity: 'info',
+    title: firstNonBlank ?? fallback,
+    tags: ['merge', 'pr'],
+    verified: false,
+  };
+}
+
+function toEpiconEntry(commit: GitHubCommit): EpiconEntry | null {
+  const message = commit.commit.message.trim();
+  const parsed =
+    parseHeartbeat(message) ?? parseZeus(message) ?? parseCatalog(message) ?? parseEpicon(message) ?? parseMerge(message);
+
+  if (!parsed) return null;
+
+  const email = commit.commit.author.email;
+  const name = commit.commit.author.name;
+
+  const author =
+    parsed.author ??
+    (email.includes('mobius-bot') || name === 'mobius-bot'
+      ? 'mobius-bot'
+      : email.includes('cursor') || name.includes('Cursor')
+        ? 'cursor-agent'
+        : name === 'Michael Judan'
+          ? 'kaizencycle'
+          : name);
+
+  return {
+    id: `${commit.sha.slice(0, 8)}-${parsed.type ?? 'unknown'}`,
+    timestamp: commit.commit.author.date,
+    author,
+    title: parsed.title ?? message.split('\n')[0]?.slice(0, 120) ?? 'EPICON event',
+    type: parsed.type ?? 'unknown',
+    severity: parsed.severity ?? 'info',
+    tags: parsed.tags ?? [],
+    source: parsed.source ?? 'github-commit',
+    verified: parsed.verified ?? false,
+    cycle: parsed.cycle,
+    body: parsed.body,
+    gi: parsed.gi,
+    anomalies: parsed.anomalies,
+    sha: commit.sha,
+    verifiedBy: parsed.verifiedBy,
+  };
+}
+
+function fromMemoryFeed(): EpiconEntry[] {
+  return getPublicEpiconFeed().map((item) => ({
+    id: item.id,
+    timestamp: item.created_at,
+    author: item.submitted_by_login ?? 'operator',
+    title: item.title,
+    body: item.summary,
+    type: 'epicon',
+    severity: item.status === 'contradicted' ? 'degraded' : 'info',
+    source: 'memory-feed',
+    tags: item.tags,
+    verified: item.status === 'verified',
+  }));
+}
+
+async function fromRedis(): Promise<EpiconEntry[]> {
+  const redis = getRedisClient();
+  if (!redis) return [];
+
+  try {
+    const raw = await redis.lrange<string>('mobius:epicon:feed', 0, 99);
+    return raw
+      .map((entry) => {
+        try {
+          return JSON.parse(entry) as EpiconEntry;
+        } catch {
+          return null;
+        }
+      })
+      .filter((entry): entry is EpiconEntry => entry !== null);
+  } catch {
+    return [];
+  }
+}
+
+function dedupeSort(entries: EpiconEntry[]): EpiconEntry[] {
+  const seen = new Set<string>();
+
+  return entries
+    .filter((entry) => {
+      if (seen.has(entry.id)) return false;
+      seen.add(entry.id);
+      return true;
+    })
+    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+}
+
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const limit = Math.min(Number.parseInt(params.get('limit') ?? '30', 10) || 30, 100);
+  const typeFilter = params.get('type');
+  const minGI = params.get('minGI');
+  const minGiValue = minGI ? Number.parseFloat(minGI) : undefined;
+
+  const [commits, kvEntries] = await Promise.all([fetchGitHubCommits(80), fromRedis()]);
+  const commitEntries = commits.map(toEpiconEntry).filter((entry): entry is EpiconEntry => entry !== null);
+  const memoryEntries = fromMemoryFeed();
+
+  let entries = dedupeSort([...kvEntries, ...commitEntries, ...memoryEntries]);
+
+  if (typeFilter) entries = entries.filter((entry) => entry.type === typeFilter);
+  if (minGiValue !== undefined && !Number.isNaN(minGiValue)) {
+    entries = entries.filter((entry) => entry.gi === undefined || entry.gi >= minGiValue);
+  }
+
+  const items = entries.slice(0, limit);
+  const heartbeats = items.filter((entry) => entry.type === 'heartbeat');
+
+  return NextResponse.json(
+    {
+      ok: true,
+      count: items.length,
+      total: entries.length,
+      sources: {
+        github: commitEntries.length,
+        kv: kvEntries.length,
+        memory: memoryEntries.length,
+        kvConfigured: !!getRedisClient(),
+      },
+      summary: {
+        latestGI: heartbeats.find((entry) => entry.gi !== undefined)?.gi ?? null,
+        degradedCount: heartbeats.filter((entry) => entry.severity === 'degraded' || entry.severity === 'critical')
+          .length,
+        lastHeartbeat: heartbeats[0]?.timestamp ?? null,
+        lastZeusVerify: items.find((entry) => entry.type === 'zeus-verify')?.timestamp ?? null,
+      },
+      items,
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=60, stale-while-revalidate=120',
+        'X-Mobius-Source': 'epicon-github-bridge',
+        'X-Mobius-KV': getRedisClient() ? 'active' : 'unconfigured',
+      },
+    },
+  );
 }

--- a/app/api/ledger/backfill/route.ts
+++ b/app/api/ledger/backfill/route.ts
@@ -1,10 +1,245 @@
-import { NextResponse } from 'next/server';
-import { ledgerBackfill } from '@/lib/mock/ledgerBackfill';
+import { NextRequest, NextResponse } from 'next/server';
+import { Redis } from '@upstash/redis';
+
+type EpiconEntry = {
+  id: string;
+  cycle?: string;
+  timestamp: string;
+  author: string;
+  title: string;
+  body?: string;
+  type: 'heartbeat' | 'catalog' | 'zeus-verify' | 'zeus-report' | 'epicon' | 'merge' | 'unknown';
+  severity: 'nominal' | 'degraded' | 'elevated' | 'critical' | 'info';
+  gi?: number;
+  anomalies?: string[];
+  sha?: string;
+  source: 'github-commit' | 'backfill';
+  tags: string[];
+  verified: boolean;
+  verifiedBy?: string;
+};
+
+type GitHubCommit = {
+  sha: string;
+  commit: {
+    message: string;
+    author: {
+      name: string;
+      email: string;
+      date: string;
+    };
+  };
+};
+
+function getRedisClient(): Redis | null {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  try {
+    return new Redis({ url, token });
+  } catch {
+    return null;
+  }
+}
+
+function isAuthorized(req: NextRequest): boolean {
+  const secret = process.env.BACKFILL_SECRET;
+  if (!secret) return false;
+  return req.headers.get('authorization') === `Bearer ${secret}`;
+}
+
+function parseCommit(commit: GitHubCommit): EpiconEntry | null {
+  const message = commit.commit.message.trim();
+  const authorName = commit.commit.author.name;
+  const authorEmail = commit.commit.author.email;
+
+  let partial: Partial<EpiconEntry> | null = null;
+
+  const hb = /^heartbeat:\s*(nominal|degraded|elevated|critical)/i.exec(message);
+  if (hb) {
+    const status = hb[1].toLowerCase() as EpiconEntry['severity'];
+    const giMatch = /GI\s+([\d.]+)/i.exec(message);
+    const gi = giMatch ? Number.parseFloat(giMatch[1]) : undefined;
+    const anomaliesMatch = /(\d+)\s+anomal/i.exec(message);
+    const anomalyCount = anomaliesMatch ? Number.parseInt(anomaliesMatch[1], 10) : 0;
+
+    partial = {
+      type: 'heartbeat',
+      severity: status,
+      gi,
+      title: `Heartbeat: ${status.toUpperCase()} · GI ${gi ?? '–'} · ${anomalyCount} anomalies`,
+      tags: ['heartbeat', status],
+      verified: false,
+    };
+  } else if (/^zeus:/i.test(message)) {
+    const isConfirm = /verification confirmed/i.test(message);
+    const reviewed = /reviewed\s+([\w.-]+)/i.exec(message);
+
+    partial = {
+      type: isConfirm ? 'zeus-verify' : 'zeus-report',
+      severity: isConfirm ? 'nominal' : 'info',
+      title: isConfirm
+        ? `ZEUS: Verification confirmed${reviewed ? ` · ${reviewed[1]}` : ''}`
+        : message.split('\n')[0]?.trim() ?? 'ZEUS report',
+      tags: ['zeus', 'verification'],
+      verified: isConfirm,
+      verifiedBy: isConfirm ? 'ZEUS' : undefined,
+    };
+  } else if (/chore\(catalog\)/i.test(message)) {
+    partial = {
+      type: 'catalog',
+      severity: 'info',
+      title: 'Catalog snapshot updated',
+      tags: ['catalog', 'automated'],
+      verified: false,
+      author: 'mobius-bot',
+    };
+  } else if (/^EPICON\s+(C-\d+):\s+(.+)/i.test(message)) {
+    const match = /^EPICON\s+(C-\d+):\s+(.+)/i.exec(message);
+    partial = {
+      type: 'epicon',
+      severity: 'info',
+      cycle: match?.[1].toUpperCase(),
+      title: match?.[2].split('\n')[0]?.trim() ?? 'EPICON entry',
+      tags: ['epicon', 'backfill'],
+      verified: false,
+      source: 'backfill',
+    };
+  } else if (/^Merge pull request/i.test(message)) {
+    const lines = message.split('\n');
+    const title = lines.find((line, idx) => idx > 0 && line.trim().length > 0)?.trim() ?? lines[0]?.trim() ?? 'Merge';
+    partial = {
+      type: 'merge',
+      severity: 'info',
+      title,
+      tags: ['merge', 'pr'],
+      verified: false,
+    };
+  }
+
+  if (!partial) return null;
+
+  const author =
+    partial.author ??
+    (authorEmail.includes('mobius-bot')
+      ? 'mobius-bot'
+      : authorEmail.includes('cursor') || authorName.includes('Cursor')
+        ? 'cursor-agent'
+        : authorName === 'Michael Judan'
+          ? 'kaizencycle'
+          : authorName);
+
+  return {
+    id: `${commit.sha.slice(0, 8)}-${partial.type ?? 'unknown'}`,
+    timestamp: commit.commit.author.date,
+    author,
+    title: partial.title ?? message.split('\n')[0]?.trim() ?? 'Commit event',
+    type: partial.type ?? 'unknown',
+    severity: partial.severity ?? 'info',
+    tags: partial.tags ?? [],
+    source: partial.source ?? 'github-commit',
+    verified: partial.verified ?? false,
+    verifiedBy: partial.verifiedBy,
+    gi: partial.gi,
+    anomalies: partial.anomalies,
+    body: partial.body,
+    cycle: partial.cycle,
+    sha: commit.sha,
+  };
+}
+
+async function fetchCommits(maxPages = 5): Promise<GitHubCommit[]> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  const out: GitHubCommit[] = [];
+
+  for (let page = 1; page <= maxPages; page += 1) {
+    const url = `https://api.github.com/repos/kaizencycle/mobius-civic-ai-terminal/commits?per_page=100&sha=main&page=${page}`;
+    const res = await fetch(url, { headers, cache: 'no-store' });
+    if (!res.ok) break;
+    const data: unknown = await res.json();
+    if (!Array.isArray(data) || data.length === 0) break;
+    out.push(...(data as GitHubCommit[]));
+    if (data.length < 100) break;
+  }
+
+  return out;
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const redis = getRedisClient();
+  if (!redis) {
+    return NextResponse.json(
+      { ok: false, error: 'KV not configured. Set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN.' },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const commits = await fetchCommits(5);
+    const entries = commits.map(parseCommit).filter((entry): entry is EpiconEntry => entry !== null);
+
+    const existingRaw = await redis.lrange<string>('mobius:epicon:feed', 0, -1);
+    const existingIds = new Set(
+      existingRaw
+        .map((item) => {
+          try {
+            const parsed = JSON.parse(item) as Partial<EpiconEntry>;
+            return parsed.id;
+          } catch {
+            return null;
+          }
+        })
+        .filter((id): id is string => Boolean(id)),
+    );
+
+    const toWrite = entries.filter((entry) => !existingIds.has(entry.id));
+
+    if (toWrite.length > 0) {
+      await redis.lpush(
+        'mobius:epicon:feed',
+        ...toWrite.map((entry) => JSON.stringify(entry)),
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      parsed: entries.length,
+      skipped: entries.length - toWrite.length,
+      written: toWrite.length,
+      sample: toWrite.slice(0, 3).map((entry) => ({ id: entry.id, type: entry.type, title: entry.title })),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}
 
 export async function GET() {
+  const kvConfigured = Boolean(getRedisClient());
+  const backfillProtected = Boolean(process.env.BACKFILL_SECRET);
+
   return NextResponse.json({
     ok: true,
-    count: ledgerBackfill.length,
-    items: ledgerBackfill,
+    ready: kvConfigured && backfillProtected,
+    kvConfigured,
+    backfillProtected,
+    instructions: kvConfigured
+      ? 'POST with Authorization: Bearer $BACKFILL_SECRET to seed history'
+      : 'Configure UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN first',
   });
 }


### PR DESCRIPTION
### Motivation
- The public EPICON feed was frequently empty because agents write important signals into Git commits and there was no bridge or durable KV ledger feeding `/api/epicon/feed`. 
- The change makes the terminal surface real ledger-like events immediately by surfacing commit-derived events and provides a path to seed a persistent ledger for future writes.

### Description
- Replaced `app/api/epicon/feed/route.ts` so the feed now fetches and parses GitHub commit history (heartbeat/ZEUS/catalog/EPICON/merge patterns), optionally merges persisted entries from Upstash Redis (`mobius:epicon:feed`) and the in-memory public feed, then de-duplicates, sorts, and returns richer metadata and filters (`limit`, `type`, `minGI`).
- Replaced `app/api/ledger/backfill/route.ts` with a protected, idempotent backfill endpoint that paginates GitHub commits, parses EPICON-shaped entries, and seeds the `mobius:epicon:feed` Redis list while skipping existing IDs, and exposes a GET readiness/status response.
- Added lightweight Upstash Redis client usage with environment checks so behavior gracefully falls back to memory when KV is unconfigured, and preserved compatibility with existing in-memory EPICON submissions.

### Testing
- `npx tsc --noEmit` completed successfully with no type errors.
- `npm run build` completed successfully and the app build reported the updated routes (including `/api/epicon/feed` and `/api/ledger/backfill`).
- `npm run lint` could not be run non-interactively in this environment because `next lint` prompted for interactive ESLint configuration, so linting was not validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c550d84490832dbace9a2f39ea38fe)