### PR TITLE
fix(epicon): unify promotable discovery and enable promotion trigger

### DIFF
--- a/app/api/epicon/promote/route.ts
+++ b/app/api/epicon/promote/route.ts
@@ -1,22 +1,45 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { Redis } from '@upstash/redis';
 import { getEchoEpicon, getEchoStatus } from '@/lib/echo/store';
 import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
-import type { EpiconItem } from '@/lib/terminal/types';
+import { getMemoryLedgerEntries } from '@/lib/epicon/memoryLedgerFeed';
 import type { EpiconLedgerFeedEntry } from '@/lib/epicon/ledgerFeedTypes';
+import type { EpiconItem } from '@/lib/terminal/types';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { defaultPromotionState, getPromotionState, savePromotionState } from '@/lib/epicon/promotion';
 
 export const dynamic = 'force-dynamic';
 
 type Agent = 'ZEUS' | 'JADE' | 'HERMES' | 'AUREA' | 'ATLAS';
+type PromotionState = Awaited<ReturnType<typeof getPromotionState>>;
+type PromotableCategory = EpiconItem['category'];
 
 const AGENT_ROUTING: Record<EpiconItem['category'], Agent[]> = {
   market: ['HERMES', 'ZEUS', 'AUREA'],
-  geopolitical: ['ZEUS', 'AUREA', 'ATLAS'],
+  geopolitical: ['ZEUS', 'AUREA'],
   infrastructure: ['ATLAS', 'ZEUS'],
   narrative: ['AUREA', 'JADE'],
   governance: ['ZEUS', 'JADE', 'AUREA'],
 };
+const PROMOTABLE_CATEGORIES = new Set<PromotableCategory>([
+  'market',
+  'infrastructure',
+  'geopolitical',
+  'governance',
+  'narrative',
+]);
+
+function getRedisClient(): Redis | null {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  try {
+    return new Redis({ url, token });
+  } catch {
+    return null;
+  }
+}
 
 function severityFromConfidence(confidenceTier: number): EpiconLedgerFeedEntry['severity'] {
   if (confidenceTier >= 3) return 'high';
@@ -57,21 +80,136 @@ function buildCommit(agent: Agent, epicon: EpiconItem, cycleId: string, seq: num
   };
 }
 
-function getPromotablePending(maxItems: number): EpiconItem[] {
-  return getEchoEpicon()
-    .filter((item) => item.status === 'pending')
+function parsePendingLedgerEntry(row: EpiconLedgerFeedEntry): EpiconItem | null {
+  const category = row.category;
+  if (!category || !PROMOTABLE_CATEGORIES.has(category as PromotableCategory)) return null;
+
+  const status = row.status ?? (row.verified ? 'committed' : 'pending');
+  if (status !== 'pending') return null;
+
+  const confidenceTier =
+    typeof row.confidenceTier === 'number' && Number.isInteger(row.confidenceTier) && row.confidenceTier >= 0 && row.confidenceTier <= 4
+      ? (row.confidenceTier as EpiconItem['confidenceTier'])
+      : 1;
+
+  return {
+    id: row.derivedFrom ?? row.id,
+    title: row.title,
+    category: category as PromotableCategory,
+    status: 'pending',
+    confidenceTier,
+    ownerAgent: row.author || 'ECHO',
+    sources: [],
+    timestamp: row.timestamp,
+    summary: row.body ?? row.title,
+    trace: [],
+    feedSource: row.source,
+  };
+}
+
+async function getLedgerPendingEpicon(): Promise<EpiconItem[]> {
+  const redis = getRedisClient();
+  const rows: EpiconLedgerFeedEntry[] = [];
+
+  if (redis) {
+    try {
+      const [primary, alias] = await Promise.all([
+        redis.lrange<string>('mobius:epicon:feed', 0, 199),
+        redis.lrange<string>('epicon:feed', 0, 199),
+      ]);
+
+      for (const raw of [...primary, ...alias]) {
+        try {
+          rows.push(JSON.parse(raw) as EpiconLedgerFeedEntry);
+        } catch {
+          // ignore malformed rows
+        }
+      }
+    } catch {
+      // continue with in-memory fallback
+    }
+  }
+
+  rows.push(...getMemoryLedgerEntries(200));
+  return rows.map(parsePendingLedgerEntry).filter((item): item is EpiconItem => item !== null);
+}
+
+async function getPromotablePending(state: PromotionState): Promise<EpiconItem[]> {
+  const fromEcho = getEchoEpicon();
+  const fromLedger = await getLedgerPendingEpicon();
+  const pendingById = new Map<string, EpiconItem>();
+
+  for (const item of [...fromEcho, ...fromLedger]) {
+    if (item.status !== 'pending') continue;
+    if (item.confidenceTier < 1) continue;
+    if (!PROMOTABLE_CATEGORIES.has(item.category)) continue;
+    if (state[item.id]?.promotion_state === 'promoted') continue;
+    pendingById.set(item.id, item);
+  }
+
+  return [...pendingById.values()]
     .sort((a, b) => {
       if (b.confidenceTier !== a.confidenceTier) return b.confidenceTier - a.confidenceTier;
       return parseTimestamp(b.timestamp) - parseTimestamp(a.timestamp);
-    })
-    .slice(0, maxItems);
+    });
 }
 
-export async function GET() {
+async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: string, state: PromotionState) {
+  const pending = (await getPromotablePending(state)).slice(0, maxItems);
+  let promoted = 0;
+  let committed = 0;
+  let failed = 0;
+  let seq = 1;
+
+  for (const epicon of pending) {
+    const existing = state[epicon.id] ?? defaultPromotionState(nowIso);
+    const assignedAgents = AGENT_ROUTING[epicon.category] ?? ['ZEUS'];
+
+    if (existing.promotion_state === 'promoted' && existing.assigned_agents.length > 0) {
+      continue;
+    }
+
+    existing.promotion_state = 'selected';
+    existing.assigned_agents = assignedAgents;
+    existing.last_attempt_at = nowIso;
+
+    try {
+      for (const agent of assignedAgents) {
+        const alreadyCommitted = existing.committed_entries.some((entryId) => entryId.includes(`-${agent}-`));
+        if (alreadyCommitted) continue;
+
+        const commit = buildCommit(agent, epicon, cycleId, seq++);
+        await pushLedgerEntry(commit);
+        existing.committed_entries.push(commit.id);
+        committed += 1;
+      }
+
+      existing.promotion_state = 'promoted';
+      promoted += 1;
+    } catch {
+      existing.promotion_state = 'failed';
+      existing.failed_attempts += 1;
+      failed += 1;
+    }
+
+    state[epicon.id] = existing;
+  }
+
+  await savePromotionState(state);
+  return { pending, promoted, committed, failed };
+}
+
+export async function GET(request: NextRequest) {
+  const runCycle = request.nextUrl.searchParams.get('trigger') === '1';
+  const maxItems = Number.parseInt(request.nextUrl.searchParams.get('maxItems') ?? '5', 10);
+  const boundedMaxItems = Number.isFinite(maxItems) ? Math.min(Math.max(maxItems, 1), 10) : 5;
   const nowIso = new Date().toISOString();
   const cycleId = currentCycleId();
-  const pending = getEchoEpicon().filter((item) => item.status === 'pending');
   const state = await getPromotionState();
+  if (runCycle) {
+    await runPromotionCycle(boundedMaxItems, nowIso, cycleId, state);
+  }
+  const pending = await getPromotablePending(state);
 
   let promotedThisCycle = 0;
   let committedAgentCount = 0;
@@ -113,57 +251,16 @@ export async function POST(request: NextRequest) {
   const maxItems = typeof body.maxItems === 'number' ? Math.min(Math.max(body.maxItems, 1), 10) : 5;
   const nowIso = new Date().toISOString();
   const cycleId = currentCycleId();
-  const pending = getPromotablePending(maxItems);
   const state = await getPromotionState();
-
-  let promoted = 0;
-  let committed = 0;
-  let failed = 0;
-  let seq = 1;
-
-  for (const epicon of pending) {
-    const existing = state[epicon.id] ?? defaultPromotionState(nowIso);
-    const assignedAgents = AGENT_ROUTING[epicon.category] ?? ['ZEUS'];
-
-    if (existing.promotion_state === 'promoted' && existing.assigned_agents.length > 0) {
-      continue;
-    }
-
-    existing.promotion_state = 'selected';
-    existing.assigned_agents = assignedAgents;
-    existing.last_attempt_at = nowIso;
-
-    try {
-      for (const agent of assignedAgents) {
-        const alreadyCommitted = existing.committed_entries.some((entryId) => entryId.includes(`-${agent}-`));
-        if (alreadyCommitted) continue;
-
-        const commit = buildCommit(agent, epicon, cycleId, seq++);
-        await pushLedgerEntry(commit);
-        existing.committed_entries.push(commit.id);
-        committed += 1;
-      }
-
-      existing.promotion_state = 'promoted';
-      promoted += 1;
-    } catch {
-      existing.promotion_state = 'failed';
-      existing.failed_attempts += 1;
-      failed += 1;
-    }
-
-    state[epicon.id] = existing;
-  }
-
-  await savePromotionState(state);
+  const run = await runPromotionCycle(maxItems, nowIso, cycleId, state);
 
   return NextResponse.json({
     ok: true,
     cycleId,
-    processed: pending.length,
-    promoted,
-    committed,
-    failed,
+    processed: run.pending.length,
+    promoted: run.promoted,
+    committed: run.committed,
+    failed: run.failed,
     maxItems,
     timestamp: nowIso,
   });

--- a/lib/terminal/api.ts
+++ b/lib/terminal/api.ts
@@ -273,7 +273,7 @@ export async function getEchoFeed(): Promise<EchoFeedData | null> {
 }
 
 export async function getPromotionStatus(): Promise<PromotionStatus | null> {
-  const raw = await fetchInternalJson('/api/epicon/promote');
+  const raw = await fetchInternalJson('/api/epicon/promote?trigger=1');
   if (!raw || typeof raw !== 'object') return null;
   const counters = (raw as { counters?: unknown }).counters;
   if (!counters || typeof counters !== 'object') return null;


### PR DESCRIPTION
### Motivation
- The promoter was not seeing the same pending EPICONs the UI renders, causing `live_ingest_count > 0` while `pending_promotable_count` stayed zero. 
- The promoter needed a relaxed, explicit promotable rule set so valid pending EPICONs become eligible for agent commits. 
- Promotion should be executable by the regular status polling path so promotion can run without manual POSTs or an external cron job.

### Description
- Merge candidate discovery from in-memory ECHO state and the ledger-backed intake (Redis + in-memory fallback) by adding `getLedgerPendingEpicon` and `parsePendingLedgerEntry` to normalize ledger rows into `EpiconItem` shapes. 
- Replace the old selector with `getPromotablePending(state)` that dedupes, filters (`status === 'pending'`, `confidenceTier >= 1`, allowed categories), and sorts candidates before promotion. 
- Add a reusable executor `runPromotionCycle(maxItems, nowIso, cycleId, state)` that writes agent commits via `pushLedgerEntry` and updates promotion state; expose it via `POST /api/epicon/promote` and `GET /api/epicon/promote?trigger=1` so status polling can optionally trigger a promotion run. 
- Adjust routing priorities (geopolitical now routes to `['ZEUS','AUREA']`) and add small type helpers (`PromotionState`, `PromotableCategory`) and a safe Upstash Redis client helper `getRedisClient`. 
- Update the terminal polling to call the trigger path by changing `getPromotionStatus()` to fetch `/api/epicon/promote?trigger=1` so the UI’s periodic status fetch can drive promotions automatically.

### Testing
- Typecheck: ran `npx tsc --noEmit` and it passed. 
- Lint: attempted `npm run lint` but the repository’s Next.js ESLint bootstrap is interactive and blocked non-interactive execution. 
- Basic integration: verified the promotion endpoint supports `GET /api/epicon/promote?trigger=1` and `POST /api/epicon/promote` and that the endpoint returns updated promotion counters and items after a run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf1affb740832d9170df95f422c435)