### PR TITLE
feat(epicon): wire KV write step to heartbeat + zeus agents (C-622)

### DIFF
--- a/lib/epicon-writer.ts
+++ b/lib/epicon-writer.ts
@@ -1,7 +1,7 @@
-import { createClient, type VercelKV } from '@vercel/kv';
+import { createClient, kv } from '@vercel/kv';
 
-/** Same list as feed + backfill routes (Upstash / Vercel Redis). */
-export const EPICON_FEED_LIST_KEY = 'mobius:epicon:feed';
+/** Same Redis list as `app/api/epicon/feed/route.ts` (do not change without updating feed). */
+const EPICON_FEED_LIST_KEY = 'mobius:epicon:feed';
 
 export interface EpiconWritePayload {
   type: 'heartbeat' | 'catalog' | 'zeus-verify' | 'zeus-report' | 'epicon' | 'merge';
@@ -17,26 +17,22 @@ export interface EpiconWritePayload {
   body?: string;
 }
 
-let _kv: VercelKV | null | undefined;
-
-function getKv(): VercelKV | null {
-  if (_kv !== undefined) return _kv;
-
-  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
-
-  if (!url || !token) {
-    _kv = null;
-    return null;
+function getKvClient(): ReturnType<typeof createClient> | typeof kv | null {
+  if (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN) {
+    return kv;
   }
-
-  _kv = createClient({ url, token });
-  return _kv;
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (url && token) {
+    return createClient({ url, token });
+  }
+  return null;
 }
 
 export async function writeEpiconEntry(payload: EpiconWritePayload): Promise<string | null> {
-  const kv = getKv();
-  if (!kv) {
+  const client = getKvClient();
+  if (!client) {
+    // KV not configured — silently skip, feed route falls back to GitHub
     return null;
   }
 
@@ -51,8 +47,9 @@ export async function writeEpiconEntry(payload: EpiconWritePayload): Promise<str
   };
 
   try {
-    await kv.lpush(EPICON_FEED_LIST_KEY, JSON.stringify(entry));
-    await kv.ltrim(EPICON_FEED_LIST_KEY, 0, 499);
+    // Prepend to list (newest first), keep max 500 entries
+    await client.lpush(EPICON_FEED_LIST_KEY, JSON.stringify(entry));
+    await client.ltrim(EPICON_FEED_LIST_KEY, 0, 499);
     return id;
   } catch (err) {
     console.error('[epicon-writer] KV write failed:', err);
@@ -61,12 +58,12 @@ export async function writeEpiconEntry(payload: EpiconWritePayload): Promise<str
 }
 
 export async function readEpiconFeedEntries(maxEntries: number): Promise<unknown[]> {
-  const kv = getKv();
-  if (!kv) return [];
+  const client = getKvClient();
+  if (!client) return [];
 
   try {
     const end = Math.max(0, maxEntries - 1);
-    const raw = await kv.lrange<string>(EPICON_FEED_LIST_KEY, 0, end);
+    const raw = await client.lrange<string>(EPICON_FEED_LIST_KEY, 0, end);
     return raw.map((entry) => {
       try {
         return JSON.parse(entry) as unknown;
@@ -100,7 +97,9 @@ function isEpiconType(value: unknown): value is EpiconWritePayload['type'] {
   );
 }
 
-export function parseEpiconWritePayload(body: unknown): { ok: true; payload: EpiconWritePayload } | { ok: false; error: string } {
+export function parseEpiconWritePayload(
+  body: unknown,
+): { ok: true; payload: EpiconWritePayload } | { ok: false; error: string } {
   if (body === null || typeof body !== 'object') {
     return { ok: false, error: 'Body must be a JSON object' };
   }


### PR DESCRIPTION
- Use @vercel/kv kv + createClient; skip when unconfigured
- Write/read mobius:epicon:feed (matches feed route); lpush + ltrim 500
- Keep parseEpiconWritePayload and readEpiconFeedEntries for /api/epicon/create