### PR TITLE
feat(ui): replace terminal status badges with search + sort bar [C-271]

### DIFF
--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -81,6 +81,9 @@ function TerminalPage() {
   const [kvLatency, setKvLatency] = useState<number | null>(null);
   const [ledgerExpanded, setLedgerExpanded] = useState(false);
   const [epiconFeed, setEpiconFeed] = useState<EpiconFeedResponse | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortBy, setSortBy] = useState<'time-desc' | 'time-asc' | 'type' | 'author' | 'gi-desc' | 'severity'>('time-desc');
+  const [resultCount, setResultCount] = useState(0);
   const agentSearchRef = useRef<HTMLInputElement>(null);
 
   const { allTripwires, filteredEpicon, gi, integrityStatus, mergedLedger, streamStatus } = useTerminalData(selectedNav);
@@ -267,6 +270,9 @@ function TerminalPage() {
             summary={epiconFeed?.summary ?? {}}
             sources={epiconFeed?.sources ?? { github: 0, kv: 0 }}
             total={epiconFeed?.total ?? 0}
+            searchQuery={searchQuery}
+            sortBy={sortBy}
+            onResultCountChange={setResultCount}
           />
         </section>
       );
@@ -380,20 +386,80 @@ function TerminalPage() {
                 </div>
               </div>
 
-              <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-                <div className="rounded-lg border border-slate-800 bg-slate-950/70 px-3 py-2 text-[11px] font-mono uppercase tracking-[0.12em] text-slate-300">
-                  @KAIZENCYCLE · DEVELOPER · MII 0.50 · MIC 100
-                </div>
-                <div className="flex gap-2 overflow-x-auto pb-1 xl:justify-end">
-                  {statusChips.slice(0, 5).map((chip) => (
-                    <button
-                      key={chip.label}
-                      onClick={() => setSelectedNav(chip.nav)}
-                      className={cn('whitespace-nowrap rounded-md border px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em]', chip.tone)}
+              <div className="border-t border-slate-800/80 pt-2">
+                <div className="flex items-center gap-3">
+                  <div className="relative max-w-sm flex-1">
+                    <svg
+                      className="pointer-events-none absolute left-2.5 top-1/2 h-3 w-3 -translate-y-1/2 text-slate-500"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
                     >
-                      {chip.label}
-                    </button>
-                  ))}
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M17 11A6 6 0 111 11a6 6 0 0116 0z" />
+                    </svg>
+                    <input
+                      type="text"
+                      placeholder="Search events, agents, signals..."
+                      value={searchQuery}
+                      onChange={(event) => setSearchQuery(event.target.value)}
+                      className="w-full rounded-md border border-slate-800 bg-slate-900 py-1.5 pl-8 pr-3 text-[11px] font-mono uppercase tracking-[0.06em] text-slate-300 placeholder:text-slate-600 transition-colors focus:border-sky-500/50 focus:outline-none focus:ring-1 focus:ring-sky-500/20"
+                    />
+                    {searchQuery ? (
+                      <button
+                        onClick={() => setSearchQuery('')}
+                        className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500 transition-colors hover:text-slate-300"
+                      >
+                        <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                      </button>
+                    ) : null}
+                  </div>
+
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-[9px] font-mono uppercase tracking-widest text-slate-600">Sort</span>
+                    <select
+                      value={sortBy}
+                      onChange={(event) => setSortBy(event.target.value as typeof sortBy)}
+                      className="cursor-pointer appearance-none rounded-md border border-slate-800 bg-slate-900 px-2 py-1.5 pr-6 text-[11px] font-mono text-slate-400 transition-colors focus:border-sky-500/50 focus:outline-none"
+                      style={{
+                        backgroundImage:
+                          "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%2364748b' stroke-width='2'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19 9l-7 7-7-7'/%3E%3C/svg%3E\")",
+                        backgroundRepeat: 'no-repeat',
+                        backgroundPosition: 'right 6px center',
+                        backgroundSize: '10px',
+                      }}
+                    >
+                      <option value="time-desc">Newest first</option>
+                      <option value="time-asc">Oldest first</option>
+                      <option value="type">By type</option>
+                      <option value="author">By author</option>
+                      <option value="gi-desc">GI high → low</option>
+                      <option value="severity">By severity</option>
+                    </select>
+                  </div>
+
+                  {searchQuery ? (
+                    <span className="whitespace-nowrap text-[10px] font-mono text-slate-500">
+                      {resultCount} result{resultCount !== 1 ? 's' : ''}
+                    </span>
+                  ) : null}
+
+                  <div className="ml-auto">
+                    <div
+                      className={cn(
+                        'rounded border px-2 py-1 text-[10px] font-mono uppercase tracking-widest',
+                        giScore > 0.85
+                          ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400'
+                          : giScore > 0.7
+                            ? 'border-amber-500/30 bg-amber-500/10 text-amber-400'
+                            : 'border-red-500/30 bg-red-500/10 text-red-400',
+                      )}
+                    >
+                      GI {giScore.toFixed(2)}
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/components/terminal/EventScreener.tsx
+++ b/components/terminal/EventScreener.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type ReactNode, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { cn } from '@/lib/utils';
 
 export interface EpiconFeedItem {
@@ -22,6 +22,9 @@ interface EventScreenerProps {
   summary: { latestGI?: number; degradedCount?: number; lastHeartbeat?: string };
   sources: { github: number; kv: number };
   total: number;
+  searchQuery?: string;
+  sortBy?: 'time-desc' | 'time-asc' | 'type' | 'author' | 'gi-desc' | 'severity';
+  onResultCountChange?: (count: number) => void;
 }
 
 const PAGE_SIZE = 12;
@@ -90,26 +93,54 @@ function sourceLabel(source: string): string {
   return source.length > 10 ? source.slice(0, 10) : source;
 }
 
-export default function EventScreener({ items, summary, sources, total }: EventScreenerProps) {
+export default function EventScreener({
+  items,
+  summary,
+  sources,
+  total,
+  searchQuery: externalSearchQuery,
+  sortBy,
+  onResultCountChange,
+}: EventScreenerProps) {
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
   const [authorFilter, setAuthorFilter] = useState<AuthorFilter>('all');
-  const [searchQuery, setSearchQuery] = useState('');
   const [sortCol, setSortCol] = useState<SortColumn>('time');
   const [sortDir, setSortDir] = useState<1 | -1>(-1);
   const [page, setPage] = useState(0);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [localSearchQuery, setLocalSearchQuery] = useState('');
+
+  const searchQuery = externalSearchQuery ?? localSearchQuery;
 
   const list = items ?? [];
 
   const filteredAndSorted = useMemo(() => {
     const needle = searchQuery.trim().toLowerCase();
+    const severityRank: Record<string, number> = { critical: 0, elevated: 1, nominal: 2 };
 
-    const filtered = list.filter((item) => {
+    const externallyFiltered = list.filter((item) => {
+      if (!needle) return true;
+      return (
+        item.title?.toLowerCase().includes(needle) ||
+        item.author?.toLowerCase().includes(needle) ||
+        item.type?.toLowerCase().includes(needle) ||
+        (item.tags ?? []).some((tag) => tag.toLowerCase().includes(needle))
+      );
+    });
+
+    const externallySorted = [...externallyFiltered].sort((a, b) => {
+      if (sortBy === 'time-asc') return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+      if (sortBy === 'type') return (a.type ?? '').localeCompare(b.type ?? '');
+      if (sortBy === 'author') return (a.author ?? '').localeCompare(b.author ?? '');
+      if (sortBy === 'gi-desc') return (b.gi ?? -1) - (a.gi ?? -1);
+      if (sortBy === 'severity') return (severityRank[a.severity?.toLowerCase()] ?? Number.MAX_SAFE_INTEGER) - (severityRank[b.severity?.toLowerCase()] ?? Number.MAX_SAFE_INTEGER);
+      return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+    });
+
+    const filtered = externallySorted.filter((item) => {
       if (typeFilter !== 'all' && item.type !== typeFilter) return false;
       if (authorFilter !== 'all' && item.author !== authorFilter) return false;
-      if (!needle) return true;
-      const haystack = `${item.title} ${item.author} ${item.type} ${item.id} ${item.source} ${(item.tags ?? []).join(' ')}`.toLowerCase();
-      return haystack.includes(needle);
+      return true;
     });
 
     return [...filtered].sort((a, b) => {
@@ -124,7 +155,11 @@ export default function EventScreener({ items, summary, sources, total }: EventS
       }
       return sortDir * ((a.gi ?? -1) - (b.gi ?? -1));
     });
-  }, [authorFilter, list, searchQuery, sortCol, sortDir, typeFilter]);
+  }, [authorFilter, list, searchQuery, sortBy, sortCol, sortDir, typeFilter]);
+
+  useEffect(() => {
+    onResultCountChange?.(filteredAndSorted.length);
+  }, [filteredAndSorted.length, onResultCountChange]);
 
   const pageCount = Math.max(1, Math.ceil(filteredAndSorted.length / PAGE_SIZE));
   const currentPage = Math.min(page, pageCount - 1);
@@ -217,7 +252,7 @@ export default function EventScreener({ items, summary, sources, total }: EventS
         <input
           value={searchQuery}
           onChange={(event) => {
-            setSearchQuery(event.target.value);
+            setLocalSearchQuery(event.target.value);
             setPage(0);
           }}
           placeholder="Search title, author, type..."

--- a/components/terminal/TerminalShellFallback.tsx
+++ b/components/terminal/TerminalShellFallback.tsx
@@ -1,10 +1,18 @@
 'use client';
 
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+
 export default function TerminalShellFallback({
   statusLabel = 'Booting Mobius Terminal...',
 }: {
   statusLabel?: string;
 }) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortBy, setSortBy] = useState('time-desc');
+  const resultCount: number = 0;
+  const [gi] = useState<number | null>(null);
+
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
       <div className="border-b border-slate-800 bg-slate-950/90 px-4 py-3 backdrop-blur">
@@ -20,13 +28,80 @@ export default function TerminalShellFallback({
         {statusLabel}
       </div>
 
-      <div className="border-b border-slate-800 bg-slate-950/80 px-4 py-3">
-        <div className="flex flex-wrap gap-2">
-          {['GI --', 'MII --', 'MIC --', 'TRIPWIRE WATCH', 'LEDGER syncing', 'INGEST checking', 'CYCLE checking'].map((item) => (
-            <div key={item} className="rounded-md border border-slate-800 bg-slate-900 px-2.5 py-1 text-[10px] font-mono uppercase tracking-[0.15em] text-slate-500">
-              {item}
+      <div className="border-b border-slate-800 bg-slate-950/80 px-4 py-2.5">
+        <div className="flex items-center gap-3">
+          <div className="relative max-w-sm flex-1">
+            <svg
+              className="pointer-events-none absolute left-2.5 top-1/2 h-3 w-3 -translate-y-1/2 text-slate-500"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M17 11A6 6 0 111 11a6 6 0 0116 0z" />
+            </svg>
+            <input
+              type="text"
+              placeholder="Search events, agents, signals..."
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              className="w-full rounded-md border border-slate-800 bg-slate-900 py-1.5 pl-8 pr-3 text-[11px] font-mono uppercase tracking-[0.06em] text-slate-300 placeholder:text-slate-600 transition-colors focus:border-sky-500/50 focus:outline-none focus:ring-1 focus:ring-sky-500/20"
+            />
+            {searchQuery ? (
+              <button
+                onClick={() => setSearchQuery('')}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500 transition-colors hover:text-slate-300"
+              >
+                <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            ) : null}
+          </div>
+
+          <div className="flex items-center gap-1.5">
+            <span className="text-[9px] font-mono uppercase tracking-widest text-slate-600">Sort</span>
+            <select
+              value={sortBy}
+              onChange={(event) => setSortBy(event.target.value)}
+              className="cursor-pointer appearance-none rounded-md border border-slate-800 bg-slate-900 px-2 py-1.5 pr-6 text-[11px] font-mono text-slate-400 transition-colors focus:border-sky-500/50 focus:outline-none"
+              style={{
+                backgroundImage:
+                  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%2364748b' stroke-width='2'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19 9l-7 7-7-7'/%3E%3C/svg%3E\")",
+                backgroundRepeat: 'no-repeat',
+                backgroundPosition: 'right 6px center',
+                backgroundSize: '10px',
+              }}
+            >
+              <option value="time-desc">Newest first</option>
+              <option value="time-asc">Oldest first</option>
+              <option value="type">By type</option>
+              <option value="author">By author</option>
+              <option value="gi-desc">GI high → low</option>
+              <option value="severity">By severity</option>
+            </select>
+          </div>
+
+          {searchQuery ? (
+            <span className="whitespace-nowrap text-[10px] font-mono text-slate-500">
+              {resultCount} result{resultCount !== 1 ? 's' : ''}
+            </span>
+          ) : null}
+
+          <div className="ml-auto">
+            <div
+              className={cn(
+                'rounded border px-2 py-1 text-[10px] font-mono uppercase tracking-widest',
+                gi != null && gi > 0.85
+                  ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400'
+                  : gi != null && gi > 0.7
+                    ? 'border-amber-500/30 bg-amber-500/10 text-amber-400'
+                    : 'border-red-500/30 bg-red-500/10 text-red-400',
+              )}
+            >
+              GI {gi?.toFixed(2) ?? '--'}
             </div>
-          ))}
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- Replace the fragile badge-pill row in the terminal header with a single search input and sort control to make event/agent/signal discovery keyboard-first and consistent with operator workflows.  
- Surface a compact GI chip in the same bar while removing the other status pills so system integrity remains visible but the toolbar becomes the primary control for the feed.  
- Ensure the static/resilient fallback shell mirrors the new toolbar so prerendered pages reflect the intended UI while client hydration is resolved.

### Description
- Added top-level state `searchQuery`, `sortBy`, and `resultCount` to the terminal page and rendered the search + sort toolbar (with compact GI chip) in `app/terminal/page.tsx`.  
- Extended `EventScreener` to accept `searchQuery`, `sortBy`, and `onResultCountChange` props, implemented external filtering predicates and sorting modes (`time-desc`, `time-asc`, `type`, `author`, `gi-desc`, `severity`), and wired the filtered count back via the callback in `components/terminal/EventScreener.tsx`.  
- Replaced the old badge pills in the resilient shell with the same search/sort toolbar and added minimal local state so the prerender fallback reflects the new UI in `components/terminal/TerminalShellFallback.tsx`.  
- Preserved existing client-component configuration and TypeScript strictness and did not add any new npm packages.

### Testing
- Ran `npm -s run -s tsc -- --noEmit` in this environment which failed due to the repository's npm script configuration.  
- Ran `npx tsc --noEmit` after addressing type issues which completed successfully, confirming the TypeScript build passes.  
- No additional automated unit/integration tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1ba18a4ec832db622eeaf192d9ca1)