### PR TITLE
feat(identity): soulbound MIC wallet — KV-persisted stable identity [C-630]

### DIFF
--- a/app/api/identity/me/route.ts
+++ b/app/api/identity/me/route.ts
@@ -1,15 +1,32 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getIdentity, getIdentityPermissions } from '@/lib/identity/store';
+import { getPermissionsForRole } from '@/lib/identity/permissions';
+import { getOrCreateIdentity } from '@/lib/identity/identityStore';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(req: NextRequest) {
-  const username = req.nextUrl.searchParams.get('username') || 'kaizencycle';
-  const identity = getIdentity(username);
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': 'https://mobius-browser-shell.vercel.app',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+} as const;
 
-  return NextResponse.json({
-    ok: true,
-    identity,
-    permissions: getIdentityPermissions(username),
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: CORS_HEADERS,
   });
+}
+
+export async function GET(_req: NextRequest) {
+  const identity = await getOrCreateIdentity();
+
+  return NextResponse.json(
+    {
+      ok: true,
+      identity,
+      permissions: getPermissionsForRole(identity.role === 'operator' ? 'developer' : identity.role),
+    },
+    {
+      headers: CORS_HEADERS,
+    },
+  );
 }

--- a/app/api/identity/sync/route.ts
+++ b/app/api/identity/sync/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { syncIdentityRecord } from '@/lib/identity/identityStore';
+
+export const dynamic = 'force-dynamic';
+
+type SyncPayload = {
+  username?: string;
+  source?: string;
+};
+
+function isAuthorized(req: NextRequest): boolean {
+  const cronSecret = process.env.CRON_SECRET;
+  const serviceSecret = process.env.MOBIUS_SERVICE_SECRET;
+  const providedCronSecret = req.headers.get('x-cron-secret');
+  const providedServiceSecret = req.headers.get('x-mobius-service-secret');
+
+  if (cronSecret && providedCronSecret === cronSecret) {
+    return true;
+  }
+
+  if (serviceSecret && providedServiceSecret === serviceSecret) {
+    return true;
+  }
+
+  return false;
+}
+
+export async function POST(req: NextRequest) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const payload = (await req.json().catch(() => ({}))) as SyncPayload;
+
+  try {
+    const { identity, mic } = await syncIdentityRecord(payload.username);
+
+    return NextResponse.json({
+      ok: true,
+      identity,
+      mic,
+      source: payload.source ?? 'unknown',
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to sync identity';
+    return NextResponse.json({ ok: false, error: message }, { status: 400 });
+  }
+}

--- a/app/api/mic/account/route.ts
+++ b/app/api/mic/account/route.ts
@@ -1,25 +1,39 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getMicAccount } from '@/lib/mic/store';
-import { getIdentity } from '@/lib/identity/store';
+import { getMICAccount, getOrCreateIdentity } from '@/lib/identity/identityStore';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(req: NextRequest) {
-  const login = req.nextUrl.searchParams.get('login') || 'kaizencycle';
-  const identity = getIdentity(login);
-  const account = getMicAccount(login);
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': 'https://mobius-browser-shell.vercel.app',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+} as const;
 
-  return NextResponse.json({
-    ok: true,
-    account: {
-      login: account.login,
-      balance: account.balance,
-      mobius_id: identity.mobius_id,
-      role: identity.role,
-      locked: 0,
-      rewards_earned: 0,
-      mic_burned: 0,
-      updated_at: new Date().toISOString(),
-    },
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: CORS_HEADERS,
   });
+}
+
+export async function GET(_req: NextRequest) {
+  const [identity, account] = await Promise.all([getOrCreateIdentity(), getMICAccount()]);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      account: {
+        login: account.login,
+        balance: account.balance,
+        mobius_id: identity.mobius_id,
+        role: identity.role,
+        locked: account.locked,
+        rewards_earned: account.rewards_earned,
+        mic_burned: account.mic_burned,
+        updated_at: account.updated_at,
+      },
+    },
+    {
+      headers: CORS_HEADERS,
+    },
+  );
 }

--- a/lib/identity/identityStore.ts
+++ b/lib/identity/identityStore.ts
@@ -1,0 +1,120 @@
+import { kvGet, kvSet } from '@/lib/kv/store';
+
+const OPERATOR_USERNAME = 'kaizencycle';
+const IDENTITY_KEY = `identity:${OPERATOR_USERNAME}`;
+const MIC_KEY = `mic:${OPERATOR_USERNAME}`;
+
+export interface MobiusIdentity {
+  mobius_id: string;
+  ledger_id: string;
+  username: string;
+  display_name: string;
+  role: 'developer' | 'operator' | 'observer';
+  status: 'active' | 'suspended';
+  mii_score: number;
+  mic_balance: number;
+  epicon_count: number;
+  agent_permissions: string[];
+  joined_at: string;
+  last_active_at: string;
+}
+
+export interface MICAccount {
+  login: string;
+  balance: number;
+  locked: number;
+  rewards_earned: number;
+  mic_burned: number;
+  updated_at: string;
+}
+
+function sanitizeBase64(value: string): string {
+  return value.replace(/[^a-z0-9]/gi, '').toLowerCase();
+}
+
+function deterministicId(prefix: 'mbx' | 'ldr', seed: string): string {
+  const encoded = Buffer.from(seed).toString('base64');
+  const stable = sanitizeBase64(encoded).slice(0, 8).padEnd(8, '0');
+  return `${prefix}_${stable}`;
+}
+
+function createDefaultMICAccount(now: string): MICAccount {
+  return {
+    login: OPERATOR_USERNAME,
+    balance: 100,
+    locked: 0,
+    rewards_earned: 0,
+    mic_burned: 0,
+    updated_at: now,
+  };
+}
+
+function createDefaultIdentity(now: string, micBalance: number): MobiusIdentity {
+  return {
+    mobius_id: deterministicId('mbx', OPERATOR_USERNAME),
+    ledger_id: deterministicId('ldr', `${OPERATOR_USERNAME}:ledger`),
+    username: OPERATOR_USERNAME,
+    display_name: 'Michael',
+    role: 'developer',
+    status: 'active',
+    mii_score: 0.5,
+    mic_balance: micBalance,
+    epicon_count: 0,
+    agent_permissions: ['ECHO', 'ZEUS', 'ATLAS', 'AUREA'],
+    joined_at: now,
+    last_active_at: now,
+  };
+}
+
+export async function getMICAccount(): Promise<MICAccount> {
+  const existing = await kvGet<MICAccount>(MIC_KEY);
+  if (existing) {
+    return existing;
+  }
+
+  const now = new Date().toISOString();
+  const created = createDefaultMICAccount(now);
+  await kvSet(MIC_KEY, created);
+  return created;
+}
+
+export async function updateMICBalance(delta: number): Promise<MICAccount> {
+  const current = await getMICAccount();
+  const updated: MICAccount = {
+    ...current,
+    balance: Math.max(0, current.balance + delta),
+    updated_at: new Date().toISOString(),
+  };
+
+  await kvSet(MIC_KEY, updated);
+  return updated;
+}
+
+export async function getOrCreateIdentity(): Promise<MobiusIdentity> {
+  const micAccount = await getMICAccount();
+  const now = new Date().toISOString();
+  const existing = await kvGet<MobiusIdentity>(IDENTITY_KEY);
+
+  if (existing) {
+    const updated: MobiusIdentity = {
+      ...existing,
+      mic_balance: micAccount.balance,
+      last_active_at: now,
+    };
+    await kvSet(IDENTITY_KEY, updated);
+    return updated;
+  }
+
+  const created = createDefaultIdentity(now, micAccount.balance);
+  await kvSet(IDENTITY_KEY, created);
+  return created;
+}
+
+export async function syncIdentityRecord(username?: string): Promise<{ identity: MobiusIdentity; mic: MICAccount }> {
+  if (username && username !== OPERATOR_USERNAME) {
+    throw new Error('Unsupported username');
+  }
+
+  const [identity, mic] = await Promise.all([getOrCreateIdentity(), getMICAccount()]);
+  return { identity, mic };
+}


### PR DESCRIPTION
### Motivation
- Fix ephemeral identity and hardcoded MIC balance so `mobius_id`/`ledger_id` and MIC balances are stable and durable across requests. 
- Make MIC soulbound to a deterministic operator identity so the browser shell and terminal share the same wallet state. 
- Provide a secure sync surface and cross-origin access so external surfaces (browser shell) can read/sync the KV-backed identity. 

### Description
- Add a KV-backed identity + MIC store at `lib/identity/identityStore.ts` with deterministic ID derivation (`deterministicId`), `getMICAccount`, `updateMICBalance`, `getOrCreateIdentity`, and `syncIdentityRecord` using the existing `kvGet`/`kvSet` layer and keys `identity:kaizencycle` and `mic:kaizencycle`.
- Replace ephemeral generation in `app/api/identity/me/route.ts` with `getOrCreateIdentity()` and map role permissions via `getPermissionsForRole`, while adding `OPTIONS` + CORS headers for the browser shell origin.
- Replace hardcoded MIC response in `app/api/mic/account/route.ts` with KV-backed `getMICAccount()` (joined with `getOrCreateIdentity()`), preserve response shape, and add `OPTIONS` + CORS headers.
- Add new authenticated `POST /api/identity/sync` at `app/api/identity/sync/route.ts` that accepts `{ username?, source? }`, validates `x-cron-secret` or `x-mobius-service-secret`, and returns the KV-backed identity and MIC account for cross-surface sync.

### Testing
- Type-checking passed with `pnpm exec tsc --noEmit` (no errors).
- Lint run with `pnpm lint` could not complete non-interactively due to the repository's interactive Next.js ESLint setup prompt, so automated linting did not finish.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d129d0ef1c832d831f77931fe75909)