### PR TITLE
fix(terminal): resolve three data-not-loading bugs

### DIFF
--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -79,26 +79,24 @@ function TerminalPage() {
     let mounted = true;
 
     async function loadSidePanels() {
-      try {
-        const [agentsRes, microRes, kvRes] = await Promise.all([
-          fetch('/api/agents/status', { cache: 'no-store' }),
-          fetch('/api/signals/micro', { cache: 'no-store' }),
-          fetch('/api/kv/health', { cache: 'no-store' }),
-        ]);
-        const agentsJson: AgentStatusResponse = await agentsRes.json();
-        const microJson: MicroSweepResponse = await microRes.json();
-        const kvJson: KvHealthResponse = await kvRes.json();
-        if (!mounted) return;
+      const [agentsResult, microResult, kvResult] = await Promise.allSettled([
+        fetch('/api/agents/status', { cache: 'no-store' }).then((r) => r.json() as Promise<AgentStatusResponse>),
+        fetch('/api/signals/micro', { cache: 'no-store' }).then((r) => r.json() as Promise<MicroSweepResponse>),
+        fetch('/api/kv/health', { cache: 'no-store' }).then((r) => r.json() as Promise<KvHealthResponse>),
+      ]);
+      if (!mounted) return;
 
-        if (agentsJson.ok) setAgentRoster(agentsJson.agents ?? []);
-        if (microJson.ok) {
-          setMicro(microJson);
-          const time = new Date(microJson.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-          setMicroHistory((prev) => [...prev, { time, composite: microJson.composite }].slice(-12));
-        }
-        setKvLatency(kvJson.latencyMs ?? null);
-      } catch {
-        // silent degradation
+      if (agentsResult.status === 'fulfilled' && agentsResult.value.ok) {
+        setAgentRoster(agentsResult.value.agents ?? []);
+      }
+      if (microResult.status === 'fulfilled' && microResult.value.ok) {
+        const microJson = microResult.value;
+        setMicro(microJson);
+        const time = new Date(microJson.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        setMicroHistory((prev) => [...prev, { time, composite: microJson.composite }].slice(-12));
+      }
+      if (kvResult.status === 'fulfilled') {
+        setKvLatency(kvResult.value.latencyMs ?? null);
       }
     }
 

--- a/hooks/useTerminalData.ts
+++ b/hooks/useTerminalData.ts
@@ -216,6 +216,7 @@ export function useTerminalData(selectedNav: NavKey) {
     let mounted = true;
 
     async function loadEcho() {
+      try {
       const [feed, promotion] = await Promise.all([getEchoFeed(), getPromotionStatus()]);
       if (!mounted || !feed) return;
 
@@ -252,6 +253,9 @@ export function useTerminalData(selectedNav: NavKey) {
             committedEntries: row.committed_entries,
           };
         }));
+      }
+      } catch {
+        // silent degradation — echo data unavailable
       }
     }
 

--- a/lib/terminal/api.ts
+++ b/lib/terminal/api.ts
@@ -182,7 +182,7 @@ export async function getEpiconFeed(): Promise<EpiconFeedBundle> {
     return { epicon: mockEpicon, ledgerRows: [] };
   }
   const items = (raw as { items?: unknown }).items;
-  if (!Array.isArray(items)) {
+  if (!Array.isArray(items) || items.length === 0) {
     return { epicon: mockEpicon, ledgerRows: [] };
   }
 


### PR DESCRIPTION
- getEpiconFeed() now falls back to mockEpicon when the feed returns an empty items array (e.g. GitHub rate-limited, no Redis), preventing the Pulse Ledger from going blank
- loadEcho() wrapped in try/catch so unexpected exceptions don't break the 15s polling interval silently
- loadSidePanels() switched to Promise.allSettled so a single failing API (e.g. /api/signals/micro returning 500) no longer prevents the Agent Roster and KV Latency panels from loading

https://claude.ai/code/session_015j7zAAPeXWgZbMt7ECx1ni