### PR TITLE
fix(treasury): degrade cross-check and alerts routes instead of 500

### DIFF
--- a/app/api/treasury/alerts/route.ts
+++ b/app/api/treasury/alerts/route.ts
@@ -1,15 +1,45 @@
 import { NextResponse } from 'next/server';
 import { getTreasuryAlerts } from '@/lib/treasury/alerts';
+import { getTreasuryCrossCheck } from '@/lib/treasury/cross-check';
+import { getTreasuryDeepComposition } from '@/lib/treasury/deep-composition';
+import { getTreasuryWatchSnapshot } from '@/lib/treasury/watch';
 
 export const dynamic = 'force-dynamic';
+
+let lastGoodAlerts: Awaited<ReturnType<typeof getTreasuryAlerts>> | null = null;
+
+async function classifyAlertsFailure() {
+  try {
+    await getTreasuryWatchSnapshot();
+  } catch {
+    return 'upstream_watch_snapshot_unavailable';
+  }
+
+  try {
+    await getTreasuryCrossCheck();
+  } catch {
+    return 'upstream_cross_check_unavailable';
+  }
+
+  try {
+    await getTreasuryDeepComposition();
+  } catch {
+    return 'upstream_deep_composition_unavailable';
+  }
+
+  return 'upstream_dependency_failure';
+}
 
 export async function GET() {
   try {
     const payload = await getTreasuryAlerts();
+    lastGoodAlerts = payload;
 
     return NextResponse.json(
       {
         ok: true,
+        degraded: false,
+        source: 'primary',
         ...payload,
       },
       {
@@ -20,12 +50,17 @@ export async function GET() {
       },
     );
   } catch (error) {
+    const reason = await classifyAlertsFailure();
+    console.error('[treasury/alerts] upstream failure', { reason, error });
+
     return NextResponse.json(
       {
         ok: false,
-        error: error instanceof Error ? error.message : 'Unknown Treasury alert engine error',
+        degraded: true,
+        reason,
+        source: lastGoodAlerts ? 'last-good-cache' : 'fallback',
+        ...(lastGoodAlerts ? { data: lastGoodAlerts } : {}),
       },
-      { status: 500 },
     );
   }
 }

--- a/app/api/treasury/cross-check/route.ts
+++ b/app/api/treasury/cross-check/route.ts
@@ -3,13 +3,26 @@ import { getTreasuryCrossCheck } from '@/lib/treasury/cross-check';
 
 export const dynamic = 'force-dynamic';
 
+let lastGoodCrossCheck: Awaited<ReturnType<typeof getTreasuryCrossCheck>> | null = null;
+
+function classifyCrossCheckFailure(error: unknown) {
+  const message = error instanceof Error ? error.message.toLowerCase() : '';
+
+  if (message.includes('schedules')) return 'upstream_schedules_unavailable';
+  if (message.includes('mspd')) return 'upstream_mspd_unavailable';
+  if (message.includes('no rows')) return 'upstream_empty_dataset';
+  return 'upstream_dependency_failure';
+}
+
 export async function GET() {
   try {
     const payload = await getTreasuryCrossCheck();
+    lastGoodCrossCheck = payload;
 
     return NextResponse.json(
       {
         ok: true,
+        degraded: false,
         ...payload,
       },
       {
@@ -20,12 +33,17 @@ export async function GET() {
       },
     );
   } catch (error) {
+    const reason = classifyCrossCheckFailure(error);
+    console.error('[treasury/cross-check] upstream failure', { reason, error });
+
     return NextResponse.json(
       {
         ok: false,
-        error: error instanceof Error ? error.message : 'Unknown Treasury cross-check error',
+        degraded: true,
+        reason,
+        source: lastGoodCrossCheck ? 'last-good-cache' : 'fallback',
+        ...(lastGoodCrossCheck ? { data: lastGoodCrossCheck } : {}),
       },
-      { status: 500 },
     );
   }
 }


### PR DESCRIPTION
### Motivation

- Treasury adapter upstream failures were causing `/api/treasury/cross-check` and `/api/treasury/alerts` to return HTTP 500 and crash the UI instead of degrading gracefully.
- Preserve last-good data and surface machine-readable reasons so the terminal remains usable while adapters are hardened.

### Description

- Updated `app/api/treasury/cross-check/route.ts` to record a `lastGoodCrossCheck`, classify upstream errors via `classifyCrossCheckFailure`, log the failure server-side, and return a non-fatal JSON fallback (`ok: false`, `degraded: true`, `reason`, `source`) and include `data` when a last-good payload exists instead of returning HTTP 500.
- Updated `app/api/treasury/alerts/route.ts` to record `lastGoodAlerts`, probe upstream dependencies (`getTreasuryWatchSnapshot`, `getTreasuryCrossCheck`, `getTreasuryDeepComposition`) in `classifyAlertsFailure` to produce a machine-readable failure reason, log server-side, and return the same non-fatal JSON fallback with last-good payload when available instead of returning HTTP 500.
- Minor TypeScript hygiene: removed duplicate `source` field emission that caused a `tsc` error during validation.

### Testing

- Ran `npx tsc --noEmit` and type-checking passed after the duplicate `source` field fix.
- Ran `npm run lint` but it could not complete non-interactively due to Next.js prompting for an initial ESLint configuration in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf1224e0e4832da7061b89eecbc817)