### PR TITLE
fix(signals): attach service auth to self-ping in micro route [C-629]

### DIFF
--- a/lib/agents/micro/daedalus.ts
+++ b/lib/agents/micro/daedalus.ts
@@ -117,12 +117,14 @@ async function pollSelfPing(): Promise<MicroSignal | null> {
 
   const url = `https://${baseUrl.replace(/^https?:\/\//, '')}/api/runtime/heartbeat`;
   const start = Date.now();
-  const authorization = serviceAuthorizationHeaderValue();
+  const secret = serviceAuthorizationHeaderValue();
+  const headers: Record<string, string> = {};
+  if (secret) headers['x-mobius-secret'] = secret;
 
   try {
     const res = await fetch(url, {
       cache: 'no-store',
-      headers: authorization ? { authorization } : undefined,
+      headers,
     });
     const latencyMs = Date.now() - start;
 


### PR DESCRIPTION
### Motivation
- The `/api/signals/micro` self-ping was calling `/api/runtime/heartbeat` without the service auth secret, producing 401s and lowering the DAEDALUS-µ self-ping score, so the self-ping needs to include the service auth header.

### Description
- Update `lib/agents/micro/daedalus.ts` by changing `pollSelfPing` to call `serviceAuthorizationHeaderValue()` and attach the secret as an `x-mobius-secret` header on the fetch to `/api/runtime/heartbeat`, while preserving existing scoring and latency logic.

### Testing
- Ran `npx tsc --noEmit` which passed, and attempted `npm run lint` which invoked an interactive `next lint` setup and did not complete in non-interactive mode; TypeScript check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce94cc9ce4832d9d8f7ae093e94df9)