### PR TITLE
fix(terminal): restore client runtime stability on production

### DIFF
--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -478,7 +478,11 @@ type LedgerRowProps = {
 const LedgerRow = memo(function LedgerRow({ entry, isSelected, isExpanded, onSelect }: LedgerRowProps) {
   const confidence = Math.min(100, Math.max(10, Math.round(((entry.confidenceTier ?? 2) / 4) * 100)));
   const relTime = useRelativeTime(entry.timestamp);
-  const isoTime = new Date(entry.timestamp).toISOString();
+  const isoTime = useMemo(() => {
+    const parsed = new Date(entry.timestamp);
+    if (Number.isNaN(parsed.getTime())) return undefined;
+    return parsed.toISOString();
+  }, [entry.timestamp]);
 
   const handleSelect = useCallback(() => {
     onSelect(entry.id);
@@ -495,7 +499,7 @@ const LedgerRow = memo(function LedgerRow({ entry, isSelected, isExpanded, onSel
               <div className="truncate text-xs text-slate-500">{entry.summary}</div>
             </div>
           </div>
-          <time dateTime={isoTime} title={isoTime} className="shrink-0 text-right text-[10px] font-mono text-slate-500">{relTime}</time>
+          <time dateTime={isoTime} title={isoTime ?? entry.timestamp} className="shrink-0 text-right text-[10px] font-mono text-slate-500">{relTime}</time>
         </div>
         <div className="mt-2 flex items-center gap-2 text-[10px] font-mono text-slate-400">
           <span>confidence</span>


### PR DESCRIPTION
### Motivation
- The terminal client was crashing during hydration when rendering ledger rows because `new Date(entry.timestamp).toISOString()` was called unguarded and throws for invalid timestamps.
- The change aims to make client rendering resilient to malformed ledger data so the `/terminal` page no longer triggers a client-side exception.

### Description
- Replace the direct `toISOString()` call with a safe conversion using `useMemo` that returns `undefined` when `new Date(entry.timestamp)` is invalid in `LedgerRow` in `app/terminal/page.tsx`.
- Update the `<time>` element to use the safe `isoTime` for `dateTime` and fall back to the raw `entry.timestamp` for the tooltip when `isoTime` is not available.
- Keep the displayed relative time logic unchanged so UI remains consistent when timestamps are valid.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully after the patch.
- `npm run lint` could not be run non-interactively in this environment because `next lint` prompts for initial ESLint configuration, so it did not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d11f0a2888832d86732a160dd9ce09)