### PR TITLE
Ignore stale events in batch transform and base integrity on fresh entries

### DIFF
--- a/lib/echo/transform.ts
+++ b/lib/echo/transform.ts
@@ -158,12 +158,25 @@ export type IngestResult = {
   timestamp: string;
 };
 
+function isFreshEntry(timestamp: string, maxAgeHours = 48): boolean {
+  try {
+    const entryTime = new Date(timestamp).getTime();
+    if (!Number.isFinite(entryTime)) return false;
+
+    const cutoff = Date.now() - maxAgeHours * 60 * 60 * 1000;
+    return entryTime >= cutoff;
+  } catch {
+    return false; // malformed timestamp — reject silently
+  }
+}
+
 export function transformBatch(events: RawEvent[]): IngestResult {
+  const freshEvents = events.filter((event) => isFreshEntry(event.timestamp));
   const epicon: EpiconItem[] = [];
   const ledger: LedgerEntry[] = [];
   const alerts: CivicRadarAlert[] = [];
 
-  for (const raw of events) {
+  for (const raw of freshEvents) {
     const item = toEpiconItem(raw);
     epicon.push(item);
     ledger.push(toLedgerEntry(raw, item.id));
@@ -174,7 +187,7 @@ export function transformBatch(events: RawEvent[]): IngestResult {
 
   // Run integrity rating across all agents (ATLAS, ZEUS, JADE, EVE)
   const cycleId = getCurrentCycleId();
-  const integrity = rateBatch(events, epicon, cycleId);
+  const integrity = rateBatch(freshEvents, epicon, cycleId);
 
   // Update ledger deltas with integrity-engine-computed values
   for (let i = 0; i < ledger.length; i++) {
@@ -203,7 +216,7 @@ export function transformBatch(events: RawEvent[]): IngestResult {
     ledger,
     alerts,
     integrity,
-    sourceCount: events.length,
+    sourceCount: freshEvents.length,
     timestamp: new Date().toISOString(),
   };
 }


### PR DESCRIPTION
### Motivation

- Prevent old or malformed events from skewing ingestion metrics and integrity ratings by excluding them from batch processing.

### Description

- Add `isFreshEntry(timestamp, maxAgeHours = 48)` to validate timestamps and reject entries older than 48 hours or malformed timestamps.  
- Filter input `events` to `freshEvents` and iterate over `freshEvents` when building `epicon`, `ledger`, and `alerts`.  
- Call `rateBatch` with `freshEvents` instead of the full original `events` array so integrity ratings reflect only recent data.  
- Update returned `sourceCount` to reflect the number of `freshEvents` and keep malformed timestamps silently rejected.

### Testing

- Ran the repository test suite via `npm test` and the linter via `npm run lint`, and both completed successfully.  
- Verified that batch transformation produces identical results for in-range timestamps and excludes out-of-range or malformed timestamps in integrity and `sourceCount` calculations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6a2cbc7a4832d8755cf101ee1a671)