### PR TITLE
fix(signals): correct self-ping auth header name mismatch [C-629]

### DIFF
--- a/lib/agents/micro/daedalus.ts
+++ b/lib/agents/micro/daedalus.ts
@@ -119,7 +119,7 @@ async function pollSelfPing(): Promise<MicroSignal | null> {
   const start = Date.now();
   const secret = serviceAuthorizationHeaderValue();
   const headers: Record<string, string> = {};
-  if (secret) headers['x-mobius-secret'] = secret;
+  if (secret) headers.authorization = secret;
 
   try {
     const res = await fetch(url, {


### PR DESCRIPTION
### Motivation
- Fix a 401 on the DAEDALUS self-ping by aligning the outbound header with the runtime heartbeat auth guard, because `serviceAuthorizationHeaderValue()` returns a `Bearer` token and the heartbeat route checks the `authorization` header rather than `x-mobius-secret`.

### Description
- Change the DAEDALUS self-ping in `lib/agents/micro/daedalus.ts` to send the value from `serviceAuthorizationHeaderValue()` in the `authorization` header instead of `x-mobius-secret`.

### Testing
- Ran `npx tsc --noEmit` which completed without type errors (only an unrelated npm env warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce98283a98832da672459c71bbe516)