### PR TITLE
C-625: Live/mock fallback layer + freshness envelope + fixture removal

### DIFF
--- a/app/api/agents/status/route.ts
+++ b/app/api/agents/status/route.ts
@@ -1,6 +1,99 @@
 import { NextResponse } from 'next/server';
-import { agentStatus } from '@/lib/mock/agentStatus';
+import { mockAgentStatus } from '@/lib/mock-data';
+import {
+  isFresh,
+  liveEnvelope,
+  mockEnvelope,
+  staleCacheEnvelope,
+} from '@/lib/response-envelope';
 
-export async function GET() {
-  return NextResponse.json(agentStatus);
+type RuntimeFreshnessStatus = 'fresh' | 'nominal' | 'stale' | 'degraded' | 'unknown';
+
+type RuntimeStatusResponse = {
+  ok?: boolean;
+  last_run: string | null;
+  cycle_id?: string | null;
+  freshness?: {
+    status?: RuntimeFreshnessStatus;
+    seconds?: number | null;
+  };
+};
+
+const AGENT_BASE = [
+  { id: 'atlas', name: 'ATLAS', role: 'Strategic Reasoning', tier: 'Sentinel', color: 'cerulean' },
+  { id: 'zeus', name: 'ZEUS', role: 'Verification Authority', tier: 'Sentinel', color: 'gold' },
+  { id: 'hermes', name: 'HERMES', role: 'Routing and Prioritization', tier: 'Steward', color: 'coral' },
+  { id: 'aurea', name: 'AUREA', role: 'Oversight and Synthesis', tier: 'Architect', color: 'amber' },
+  { id: 'jade', name: 'JADE', role: 'Annotation and Memory Framing', tier: 'Architect', color: 'jade' },
+  { id: 'daedalus', name: 'DAEDALUS', role: 'Systems Builder', tier: 'Architect', color: 'bronze' },
+  { id: 'echo', name: 'ECHO', role: 'Event Ingestion', tier: 'Steward', color: 'silver' },
+  { id: 'eve', name: 'EVE', role: 'Observer / Watchtower', tier: 'Observer', color: 'rose' },
+] as const;
+
+let staleSnapshot: { cycle: string; timestamp: string } | null = null;
+
+function toAgentStatus(status: 'alive' | 'unknown') {
+  return AGENT_BASE.map((agent) => ({
+    ...agent,
+    status,
+    detail:
+      status === 'alive'
+        ? 'Live heartbeat observed from runtime status.'
+        : 'Heartbeat is stale; agent state is currently unknown.',
+    heartbeat_ok: status === 'alive',
+    last_action:
+      status === 'alive'
+        ? 'Live heartbeat received'
+        : 'Awaiting fresh runtime heartbeat',
+  }));
+}
+
+export async function GET(request: Request) {
+  try {
+    const runtimeUrl = new URL('/api/runtime/status', request.url);
+    const runtimeRes = await fetch(runtimeUrl, { cache: 'no-store' });
+    if (!runtimeRes.ok) throw new Error(`runtime status ${runtimeRes.status}`);
+
+    const runtime = (await runtimeRes.json()) as RuntimeStatusResponse;
+    const timestamp = runtime.last_run ?? new Date().toISOString();
+    const cycle = runtime.cycle_id ?? 'unknown';
+
+    staleSnapshot = { cycle, timestamp };
+
+    if (runtime.freshness?.status === 'fresh' && runtime.last_run && isFresh(runtime.last_run)) {
+      return NextResponse.json({
+        ok: true,
+        ...liveEnvelope(timestamp),
+        cycle,
+        timestamp,
+        agents: toAgentStatus('alive'),
+      });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      ...staleCacheEnvelope(timestamp, 'Heartbeat stale'),
+      cycle,
+      timestamp,
+      agents: toAgentStatus('unknown'),
+    });
+  } catch (error) {
+    const mock = mockAgentStatus();
+    console.error('agents/status runtime fetch failed', error);
+
+    if (staleSnapshot) {
+      return NextResponse.json({
+        ok: true,
+        ...staleCacheEnvelope(staleSnapshot.timestamp, 'Heartbeat stale'),
+        cycle: staleSnapshot.cycle,
+        timestamp: staleSnapshot.timestamp,
+        agents: toAgentStatus('unknown'),
+      });
+    }
+
+    return NextResponse.json({
+      ...mock,
+      ...mockEnvelope('Runtime status unreachable'),
+    });
+  }
 }

--- a/app/api/eve/global-news/route.ts
+++ b/app/api/eve/global-news/route.ts
@@ -11,6 +11,13 @@
 import { NextResponse } from 'next/server';
 
 import { fetchEveGlobalNews } from '@/lib/eve/global-news';
+import { mockEveNews } from '@/lib/mock-data';
+import {
+  isFresh,
+  liveEnvelope,
+  mockEnvelope,
+  staleCacheEnvelope,
+} from '@/lib/response-envelope';
 
 export const dynamic = 'force-dynamic';
 
@@ -27,8 +34,39 @@ export async function GET() {
   const now = Date.now();
 
   if (cached && now - cached.ts < CACHE_TTL_MS) {
+    const freshItems = cached.data.items.filter((item) =>
+      isFresh(item.timestamp, 48 * 60 * 60 * 1000)
+    );
+    if (freshItems.length === 0) {
+      const items = mockEveNews();
+      return NextResponse.json(
+        {
+          ok: true,
+          ...mockEnvelope('EVE live feed returned no fresh items'),
+          cached: true,
+          ...cached.data,
+          total_items: items.length,
+          items,
+        },
+        {
+          headers: {
+            'Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300',
+            'X-Mobius-Source': 'eve-global-news-cached',
+            'X-Mobius-Agent': 'EVE',
+          },
+        }
+      );
+    }
+
     return NextResponse.json(
-      { ok: true, cached: true, ...cached.data },
+      {
+        ok: true,
+        ...liveEnvelope(cached.data.timestamp),
+        cached: true,
+        ...cached.data,
+        total_items: freshItems.length,
+        items: freshItems,
+      },
       {
         headers: {
           'Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300',
@@ -41,10 +79,39 @@ export async function GET() {
 
   try {
     const synthesis = await fetchEveGlobalNews();
-    cached = { data: synthesis, ts: now };
+    const freshItems = synthesis.items.filter((item) =>
+      isFresh(item.timestamp, 48 * 60 * 60 * 1000)
+    );
+    if (freshItems.length === 0) {
+      const items = mockEveNews();
+      return NextResponse.json(
+        {
+          ok: true,
+          ...mockEnvelope('EVE live feed returned no fresh items'),
+          cached: false,
+          ...synthesis,
+          total_items: items.length,
+          items,
+        },
+        {
+          headers: {
+            'Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300',
+            'X-Mobius-Source': 'eve-global-news-live',
+            'X-Mobius-Agent': 'EVE',
+          },
+        }
+      );
+    }
+
+    const freshSynthesis = {
+      ...synthesis,
+      total_items: freshItems.length,
+      items: freshItems,
+    };
+    cached = { data: freshSynthesis, ts: now };
 
     return NextResponse.json(
-      { ok: true, cached: false, ...synthesis },
+      { ok: true, ...liveEnvelope(synthesis.timestamp), cached: false, ...freshSynthesis },
       {
         headers: {
           'Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300',
@@ -54,12 +121,47 @@ export async function GET() {
       }
     );
   } catch (error) {
+    if (cached) {
+      return NextResponse.json(
+        {
+          ok: true,
+          ...staleCacheEnvelope(cached.data.timestamp, 'EVE live feed unavailable'),
+          cached: true,
+          ...cached.data,
+        },
+        {
+          headers: {
+            'Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300',
+            'X-Mobius-Source': 'eve-global-news-stale-cache',
+            'X-Mobius-Agent': 'EVE',
+          },
+        }
+      );
+    }
+
+    const items = mockEveNews();
+    console.error('EVE global-news fetch failed', error);
     return NextResponse.json(
       {
-        ok: false,
-        error: error instanceof Error ? error.message : 'Unknown error',
+        ok: true,
+        ...mockEnvelope('EVE live feed unavailable'),
+        cached: false,
+        timestamp: new Date().toISOString(),
+        agent: 'EVE',
+        total_items: items.length,
+        items,
+        pattern_notes: ['No live items available - EVE feed degraded gracefully'],
+        dominant_region: 'Global',
+        dominant_category: 'geopolitical',
+        global_tension: 'low',
       },
-      { status: 500 }
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300',
+          'X-Mobius-Source': 'eve-global-news-mock',
+          'X-Mobius-Agent': 'EVE',
+        },
+      }
     );
   }
 }

--- a/app/api/runtime/status/route.ts
+++ b/app/api/runtime/status/route.ts
@@ -1,16 +1,89 @@
 import { NextResponse } from 'next/server';
-import { getHeartbeat } from '@/lib/runtime/heartbeat';
-import { getStalenessStatus } from '@/lib/runtime/staleness';
+import { mockRuntimeStatus } from '@/lib/mock-data';
+import { mockEnvelope } from '@/lib/response-envelope';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
-  const lastRun = getHeartbeat();
-  const status = getStalenessStatus(lastRun);
+type GitHubCommit = {
+  commit?: {
+    message?: string;
+    author?: {
+      date?: string;
+    };
+  };
+};
 
-  return NextResponse.json({
-    ok: true,
-    last_run: lastRun,
-    freshness: status,
-  });
+function computeFreshness(seconds: number) {
+  if (seconds < 600) return 'fresh' as const;
+  if (seconds < 1800) return 'nominal' as const;
+  if (seconds < 3600) return 'stale' as const;
+  return 'degraded' as const;
+}
+
+function extractCycleId(message: string | undefined): string | null {
+  if (!message) return null;
+  const match = message.match(/heartbeat:\s*([A-Za-z]-\d+)/i);
+  return match?.[1] ?? null;
+}
+
+export async function GET() {
+  try {
+    const headers: HeadersInit = { Accept: 'application/vnd.github+json' };
+    const token = process.env.GITHUB_TOKEN;
+    if (token) headers.Authorization = `Bearer ${token}`;
+
+    const res = await fetch(
+      'https://api.github.com/repos/kaizencycle/mobius-civic-ai-terminal/commits?per_page=1&sha=main',
+      {
+        headers,
+        cache: 'no-store',
+      }
+    );
+    if (!res.ok) throw new Error(`GitHub commits fetch failed (${res.status})`);
+
+    const commits = (await res.json()) as GitHubCommit[];
+    const latest = commits[0];
+    const lastRun = latest?.commit?.author?.date ?? null;
+    if (!lastRun) throw new Error('Latest commit missing author date');
+
+    const seconds = Math.max(
+      0,
+      Math.floor((Date.now() - new Date(lastRun).getTime()) / 1000)
+    );
+
+    return NextResponse.json(
+      {
+        ok: true,
+        source: 'github-commit',
+        freshAt: lastRun,
+        staleAt: null,
+        degraded: false,
+        last_run: lastRun,
+        cycle_id: extractCycleId(latest?.commit?.message),
+        freshness: {
+          status: computeFreshness(seconds),
+          seconds,
+        },
+      },
+      {
+        headers: {
+          'Cache-Control': 'public, max-age=60',
+        },
+      }
+    );
+  } catch (error) {
+    console.error('runtime/status github fetch failed', error);
+    return NextResponse.json(
+      {
+        ok: true,
+        ...mockRuntimeStatus(),
+        ...mockEnvelope('GitHub heartbeat unavailable'),
+      },
+      {
+        headers: {
+          'Cache-Control': 'public, max-age=60',
+        },
+      }
+    );
+  }
 }

--- a/app/api/tripwire/status/route.ts
+++ b/app/api/tripwire/status/route.ts
@@ -1,14 +1,27 @@
 import { NextResponse } from 'next/server';
-import { getHeartbeat } from '@/lib/runtime/heartbeat';
-import { getStalenessStatus } from '@/lib/runtime/staleness';
 import { getTripwireState } from '@/lib/tripwire/store';
+import { mockTripwire } from '@/lib/mock-data';
+import { liveEnvelope, mockEnvelope } from '@/lib/response-envelope';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  return NextResponse.json({
-    ok: true,
-    tripwire: getTripwireState(),
-    freshness: getStalenessStatus(getHeartbeat()),
-  });
+  try {
+    return NextResponse.json({
+      ok: true,
+      ...liveEnvelope(),
+      tripwire: getTripwireState(),
+      last_updated: new Date().toISOString(),
+      freshness: { status: 'fresh', seconds: 0 },
+    });
+  } catch (error) {
+    console.error('tripwire/status evaluation failed', error);
+    return NextResponse.json({
+      ok: true,
+      ...mockEnvelope('Tripwire evaluation failed'),
+      tripwire: mockTripwire(),
+      last_updated: new Date().toISOString(),
+      freshness: { status: 'unknown', seconds: null },
+    });
+  }
 }

--- a/components/signals/PulseTimeline.tsx
+++ b/components/signals/PulseTimeline.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import type { DataSource } from '@/lib/response-envelope';
+import DataSourceBadge from '@/components/terminal/DataSourceBadge';
 
 type Signal = {
   id: string;
@@ -16,10 +18,13 @@ type Signal = {
 
 type RuntimeStatus = {
   ok: true;
-  last_run: string;
+  source?: DataSource;
+  freshAt?: string | null;
+  degraded?: boolean;
+  last_run: string | null;
   freshness: {
-    status: 'fresh' | 'degraded' | 'stale';
-    seconds: number;
+    status: 'fresh' | 'nominal' | 'degraded' | 'stale' | 'unknown';
+    seconds: number | null;
   };
 };
 
@@ -48,6 +53,7 @@ type MicroSweepResponse = {
 
 function freshnessLabel(runtime: RuntimeStatus | null) {
   if (runtime?.freshness.status === 'fresh') return 'System live';
+  if (runtime?.freshness.status === 'nominal') return 'System nominal';
   if (runtime?.freshness.status === 'degraded') return 'System degraded';
   if (runtime?.freshness.status === 'stale') return 'System stale';
   return 'Checking system freshness';
@@ -55,6 +61,7 @@ function freshnessLabel(runtime: RuntimeStatus | null) {
 
 function freshnessTone(runtime: RuntimeStatus | null) {
   if (runtime?.freshness.status === 'fresh') return 'text-emerald-300';
+  if (runtime?.freshness.status === 'nominal') return 'text-sky-300';
   if (runtime?.freshness.status === 'degraded') return 'text-amber-300';
   if (runtime?.freshness.status === 'stale') return 'text-rose-300';
   return 'text-slate-500';
@@ -121,9 +128,11 @@ export default function PulseTimeline() {
 
   const themis = micro?.agents.find((agent) => agent.agentName === 'THEMIS');
   const visibleAgents = micro?.agents ?? [];
+  const source = runtime?.source ?? 'mock';
+  const degraded = Boolean(runtime?.degraded);
 
   return (
-    <div>
+    <div className={degraded ? 'rounded-xl border border-amber-500/40 p-3' : ''}>
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <div className={`text-xs uppercase tracking-[0.18em] ${freshnessTone(runtime)}`}>{freshnessLabel(runtime)}</div>
@@ -133,6 +142,9 @@ export default function PulseTimeline() {
         </div>
 
         <div className="text-right text-xs text-slate-500">
+          <div className="mb-2 flex justify-end">
+            <DataSourceBadge source={source} freshAt={runtime?.freshAt ?? null} degraded={degraded} />
+          </div>
           <div>{runtime?.last_run ? `Updated ${new Date(runtime.last_run).toLocaleString()}` : 'Awaiting heartbeat'}</div>
           <div>{signals.length} active signals</div>
           <div>{micro ? `${visibleAgents.length} micro agents · composite ${micro.composite.toFixed(3)}` : 'Micro sweep pending'}</div>
@@ -266,6 +278,11 @@ export default function PulseTimeline() {
           </div>
         ))}
       </div>
+      {degraded ? (
+        <div className="mt-3 text-xs text-amber-300">
+          Showing mock/cached data — live source offline
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/components/terminal/AgentCortexPanel.tsx
+++ b/components/terminal/AgentCortexPanel.tsx
@@ -2,8 +2,10 @@
 
 import { useEffect, useState } from 'react';
 import type { Agent } from '@/lib/terminal/types';
+import type { DataSource } from '@/lib/response-envelope';
 import { useMobiusIdentity } from '@/hooks/useMobiusIdentity';
 import { statusColor, cn } from '@/lib/terminal/utils';
+import DataSourceBadge from './DataSourceBadge';
 import SectionLabel from './SectionLabel';
 
 type AgentMode = 'nominal' | 'degraded' | 'critical';
@@ -27,6 +29,12 @@ type MicroSweepResponse = {
   agents: MicroAgent[];
 };
 
+type AgentStatusEnvelope = {
+  source?: DataSource;
+  freshAt?: string | null;
+  degraded?: boolean;
+};
+
 export default function AgentCortexPanel({
   agents,
   selectedId,
@@ -39,6 +47,9 @@ export default function AgentCortexPanel({
   const { identity, hasPermission, loading } = useMobiusIdentity();
   const [themis, setThemis] = useState<MicroAgent | null>(null);
   const [microCached, setMicroCached] = useState(false);
+  const [source, setSource] = useState<DataSource>('mock');
+  const [freshAt, setFreshAt] = useState<string | null>(null);
+  const [degraded, setDegraded] = useState(false);
   const canInvoke = hasPermission('agents:invoke');
   const visibleAgents = identity
     ? agents.filter((agent) => identity.agent_permissions.includes(agent.name.toUpperCase()))
@@ -49,13 +60,20 @@ export default function AgentCortexPanel({
 
     async function loadMicroState() {
       try {
-        const res = await fetch('/api/signals/micro', { cache: 'no-store' });
-        const json: MicroSweepResponse = await res.json();
+        const [microRes, agentsRes] = await Promise.all([
+          fetch('/api/signals/micro', { cache: 'no-store' }),
+          fetch('/api/agents/status', { cache: 'no-store' }),
+        ]);
+        const json: MicroSweepResponse = await microRes.json();
+        const agentsJson: AgentStatusEnvelope = await agentsRes.json();
         if (!alive || !json.ok) return;
 
         const nextThemis = json.agents.find((agent) => agent.agentName === 'THEMIS') ?? null;
         setThemis(nextThemis);
         setMicroCached(Boolean(json.cached));
+        setSource(agentsJson.source ?? 'mock');
+        setFreshAt(agentsJson.freshAt ?? null);
+        setDegraded(Boolean(agentsJson.degraded));
       } catch {
         // Keep prior THEMIS state if refresh fails.
       }
@@ -93,11 +111,19 @@ export default function AgentCortexPanel({
   }
 
   return (
-    <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-      <SectionLabel
-        title="Agent Cortex"
-        subtitle="Live substrate operator map"
-      />
+    <section
+      className={cn(
+        'rounded-xl border bg-slate-900/60 p-4',
+        degraded ? 'border-amber-500/40' : 'border-slate-800'
+      )}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <SectionLabel
+          title="Agent Cortex"
+          subtitle="Live substrate operator map"
+        />
+        <DataSourceBadge source={source} freshAt={freshAt} degraded={degraded} />
+      </div>
       {identity ? (
         <div className="mt-3 text-[11px] font-mono uppercase tracking-[0.14em] text-slate-500">
           @{identity.username} · {identity.role} · agent access {identity.agent_permissions.join(', ')}
@@ -223,6 +249,11 @@ export default function AgentCortexPanel({
           </button>
         ))}
       </div>
+      {degraded ? (
+        <div className="mt-3 text-xs text-amber-300">
+          Showing mock/cached data — live source offline
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/components/terminal/DataSourceBadge.tsx
+++ b/components/terminal/DataSourceBadge.tsx
@@ -1,0 +1,55 @@
+import type { DataSource } from '@/lib/response-envelope';
+
+type Props = {
+  source: DataSource;
+  freshAt: string | null;
+  degraded: boolean;
+};
+
+function minutesAgo(freshAt: string | null): string {
+  if (!freshAt) return 'unknown';
+  const ms = Date.now() - new Date(freshAt).getTime();
+  const minutes = Math.max(0, Math.floor(ms / 60000));
+  return `${minutes}m ago`;
+}
+
+export default function DataSourceBadge({ source, freshAt, degraded }: Props) {
+  if (source === 'live') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-md border border-sky-500/30 bg-sky-500/10 px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em] text-sky-300">
+        <span className="h-1.5 w-1.5 rounded-full bg-sky-400" />
+        LIVE
+      </span>
+    );
+  }
+
+  if (source === 'stale-cache') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em] text-amber-300">
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-400" />
+        CACHED · {minutesAgo(freshAt)}
+      </span>
+    );
+  }
+
+  if (source === 'github-commit') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-md border border-sky-300/30 bg-sky-300/10 px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em] text-sky-300">
+        <span className="h-1.5 w-1.5 rounded-full bg-sky-300" />
+        VIA GITHUB
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-md border border-dashed px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em] ${
+        degraded
+          ? 'border-slate-500 bg-slate-500/10 text-slate-300'
+          : 'border-slate-600 bg-slate-900 text-slate-400'
+      }`}
+    >
+      MOCK DATA
+    </span>
+  );
+}

--- a/components/terminal/LedgerPanel.tsx
+++ b/components/terminal/LedgerPanel.tsx
@@ -2,7 +2,9 @@
 
 import { useState, useMemo } from 'react';
 import type { LedgerEntry } from '@/lib/terminal/types';
+import type { DataSource } from '@/lib/response-envelope';
 import { cn } from '@/lib/terminal/utils';
+import DataSourceBadge from './DataSourceBadge';
 import SectionLabel from './SectionLabel';
 import SortBar, { type SortOption } from './SortBar';
 
@@ -62,14 +64,29 @@ export default function LedgerPanel({
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
 
   const sorted = useMemo(() => sortLedger(entries, sortKey, sortDir), [entries, sortKey, sortDir]);
+  const source = useMemo<DataSource>(() => {
+    if (entries.some((entry) => entry.source === 'echo')) return 'live';
+    if (entries.some((entry) => entry.source === 'backfill')) return 'stale-cache';
+    return 'mock';
+  }, [entries]);
+  const freshAt = sorted[0]?.timestamp ?? null;
+  const degraded = source !== 'live';
 
   return (
-    <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+    <section
+      className={cn(
+        'rounded-xl border bg-slate-900/60 p-4',
+        degraded ? 'border-amber-500/40' : 'border-slate-800'
+      )}
+    >
       <div className="flex items-start justify-between gap-3 flex-wrap">
-        <SectionLabel
-          title="Civic Ledger"
-          subtitle="Immutable event record — Mobius Substrate"
-        />
+        <div className="flex items-start gap-3 flex-wrap">
+          <SectionLabel
+            title="Civic Ledger"
+            subtitle="Immutable event record — Mobius Substrate"
+          />
+          <DataSourceBadge source={source} freshAt={freshAt} degraded={degraded} />
+        </div>
         <SortBar
           options={SORT_OPTIONS}
           active={sortKey}
@@ -159,6 +176,11 @@ export default function LedgerPanel({
           </button>
         ))}
       </div>
+      {degraded ? (
+        <div className="mt-3 text-xs text-amber-300">
+          Showing mock/cached data — live source offline
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/components/terminal/TripwireWatchCard.tsx
+++ b/components/terminal/TripwireWatchCard.tsx
@@ -1,5 +1,8 @@
+import { useEffect, useState } from 'react';
 import type { Tripwire, TripwireLayer } from '@/lib/terminal/types';
+import type { DataSource } from '@/lib/response-envelope';
 import { tripwireStyle, cn } from '@/lib/terminal/utils';
+import DataSourceBadge from './DataSourceBadge';
 import SectionLabel from './SectionLabel';
 
 const LAYER_COLORS: Record<TripwireLayer, string> = {
@@ -21,16 +24,57 @@ export default function TripwireWatchCard({
   onSelect?: (tripwire: Tripwire) => void;
 }) {
   const autoCount = tripwires.filter((t) => t.autoDetected).length;
+  const [source, setSource] = useState<DataSource>('mock');
+  const [freshAt, setFreshAt] = useState<string | null>(null);
+  const [degraded, setDegraded] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+
+    async function loadStatus() {
+      try {
+        const res = await fetch('/api/tripwire/status', { cache: 'no-store' });
+        const json = (await res.json()) as {
+          source?: DataSource;
+          freshAt?: string | null;
+          degraded?: boolean;
+        };
+        if (!alive) return;
+        setSource(json.source ?? 'mock');
+        setFreshAt(json.freshAt ?? null);
+        setDegraded(Boolean(json.degraded));
+      } catch {
+        // Keep prior status if refresh fails.
+      }
+    }
+
+    loadStatus();
+    const interval = setInterval(loadStatus, 15000);
+    return () => {
+      alive = false;
+      clearInterval(interval);
+    };
+  }, []);
 
   return (
-    <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+    <div
+      className={cn(
+        'rounded-xl border bg-slate-900/60 p-4',
+        degraded ? 'border-amber-500/40' : 'border-slate-800'
+      )}
+    >
       <div className="flex items-start justify-between gap-3">
-        <SectionLabel title="Tripwire Watch" subtitle="Substrate anomalies" />
-        {autoCount > 0 && (
-          <span className="rounded-md border border-cyan-500/20 bg-cyan-500/10 px-2 py-1 text-[10px] font-mono uppercase tracking-[0.15em] text-cyan-300">
-            {autoCount} auto
-          </span>
-        )}
+        <div className="flex items-start gap-2">
+          <SectionLabel title="Tripwire Watch" subtitle="Substrate anomalies" />
+          <DataSourceBadge source={source} freshAt={freshAt} degraded={degraded} />
+        </div>
+        <div className="flex items-center gap-2">
+          {autoCount > 0 && (
+            <span className="rounded-md border border-cyan-500/20 bg-cyan-500/10 px-2 py-1 text-[10px] font-mono uppercase tracking-[0.15em] text-cyan-300">
+              {autoCount} auto
+            </span>
+          )}
+        </div>
       </div>
       <div className="mt-3 space-y-3">
         {tripwires.length === 0 && (
@@ -93,6 +137,11 @@ export default function TripwireWatchCard({
           </button>
         ))}
       </div>
+      {degraded ? (
+        <div className="mt-3 text-xs text-amber-300">
+          Showing mock/cached data — live source offline
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/lib/eve/global-news.ts
+++ b/lib/eve/global-news.ts
@@ -6,9 +6,7 @@
  * for the existing EPICON ingest pipeline.
  *
  * Sources:
- * 1. Saurav / NewsAPI mirror (free, no auth)
- * 2. Wikipedia Current Events via MediaWiki API (free, no auth)
- * 3. GDELT document API (free, no auth)
+ * 1. Wikipedia Current Events via MediaWiki API (free, no auth)
  *
  * CC0 Public Domain
  */
@@ -45,14 +43,6 @@ export type EveSynthesis = {
   dominant_region: string;
   dominant_category: NewsCategory;
   global_tension: 'low' | 'moderate' | 'elevated' | 'high';
-};
-
-type SauravArticle = {
-  title?: string;
-  description?: string;
-  url?: string;
-  source?: { name?: string };
-  publishedAt?: string;
 };
 
 type GDELTArticle = {
@@ -329,34 +319,6 @@ function generateEveTag(title: string, category: NewsCategory): string {
   return 'Cross-domain signal - EVE observing';
 }
 
-async function fetchSauravHeadlines(): Promise<EveNewsItem[]> {
-  const url =
-    'https://saurav.tech/NewsAPI/top-headlines/category/general/us.json';
-
-  const data = await fetchJson<{ articles?: SauravArticle[] }>(url);
-  const articles = data?.articles ?? [];
-
-  return articles.slice(0, 8).map((article, index) => {
-    const title = article.title?.trim() || 'Untitled headline';
-    const category = categorizeHeadline(title);
-    const region = inferRegion(title, article.source?.name ?? '');
-    const severity = inferSeverity(title, category);
-
-    return {
-      id: `eve-saurav-${index}-${normalizeDedupKey(title)}`,
-      title,
-      summary: article.description?.trim() || title,
-      url: article.url || '',
-      source: article.source?.name || 'Saurav/NewsAPI',
-      region,
-      timestamp: toIsoOrNow(article.publishedAt),
-      category,
-      severity,
-      eve_tag: generateEveTag(title, category),
-    };
-  });
-}
-
 function extractWikipediaSectionHtml(
   html: string,
   monthName: string,
@@ -547,16 +509,10 @@ function generatePatternNotes(items: EveNewsItem[]): string[] {
 }
 
 export async function fetchEveGlobalNews(): Promise<EveSynthesis> {
-  const [saurav, wiki, gdelt] = await Promise.allSettled([
-    fetchSauravHeadlines(),
-    fetchWikipediaCurrentEvents(),
-    fetchGDELTGlobal(),
-  ]);
+  const [wiki] = await Promise.allSettled([fetchWikipediaCurrentEvents()]);
 
   const items: EveNewsItem[] = [
-    ...(saurav.status === 'fulfilled' ? saurav.value : []),
     ...(wiki.status === 'fulfilled' ? wiki.value : []),
-    ...(gdelt.status === 'fulfilled' ? gdelt.value : []),
   ];
 
   const seen = new Set<string>();

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -1,0 +1,129 @@
+const AGENTS = [
+  { id: 'atlas', name: 'ATLAS', role: 'Strategic Reasoning', tier: 'Sentinel', color: 'cerulean' },
+  { id: 'zeus', name: 'ZEUS', role: 'Verification Authority', tier: 'Sentinel', color: 'gold' },
+  { id: 'hermes', name: 'HERMES', role: 'Routing and Prioritization', tier: 'Steward', color: 'coral' },
+  { id: 'aurea', name: 'AUREA', role: 'Oversight and Synthesis', tier: 'Architect', color: 'amber' },
+  { id: 'jade', name: 'JADE', role: 'Annotation and Memory Framing', tier: 'Architect', color: 'jade' },
+  { id: 'daedalus', name: 'DAEDALUS', role: 'Systems Builder', tier: 'Architect', color: 'bronze' },
+  { id: 'echo', name: 'ECHO', role: 'Event Ingestion', tier: 'Steward', color: 'silver' },
+  { id: 'eve', name: 'EVE', role: 'Observer / Watchtower', tier: 'Observer', color: 'rose' },
+] as const;
+
+export function mockAgentStatus() {
+  const timestamp = new Date().toISOString();
+  return {
+    ok: true,
+    cycle: 'unknown',
+    timestamp,
+    source: 'mock' as const,
+    agents: AGENTS.map((agent) => ({
+      ...agent,
+      status: 'unknown' as const,
+      detail: 'Representative placeholder while live agent heartbeat is unavailable.',
+      heartbeat_ok: false,
+      last_action: 'Live source unavailable',
+    })),
+  };
+}
+
+export function mockIntegrityStatus() {
+  return {
+    ok: true,
+    global_integrity: 0.5,
+    mode: 'unknown',
+    terminal_status: 'disconnected',
+    source: 'mock' as const,
+    primary_driver: 'Live data unavailable',
+  };
+}
+
+export function mockSignals() {
+  const timestamp = new Date().toISOString();
+  return [
+    {
+      id: 'mock-signal-awaiting-feed',
+      source: 'mock' as const,
+      category: 'infrastructure' as const,
+      severity: 'low' as const,
+      title: 'Awaiting live signal feed',
+      summary: 'Representative placeholder while upstream signal providers reconnect.',
+      timestamp,
+    },
+    {
+      id: 'mock-signal-source-offline',
+      source: 'mock' as const,
+      category: 'infrastructure' as const,
+      severity: 'low' as const,
+      title: 'Signal source offline',
+      summary: 'Representative placeholder indicating a temporary telemetry outage.',
+      timestamp,
+    },
+    {
+      id: 'mock-signal-entry',
+      source: 'mock' as const,
+      category: 'infrastructure' as const,
+      severity: 'low' as const,
+      title: 'Mock entry',
+      summary: 'Representative placeholder entry to keep the terminal surface populated.',
+      timestamp,
+    },
+  ];
+}
+
+export function mockTripwire() {
+  return {
+    active: false,
+    level: 'unknown',
+    reason: 'Tripwire data unavailable — live source offline',
+  };
+}
+
+export function mockEveNews() {
+  const timestamp = new Date().toISOString();
+  return [
+    {
+      id: 'eve-mock-live-feed-offline',
+      title: 'Live news feed offline',
+      summary: 'Representative placeholder while EVE reconnects to live geopolitical inputs.',
+      url: '',
+      source: 'mock' as const,
+      region: 'Global',
+      timestamp,
+      category: 'geopolitical' as const,
+      severity: 'low' as const,
+      eve_tag: 'Mock fallback active',
+    },
+    {
+      id: 'eve-mock-reconnecting',
+      title: 'Reconnecting to EVE…',
+      summary: 'Representative placeholder while live current-events polling resumes.',
+      url: '',
+      source: 'mock' as const,
+      region: 'Global',
+      timestamp,
+      category: 'geopolitical' as const,
+      severity: 'low' as const,
+      eve_tag: 'Mock fallback active',
+    },
+    {
+      id: 'eve-mock-awaiting-signal',
+      title: 'Awaiting signal',
+      summary: 'Representative placeholder until fresh EVE global news arrives.',
+      url: '',
+      source: 'mock' as const,
+      region: 'Global',
+      timestamp,
+      category: 'geopolitical' as const,
+      severity: 'low' as const,
+      eve_tag: 'Mock fallback active',
+    },
+  ];
+}
+
+export function mockRuntimeStatus() {
+  return {
+    last_run: null,
+    freshness: { status: 'unknown', seconds: null },
+    source: 'mock' as const,
+  };
+}

--- a/lib/response-envelope.ts
+++ b/lib/response-envelope.ts
@@ -1,0 +1,49 @@
+export type DataSource = 'live' | 'mock' | 'stale-cache' | 'github-commit';
+
+export interface ResponseEnvelope {
+  source: DataSource;
+  freshAt: string | null;
+  staleAt: string | null;
+  degraded: boolean;
+  degradedReason?: string;
+}
+
+export function liveEnvelope(fetchedAt?: string): ResponseEnvelope {
+  return {
+    source: 'live',
+    freshAt: fetchedAt ?? new Date().toISOString(),
+    staleAt: null,
+    degraded: false,
+  };
+}
+
+export function mockEnvelope(reason: string): ResponseEnvelope {
+  return {
+    source: 'mock',
+    freshAt: null,
+    staleAt: new Date().toISOString(),
+    degraded: true,
+    degradedReason: reason,
+  };
+}
+
+export function staleCacheEnvelope(
+  originalFetchAt: string,
+  reason: string
+): ResponseEnvelope {
+  return {
+    source: 'stale-cache',
+    freshAt: originalFetchAt,
+    staleAt: new Date().toISOString(),
+    degraded: true,
+    degradedReason: reason,
+  };
+}
+
+export function isFresh(timestamp: string, maxAgeMs = 5 * 60 * 1000): boolean {
+  try {
+    return Date.now() - new Date(timestamp).getTime() < maxAgeMs;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a single, consistent response envelope for all API routes so each response declares its data source and freshness state. 
- Prevent hardcoded test fixtures from bleeding into production flows by removing the `eve-saurav-*` fixture path from the EVE news synthesis. 
- Ensure the terminal never goes blank by falling back to representative mock data when live sources are unavailable. 
- Surface source and degraded state in the UI so operators can see LIVE / CACHED / MOCK status per chamber.

### Description

- Added `lib/response-envelope.ts` with `DataSource`, `ResponseEnvelope`, `liveEnvelope`, `mockEnvelope`, `staleCacheEnvelope`, and `isFresh` helpers for shared envelope handling. 
- Added `lib/mock-data.ts` providing runtime-generated mock datasets for agents, integrity, signals, tripwire, EVE news, and runtime status used as safe fallbacks. 
- Removed the Saurav/NewsAPI ingestion path from `lib/eve/global-news.ts` and constrained EVE synthesis to live Wikipedia current-events, eliminating `eve-saurav-*` fixture IDs. 
- Enhanced `app/api/eve/global-news/route.ts` to filter for fresh items (48h window), return `live`/`stale-cache`/`mock` envelopes as appropriate, and return mock EVE items when no fresh live items are available. 
- Reworked `app/api/runtime/status/route.ts` to use the latest GitHub commit as the heartbeat, compute freshness bands (`fresh|nominal|stale|degraded`), expose `freshAt`/`source` metadata and cache for 60s, and fall back to mock when GitHub is unreachable. 
- Reworked `app/api/agents/status/route.ts` to derive cycle and timestamp from `/api/runtime/status`, set agent posture based on heartbeat freshness, and return live/stale/mock envelope variants. 
- Updated `app/api/tripwire/status/route.ts` to stamp `last_updated` per call, return fresh freshness on success, and fallback to mock envelope on evaluation failure. 
- Added `components/terminal/DataSourceBadge.tsx` and integrated source/degraded visuals (badge, amber degraded border, single-line amber message) into Pulse, Agent Cortex, Civic Ledger, and Tripwire UI components. 

### Testing

- Ran `npx tsc --noEmit` in strict mode and it completed with zero TypeScript errors. 
- Verified removal of fixtures with `rg -n "eve-saurav|2022-04-21" app lib components` which returned zero matches. 
- Local commit created on branch `cursor/c625-live-mock-fallback` containing the multi-file changes; CI/preview deploy should be used to validate UI badges and runtime behavior in an integrated environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c960c590832d94ec6ffd60330e96)