### PR TITLE
fix(ledger): dedupe ingest and separate live agent memory from backfill

### DIFF
--- a/app/api/eve/cycle-advance/route.ts
+++ b/app/api/eve/cycle-advance/route.ts
@@ -97,6 +97,7 @@ export async function POST() {
         ratings: [],
       },
       sourceCount: 0,
+      duplicateSuppressedCount: 0,
       timestamp: now.toISOString(),
     });
 

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -108,6 +108,7 @@ function TerminalPage() {
     allTripwires,
     dataRef,
     dominantTripwireState,
+    duplicateSuppressedCount,
     echoAlerts,
     echoIntegrity,
     filteredAgents,
@@ -332,6 +333,7 @@ function TerminalPage() {
             {showLedger && (
               <LedgerPanel
                 entries={mergedLedger}
+                duplicateSuppressedCount={duplicateSuppressedCount}
                 selectedId={inspectorTarget.kind === 'ledger' ? inspectorTarget.data.id : undefined}
                 onSelect={(entry) => setInspectorTarget({ kind: 'ledger', data: entry })}
               />

--- a/components/terminal/LedgerPanel.tsx
+++ b/components/terminal/LedgerPanel.tsx
@@ -53,10 +53,12 @@ function sortLedger(entries: LedgerEntry[], key: LedgerSortKey, dir: 'asc' | 'de
 
 export default function LedgerPanel({
   entries,
+  duplicateSuppressedCount = 0,
   selectedId,
   onSelect,
 }: {
   entries: LedgerEntry[];
+  duplicateSuppressedCount?: number;
   selectedId?: string;
   onSelect?: (entry: LedgerEntry) => void;
 }) {
@@ -64,6 +66,19 @@ export default function LedgerPanel({
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
 
   const sorted = useMemo(() => sortLedger(entries, sortKey, sortDir), [entries, sortKey, sortDir]);
+  const liveIngestEntries = useMemo(
+    () => sorted.filter((entry) => entry.source === 'echo' && entry.status === 'pending'),
+    [sorted],
+  );
+  const liveCommittedEntries = useMemo(
+    () => sorted.filter((entry) => (entry.source === 'echo' || entry.source === 'eve-synthesis') && entry.status === 'committed'),
+    [sorted],
+  );
+  const backfillEntries = useMemo(
+    () => sorted.filter((entry) => entry.source === 'backfill' || entry.source === 'mock'),
+    [sorted],
+  );
+  const cycleId = liveIngestEntries[0]?.cycleId ?? liveCommittedEntries[0]?.cycleId ?? sorted[0]?.cycleId ?? 'unknown';
   const source = useMemo<DataSource>(() => {
     if (entries.some((entry) => entry.source === 'echo')) return 'live';
     if (entries.some((entry) => entry.source === 'eve-synthesis')) return 'live';
@@ -96,7 +111,19 @@ export default function LedgerPanel({
         />
       </div>
       <div className="mt-3 space-y-2">
-        {sorted.map((entry) => (
+        <div className="grid grid-cols-2 gap-2 rounded-lg border border-slate-800 bg-slate-950/70 p-2 text-[11px] font-mono uppercase tracking-[0.1em] text-slate-300">
+          <div>live_ingest_count: <span className="text-amber-300">{liveIngestEntries.length}</span></div>
+          <div>live_committed_agent_count: <span className="text-emerald-300">{liveCommittedEntries.length}</span></div>
+          <div>backfill_count: <span className="text-slate-200">{backfillEntries.length}</span></div>
+          <div>duplicate_suppressed_count: <span className="text-fuchsia-300">{duplicateSuppressedCount}</span></div>
+        </div>
+        <div className="text-[11px] font-mono uppercase tracking-[0.1em] text-slate-500">
+          Cycle {cycleId} · default focus: committed agent memory
+        </div>
+      </div>
+
+      <div className="mt-3 space-y-4">
+        {liveCommittedEntries.map((entry) => (
           <button
             key={entry.id}
             onClick={() => onSelect?.(entry)}
@@ -181,6 +208,42 @@ export default function LedgerPanel({
             </div>
           </button>
         ))}
+        {liveCommittedEntries.length === 0 ? (
+          <div className="rounded-lg border border-slate-800 bg-slate-950/40 p-3 text-xs text-slate-400">
+            No live committed agent records in the active cycle yet.
+          </div>
+        ) : null}
+
+        {liveIngestEntries.length > 0 ? (
+          <details className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-2">
+            <summary className="cursor-pointer text-xs font-mono uppercase tracking-[0.1em] text-amber-300">
+              Live ingest (pending) · {liveIngestEntries.length}
+            </summary>
+            <div className="mt-2 space-y-2">
+              {liveIngestEntries.map((entry) => (
+                <button
+                  key={entry.id}
+                  onClick={() => onSelect?.(entry)}
+                  className={cn(
+                    'cv-auto w-full rounded-lg border p-3 text-left transition border-amber-500/20 bg-slate-950/60 hover:border-amber-400/40',
+                    selectedId === entry.id && 'border-amber-400/60 bg-amber-500/10',
+                  )}
+                >
+                  <div className="text-xs font-mono text-slate-400">{entry.id}</div>
+                  <div className="mt-1 text-sm font-semibold text-slate-100">{entry.title ?? entry.summary}</div>
+                </button>
+              ))}
+            </div>
+          </details>
+        ) : null}
+
+        {backfillEntries.length > 0 ? (
+          <details className="rounded-lg border border-slate-800 bg-slate-950/40 p-2">
+            <summary className="cursor-pointer text-xs font-mono uppercase tracking-[0.1em] text-slate-400">
+              Historical backfill · {backfillEntries.length}
+            </summary>
+          </details>
+        ) : null}
       </div>
       {degraded ? (
         <div className="mt-3 text-xs text-amber-300">

--- a/hooks/useTerminalData.ts
+++ b/hooks/useTerminalData.ts
@@ -82,6 +82,7 @@ export function useTerminalData(selectedNav: NavKey) {
   const [echoIntegrity, setEchoIntegrity] = useState<CycleIntegritySummary | null>(null);
   const [showCreateEpicon, setShowCreateEpicon] = useState(false);
   const [operatorMessage, setOperatorMessage] = useState('Terminal live. Awaiting operator action.');
+  const [duplicateSuppressedCount, setDuplicateSuppressedCount] = useState(0);
 
   const mergedLedger = useMemo(() => {
     const seen = new Set<string>();
@@ -214,6 +215,7 @@ export function useTerminalData(selectedNav: NavKey) {
       setEchoLedger(feed.ledger);
       setEchoAlerts(feed.alerts);
       if (feed.integrity) setEchoIntegrity(feed.integrity);
+      setDuplicateSuppressedCount(feed.status.duplicateSuppressedCount ?? 0);
     }
 
     loadEcho();
@@ -317,6 +319,7 @@ export function useTerminalData(selectedNav: NavKey) {
     integritySignal,
     mergedLedger,
     operatorMessage,
+    duplicateSuppressedCount,
     setEchoAlerts,
     setEchoIntegrity,
     setEchoLedger,

--- a/lib/echo/store.ts
+++ b/lib/echo/store.ts
@@ -24,6 +24,7 @@ type EchoStore = {
   lastIngest: string | null;
   cycleId: string;
   totalIngested: number;
+  duplicateSuppressedCount: number;
 };
 
 // Module-level singleton — survives across requests in a warm serverless instance
@@ -35,17 +36,43 @@ const store: EchoStore = {
   lastIngest: null,
   cycleId: currentCycleId(),
   totalIngested: 0,
+  duplicateSuppressedCount: 0,
 };
 
 export function pushIngestResult(result: IngestResult): void {
-  // Prepend new items, cap at max
-  store.epicon = [...result.epicon, ...store.epicon].slice(0, MAX_EPICON);
-  store.ledger = [...result.ledger, ...store.ledger].slice(0, MAX_LEDGER);
+  const epiconSeen = new Set(store.epicon.map((item) => [item.category, item.title, item.timestamp].join('|')));
+  const ledgerSeen = new Set(store.ledger.map((row) => [row.source ?? 'unknown', row.category ?? 'unknown', row.title ?? row.summary, row.timestamp, row.status].join('|')));
+  const newEpicon: typeof store.epicon = [];
+  const newLedger: typeof store.ledger = [];
+  let duplicateSuppressed = result.duplicateSuppressedCount;
+
+  for (let i = 0; i < result.epicon.length; i++) {
+    const epicon = result.epicon[i];
+    const ledger = result.ledger[i];
+    if (!epicon || !ledger) continue;
+
+    const epiconKey = [epicon.category, epicon.title, epicon.timestamp].join('|');
+    const ledgerKey = [ledger.source ?? 'unknown', ledger.category ?? 'unknown', ledger.title ?? ledger.summary, ledger.timestamp, ledger.status].join('|');
+    if (epiconSeen.has(epiconKey) || ledgerSeen.has(ledgerKey)) {
+      duplicateSuppressed += 1;
+      continue;
+    }
+
+    epiconSeen.add(epiconKey);
+    ledgerSeen.add(ledgerKey);
+    newEpicon.push(epicon);
+    newLedger.push(ledger);
+  }
+
+  // Prepend deduped items, cap at max
+  store.epicon = [...newEpicon, ...store.epicon].slice(0, MAX_EPICON);
+  store.ledger = [...newLedger, ...store.ledger].slice(0, MAX_LEDGER);
   store.alerts = [...result.alerts, ...store.alerts].slice(0, MAX_ALERTS);
   store.integrity = result.integrity;
   store.lastIngest = result.timestamp;
   store.cycleId = result.cycleId;
-  store.totalIngested += result.sourceCount;
+  store.totalIngested += newLedger.length;
+  store.duplicateSuppressedCount += duplicateSuppressed;
 }
 
 export function getEchoEpicon(): EpiconItem[] {
@@ -69,11 +96,13 @@ export function getEchoStatus(): {
   cycleId: string;
   totalIngested: number;
   counts: { epicon: number; ledger: number; alerts: number };
+  duplicateSuppressedCount: number;
 } {
   return {
     lastIngest: store.lastIngest,
     cycleId: store.cycleId,
     totalIngested: store.totalIngested,
+    duplicateSuppressedCount: store.duplicateSuppressedCount,
     counts: {
       epicon: store.epicon.length,
       ledger: store.ledger.length,
@@ -89,4 +118,5 @@ export function clearStore(): void {
   store.integrity = null;
   store.lastIngest = null;
   store.totalIngested = 0;
+  store.duplicateSuppressedCount = 0;
 }

--- a/lib/echo/transform.ts
+++ b/lib/echo/transform.ts
@@ -116,9 +116,13 @@ export function toLedgerEntry(raw: RawEvent, epiconId: string): LedgerEntry {
     type: 'epicon',
     agentOrigin: 'ECHO',
     timestamp: formatTimestamp(raw.timestamp),
-    summary: `${epiconId} ingested — ${raw.title.slice(0, 60)}${raw.title.length > 60 ? '...' : ''} via ${agent}`,
+    title: raw.title,
+    summary: `${epiconId} ingested from ${raw.source} via ${agent}.`,
     integrityDelta: delta,
     status: raw.severity === 'high' ? 'pending' : 'committed',
+    category: raw.category,
+    confidenceTier: severityToConfidence(raw.severity),
+    source: 'echo',
   };
 }
 
@@ -155,6 +159,7 @@ export type IngestResult = {
   alerts: CivicRadarAlert[];
   integrity: CycleIntegritySummary;
   sourceCount: number;
+  duplicateSuppressedCount: number;
   timestamp: string;
 };
 
@@ -170,13 +175,46 @@ function isFreshEntry(timestamp: string, maxAgeHours = 48): boolean {
   }
 }
 
+function normalizeText(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function deriveRawEventFingerprint(event: RawEvent): string {
+  const bucketMinutes = 10;
+  const time = new Date(event.timestamp).getTime();
+  const bucket = Number.isFinite(time) ? Math.floor(time / (bucketMinutes * 60 * 1000)) : event.timestamp;
+  const symbol = typeof event.metadata?.coin === 'string' ? event.metadata.coin.toLowerCase() : '';
+  return [
+    event.source.toLowerCase(),
+    event.category,
+    symbol,
+    bucket,
+    normalizeText(event.title),
+    normalizeText(event.summary),
+  ].join('|');
+}
+
 export function transformBatch(events: RawEvent[]): IngestResult {
   const freshEvents = events.filter((event) => isFreshEntry(event.timestamp));
+  const dedupedEvents: RawEvent[] = [];
+  const seenFingerprints = new Set<string>();
+  let duplicateSuppressedCount = 0;
+
+  for (const event of freshEvents) {
+    const fingerprint = deriveRawEventFingerprint(event);
+    if (seenFingerprints.has(fingerprint)) {
+      duplicateSuppressedCount += 1;
+      continue;
+    }
+    seenFingerprints.add(fingerprint);
+    dedupedEvents.push(event);
+  }
+
   const epicon: EpiconItem[] = [];
   const ledger: LedgerEntry[] = [];
   const alerts: CivicRadarAlert[] = [];
 
-  for (const raw of freshEvents) {
+  for (const raw of dedupedEvents) {
     const item = toEpiconItem(raw);
     epicon.push(item);
     ledger.push(toLedgerEntry(raw, item.id));
@@ -187,7 +225,7 @@ export function transformBatch(events: RawEvent[]): IngestResult {
 
   // Run integrity rating across all agents (ATLAS, ZEUS, JADE, EVE)
   const cycleId = getCurrentCycleId();
-  const integrity = rateBatch(freshEvents, epicon, cycleId);
+  const integrity = rateBatch(dedupedEvents, epicon, cycleId);
 
   // Update ledger deltas with integrity-engine-computed values
   for (let i = 0; i < ledger.length; i++) {
@@ -216,7 +254,8 @@ export function transformBatch(events: RawEvent[]): IngestResult {
     ledger,
     alerts,
     integrity,
-    sourceCount: freshEvents.length,
+    sourceCount: dedupedEvents.length,
+    duplicateSuppressedCount,
     timestamp: new Date().toISOString(),
   };
 }

--- a/lib/terminal/api.ts
+++ b/lib/terminal/api.ts
@@ -237,6 +237,7 @@ export type EchoFeedData = {
     lastIngest: string | null;
     cycleId: string;
     totalIngested: number;
+    duplicateSuppressedCount: number;
     counts: { epicon: number; ledger: number; alerts: number };
   };
 };


### PR DESCRIPTION
### Motivation
- Prevent repeated external ingest from flooding the ledger view and make the terminal clearly distinguish live ingest, committed agent memory, and historical backfill.
- Surface a simple metric for duplicate suppression so operators can see how much ingest is being collapsed before it pollutes the chamber.

### Description
- Add pre-write deduplication in the ECHO transform pipeline by deriving a stable fingerprint and suppressing duplicates before generating EPICON and ledger rows, exposing `duplicateSuppressedCount` on the ingest result (`lib/echo/transform.ts`).
- Enrich ECHO ledger entries with `title`, `category`, `confidenceTier`, and `source: 'echo'` so UI can classify live vs backfill rows (`lib/echo/transform.ts`).
- Add store-level duplicate suppression when merging ingest results into the in-memory ECHO store and persist a cumulative `duplicateSuppressedCount` in `getEchoStatus()` (`lib/echo/store.ts`).
- Surface the duplicate counter through the terminal API and hooks (`lib/terminal/api.ts`, `hooks/useTerminalData.ts`) and pass it into the Ledger Chamber UI (`app/terminal/page.tsx`).
- Update the Ledger Chamber (`components/terminal/LedgerPanel.tsx`) to: focus default view on live committed agent records, show a collapsible section for live pending ingest, show a collapsible section for historical backfill, and render counters `live_ingest_count`, `live_committed_agent_count`, `backfill_count`, and `duplicate_suppressed_count`.
- Ensure the EVE cycle-advance ingest payload matches the expanded `IngestResult` shape by including `duplicateSuppressedCount: 0` in the cycle transition path (`app/api/eve/cycle-advance/route.ts`).

### Testing
- `npx tsc --noEmit` completed successfully with no type errors.
- `npm run lint` could not be completed in this environment due to an interactive Next.js ESLint setup prompt, so linting remains unverified.
- Manual sanity: updated UI props and new fields were wired through `useTerminalData` to `LedgerPanel` and type-check ensured the new `IngestResult` fields are present where required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf1507dd30832d9c2ab3dd84ff6706)