### PR TITLE
fix(auth): definitive heartbeat 401 resolution [C-629]

### DIFF
--- a/lib/agents/micro/daedalus.ts
+++ b/lib/agents/micro/daedalus.ts
@@ -119,7 +119,7 @@ async function pollSelfPing(): Promise<MicroSignal | null> {
   const start = Date.now();
   const secret = serviceAuthorizationHeaderValue();
   const headers: Record<string, string> = {};
-  if (secret) headers.authorization = secret;
+  if (secret) headers.Authorization = secret;
 
   try {
     const res = await fetch(url, {

--- a/lib/security/serviceAuth.ts
+++ b/lib/security/serviceAuth.ts
@@ -4,15 +4,16 @@ import type { NextRequest } from 'next/server';
 type ServiceSecretName = 'MOBIUS_SERVICE_SECRET' | 'CRON_SECRET' | 'BACKFILL_SECRET';
 
 function configuredSecrets(): Array<{ name: ServiceSecretName; value: string }> {
-  const pairs: ServiceSecretName[] = ['MOBIUS_SERVICE_SECRET', 'CRON_SECRET', 'BACKFILL_SECRET'];
+  const pairs: Array<{ name: ServiceSecretName; value: string | undefined }> = [
+    { name: 'MOBIUS_SERVICE_SECRET', value: process.env.MOBIUS_SERVICE_SECRET },
+    { name: 'CRON_SECRET', value: process.env.CRON_SECRET },
+    { name: 'BACKFILL_SECRET', value: process.env.BACKFILL_SECRET },
+  ];
 
   return pairs
-    .map((name) => {
-      const value = process.env[name];
-      return typeof value === 'string' && value.trim()
-        ? { name, value: value.trim() }
-        : null;
-    })
+    .map(({ name, value }) => (typeof value === 'string' && value.trim()
+      ? { name, value: value.trim() }
+      : null))
     .filter((item): item is { name: ServiceSecretName; value: string } => item !== null);
 }
 


### PR DESCRIPTION
### Motivation

- Heartbeat calls to `/api/runtime/heartbeat` were returning 401 because `serviceAuthorizationHeaderValue()` was not reliably resolving the configured secret in runtime bundles and the self-ping caller used a non-canonical header key. 
- The change makes secret resolution deterministic and aligns the self-ping caller header to ensure the route sees the expected `Bearer <secret>` value.

### Description

- In `lib/security/serviceAuth.ts` replaced dynamic env-key lookup with explicit reads of `process.env.MOBIUS_SERVICE_SECRET`, `process.env.CRON_SECRET`, and `process.env.BACKFILL_SECRET`, preserving priority and trimming values. 
- Kept `serviceAuthorizationHeaderValue()` behavior unchanged so it still returns `Bearer <value>` when a primary secret is present. 
- In `lib/agents/micro/daedalus.ts` changed the self-ping request to set the header key as `Authorization` (capitalized) when a secret is present. 
- Verified there are no remaining browser-side `runtime/heartbeat` fetches in `app/`, `components/`, or `lib/` (only the server-side DAEDALUS self-ping remains).

### Testing

- Ran `rg`/`grep` for `runtime/heartbeat` across `app/`, `components/`, and `lib/`, which located only the expected server-side call and the heartbeat route. (succeeded)
- Attempted `npm run lint`, but the interactive Next.js ESLint setup prompt prevented non-interactive linting in this environment, so lint could not be completed. (blocked)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cef2b84118832db845821aebc5327c)