### PR TITLE
fix(markets): graceful degradation for unprovisioned market & treasury routes

### DIFF
--- a/app/api/markets/market-sweep-export/route.ts
+++ b/app/api/markets/market-sweep-export/route.ts
@@ -20,15 +20,25 @@ export async function GET() {
       },
     );
   } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown market sweep export error';
+    const keyMissing = /api key|token|unauthorized|forbidden|401/i.test(message);
+
     return NextResponse.json(
       {
         ok: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : 'Unknown market sweep export error',
+        degraded: true,
+        reason: keyMissing ? 'API key not configured' : 'Upstream market provider unavailable',
+        source: 'mock',
+        error: message,
       },
-      { status: 500 },
+      {
+        status: 200,
+        headers: {
+          'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=120',
+          'X-Mobius-Source': 'market-sweep-export-degraded',
+        },
+      },
     );
   }
 }

--- a/app/api/markets/narrator/route.ts
+++ b/app/api/markets/narrator/route.ts
@@ -23,15 +23,24 @@ export async function GET(request: NextRequest) {
       },
     );
   } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown market narrator error';
+    const keyMissing = /api key|token|unauthorized|forbidden|401/i.test(message);
+
     return NextResponse.json(
       {
         ok: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : 'Unknown market narrator error',
+        degraded: true,
+        reason: keyMissing ? 'API key not configured' : 'Upstream market provider unavailable',
+        source: 'mock',
+        error: message,
       },
-      { status: 500 },
+      {
+        status: 200,
+        headers: {
+          'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=120',
+          'X-Mobius-Source': 'market-narrator-degraded',
+        },
+      },
     );
   }
 }

--- a/app/api/markets/rates-dollar-fusion/route.ts
+++ b/app/api/markets/rates-dollar-fusion/route.ts
@@ -20,15 +20,25 @@ export async function GET() {
       },
     );
   } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown rates-dollar fusion error';
+    const keyMissing = /api key|token|unauthorized|forbidden|401/i.test(message);
+
     return NextResponse.json(
       {
         ok: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : 'Unknown rates-dollar fusion error',
+        degraded: true,
+        reason: keyMissing ? 'API key not configured' : 'Upstream market provider unavailable',
+        source: 'mock',
+        error: message,
       },
-      { status: 500 },
+      {
+        status: 200,
+        headers: {
+          'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=120',
+          'X-Mobius-Source': 'rates-dollar-fusion-degraded',
+        },
+      },
     );
   }
 }

--- a/app/api/treasury/market-bridge/route.ts
+++ b/app/api/treasury/market-bridge/route.ts
@@ -20,12 +20,25 @@ export async function GET() {
       },
     );
   } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown Treasury market bridge error';
+    const keyMissing = /api key|token|unauthorized|forbidden|401/i.test(message);
+
     return NextResponse.json(
       {
         ok: false,
-        error: error instanceof Error ? error.message : 'Unknown Treasury market bridge error',
+        degraded: true,
+        reason: keyMissing ? 'API key not configured' : 'Upstream market provider unavailable',
+        source: 'mock',
+        error: message,
       },
-      { status: 500 },
+      {
+        status: 200,
+        headers: {
+          'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=120',
+          'X-Mobius-Source': 'treasury-market-bridge-degraded',
+        },
+      },
     );
   }
 }


### PR DESCRIPTION
### Motivation
- Several newly deployed market/treasury routes were returning HTTP 500 when upstream providers or API keys were missing, causing UI panels to fail; the goal is to avoid hard failures and surface a clear degraded state instead.

### Description
- Updated four route handlers to degrade gracefully on errors instead of returning 500: `/api/markets/market-sweep-export`, `/api/markets/narrator`, `/api/markets/rates-dollar-fusion`, and `/api/treasury/market-bridge`.
- Degraded responses now return a 200 JSON envelope containing `ok: false`, `degraded: true`, `reason` (detects likely unprovisioned auth via message matching and surfaces `"API key not configured"`), `source: "mock"`, and `error` for observability.
- Added distinct `X-Mobius-Source` headers for degraded responses and shorter cache TTLs for degraded state to aid monitoring and debugging.
- This follows the existing fallback pattern used by other endpoints and does not introduce mocked domain-specific data.

### Testing
- `npx tsc --noEmit` was run and succeeded.
- `npm run lint` could not be executed non-interactively in this environment because the Next.js ESLint setup prompts for initial configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceeefc82a8832da2264e2177214fa1)