### PR TITLE
fix(daedalus): attach service auth header to heartbeat self-ping [C-629]

### DIFF
--- a/lib/agents/micro/daedalus.ts
+++ b/lib/agents/micro/daedalus.ts
@@ -15,6 +15,7 @@ import {
   normalizeInverse,
   safeFetch,
 } from './core';
+import { serviceAuthorizationHeaderValue } from '@/lib/security/serviceAuth';
 
 export const DAEDALUS_CONFIG: MicroAgentConfig = {
   name: 'DAEDALUS-µ',
@@ -116,9 +117,13 @@ async function pollSelfPing(): Promise<MicroSignal | null> {
 
   const url = `https://${baseUrl.replace(/^https?:\/\//, '')}/api/runtime/heartbeat`;
   const start = Date.now();
+  const authorization = serviceAuthorizationHeaderValue();
 
   try {
-    const res = await fetch(url, { cache: 'no-store' });
+    const res = await fetch(url, {
+      cache: 'no-store',
+      headers: authorization ? { authorization } : undefined,
+    });
     const latencyMs = Date.now() - start;
 
     if (!res.ok) {


### PR DESCRIPTION
### Motivation
- The runtime `/api/runtime/heartbeat` route now enforces service authorization, causing the DAEDALUS micro-agent self-ping to receive `401` and fail to register authenticated heartbeats when a service secret is configured. 

### Description
- Import and use `serviceAuthorizationHeaderValue()` in the DAEDALUS self-ping so the fetch to `/api/runtime/heartbeat` sends an `authorization` header when a service secret is configured. 
- Change is localized to `lib/agents/micro/daedalus.ts` and preserves existing behavior by omitting the header when no service secret is configured. 

### Testing
- Ran `npm run lint`, but the command could not complete non-interactively because Next.js prompted for an ESLint configuration, so linting was not validated in this environment. 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce929b0508832db9ca255733ae72f6)