### PR TITLE
feat(ledger): improve EventScreener search and detail actions [C-270]

### DIFF
--- a/components/terminal/EventScreener.tsx
+++ b/components/terminal/EventScreener.tsx
@@ -108,7 +108,7 @@ export default function EventScreener({ items, summary, sources, total }: EventS
       if (typeFilter !== 'all' && item.type !== typeFilter) return false;
       if (authorFilter !== 'all' && item.author !== authorFilter) return false;
       if (!needle) return true;
-      const haystack = `${item.title} ${item.id} ${item.source} ${(item.tags ?? []).join(' ')}`.toLowerCase();
+      const haystack = `${item.title} ${item.author} ${item.type} ${item.id} ${item.source} ${(item.tags ?? []).join(' ')}`.toLowerCase();
       return haystack.includes(needle);
     });
 
@@ -220,7 +220,7 @@ export default function EventScreener({ items, summary, sources, total }: EventS
             setSearchQuery(event.target.value);
             setPage(0);
           }}
-          placeholder="Search title, id, tags..."
+          placeholder="Search title, author, type..."
           className="min-w-48 flex-1 rounded border border-slate-800 bg-slate-900 px-2 py-1 text-[10px] font-mono text-slate-200 placeholder:text-slate-600"
         />
 
@@ -356,10 +356,32 @@ export default function EventScreener({ items, summary, sources, total }: EventS
           ) : null}
 
           <div className="mt-3 flex flex-wrap gap-2 border-t border-slate-800 pt-3">
-            <a href="/api/epicon/candidates" className="rounded border border-slate-700 px-2 py-1 text-[10px] font-mono text-slate-300 hover:border-sky-500/40 hover:text-sky-300">
-              Analyze event
+            <a
+              href={`/terminal?chat=${encodeURIComponent(`Analyze event ${selected.id}: ${selected.title}`)}`}
+              className="rounded border border-slate-700 px-2 py-1 text-[10px] font-mono text-slate-300 hover:border-sky-500/40 hover:text-sky-300"
+            >
+              Analyze
             </a>
-            <a href="/api/zeus/verify?concept=event" className="rounded border border-slate-700 px-2 py-1 text-[10px] font-mono text-slate-300 hover:border-sky-500/40 hover:text-sky-300">
+            <a
+              href={`/terminal?chat=${encodeURIComponent(`Estimate GI impact for event ${selected.id}`)}`}
+              className="rounded border border-slate-700 px-2 py-1 text-[10px] font-mono text-slate-300 hover:border-sky-500/40 hover:text-sky-300"
+            >
+              GI impact
+            </a>
+            <a
+              href={`/terminal?chat=${encodeURIComponent(
+                selected.sha
+                  ? `Explain commit ${selected.sha.slice(0, 12)} and its civic impact`
+                  : `Explain GI context for event ${selected.id}`,
+              )}`}
+              className="rounded border border-slate-700 px-2 py-1 text-[10px] font-mono text-slate-300 hover:border-sky-500/40 hover:text-sky-300"
+            >
+              {selected.sha ? 'Explain commit' : 'Explain GI'}
+            </a>
+            <a
+              href="/api/zeus/verify?concept=event"
+              className="rounded border border-slate-700 px-2 py-1 text-[10px] font-mono text-slate-300 hover:border-sky-500/40 hover:text-sky-300"
+            >
               ZEUS verify
             </a>
           </div>


### PR DESCRIPTION
### Motivation
- Make the Ledger chamber's Event Screener more useful for operators by expanding the free-text search surface and adding quick action links that route into the terminal chat for rapid analysis and GI estimation.

### Description
- Expanded free-text filtering in `components/terminal/EventScreener.tsx` to include `title`, `author`, and `type` in the searchable `haystack` and updated the search input placeholder to `"Search title, author, type..."`.
- Added deep-link action buttons in the detail panel that open the terminal chat with prefilled prompts for `Analyze`, `GI impact`, and a conditional `Explain commit` / `Explain GI` label based on SHA presence, while keeping the existing `ZEUS verify` action and EVE source badge behavior.
- Kept existing sort, pagination, and detail-panel rendering behavior; no new dependencies introduced and component still renders loading/skeleton and empty states correctly.

### Testing
- Ran TypeScript checks with `npx tsc --noEmit` which completed successfully (no type errors).
- No additional automated unit tests were added or run in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1b7243000832d9263c2c06f467223)