### PR TITLE
fix(treasury): update MSPD and schedules endpoint paths

### DIFF
--- a/lib/treasury/cross-check.ts
+++ b/lib/treasury/cross-check.ts
@@ -46,7 +46,7 @@ const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 
 const TREASURY_SCHEDULES_MONTH_URL =
   process.env.TREASURY_SCHEDULES_MONTH_URL ??
-  'https://api.fiscaldata.treasury.gov/services/api/fiscal_service/v1/debt/schedules_federal_debt_by_month?sort=-record_date&page[size]=1000';
+  'https://api.fiscaldata.treasury.gov/services/api/fiscal_service/v2/accounting/od/schedules_federal_debt?filter=record_date:lte:2026-02-28&sort=-record_date&page[size]=1000';
 
 const TOLERANCE_PCT = 0.005;
 const TOLERANCE_USD = 5_000_000_000;

--- a/lib/treasury/deep-composition.ts
+++ b/lib/treasury/deep-composition.ts
@@ -34,7 +34,7 @@ const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 
 const MSPD_SUMMARY_URL =
   process.env.TREASURY_MSPD_SUMMARY_URL ??
-  'https://api.fiscaldata.treasury.gov/services/api/fiscal_service/v1/accounting/mspd/summary_of_treasury_securities_outstanding?sort=-record_date&page[size]=500';
+  'https://api.fiscaldata.treasury.gov/services/api/fiscal_service/v1/debt/mspd/mspd_table_1?filter=record_date:lte:2026-02-28&sort=-record_date&page[size]=500';
 
 const CANONICAL_ORDER = [
   'Marketable',


### PR DESCRIPTION
### Motivation
- The Treasury MSPD and schedules fetches were returning 404/500 due to incorrect API endpoint paths and risking requests for unpublished March 2026 rows. 

### Description
- Updated `lib/treasury/deep-composition.ts` to use `v1/debt/mspd/mspd_table_1` instead of the old accounting MSPD path and added `filter=record_date:lte:2026-02-28` to avoid unpublished March rows. 
- Updated `lib/treasury/cross-check.ts` to use `v2/accounting/od/schedules_federal_debt` instead of the previous `schedules_federal_debt_by_month` path and added `filter=record_date:lte:2026-02-28`. 
- No other logic changes were made; both changes only adjust the default fetch URL strings and respect environment overrides via `TREASURY_MSPD_SUMMARY_URL` / `TREASURY_SCHEDULES_MONTH_URL`.

### Testing
- Ran `git status` and confirmed the modified files `lib/treasury/deep-composition.ts` and `lib/treasury/cross-check.ts` were staged and committed successfully with message `fix(treasury): update MSPD and schedules endpoint paths`.
- Attempted endpoint validation with `curl` but outbound requests are blocked by the environment (CONNECT tunnel failed / 403), so live API verification could not complete.
- Ran `npm run lint` which could not finish in this non-interactive environment because `next lint` prompted for interactive ESLint setup, so linting was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbe592aa88832dae119e7672fb7cd8)