### PR TITLE
C-627: JADE/HERMES civic integrity signal pipeline (SEO/GEO/AEO)

### DIFF
--- a/app/api/hermes/aeo-check/route.ts
+++ b/app/api/hermes/aeo-check/route.ts
@@ -1,0 +1,184 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { callClaudeJson } from '@/lib/integrity/claude';
+import type { AeoLayer, GeoLayer } from '@/lib/integrity-signal';
+
+export const dynamic = 'force-dynamic';
+
+type HermesAeoResponse = {
+  snippet_match: boolean;
+  direct_answer: string;
+  contradiction_detected: boolean;
+  contradiction_detail: string | null;
+  confidence: number;
+};
+
+type TripwireGetResponse = {
+  tripwire?: {
+    active?: boolean;
+    level?: string;
+  };
+};
+
+const SYSTEM_PROMPT = `You are HERMES, AEO (Answer Engine Optimization) layer. Your role is to assess whether a civic claim would be accurately represented as a direct answer in AI-powered search (Perplexity, ChatGPT, Gemini, etc.) and detect any contradictions between the claimed fact and likely direct answers.
+Respond ONLY with valid JSON matching this exact shape:
+{
+  "snippet_match": true,
+  "direct_answer": "The direct answer an AI engine would give to this claim",
+  "contradiction_detected": false,
+  "contradiction_detail": null,
+  "confidence": 0.0
+}
+"contradiction_detected" = true if the direct_answer substantively contradicts the original claim text.`;
+
+function serverBaseUrl(request: NextRequest): string {
+  const host = request.headers.get('x-forwarded-host') ?? request.headers.get('host');
+  const proto = request.headers.get('x-forwarded-proto') ?? 'https';
+  if (host) return `${proto}://${host}`;
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  return 'http://127.0.0.1:3000';
+}
+
+function parseAeoResponse(value: unknown): HermesAeoResponse | null {
+  if (!value || typeof value !== 'object') return null;
+  const obj = value as Record<string, unknown>;
+
+  const snippetMatch = obj.snippet_match;
+  const directAnswer = obj.direct_answer;
+  const contradictionDetected = obj.contradiction_detected;
+  const contradictionDetail = obj.contradiction_detail;
+  const confidence = obj.confidence;
+
+  if (typeof snippetMatch !== 'boolean') return null;
+  if (typeof directAnswer !== 'string' || !directAnswer.trim()) return null;
+  if (typeof contradictionDetected !== 'boolean') return null;
+  if (!(typeof contradictionDetail === 'string' || contradictionDetail === null)) return null;
+  if (typeof confidence !== 'number') return null;
+
+  return {
+    snippet_match: snippetMatch,
+    direct_answer: directAnswer.trim(),
+    contradiction_detected: contradictionDetected,
+    contradiction_detail: contradictionDetail,
+    confidence: Math.min(Math.max(confidence, 0), 1),
+  };
+}
+
+async function maybeTriggerTripwire(
+  request: NextRequest,
+  claim: string,
+): Promise<boolean> {
+  const secret = process.env.BACKFILL_SECRET;
+  if (!secret || !secret.trim()) return false;
+
+  const base = serverBaseUrl(request);
+
+  try {
+    const statusRes = await fetch(`${base}/api/tripwire/status`, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    });
+
+    const statusJson = (await statusRes.json().catch((): unknown => null)) as TripwireGetResponse | null;
+    const level = statusJson?.tripwire?.level;
+    const alreadyTriggered = level === 'high' || level === 'triggered';
+    const suspended = level === 'suspended';
+    if (alreadyTriggered || suspended) return false;
+
+    const reason = `HERMES AEO: contradiction detected in ${claim.slice(0, 120)}`;
+
+    const triggerRes = await fetch(`${base}/api/tripwire/status`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Authorization: `Bearer ${secret}`,
+      },
+      body: JSON.stringify({
+        triggered: true,
+        reason,
+        agent: 'HERMES',
+        severity: 'high',
+      }),
+      cache: 'no-store',
+    });
+
+    return triggerRes.ok;
+  } catch (error) {
+    console.error('hermes/aeo-check tripwire trigger failed', error);
+    return false;
+  }
+}
+
+export async function GET() {
+  return NextResponse.json({ ok: true, info: 'POST { claim, source_node } for AEO layer check' });
+}
+
+export async function POST(request: NextRequest) {
+  const payload = (await request.json().catch((): unknown => null)) as
+    | { claim?: unknown; source_node?: unknown; geo_context?: unknown }
+    | null;
+
+  const claim = typeof payload?.claim === 'string' ? payload.claim.trim() : '';
+  const sourceNode = typeof payload?.source_node === 'string' ? payload.source_node.trim() : '';
+  const geoContext = payload?.geo_context as GeoLayer | undefined;
+
+  if (!claim || !sourceNode) {
+    return NextResponse.json({ ok: false, error: 'claim and source_node are required' }, { status: 400 });
+  }
+
+  const geoContextSummary = geoContext
+    ? `GEO context => ai_consensus=${geoContext.ai_consensus}, citation_count=${geoContext.citation_count}, semantic_drift=${geoContext.semantic_drift}`
+    : 'GEO context unavailable';
+
+  try {
+    const userPrompt = `Check AEO accuracy: Claim: ${claim}. Source: ${sourceNode}. GEO context: ${geoContextSummary}`;
+
+    const claude = await callClaudeJson(SYSTEM_PROMPT, userPrompt);
+    if (!claude.ok) {
+      console.error('hermes/aeo-check Claude call failed', claude.error);
+      return NextResponse.json({ ok: false, error: claude.error, httpStatus: claude.httpStatus }, { status: 503 });
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(claude.jsonText) as unknown;
+    } catch {
+      return NextResponse.json(
+        { ok: false, error: 'Claude returned malformed JSON', raw: claude.jsonText },
+        { status: 502 },
+      );
+    }
+
+    const validated = parseAeoResponse(parsed);
+    if (!validated) {
+      return NextResponse.json(
+        { ok: false, error: 'Claude response failed schema validation', raw: claude.jsonText },
+        { status: 502 },
+      );
+    }
+
+    const aeoLayer: AeoLayer = {
+      snippet_match: validated.snippet_match,
+      direct_answer: validated.direct_answer,
+      contradiction_detected: validated.contradiction_detected,
+    };
+
+    const tripwireTriggered = validated.contradiction_detected
+      ? await maybeTriggerTripwire(request, claim)
+      : false;
+
+    return NextResponse.json({
+      ok: true,
+      agent: 'HERMES',
+      aeo_layer: aeoLayer,
+      contradiction_detail: validated.contradiction_detail,
+      confidence: validated.confidence,
+      tripwire_triggered: tripwireTriggered,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('hermes/aeo-check failed', error);
+    return NextResponse.json({ ok: false, error: 'AEO assessment failed' }, { status: 500 });
+  }
+}

--- a/app/api/hermes/geo-check/route.ts
+++ b/app/api/hermes/geo-check/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { callClaudeJson } from '@/lib/integrity/claude';
+import type { GeoLayer, SeoLayer } from '@/lib/integrity-signal';
+
+export const dynamic = 'force-dynamic';
+
+type HermesGeoResponse = {
+  ai_consensus: 'aligned' | 'divergent' | 'conflicting';
+  citation_count: number;
+  semantic_drift: number;
+  drift_explanation: string;
+  circular_reporting_risk: boolean;
+  hermes_routing_note: string;
+};
+
+const SYSTEM_PROMPT = `You are HERMES, the Routing and Prioritization agent of the Mobius Civic AI Terminal. Your new capability is Generative Engine Optimization (GEO) assessment — evaluating how AI language models are currently contextualizing civic claims, and detecting semantic drift from the authoritative source.
+Respond ONLY with valid JSON matching this exact shape:
+{
+  "ai_consensus": "aligned|divergent|conflicting",
+  "citation_count": 0,
+  "semantic_drift": 0.0,
+  "drift_explanation": "One sentence explaining what drifted if drift > 0.3",
+  "circular_reporting_risk": false,
+  "hermes_routing_note": "One sentence HERMES routing recommendation"
+}
+"circular_reporting_risk" = true if AI models appear to cite each other without a verifiable primary source (ai_consensus=aligned but primary_source_found=false in SEO context).`;
+
+function parseGeoResponse(value: unknown): HermesGeoResponse | null {
+  if (!value || typeof value !== 'object') return null;
+  const obj = value as Record<string, unknown>;
+
+  const aiConsensus = obj.ai_consensus;
+  const citationCount = obj.citation_count;
+  const semanticDrift = obj.semantic_drift;
+  const driftExplanation = obj.drift_explanation;
+  const circularRisk = obj.circular_reporting_risk;
+  const routingNote = obj.hermes_routing_note;
+
+  if (aiConsensus !== 'aligned' && aiConsensus !== 'divergent' && aiConsensus !== 'conflicting') return null;
+  if (typeof citationCount !== 'number') return null;
+  if (typeof semanticDrift !== 'number') return null;
+  if (typeof driftExplanation !== 'string') return null;
+  if (typeof circularRisk !== 'boolean') return null;
+  if (typeof routingNote !== 'string' || !routingNote.trim()) return null;
+
+  return {
+    ai_consensus: aiConsensus,
+    citation_count: Math.max(0, Math.min(50, Math.round(citationCount))),
+    semantic_drift: Math.min(Math.max(semanticDrift, 0), 1),
+    drift_explanation: driftExplanation.trim(),
+    circular_reporting_risk: circularRisk,
+    hermes_routing_note: routingNote.trim(),
+  };
+}
+
+export async function GET() {
+  return NextResponse.json({ ok: true, info: 'POST { claim, source_node } for GEO layer check' });
+}
+
+export async function POST(request: NextRequest) {
+  const payload = (await request.json().catch((): unknown => null)) as
+    | { claim?: unknown; source_node?: unknown; seo_context?: unknown }
+    | null;
+
+  const claim = typeof payload?.claim === 'string' ? payload.claim.trim() : '';
+  const sourceNode = typeof payload?.source_node === 'string' ? payload.source_node.trim() : '';
+  const seoContext = payload?.seo_context as SeoLayer | undefined;
+
+  if (!claim || !sourceNode) {
+    return NextResponse.json({ ok: false, error: 'claim and source_node are required' }, { status: 400 });
+  }
+
+  const seoContextSummary = seoContext
+    ? `SEO context => authority_score=${seoContext.authority_score}, primary_source_found=${seoContext.primary_source_found}, top_domains=${seoContext.top_domains.join(',')}`
+    : 'SEO context unavailable';
+
+  try {
+    const userPrompt = `Claim: ${claim}\nSource: ${sourceNode}\n${seoContextSummary}`;
+    const claude = await callClaudeJson(SYSTEM_PROMPT, userPrompt);
+
+    if (!claude.ok) {
+      console.error('hermes/geo-check Claude call failed', claude.error);
+      return NextResponse.json({ ok: false, error: claude.error, httpStatus: claude.httpStatus }, { status: 503 });
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(claude.jsonText) as unknown;
+    } catch {
+      return NextResponse.json(
+        { ok: false, error: 'Claude returned malformed JSON', raw: claude.jsonText },
+        { status: 502 },
+      );
+    }
+
+    const validated = parseGeoResponse(parsed);
+    if (!validated) {
+      return NextResponse.json(
+        { ok: false, error: 'Claude response failed schema validation', raw: claude.jsonText },
+        { status: 502 },
+      );
+    }
+
+    const forcedCircularRisk = seoContext?.primary_source_found === false && validated.ai_consensus === 'aligned';
+    const circularReportingRisk = forcedCircularRisk ? true : validated.circular_reporting_risk;
+
+    const geoLayer: GeoLayer = {
+      ai_consensus: validated.ai_consensus,
+      citation_count: validated.citation_count,
+      semantic_drift: validated.semantic_drift,
+    };
+
+    return NextResponse.json({
+      ok: true,
+      agent: 'HERMES',
+      geo_layer: geoLayer,
+      circular_reporting_risk: circularReportingRisk,
+      drift_explanation: validated.drift_explanation,
+      hermes_routing_note: validated.hermes_routing_note,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('hermes/geo-check failed', error);
+    return NextResponse.json({ ok: false, error: 'GEO assessment failed' }, { status: 500 });
+  }
+}

--- a/app/api/integrity-status/route.ts
+++ b/app/api/integrity-status/route.ts
@@ -28,6 +28,12 @@ function resolveActiveAgentCount() {
   return mockAgents.filter((agent) => agent.heartbeatOk && agent.status !== 'idle').length;
 }
 
+function normalizeTripwireLevel(level: ReturnType<typeof getTripwireState>['level']): 'none' | 'watch' | 'elevated' {
+  if (level === 'high' || level === 'triggered' || level === 'suspended' || level === 'elevated') return 'elevated';
+  if (level === 'medium' || level === 'watch') return 'watch';
+  return 'none';
+}
+
 export async function GET() {
   const freshness = getStalenessStatus(getHeartbeat());
   const tripwire = getTripwireState();
@@ -41,7 +47,7 @@ export async function GET() {
   const computed = computeGI({
     zeusScores: signalData.scores,
     freshness: effectiveFreshness,
-    tripwire: tripwire.level,
+    tripwire: normalizeTripwireLevel(tripwire.level),
     activeAgents: resolveActiveAgentCount(),
   });
 

--- a/app/api/jade/integrity-signal/route.ts
+++ b/app/api/jade/integrity-signal/route.ts
@@ -1,0 +1,232 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  computeIntegrityScore,
+  determineTripwire,
+  type AeoLayer,
+  type GeoLayer,
+  type MobiusCivicIntegritySignal,
+  type SeoLayer,
+} from '@/lib/integrity-signal';
+import { setLatestIntegritySignal } from '@/lib/integrity/signal-store';
+
+export const dynamic = 'force-dynamic';
+
+type VerifyClaimResponse = {
+  ok: boolean;
+  seo_layer?: SeoLayer;
+  jade_annotation?: string;
+  schema_type?: string;
+  error?: string;
+};
+
+type GeoCheckResponse = {
+  ok: boolean;
+  geo_layer?: GeoLayer;
+  circular_reporting_risk?: boolean;
+  hermes_routing_note?: string;
+  drift_explanation?: string;
+  error?: string;
+};
+
+type AeoCheckResponse = {
+  ok: boolean;
+  aeo_layer?: AeoLayer;
+  contradiction_detail?: string | null;
+  tripwire_triggered?: boolean;
+  error?: string;
+};
+
+function serverBaseUrl(request: NextRequest): string {
+  const host = request.headers.get('x-forwarded-host') ?? request.headers.get('host');
+  const proto = request.headers.get('x-forwarded-proto') ?? 'https';
+  if (host) return `${proto}://${host}`;
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  return 'http://127.0.0.1:3000';
+}
+
+async function readJson<T>(res: Response): Promise<T | null> {
+  try {
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+function truncateClaim(claim: string, max = 60): string {
+  if (claim.length <= max) return claim;
+  return `${claim.slice(0, max - 1)}…`;
+}
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    info: 'POST { claim, source_node } for full SEO/GEO/AEO integrity signal',
+    schema: 'MobiusCivicIntegritySignal',
+    scoring: {
+      seo_weight: '40%',
+      geo_weight: '35%',
+      aeo_weight: '25%',
+      tripwire_triggers: [
+        'contradiction_detected === true',
+        "ai_consensus === 'conflicting'",
+        'semantic_drift > 0.7',
+        "ai_consensus === 'divergent' AND !primary_source_found",
+      ],
+    },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const secret = process.env.BACKFILL_SECRET;
+  if (!secret || !secret.trim()) {
+    return NextResponse.json({ ok: false, error: 'BACKFILL_SECRET is not configured' }, { status: 503 });
+  }
+
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const payload = (await request.json().catch((): unknown => null)) as
+    | { claim?: unknown; source_node?: unknown; cycleId?: unknown }
+    | null;
+
+  const claim = typeof payload?.claim === 'string' ? payload.claim.trim() : '';
+  const sourceNode = typeof payload?.source_node === 'string' ? payload.source_node.trim() : '';
+
+  if (!claim || !sourceNode) {
+    return NextResponse.json({ ok: false, error: 'claim and source_node are required' }, { status: 400 });
+  }
+
+  const base = serverBaseUrl(request);
+  let cycleId = typeof payload?.cycleId === 'string' ? payload.cycleId.trim() : '';
+
+  if (!cycleId) {
+    try {
+      const cycleRes = await fetch(`${base}/api/eve/cycle-advance`, { cache: 'no-store' });
+      const cycleJson = await readJson<{ currentCycle?: string }>(cycleRes);
+      cycleId = typeof cycleJson?.currentCycle === 'string' ? cycleJson.currentCycle : 'C-0';
+    } catch {
+      cycleId = 'C-0';
+    }
+  }
+
+  try {
+    const seoRes = await fetch(`${base}/api/jade/verify-claim`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ claim, source_node: sourceNode, cycleId }),
+      cache: 'no-store',
+    });
+    const seoJson = await readJson<VerifyClaimResponse>(seoRes);
+
+    if (!seoRes.ok || !seoJson?.ok || !seoJson.seo_layer) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: seoJson?.error ?? 'SEO verification failed',
+          step: 'seo',
+        },
+        { status: seoRes.ok ? 502 : seoRes.status },
+      );
+    }
+
+    const seoLayer = seoJson.seo_layer;
+
+    const [geoRes, aeoRes] = await Promise.all([
+      fetch(`${base}/api/hermes/geo-check`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ claim, source_node: sourceNode, seo_context: seoLayer }),
+        cache: 'no-store',
+      }),
+      fetch(`${base}/api/hermes/aeo-check`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ claim, source_node: sourceNode }),
+        cache: 'no-store',
+      }),
+    ]);
+
+    const geoJson = await readJson<GeoCheckResponse>(geoRes);
+    if (!geoRes.ok || !geoJson?.ok || !geoJson.geo_layer) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: geoJson?.error ?? 'GEO check failed',
+          step: 'geo',
+        },
+        { status: geoRes.ok ? 502 : geoRes.status },
+      );
+    }
+
+    const geoLayer = geoJson.geo_layer;
+
+    const aeoJson = await readJson<AeoCheckResponse>(aeoRes);
+    if (!aeoRes.ok || !aeoJson?.ok || !aeoJson.aeo_layer) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: aeoJson?.error ?? 'AEO check failed',
+          step: 'aeo',
+        },
+        { status: aeoRes.ok ? 502 : aeoRes.status },
+      );
+    }
+
+    const aeoLayer = aeoJson.aeo_layer;
+    const layers = { seo_layer: seoLayer, geo_layer: geoLayer, aeo_layer: aeoLayer };
+    const integrityScore = computeIntegrityScore(layers);
+    const tripwireStatus = determineTripwire(layers);
+
+    const signal: MobiusCivicIntegritySignal = {
+      signal_id: `sig-${Date.now().toString(36)}-jade`,
+      timestamp: new Date().toISOString(),
+      claim: { text: claim, source_node: sourceNode },
+      integrity_score: integrityScore,
+      layers,
+      tripwire_status: tripwireStatus,
+      agent_origin: 'JADE',
+      cycle: cycleId,
+    };
+
+    setLatestIntegritySignal(signal);
+
+    let epiconFlagged = false;
+    if (integrityScore <= 0.5) {
+      const confidenceTier = integrityScore >= 0.7 ? 2 : integrityScore >= 0.5 ? 1 : 3;
+
+      const epiconRes = await fetch(`${base}/api/epicon/candidates`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({
+          title: `Integrity Alert: Low-confidence claim — ${truncateClaim(claim, 60)}`,
+          summary: `Integrity score ${integrityScore}. Tripwire: ${tripwireStatus}. SEO authority: ${seoLayer.authority_score}. GEO consensus: ${geoLayer.ai_consensus}. Contradiction: ${aeoLayer.contradiction_detected}`,
+          dominantTheme: 'governance',
+          confidenceTier,
+          severity: integrityScore < 0.5 ? 'high' : 'medium',
+          source: 'jade-integrity-signal',
+          patternType: aeoLayer.contradiction_detected ? 'divergence' : 'volatility',
+        }),
+        cache: 'no-store',
+      });
+
+      epiconFlagged = epiconRes.ok;
+    }
+
+    return NextResponse.json({
+      ok: true,
+      signal,
+      epicon_flagged: epiconFlagged,
+      layers_detail: {
+        jade_annotation: seoJson.jade_annotation ?? '',
+        circular_reporting_risk: geoJson.circular_reporting_risk ?? false,
+        contradiction_detail: aeoJson.contradiction_detail ?? null,
+        hermes_routing_note: geoJson.hermes_routing_note ?? '',
+      },
+    });
+  } catch (error) {
+    console.error('jade/integrity-signal failed', error);
+    return NextResponse.json({ ok: false, error: 'Integrity signal pipeline failed' }, { status: 500 });
+  }
+}

--- a/app/api/jade/verify-claim/route.ts
+++ b/app/api/jade/verify-claim/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { callClaudeJson } from '@/lib/integrity/claude';
+import type { SeoLayer } from '@/lib/integrity-signal';
+
+export const dynamic = 'force-dynamic';
+
+type JadeAuthorityResponse = {
+  top_domains: string[];
+  authority_score: number;
+  primary_source_found: boolean;
+  schema_type: 'GovernmentOrganization' | 'NewsArticle' | 'Event' | 'Person' | 'Dataset' | 'Other';
+  jade_annotation: string;
+};
+
+const SYSTEM_PROMPT = `You are JADE, the Annotation and Memory Framing agent of the Mobius Civic AI Terminal. Your new capability is SEO Authority Assessment — evaluating the discoverability and source credibility of civic claims.
+Given a civic claim, assess it as a search authority would.
+Respond ONLY with valid JSON, no markdown, matching this exact shape:
+{
+  "top_domains": ["domain1.com", "domain2.gov"],
+  "authority_score": 0.0,
+  "primary_source_found": true,
+  "schema_type": "GovernmentOrganization|NewsArticle|Event|Person|Dataset|Other",
+  "jade_annotation": "One sentence JADE framing of this claim’s authority context"
+}`;
+
+const VALID_SCHEMA_TYPES = new Set([
+  'GovernmentOrganization',
+  'NewsArticle',
+  'Event',
+  'Person',
+  'Dataset',
+  'Other',
+]);
+
+function validateResponse(value: unknown): JadeAuthorityResponse | null {
+  if (!value || typeof value !== 'object') return null;
+  const obj = value as Record<string, unknown>;
+
+  const topDomains = obj.top_domains;
+  const authorityScore = obj.authority_score;
+  const primarySourceFound = obj.primary_source_found;
+  const schemaType = obj.schema_type;
+  const jadeAnnotation = obj.jade_annotation;
+
+  if (!Array.isArray(topDomains) || !topDomains.every((d): d is string => typeof d === 'string')) return null;
+  if (typeof authorityScore !== 'number') return null;
+  if (typeof primarySourceFound !== 'boolean') return null;
+  if (typeof schemaType !== 'string' || !VALID_SCHEMA_TYPES.has(schemaType)) return null;
+  if (typeof jadeAnnotation !== 'string' || !jadeAnnotation.trim()) return null;
+
+  return {
+    top_domains: topDomains.slice(0, 5),
+    authority_score: Math.min(Math.max(authorityScore, 0), 1),
+    primary_source_found: primarySourceFound,
+    schema_type: schemaType as JadeAuthorityResponse['schema_type'],
+    jade_annotation: jadeAnnotation.trim(),
+  };
+}
+
+export async function GET() {
+  return NextResponse.json({ ok: true, info: 'POST { claim, source_node } to assess SEO authority' });
+}
+
+export async function POST(request: NextRequest) {
+  const payload = (await request.json().catch((): unknown => null)) as
+    | { claim?: unknown; source_node?: unknown; cycleId?: unknown }
+    | null;
+
+  const claim = typeof payload?.claim === 'string' ? payload.claim.trim() : '';
+  const sourceNode = typeof payload?.source_node === 'string' ? payload.source_node.trim() : '';
+  const cycleId = typeof payload?.cycleId === 'string' ? payload.cycleId.trim() : undefined;
+
+  if (!claim || !sourceNode) {
+    return NextResponse.json({ ok: false, error: 'claim and source_node are required' }, { status: 400 });
+  }
+
+  try {
+    const userPrompt = `Assess the SEO authority of this civic claim: ${claim}. Source: ${sourceNode}`;
+    const claude = await callClaudeJson(SYSTEM_PROMPT, userPrompt);
+
+    if (!claude.ok) {
+      console.error('jade/verify-claim Claude call failed', claude.error);
+      return NextResponse.json(
+        {
+          ok: false,
+          error: claude.error,
+          httpStatus: claude.httpStatus,
+        },
+        { status: 503 },
+      );
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(claude.jsonText) as unknown;
+    } catch {
+      return NextResponse.json(
+        { ok: false, error: 'Claude returned malformed JSON', raw: claude.jsonText },
+        { status: 502 },
+      );
+    }
+
+    const validated = validateResponse(parsed);
+    if (!validated) {
+      return NextResponse.json(
+        { ok: false, error: 'Claude response failed schema validation', raw: claude.jsonText },
+        { status: 502 },
+      );
+    }
+
+    const seoLayer: SeoLayer = {
+      top_domains: validated.top_domains,
+      authority_score: validated.authority_score,
+      primary_source_found: validated.primary_source_found,
+    };
+
+    return NextResponse.json({
+      ok: true,
+      agent: 'JADE',
+      claim: { text: claim, source_node: sourceNode },
+      seo_layer: seoLayer,
+      jade_annotation: validated.jade_annotation,
+      schema_type: validated.schema_type,
+      timestamp: new Date().toISOString(),
+      cycleId,
+    });
+  } catch (error) {
+    console.error('jade/verify-claim failed', error);
+    return NextResponse.json({ ok: false, error: 'SEO authority assessment failed' }, { status: 500 });
+  }
+}

--- a/app/api/signals/pulse/route.ts
+++ b/app/api/signals/pulse/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { setHeartbeat } from '@/lib/runtime/heartbeat';
 import { runSignalEngine } from '@/lib/signals/engine';
+import { getLatestIntegritySignal } from '@/lib/integrity/signal-store';
 
 export const dynamic = 'force-dynamic';
 
@@ -14,5 +15,6 @@ export async function GET() {
     signals: result.signals,
     tripwire: result.tripwire,
     refreshed_at: new Date().toISOString(),
+    integrity_signal: getLatestIntegritySignal(),
   });
 }

--- a/app/api/tripwire/status/route.ts
+++ b/app/api/tripwire/status/route.ts
@@ -1,9 +1,45 @@
-import { NextResponse } from 'next/server';
-import { getTripwireState } from '@/lib/tripwire/store';
+import { NextRequest, NextResponse } from 'next/server';
+import { getTripwireState, setTripwireState, type RuntimeTripwireState } from '@/lib/tripwire/store';
 import { mockTripwire } from '@/lib/mock-data';
 import { liveEnvelope, mockEnvelope } from '@/lib/response-envelope';
 
 export const dynamic = 'force-dynamic';
+
+type TripwireUpdatePayload = {
+  triggered: boolean;
+  reason: string;
+  agent: 'HERMES' | 'ZEUS' | 'ATLAS' | 'operator';
+  severity: 'low' | 'medium' | 'high';
+};
+
+function authorized(request: NextRequest): boolean {
+  const secret = process.env.BACKFILL_SECRET;
+  if (!secret || !secret.trim()) return false;
+  return request.headers.get('authorization') === `Bearer ${secret}`;
+}
+
+function parsePayload(value: unknown): TripwireUpdatePayload | null {
+  if (!value || typeof value !== 'object') return null;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.triggered !== 'boolean') return null;
+  if (typeof obj.reason !== 'string' || !obj.reason.trim()) return null;
+  if (
+    obj.agent !== 'HERMES' &&
+    obj.agent !== 'ZEUS' &&
+    obj.agent !== 'ATLAS' &&
+    obj.agent !== 'operator'
+  ) {
+    return null;
+  }
+  if (obj.severity !== 'low' && obj.severity !== 'medium' && obj.severity !== 'high') return null;
+
+  return {
+    triggered: obj.triggered,
+    reason: obj.reason.trim(),
+    agent: obj.agent,
+    severity: obj.severity,
+  };
+}
 
 export async function GET() {
   try {
@@ -24,4 +60,42 @@ export async function GET() {
       freshness: { status: 'unknown', seconds: null },
     });
   }
+}
+
+export async function POST(request: NextRequest) {
+  if (!authorized(request)) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const payload = parsePayload(await request.json().catch((): unknown => null));
+  if (!payload) {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid payload. Expected { triggered, reason, agent, severity }' },
+      { status: 400 },
+    );
+  }
+
+  const now = new Date().toISOString();
+  const nextTripwire: RuntimeTripwireState = payload.triggered
+    ? {
+        active: true,
+        level: payload.severity,
+        reason: payload.reason,
+        last_updated: now,
+        triggeredBy: payload.agent,
+      }
+    : {
+        active: false,
+        level: 'nominal',
+        reason: `Cleared by ${payload.agent}`,
+        last_updated: now,
+        triggeredBy: payload.agent,
+      };
+
+  setTripwireState(nextTripwire);
+
+  return NextResponse.json({
+    ok: true,
+    tripwire: nextTripwire,
+  });
 }

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -35,6 +35,7 @@ import IntegrityRatingPanel from '@/components/terminal/IntegrityRatingPanel';
 import HardHalt from '@/components/modals/HardHalt';
 import SentinelPulsePanel from '@/components/terminal/SentinelPulsePanel';
 import EveGlobalNewsPanel from '@/components/terminal/EveGlobalNewsPanel';
+import IntegritySignalTicker from '@/components/terminal/IntegritySignalTicker';
 import MacroIntegrityPulseCard from '@/components/markets/MacroIntegrityPulseCard';
 import MarketNarratorCard from '@/components/markets/MarketNarratorCard';
 import MarketSweepExportCard from '@/components/markets/MarketSweepExportCard';
@@ -115,6 +116,7 @@ function TerminalPage() {
     gi,
     integrityStatus,
     inspectorTarget,
+    integritySignal,
     mergedLedger,
     operatorMessage,
     setEchoAlerts,
@@ -411,6 +413,7 @@ function TerminalPage() {
                     description="Incoming micro-agent signals and current intake state."
                   >
                     <PulseTimeline />
+                    <IntegritySignalTicker signal={integritySignal} />
                   </TerminalSection>
 
                   <TerminalSection

--- a/components/terminal/IntegritySignalTicker.tsx
+++ b/components/terminal/IntegritySignalTicker.tsx
@@ -1,0 +1,57 @@
+import type { MobiusCivicIntegritySignal } from '@/lib/integrity-signal';
+import { cn } from '@/lib/terminal/utils';
+
+type Props = {
+  signal: MobiusCivicIntegritySignal | null;
+};
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 1)}…`;
+}
+
+function scoreTone(score: number): string {
+  if (score >= 0.8) return 'text-emerald-400 border-emerald-400/30 bg-emerald-500/10';
+  if (score >= 0.5) return 'text-amber-400 border-amber-400/30 bg-amber-500/10';
+  return 'text-red-400 border-red-400/30 bg-red-500/10';
+}
+
+export default function IntegritySignalTicker({ signal }: Props) {
+  if (!signal) return null;
+
+  const seoOk = signal.layers.seo_layer.primary_source_found;
+  const geoOk = signal.layers.geo_layer.ai_consensus === 'aligned';
+  const aeoOk = !signal.layers.aeo_layer.contradiction_detected;
+  const showTripwire = signal.tripwire_status === 'triggered';
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-950/70 px-3 py-2">
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <span className="rounded border border-sky-500/30 bg-sky-500/10 px-2 py-1 tracking-[0.14em] text-sky-300">
+          JADE
+        </span>
+        <span className="text-slate-400">{truncate(signal.signal_id, 18)}</span>
+        <span className="text-slate-200">{truncate(signal.claim.text, 50)}</span>
+        <span className={cn('rounded border px-2 py-1 font-semibold', scoreTone(signal.integrity_score))}>
+          SCORE {signal.integrity_score.toFixed(3)}
+        </span>
+
+        <span className={cn('rounded border border-slate-700 px-2 py-1', seoOk ? 'text-emerald-300' : 'text-amber-300')}>
+          SEO {seoOk ? '▣' : '□'}
+        </span>
+        <span className={cn('rounded border border-slate-700 px-2 py-1', geoOk ? 'text-emerald-300' : 'text-amber-300')}>
+          GEO {geoOk ? '▣' : '□'}
+        </span>
+        <span className={cn('rounded border border-slate-700 px-2 py-1', aeoOk ? 'text-emerald-300' : 'text-red-300')}>
+          AEO {aeoOk ? '▣' : '□'}
+        </span>
+
+        {showTripwire ? (
+          <span className="animate-pulse rounded border border-red-500/30 px-2 py-1 text-red-500">
+            ⚠ TRIPWIRE
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/hooks/useTerminalData.ts
+++ b/hooks/useTerminalData.ts
@@ -12,6 +12,7 @@ import {
   getEpiconFeed,
   getIntegrityStatus,
   getLedgerBackfill,
+  getPulseSnapshot,
   getTripwires,
   integrityStatusToGISnapshot,
   isLiveAPI,
@@ -35,6 +36,7 @@ import {
   type StreamMessage,
 } from '@/lib/terminal/stream';
 import type { StreamStatus } from '@/components/terminal/TopStatusBar';
+import type { MobiusCivicIntegritySignal } from '@/lib/integrity-signal';
 
 const CATEGORY_MAP: Partial<Record<NavKey, EpiconItem['category']>> = {
   markets: 'market',
@@ -61,6 +63,7 @@ export function useTerminalData(selectedNav: NavKey) {
   const [tripwires, setTripwires] = useState<Tripwire[]>([]);
   const [integrityStatus, setIntegrityStatus] = useState<IntegrityStatusResponse | null>(null);
   const [backfillLedger, setBackfillLedger] = useState<LedgerEntry[]>([]);
+  const [integritySignal, setIntegritySignal] = useState<MobiusCivicIntegritySignal | null>(null);
   const [feedLedgerRows, setFeedLedgerRows] = useState<LedgerEntry[]>([]);
   const [inspectorTarget, setInspectorTarget] = useState<InspectorTarget | null>(null);
   const [streamStatus, setStreamStatus] = useState<StreamStatus>(isLiveAPI ? 'reconnecting' : 'offline');
@@ -98,12 +101,13 @@ export function useTerminalData(selectedNav: NavKey) {
     let mounted = true;
 
     async function load() {
-      const [agentsData, epiconBundle, integrityData, tripwireData, ledgerBackfillData] = await Promise.all([
+      const [agentsData, epiconBundle, integrityData, tripwireData, ledgerBackfillData, pulseSnapshot] = await Promise.all([
         getAgents(),
         getEpiconFeed(),
         getIntegrityStatus(),
         getTripwires(),
         getLedgerBackfill(),
+        getPulseSnapshot(),
       ]);
 
       if (!mounted) return;
@@ -114,6 +118,7 @@ export function useTerminalData(selectedNav: NavKey) {
       setGi((prev) => integrityStatusToGISnapshot(integrityData, prev?.score));
       setTripwires(tripwireData);
       setBackfillLedger(ledgerBackfillData);
+      setIntegritySignal(pulseSnapshot?.integrity_signal ?? null);
       setInspectorTarget((prev) => prev ?? (epiconBundle.epicon[0] ? { kind: 'epicon', data: epiconBundle.epicon[0] } : null));
     }
 
@@ -268,6 +273,7 @@ export function useTerminalData(selectedNav: NavKey) {
     gi,
     integrityStatus,
     inspectorTarget,
+    integritySignal,
     mergedLedger,
     operatorMessage,
     setEchoAlerts,

--- a/lib/integrity-signal.ts
+++ b/lib/integrity-signal.ts
@@ -1,0 +1,82 @@
+export interface SeoLayer {
+  top_domains: string[];
+  authority_score: number;
+  primary_source_found: boolean;
+}
+
+export type AiConsensus = 'aligned' | 'divergent' | 'conflicting';
+
+export interface GeoLayer {
+  ai_consensus: AiConsensus;
+  citation_count: number;
+  semantic_drift: number;
+}
+
+export interface AeoLayer {
+  snippet_match: boolean;
+  direct_answer: string;
+  contradiction_detected: boolean;
+}
+
+export interface IntegrityLayers {
+  seo_layer: SeoLayer;
+  geo_layer: GeoLayer;
+  aeo_layer: AeoLayer;
+}
+
+export type TripwireStatus = 'nominal' | 'triggered' | 'suspended';
+
+export interface MobiusCivicIntegritySignal {
+  signal_id: string;
+  timestamp: string;
+  claim: { text: string; source_node: string };
+  integrity_score: number;
+  layers: IntegrityLayers;
+  tripwire_status: TripwireStatus;
+  agent_origin: 'JADE' | 'HERMES';
+  cycle: string;
+}
+
+function clamp01(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  return Math.min(Math.max(value, 0), 1);
+}
+
+export function computeIntegrityScore(layers: IntegrityLayers): number {
+  const seo = Math.min(
+    layers.seo_layer.authority_score * 0.4 +
+      (layers.seo_layer.primary_source_found ? 0.1 : 0),
+    0.5,
+  );
+
+  const consensusScore =
+    layers.geo_layer.ai_consensus === 'aligned'
+      ? 1.0
+      : layers.geo_layer.ai_consensus === 'divergent'
+        ? 0.6
+        : 0.2;
+
+  const geo = Math.max(
+    (consensusScore - layers.geo_layer.semantic_drift * 0.3) * 0.35,
+    0,
+  );
+
+  const aeo =
+    (layers.aeo_layer.snippet_match ? 0.15 : 0) +
+    (!layers.aeo_layer.contradiction_detected ? 0.1 : 0);
+
+  return clamp01(Number.parseFloat((seo + geo + aeo).toFixed(3)));
+}
+
+export function determineTripwire(layers: IntegrityLayers): TripwireStatus {
+  if (layers.aeo_layer.contradiction_detected) return 'triggered';
+  if (layers.geo_layer.ai_consensus === 'conflicting') return 'triggered';
+  if (layers.geo_layer.semantic_drift > 0.7) return 'triggered';
+  if (
+    layers.geo_layer.ai_consensus === 'divergent' &&
+    !layers.seo_layer.primary_source_found
+  ) {
+    return 'triggered';
+  }
+  return 'nominal';
+}

--- a/lib/integrity/claude.ts
+++ b/lib/integrity/claude.ts
@@ -1,0 +1,72 @@
+const CLAUDE_MODEL = 'claude-sonnet-4-20250514';
+
+type ClaudeMessageResponse = {
+  content?: Array<{ type?: string; text?: string }>;
+};
+
+export type ClaudeCallResult =
+  | { ok: true; jsonText: string }
+  | { ok: false; error: string; httpStatus?: number; responseBody?: string };
+
+function extractText(data: ClaudeMessageResponse): string | null {
+  const block = data.content?.[0];
+  if (!block || block.type !== 'text' || typeof block.text !== 'string') return null;
+  return block.text;
+}
+
+export async function callClaudeJson(
+  system: string,
+  user: string,
+): Promise<ClaudeCallResult> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey || !apiKey.trim()) {
+    return { ok: false, error: 'ANTHROPIC_API_KEY is not configured' };
+  }
+
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: CLAUDE_MODEL,
+      max_tokens: 600,
+      system,
+      messages: [{ role: 'user', content: user }],
+    }),
+  });
+
+  const rawText = await res.text();
+  if (!res.ok) {
+    return {
+      ok: false,
+      error: 'Claude API request failed',
+      httpStatus: res.status,
+      responseBody: rawText,
+    };
+  }
+
+  let parsedBody: unknown;
+  try {
+    parsedBody = JSON.parse(rawText) as unknown;
+  } catch {
+    return {
+      ok: false,
+      error: 'Claude API returned non-JSON body',
+      responseBody: rawText,
+    };
+  }
+
+  const text = extractText(parsedBody as ClaudeMessageResponse);
+  if (text === null) {
+    return {
+      ok: false,
+      error: 'Claude response missing text content',
+      responseBody: rawText,
+    };
+  }
+
+  return { ok: true, jsonText: text };
+}

--- a/lib/integrity/signal-store.ts
+++ b/lib/integrity/signal-store.ts
@@ -1,0 +1,11 @@
+import type { MobiusCivicIntegritySignal } from '@/lib/integrity-signal';
+
+let latestIntegritySignal: MobiusCivicIntegritySignal | null = null;
+
+export function setLatestIntegritySignal(signal: MobiusCivicIntegritySignal): void {
+  latestIntegritySignal = signal;
+}
+
+export function getLatestIntegritySignal(): MobiusCivicIntegritySignal | null {
+  return latestIntegritySignal;
+}

--- a/lib/terminal/api.ts
+++ b/lib/terminal/api.ts
@@ -1,5 +1,6 @@
 import type { Agent, EpiconItem, GISnapshot, Tripwire, LedgerEntry, CivicRadarAlert } from './types';
 import type { CycleIntegritySummary } from '@/lib/echo/integrity-engine';
+import type { MobiusCivicIntegritySignal } from '@/lib/integrity-signal';
 import { ledgerBackfill, type LedgerBackfillEntry } from '@/lib/mock/ledgerBackfill';
 import { integrityStatus, type IntegrityStatusResponse } from '@/lib/mock/integrityStatus';
 import { mockAgents, mockEpicon, mockTripwires } from './mock';
@@ -246,4 +247,31 @@ export async function getEchoFeed(): Promise<EchoFeedData | null> {
   } catch {
     return null;
   }
+}
+
+
+export type PulseSnapshot = {
+  signals: Array<Record<string, unknown>>;
+  integrity_signal: MobiusCivicIntegritySignal | null;
+};
+
+export async function getPulseSnapshot(): Promise<PulseSnapshot | null> {
+  const raw = await fetchInternalJson('/api/signals/pulse');
+  if (!raw || typeof raw !== 'object') return null;
+
+  const rec = raw as Record<string, unknown>;
+  const signals = Array.isArray(rec.signals)
+    ? rec.signals.filter((item): item is Record<string, unknown> => item !== null && typeof item === 'object')
+    : [];
+
+  const integritySignal = rec.integrity_signal;
+  const typedSignal =
+    integritySignal !== null && typeof integritySignal === 'object'
+      ? (integritySignal as MobiusCivicIntegritySignal)
+      : null;
+
+  return {
+    signals,
+    integrity_signal: typedSignal,
+  };
 }

--- a/lib/tripwire/store.ts
+++ b/lib/tripwire/store.ts
@@ -1,8 +1,11 @@
+export type RuntimeTripwireLevel = 'none' | 'watch' | 'elevated' | 'nominal' | 'low' | 'medium' | 'high' | 'triggered' | 'suspended';
+
 export type RuntimeTripwireState = {
   active: boolean;
-  level: 'none' | 'watch' | 'elevated';
+  level: RuntimeTripwireLevel;
   reason: string;
   last_updated: string;
+  triggeredBy?: 'HERMES' | 'ZEUS' | 'ATLAS' | 'operator';
 };
 
 let tripwireState: RuntimeTripwireState = {


### PR DESCRIPTION
### Motivation
- Provide a standardized `MobiusCivicIntegritySignal` contract and computation so JADE and HERMES can jointly verify civic claims across SEO, GEO, and AEO lenses. 
- Enable automated detection and escalation when generative outputs contradict authoritative signals by wiring contradiction detection into the tripwire system. 
- Surface verification results to the Pulse chamber UI so operators can see live integrity tickers and optionally flag low-confidence claims for EPICON review.

### Description
- Added a typed integrity contract and helpers in `lib/integrity-signal.ts` implementing `computeIntegrityScore()` and `determineTripwire()` and introduced a Claude JSON caller in `lib/integrity/claude.ts` for simulated SEO/GEO/AEO assessments. 
- Implemented new agent routes: `POST /api/jade/verify-claim` (SEO authority + Schema.org framing), `POST /api/hermes/geo-check` (GEO consensus/semantic drift), and `POST /api/hermes/aeo-check` (AEO snippet/direct-answer contradiction with conditional tripwire trigger). 
- Implemented the orchestrator `POST /api/jade/integrity-signal` which performs `seo → [geo, aeo]` sequencing, computes the full `MobiusCivicIntegritySignal`, writes an in-memory latest-signal store (`lib/integrity/signal-store.ts`), and optionally flags EPICON candidates for low scores. 
- Extended runtime tripwire types and added authenticated `POST /api/tripwire/status` to accept agent-triggered updates, normalized expanded tripwire levels in `app/api/integrity-status/route.ts`, exposed the latest signal on `GET /api/signals/pulse`, and added `components/terminal/IntegritySignalTicker.tsx` plus wiring in `hooks/useTerminalData.ts` and `app/terminal/page.tsx` to render the new ticker.

### Testing
- Built the project with `npm run build` and the Next.js build and TypeScript checks completed successfully. 
- `npm run lint` could not finish in this environment due to an interactive Next.js ESLint setup prompt. 
- Claude-backed routes require `ANTHROPIC_API_KEY` at runtime, which is not configured in this environment, so runtime verification of the Claude responses was not executed. 
- The codebase includes guards and schema validation to fail gracefully when Claude is unavailable or returns malformed responses.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6fcf8d398832d81d3ef67bf1e4f94)