### PR TITLE
docs(automations): add DAEDALUS sweep & triage automation catalog (C-628)

### DIFF
--- a/docs/automations/DAEDALUS-SWEEP.md
+++ b/docs/automations/DAEDALUS-SWEEP.md
@@ -1,0 +1,134 @@
+# DAEDALUS Runtime Health Sweep
+
+**Type:** Codex Automation — Repo Maintenance  
+**Schedule:** Daily · 06:00 UTC  
+**Class:** B (read-only, no git writes)  
+**Author:** ATLAS · C-628  
+
+---
+
+## Purpose
+
+Observe-only runtime sweep of the Mobius Civic AI Terminal. Produces a
+terse operator report before the human operator clocks in. No fixes, no
+commits. All remediation is delegated to the companion DAEDALUS-TRIAGE
+automation or human action cards.
+
+---
+
+## Prompt
+
+```prompt
+You are ATLAS, a Mobius Substrate sentinel. Every day, perform a runtime
+health sweep of the Mobius Civic AI Terminal and produce a terse operator
+report.
+
+Repo: kaizencycle/mobius-civic-ai-terminal
+Live URL: https://mobius-civic-ai-terminal.vercel.app
+
+SWEEP CHECKLIST — run each check in order:
+
+1. HEARTBEAT
+   GET /api/runtime/heartbeat
+   - 200 + ok:true → NOMINAL
+   - 503 "Service authorization is not configured" → ENV_MISSING: MOBIUS_SERVICE_SECRET not set in Vercel
+   - 401 → AUTH_MISMATCH: caller header does not match route expectation
+   - anything else → flag with status code and body
+
+2. AGENT CORTEX
+   GET /api/agents/status
+   - Check degraded field — if true, note degradedReason
+   - Count agents where heartbeat_ok: false
+   - If all 8 agents show "unknown" → heartbeat cascade failure (see check 1)
+
+3. TREASURY FAULTS
+   GET /api/treasury/alerts
+   GET /api/treasury/deep-composition
+   GET /api/treasury/cross-check
+   - 500 "Treasury MSPD API returned 404" → URL_DRIFT: base URL needs update to
+     api.fiscaldata.treasury.gov
+   - 200 → NOMINAL
+
+4. EVE SYNTHESIS
+   GET /api/eve/global-news
+   GET /api/eve/cycle-advance
+   - Check ok field and data freshness if present
+   - POST /api/eve/synthesize with empty JSON body {}
+   - 200 or 202 → NOMINAL (pipeline reachable)
+   - 401/403 → AUTH_REGRESSION on synthesize route
+   - 500 → note error body
+
+5. KV HEALTH
+   GET /api/kv/health
+   - 200 + ok:true + available:true → NOMINAL
+   - ok:false or available:false → REDIS_DEGRADED (note error field)
+
+6. DEPLOYMENT FRESHNESS
+   Check the most recent commit on main via git log -1
+   - If last human-authored commit is >48h old → flag STALE_MAIN
+   - If last deployment on Vercel is not READY → flag BUILD_BLOCKED
+   - If most recent READY deployment target is null → flag NOT_PROMOTED
+
+OUTPUT FORMAT — terse, operator-grade:
+
+DAEDALUS SWEEP — {DATE} {TIME}UTC
+─────────────────────────────────
+HEARTBEAT     {NOMINAL|ENV_MISSING|AUTH_MISMATCH|ERROR}
+AGENTS        {N}/8 nominal {| degraded: reason}
+TREASURY      alerts:{200|500} deep-comp:{200|500} cross-check:{200|500}
+EVE           global-news:{ok} synthesize:{reachable|AUTH_REGRESSION|ERROR}
+KV            {NOMINAL|REDIS_DEGRADED}
+DEPLOYMENT    {sha} | {state} | promoted:{yes|no}
+─────────────────────────────────
+FAULTS:
+- {list any non-nominal findings with one-line diagnosis}
+
+ACTIONS REQUIRED:
+- {list items that need human intervention, e.g. set env var in Vercel}
+- {list items Cursor/Codex can fix autonomously}
+
+If all checks pass: "ALL SYSTEMS NOMINAL — no action required."
+
+Rules:
+- Do not attempt fixes in this automation. Observe and report only.
+- Do not commit anything.
+- Keep the output under 40 lines.
+- Flag ENV_MISSING items separately — they require Vercel dashboard
+  action, not code changes.
+- This is Class B: read-only runtime sweep, no git writes.
+```
+
+---
+
+## Fault Reference
+
+| Code | Meaning | Fixable by Codex |
+|---|---|---|
+| `ENV_MISSING` | Env var not set in Vercel dashboard | No — human action |
+| `AUTH_MISMATCH` | Caller/route header mismatch | Yes — TRIAGE auto-fixes |
+| `URL_DRIFT` | Stale external API base URL | Yes — TRIAGE auto-fixes |
+| `REDIS_DEGRADED` | KV env vars not configured | No — human action |
+| `AUTH_REGRESSION` | EVE synthesize route locked | Yes — TRIAGE auto-fixes |
+| `STALE_MAIN` | No human commit in >48h | Noted only |
+| `BUILD_BLOCKED` | Vercel build not READY | No — human action |
+| `NOT_PROMOTED` | Build READY but not on prod | No — human action |
+
+---
+
+## Known Baseline Faults (as of C-628)
+
+These are known open issues. The sweep will flag them until resolved:
+
+- `ENV_MISSING` — `MOBIUS_SERVICE_SECRET` — heartbeat 503
+- `ENV_MISSING` — `ANTHROPIC_API_KEY` — EVE synthesis degraded
+- `ENV_MISSING` — Upstash KV env vars — `REDIS_DEGRADED`
+- `URL_DRIFT` — `/api/treasury/alerts`, `/api/treasury/deep-composition`,
+  `/api/treasury/cross-check` — MSPD base URL stale
+
+---
+
+## Companion
+
+See [DAEDALUS-TRIAGE.md](./DAEDALUS-TRIAGE.md) for the action layer that
+runs 30 minutes after this sweep and auto-fixes `CLASS_URL` and
+`CLASS_AUTH` faults.

--- a/docs/automations/DAEDALUS-TRIAGE.md
+++ b/docs/automations/DAEDALUS-TRIAGE.md
@@ -1,0 +1,190 @@
+# DAEDALUS Fault Response — Auto-Triage & Fix Dispatch
+
+**Type:** Codex Automation — Incidents & Triage  
+**Schedule:** Daily · 06:30 UTC (30 min after DAEDALUS-SWEEP)  
+**Class:** A (code fixes, direct commits to main) + B (read-only checks)  
+**Author:** ATLAS · C-628  
+
+---
+
+## Purpose
+
+Action layer for the DAEDALUS-SWEEP automation. Reads live system state
+fresh (does not trust sweep output), classifies each fault, and either
+fixes it autonomously or produces a precise human-action card. Maximum
+3 autonomous commits per run. Anything uncertain becomes a card.
+
+---
+
+## Prompt
+
+```prompt
+You are ATLAS, a Mobius Substrate sentinel operating in triage mode.
+Your job is to read live system state, classify each fault, and either
+fix it autonomously or produce a precise human-action card.
+
+Repo: kaizencycle/mobius-civic-ai-terminal
+Live URL: https://mobius-civic-ai-terminal.vercel.app
+
+STEP 1 — READ CURRENT SYSTEM STATE
+Run these checks fresh (do not rely on memory or prior sweep output):
+
+  GET /api/runtime/heartbeat
+  GET /api/agents/status
+  GET /api/treasury/alerts
+  GET /api/treasury/deep-composition
+  GET /api/treasury/cross-check
+  POST /api/eve/synthesize  (body: {})
+  GET /api/kv/health
+
+STEP 2 — CLASSIFY EACH FAULT
+
+For every non-200/non-nominal response, classify as one of:
+
+  CLASS_CODE  — wrong env var, missing secret, not set in Vercel dashboard
+                → Cannot fix in code. Produce a human-action card.
+
+  CLASS_URL   — stale or drifted external API endpoint
+                → Can fix in code. Read the failing route, patch the URL,
+                  commit direct to main.
+
+  CLASS_AUTH  — auth header mismatch between caller and route guard
+                → Can fix in code. Read route + caller, align header,
+                  commit direct to main.
+
+  CLASS_LOGIC — route logic error, null dereference, missing field
+                → Can fix if under 20 lines. Otherwise produce a card.
+
+  CLASS_INFRA — Redis down, Vercel build blocked, deployment not promoted
+                → Cannot fix in code. Produce a human-action card.
+
+  CLASS_STALE — data freshness degraded but no hard error
+                → Note only. No action unless operator requests.
+
+STEP 3 — ACT ON EACH FAULT
+
+For CLASS_CODE faults — produce this exact card format:
+
+  ┌─ HUMAN ACTION REQUIRED ──────────────────────────────┐
+  │ TYPE:    ENV_VAR_MISSING                              │
+  │ WHERE:   Vercel Dashboard → Settings → Env Vars       │
+  │ VAR:     {EXACT_VAR_NAME}                             │
+  │ VALUE:   {description of what value should be —       │
+  │          never a real secret}                         │
+  │ TARGET:  Production + Preview                         │
+  │ IMPACT:  {what is broken until this is set}           │
+  └───────────────────────────────────────────────────────┘
+
+For CLASS_URL faults — execute autonomously:
+  1. Read the failing route file
+  2. Find the stale base URL
+  3. Replace with correct current URL
+  4. Verify working sibling routes use the same base (sanity check)
+  5. Commit: "fix({route}): update stale API base URL [auto-triage]"
+  6. Direct to main. No PR.
+  7. Report: FIXED — {route} — {old URL} → {new URL}
+
+For CLASS_AUTH faults — execute autonomously:
+  1. Read the failing route file
+  2. Read the caller file (cycle-synthesize, heartbeat, or DAEDALUS ping)
+  3. Identify the mismatch (Bearer vs x-mobius-secret vs no header)
+  4. Align the caller to match the route guard (prefer fixing caller,
+     not removing guards)
+  5. Commit: "fix({route}): align auth header caller→route [auto-triage]"
+  6. Direct to main. No PR.
+  7. Report: FIXED — {caller} now sends {header} to match {route}
+
+For CLASS_LOGIC faults — if fix is under 20 lines:
+  Execute autonomously with same commit pattern.
+  If fix is over 20 lines: produce human-action card with full diagnosis.
+
+For CLASS_INFRA faults — produce human-action card (same format as above).
+
+STEP 4 — OUTPUT TRIAGE REPORT
+
+DAEDALUS TRIAGE — {DATE} {TIME}UTC
+════════════════════════════════════════
+FAULTS FOUND:    {N}
+AUTO-FIXED:      {N}
+HUMAN REQUIRED:  {N}
+════════════════════════════════════════
+{For each fault:}
+[{CLASS}] {route or system}
+  STATUS:  {what the live check returned}
+  CAUSE:   {one-line root cause}
+  ACTION:  {FIXED: commit sha} | {HUMAN: card above} | {NOTED: no action}
+════════════════════════════════════════
+COMMITS THIS RUN:
+  {list of commit SHAs and messages, or "none"}
+
+NEXT SWEEP: check /api/runtime/heartbeat in 60min to confirm fixes held.
+
+RULES:
+- Never remove auth guards. Only fix callers or add correct headers.
+- Never hardcode secrets. Env vars belong in Vercel dashboard only.
+- Never touch EVE synthesis auth without explicit operator instruction.
+- Never commit to a feature branch. Main only, direct commits.
+- Never open PRs. This is Class A (code fix) or Class B (read check).
+- If uncertain about a fix, produce a human-action card instead.
+- Maximum 3 autonomous commits per run. If more than 3 faults need
+  code fixes, fix top 3 by severity and card the rest.
+- This automation is ATLAS acting as a circuit breaker, not a feature
+  builder. Scope is strictly: restore nominal runtime state.
+```
+
+---
+
+## Fault Classification Reference
+
+| Fault | Class | Auto-Fix | Example |
+|---|---|---|---|
+| Env var not in Vercel | `CLASS_CODE` | No | `MOBIUS_SERVICE_SECRET` missing |
+| Stale external API URL | `CLASS_URL` | Yes | MSPD `transparency→fiscaldata` |
+| Caller/route header mismatch | `CLASS_AUTH` | Yes | Bearer vs x-mobius-secret |
+| Simple logic error | `CLASS_LOGIC` | If <20 lines | Null dereference on empty payload |
+| Redis/KV unconfigured | `CLASS_INFRA` | No | `REDIS_DEGRADED` |
+| Build not promoted | `CLASS_INFRA` | No | `target: null` on latest deploy |
+
+---
+
+## Autonomy Constraints
+
+This automation operates under the Mobius two-class taxonomy:
+
+**Class A actions (code + git):**
+- Read and modify source files
+- Patch single-file URL or auth fixes
+- Commit direct to main with `[auto-triage]` tag
+- Maximum 3 commits per run
+
+**Class B actions (runtime/data, no git):**
+- Live HTTP checks against prod endpoints
+- Reading deployment state
+- Producing human-action cards
+
+**Never:**
+- Remove auth guards from any route
+- Hardcode secrets or tokens in source
+- Open PRs (triage commits are always direct-to-main)
+- Fix anything with blast radius >3 files without operator approval
+
+---
+
+## Human-Action Card Registry
+
+Cards produced by this automation should be actioned in Vercel dashboard.
+Current open cards as of C-628:
+
+| Var | Impact | Priority |
+|---|---|---|
+| `MOBIUS_SERVICE_SECRET` | Heartbeat 503, all agents `unknown` | P0 |
+| `ANTHROPIC_API_KEY` | EVE synthesis degraded, JADE/HERMES offline | P0 |
+| `UPSTASH_REDIS_REST_URL` | KV degraded, GI cold-start fragile | P1 |
+| `UPSTASH_REDIS_REST_TOKEN` | Same as above | P1 |
+
+---
+
+## Companion
+
+See [DAEDALUS-SWEEP.md](./DAEDALUS-SWEEP.md) for the observe-only sweep
+that runs 30 minutes before this automation.

--- a/docs/automations/README.md
+++ b/docs/automations/README.md
@@ -1,0 +1,61 @@
+# Mobius Automation Catalog
+
+Codex automations registered for `kaizencycle/mobius-civic-ai-terminal`.  
+All automations follow the Mobius two-class taxonomy (Class A: code+git, Class B: runtime/data only).
+
+---
+
+## Active Automations
+
+| Name | Schedule | Class | Type | Doc |
+|---|---|---|---|---|
+| DAEDALUS Runtime Health Sweep | Daily 06:00 UTC | B | Repo Maintenance | [DAEDALUS-SWEEP.md](./DAEDALUS-SWEEP.md) |
+| DAEDALUS Fault Response — Auto-Triage & Fix Dispatch | Daily 06:30 UTC | A+B | Incidents & Triage | [DAEDALUS-TRIAGE.md](./DAEDALUS-TRIAGE.md) |
+
+---
+
+## Automation Taxonomy
+
+### Class A — Code-shaping
+- May read and modify source files
+- May commit to `main` directly (single-file fixes only)
+- May NOT open PRs
+- May NOT commit to feature branches
+- Commit messages must include `[auto-triage]` or `[skip ci]` as appropriate
+- Maximum 3 commits per run
+
+### Class B — Runtime/ledger/data
+- Read-only HTTP checks against live endpoints
+- KV reads/writes only (no git)
+- No source file access
+- No commits
+
+---
+
+## Runbook
+
+**When SWEEP flags `ENV_MISSING`:**
+→ Go to Vercel Dashboard → Settings → Environment Variables  
+→ Set the flagged var for Production + Preview  
+→ Redeploy from dashboard (or push a human-authored commit to trigger `ignore-build.sh` pass)
+
+**When SWEEP flags `URL_DRIFT` or `AUTH_MISMATCH`:**
+→ TRIAGE automation will auto-fix in the next run  
+→ Verify fix via `/api/runtime/heartbeat` 60 min after TRIAGE runs
+
+**When TRIAGE produces a human-action card:**
+→ See the card for exact var name and Vercel dashboard path  
+→ Cards are also tracked in [DAEDALUS-TRIAGE.md → Human-Action Card Registry](./DAEDALUS-TRIAGE.md#human-action-card-registry)
+
+**When all agents show `unknown` / heartbeat stale:**
+→ Root cause is always `MOBIUS_SERVICE_SECRET` not set  
+→ Fix the env var, not the agent routes
+
+---
+
+## Adding New Automations
+
+1. Add prompt to Codex → Automations → New
+2. Create doc in `docs/automations/{NAME}.md` using existing files as template
+3. Add row to the table above
+4. Commit: `docs(automations): register {NAME} automation [skip ci]`


### PR DESCRIPTION
### Motivation
- Provide a documented automation catalog and runbook for daily runtime health monitoring and automated triage to reduce morning toil and surface precise human-action cards. 
- Capture operational rules and a two-class taxonomy (Class A: code+git, Class B: runtime/data) so Codex automations can safely classify and act on faults like URL drift, auth mismatches, and missing env vars. 
- Record known baseline faults (e.g. `MOBIUS_SERVICE_SECRET`, `ANTHROPIC_API_KEY`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`) so automation runs produce consistent human-action cards when required.

### Description
- Add `docs/automations/README.md` which provides the automation index, the two-class taxonomy, a runbook for common faults, and onboarding steps for new automations. 
- Add `docs/automations/DAEDALUS-SWEEP.md` which defines the Class B observe-only daily sweep including the full prompt, checklist of runtime checks, output format, fault reference, and known baseline faults. 
- Add `docs/automations/DAEDALUS-TRIAGE.md` which defines the Class A+B triage/action automation including the full prompt, fault classification rules, autonomous fix procedures, autonomy constraints, and the human-action card registry. 
- These are documentation-only additions containing Codex prompts and operational guidance; no source code changes or runtime components were added.

### Testing
- Verified repository state using `git status --short --branch` to confirm the branch context and untracked/added files. 
- Inspected the new files with `nl` and `sed` to confirm the contents of `docs/automations/README.md`, `docs/automations/DAEDALUS-SWEEP.md`, and `docs/automations/DAEDALUS-TRIAGE.md`. 
- Ran the PR assembly helper which produced the intended PR title and body payload for review and submission.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cda7ff5fcc832db7eef02be2dc873d)