### PR TITLE
fix(auth): resolve heartbeat 503 — align service secret var name

### DIFF
--- a/app/api/eve/cycle-synthesize/route.ts
+++ b/app/api/eve/cycle-synthesize/route.ts
@@ -1,6 +1,6 @@
 /**
  * POST /api/eve/cycle-synthesize — Full EVE → EPICON → ZEUS → ledger pipeline (C-626)
- * Protected: Authorization Bearer BACKFILL_SECRET
+ * Protected: Authorization Bearer MOBIUS_SERVICE_SECRET (fallback BACKFILL_SECRET)
  */
 
 import type { NextRequest } from 'next/server';
@@ -38,9 +38,12 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const secret = process.env.BACKFILL_SECRET;
+  const secret = process.env.MOBIUS_SERVICE_SECRET ?? process.env.BACKFILL_SECRET;
   if (!secret || !secret.trim()) {
-    return NextResponse.json({ ok: false, error: 'BACKFILL_SECRET is not configured' }, { status: 503 });
+    return NextResponse.json(
+      { ok: false, error: 'Service authorization is not configured (set MOBIUS_SERVICE_SECRET)' },
+      { status: 503 },
+    );
   }
 
   const auth = request.headers.get('authorization');

--- a/app/api/ledger/backfill/route.ts
+++ b/app/api/ledger/backfill/route.ts
@@ -44,8 +44,8 @@ function getRedisClient(): Redis | null {
 }
 
 function isAuthorized(req: NextRequest): boolean {
-  const secret = process.env.BACKFILL_SECRET;
-  if (!secret) return false;
+  const secret = process.env.MOBIUS_SERVICE_SECRET ?? process.env.BACKFILL_SECRET;
+  if (!secret || !secret.trim()) return false;
   return req.headers.get('authorization') === `Bearer ${secret}`;
 }
 
@@ -231,7 +231,7 @@ export async function POST(request: NextRequest) {
 
 export async function GET() {
   const kvConfigured = Boolean(getRedisClient());
-  const backfillProtected = Boolean(process.env.BACKFILL_SECRET);
+  const backfillProtected = Boolean(process.env.MOBIUS_SERVICE_SECRET ?? process.env.BACKFILL_SECRET);
 
   return NextResponse.json({
     ok: true,
@@ -239,7 +239,7 @@ export async function GET() {
     kvConfigured,
     backfillProtected,
     instructions: kvConfigured
-      ? 'POST with Authorization: Bearer $BACKFILL_SECRET to seed history'
+      ? 'POST with Authorization: Bearer $MOBIUS_SERVICE_SECRET (or legacy $BACKFILL_SECRET) to seed history'
       : 'Configure UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN first',
   });
 }

--- a/lib/security/serviceAuth.ts
+++ b/lib/security/serviceAuth.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-type ServiceSecretName = 'CRON_SECRET' | 'BACKFILL_SECRET';
+type ServiceSecretName = 'MOBIUS_SERVICE_SECRET' | 'CRON_SECRET' | 'BACKFILL_SECRET';
 
 function configuredSecrets(): Array<{ name: ServiceSecretName; value: string }> {
-  const pairs: ServiceSecretName[] = ['CRON_SECRET', 'BACKFILL_SECRET'];
+  const pairs: ServiceSecretName[] = ['MOBIUS_SERVICE_SECRET', 'CRON_SECRET', 'BACKFILL_SECRET'];
 
   return pairs
     .map((name) => {


### PR DESCRIPTION
### Motivation
- Heartbeat requests were returning 503 because the shared auth helper checked only `CRON_SECRET` and `BACKFILL_SECRET` while production sets `MOBIUS_SERVICE_SECRET`, causing service authorization to be considered unconfigured.
- The fix is to make the auth checks accept the production var name while preserving legacy fallbacks so cron/backfill endpoints remain usable.

### Description
- Updated `lib/security/serviceAuth.ts` to treat `MOBIUS_SERVICE_SECRET` as the primary service secret and to include it alongside `CRON_SECRET` and `BACKFILL_SECRET` when configuring accepted secrets.
- Updated `app/api/eve/cycle-synthesize/route.ts` to use `process.env.MOBIUS_SERVICE_SECRET ?? process.env.BACKFILL_SECRET` for its guard and to return a clearer 503 message when the service secret is missing.
- Updated `app/api/ledger/backfill/route.ts` to use the same `MOBIUS_SERVICE_SECRET` fallback in `isAuthorized`, to reflect the new primary var in readiness checks, and to update the readiness/instructions text to mention the primary and legacy names.

### Testing
- Ran TypeScript compile check with `npx tsc --noEmit`, which completed successfully.
- Attempted `npm run lint`, but the repository prompted for interactive ESLint configuration so linting could not complete non-interactively.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce8fa29030832d8b3b0ada57686c6b)