### PR TITLE
feat(eve): schedule Vercel cron for cycle synthesis and align CRON auth

### DIFF
--- a/app/api/eve/cycle-synthesize/route.ts
+++ b/app/api/eve/cycle-synthesize/route.ts
@@ -1,6 +1,8 @@
 /**
- * POST /api/eve/cycle-synthesize — EVE governance / ethics synthesis → live EPICON ledger (C-270).
- * Bearer: MOBIUS_SERVICE_SECRET | CRON_SECRET | BACKFILL_SECRET
+ * EVE governance / ethics synthesis → live EPICON ledger (C-270).
+ *
+ * GET — public preview (windowBucket, idempotencyTagPreview) or Vercel Cron cycle run when platform headers present.
+ * POST — Bearer MOBIUS_SERVICE_SECRET | CRON_SECRET | BACKFILL_SECRET (or Vercel Cron without Bearer).
  *
  * Body: `{}` for cycle window synthesis, or `{ "mode": "escalation", "reason": "gi_critical" }`
  * for escalation-class synthesis (same auth; distinct idempotency when reason is set).
@@ -16,7 +18,7 @@ import {
   processEveEscalationSynthesis,
 } from '@/lib/eve/governance-synthesis';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
-import { getServiceAuthError } from '@/lib/security/serviceAuth';
+import { getEveSynthesisAuthError, isVercelCronInvocation } from '@/lib/security/serviceAuth';
 import { runSignalEngine } from '@/lib/signals/engine';
 
 export const dynamic = 'force-dynamic';
@@ -48,14 +50,21 @@ function parseCycleBody(body: unknown): {
   return { cycleId, force, mode, reason };
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   const cycleId = currentCycleId();
   const windowBucket = cycleWindowBucket(Date.now());
   const idempotencyTag = cycleSynthesisIdempotencyTag(cycleId, windowBucket);
 
+  /** Platform-scheduled cron only — keeps unauthenticated GET as a safe preview for STEP 2 of external automations. */
+  if (isVercelCronInvocation(request)) {
+    await runSignalEngine();
+    const payload = await processEveCycleWindowSynthesis(cycleId, false);
+    return NextResponse.json(payload);
+  }
+
   return NextResponse.json({
     ok: true,
-    info: 'POST with service Authorization to run EVE governance synthesis (live EPICON ledger)',
+    info: 'POST with service Authorization to run EVE governance synthesis (live EPICON ledger). Vercel Cron GET runs cycle synthesis when scheduled.',
     mode: 'cycle',
     currentCycle: cycleId,
     windowBucket,
@@ -64,7 +73,7 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
-  const authErr = getServiceAuthError(request);
+  const authErr = getEveSynthesisAuthError(request);
   if (authErr) return authErr;
 
   let body: unknown = {};

--- a/app/api/eve/escalation-synthesize/route.ts
+++ b/app/api/eve/escalation-synthesize/route.ts
@@ -8,7 +8,7 @@ import { NextResponse } from 'next/server';
 
 import { processEveEscalationSynthesis } from '@/lib/eve/governance-synthesis';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
-import { getServiceAuthError } from '@/lib/security/serviceAuth';
+import { getEveSynthesisAuthError } from '@/lib/security/serviceAuth';
 import { runSignalEngine } from '@/lib/signals/engine';
 
 export const dynamic = 'force-dynamic';
@@ -41,7 +41,7 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
-  const authErr = getServiceAuthError(request);
+  const authErr = getEveSynthesisAuthError(request);
   if (authErr) return authErr;
 
   let body: unknown = {};

--- a/lib/security/serviceAuth.ts
+++ b/lib/security/serviceAuth.ts
@@ -128,3 +128,17 @@ export function getServiceAuthError(request: NextRequest): NextResponse | null {
 
   return null;
 }
+
+/**
+ * EVE synthesis automation: Vercel Cron (GET/POST), Bearer CRON_SECRET, or any service secret.
+ * Matches /api/runtime/heartbeat so scheduled jobs succeed when only CRON_SECRET is wired.
+ */
+export function getEveSynthesisAuthError(request: NextRequest): NextResponse | null {
+  if (isVercelCronInvocation(request)) {
+    return null;
+  }
+  if (isValidCronSecretBearer(request.headers.get('authorization'))) {
+    return null;
+  }
+  return getServiceAuthError(request);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -29,6 +29,10 @@
     {
       "path": "/api/runtime/heartbeat",
       "schedule": "45 5 * * *"
+    },
+    {
+      "path": "/api/eve/cycle-synthesize",
+      "schedule": "0 */4 * * *"
     }
   ],
   "installCommand": "pnpm install --no-frozen-lockfile"


### PR DESCRIPTION
Add getEveSynthesisAuthError so POST accepts Vercel Cron invocations and CRON_SECRET like heartbeat. GET runs synthesis only for platform cron so unauthenticated preview stays safe. Register /api/eve/cycle-synthesize on 0 */4 * * * for the 4h cadence.