### PR TITLE
Alias EVE pipeline to cycle-synthesize and harden service auth

### DIFF
--- a/app/api/agents/status/route.ts
+++ b/app/api/agents/status/route.ts
@@ -8,6 +8,9 @@ import {
   staleCacheEnvelope,
 } from '@/lib/response-envelope';
 
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 type HeartbeatPayload = {
   ok?: boolean;
   timestamp?: string;

--- a/app/api/eve/pipeline-synthesize/route.ts
+++ b/app/api/eve/pipeline-synthesize/route.ts
@@ -1,13 +1,17 @@
 /**
- * POST /api/eve/pipeline-synthesize — Full EVE → EPICON → ZEUS → ledger pipeline (C-626).
- * Model-backed path; use /api/eve/cycle-synthesize for rule-based governance lane (C-270).
+ * POST /api/eve/pipeline-synthesize — compatibility alias to cycle synthesis.
+ *
+ * External automations historically targeted this endpoint. To keep those runs
+ * healthy and avoid long-running model pipeline hangs, this route now forwards
+ * directly to `/api/eve/cycle-synthesize`.
+ *
  * Bearer: MOBIUS_SERVICE_SECRET | CRON_SECRET | BACKFILL_SECRET
  */
 
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
-import { getServiceAuthError } from '@/lib/security/serviceAuth';
+import { getEveSynthesisAuthError } from '@/lib/security/serviceAuth';
 
 export const dynamic = 'force-dynamic';
 
@@ -28,166 +32,35 @@ async function readJson(res: Response): Promise<unknown> {
 }
 
 export async function GET(request: NextRequest) {
-  const base = serverBaseUrl(request);
-  const cycleRes = await fetch(`${base}/api/eve/cycle-advance`, { cache: 'no-store' });
-  const cycleJson = (await readJson(cycleRes)) as { currentCycle?: string } | null;
-
   return NextResponse.json({
     ok: true,
-    info: 'POST to run full model-backed EVE synthesis pipeline for current cycle',
-    pipeline: ['synthesize', 'candidate', 'verify', 'publish'],
-    currentCycle: cycleJson?.currentCycle ?? null,
-    governanceLane: '/api/eve/cycle-synthesize',
+    info: 'Compatibility alias: forwards to /api/eve/cycle-synthesize',
+    canonicalRoute: '/api/eve/cycle-synthesize',
   });
 }
 
 export async function POST(request: NextRequest) {
-  const authErr = getServiceAuthError(request);
+  const authErr = getEveSynthesisAuthError(request);
   if (authErr) return authErr;
 
-  if (!process.env.ANTHROPIC_API_KEY?.trim()) {
-    return NextResponse.json(
-      { ok: false, error: 'ANTHROPIC_API_KEY is not configured — pipeline synthesis disabled' },
-      { status: 503 },
-    );
-  }
-
   const base = serverBaseUrl(request);
-  const pipelineHeaders: Record<string, string> = {
+  const forwardHeaders: Record<string, string> = {
     'Content-Type': 'application/json',
     Accept: 'application/json',
   };
+  const authorization = request.headers.get('authorization');
+  if (authorization) {
+    forwardHeaders.Authorization = authorization;
+  }
+  const bodyText = await request.text();
 
-  const cycleRes = await fetch(`${base}/api/eve/cycle-advance`, { cache: 'no-store' });
-  const cycleJson = (await readJson(cycleRes)) as { currentCycle?: string } | null;
-  const cycleId =
-    typeof cycleJson?.currentCycle === 'string' && cycleJson.currentCycle.trim()
-      ? cycleJson.currentCycle.trim()
-      : 'C-0';
-
-  const synRes = await fetch(`${base}/api/eve/synthesize`, {
+  const cycleRes = await fetch(`${base}/api/eve/cycle-synthesize`, {
     method: 'POST',
-    headers: pipelineHeaders,
-    body: JSON.stringify({ cycleId }),
+    headers: forwardHeaders,
+    body: bodyText.trim() ? bodyText : '{}',
     cache: 'no-store',
   });
-  const synJson = (await readJson(synRes)) as Record<string, unknown> | null;
-  if (!synRes.ok || !synJson || synJson.ok !== true) {
-    return NextResponse.json(
-      {
-        ok: false,
-        step: 'synthesize',
-        error: typeof synJson?.error === 'string' ? synJson.error : 'Synthesis failed',
-        details: synJson,
-      },
-      { status: synRes.ok ? 502 : synRes.status },
-    );
-  }
+  const cycleJson = await readJson(cycleRes);
 
-  const itemCount = typeof synJson.itemCount === 'number' ? synJson.itemCount : 0;
-
-  const synthesisObj = synJson.synthesis;
-  if (synthesisObj === null || typeof synthesisObj !== 'object') {
-    return NextResponse.json(
-      { ok: false, step: 'candidate', error: 'Synthesis response missing synthesis object' },
-      { status: 502 },
-    );
-  }
-
-  const candRes = await fetch(`${base}/api/epicon/candidates`, {
-    method: 'POST',
-    headers: pipelineHeaders,
-    body: JSON.stringify({ cycleId, synthesis: synthesisObj }),
-    cache: 'no-store',
-  });
-  const candJson = (await readJson(candRes)) as Record<string, unknown> | null;
-  if (!candRes.ok || !candJson || candJson.ok !== true) {
-    return NextResponse.json(
-      {
-        ok: false,
-        step: 'candidate',
-        error: typeof candJson?.error === 'string' ? candJson.error : 'Candidate creation failed',
-        details: candJson,
-      },
-      { status: candRes.ok ? 502 : candRes.status },
-    );
-  }
-
-  const candidate = candJson.candidate as { id?: string } | undefined;
-  const candidateId = typeof candidate?.id === 'string' ? candidate.id : '';
-  if (!candidateId) {
-    return NextResponse.json(
-      { ok: false, step: 'candidate', error: 'Missing candidate id in response' },
-      { status: 502 },
-    );
-  }
-
-  const verRes = await fetch(`${base}/api/zeus/verify`, {
-    method: 'POST',
-    headers: pipelineHeaders,
-    body: JSON.stringify({ candidateId }),
-    cache: 'no-store',
-  });
-  const verJson = (await readJson(verRes)) as Record<string, unknown> | null;
-  if (!verRes.ok || !verJson || verJson.ok !== true) {
-    return NextResponse.json(
-      {
-        ok: false,
-        step: 'verify',
-        error: typeof verJson?.error === 'string' ? verJson.error : 'Verification failed',
-        details: verJson,
-      },
-      { status: verRes.ok ? 502 : verRes.status },
-    );
-  }
-
-  const verdict = typeof verJson.verdict === 'string' ? verJson.verdict : '';
-  const zeusScore = typeof verJson.zeusScore === 'number' ? verJson.zeusScore : 0;
-
-  if (verdict === 'contested') {
-    return NextResponse.json({
-      ok: true,
-      published: false,
-      reason: 'ZEUS contested — operator review required',
-      candidate: candJson.candidate,
-      cycleId,
-      timestamp: new Date().toISOString(),
-    });
-  }
-
-  const pubRes = await fetch(`${base}/api/epicon/publish`, {
-    method: 'POST',
-    headers: pipelineHeaders,
-    body: JSON.stringify({ candidateId }),
-    cache: 'no-store',
-  });
-  const pubJson = (await readJson(pubRes)) as Record<string, unknown> | null;
-  if (!pubRes.ok || !pubJson || pubJson.ok !== true) {
-    return NextResponse.json(
-      {
-        ok: false,
-        step: 'publish',
-        error: typeof pubJson?.error === 'string' ? pubJson.error : 'Publish failed',
-        details: pubJson,
-      },
-      { status: pubRes.ok ? 502 : pubRes.status },
-    );
-  }
-
-  const published = pubJson.published as Record<string, unknown> | undefined;
-  const entryId = typeof published?.id === 'string' ? published.id : candidateId;
-
-  return NextResponse.json({
-    ok: true,
-    cycleId,
-    timestamp: new Date().toISOString(),
-    pipeline: {
-      synthesize: { ok: true, itemCount },
-      candidate: { ok: true, candidateId },
-      verify: { ok: true, verdict, zeusScore },
-      publish: { ok: true, entryId },
-    },
-    entry: pubJson.published,
-    message: 'EVE pipeline synthesis complete — EPICON entry committed to ledger',
-  });
+  return NextResponse.json(cycleJson, { status: cycleRes.status });
 }

--- a/lib/security/serviceAuth.ts
+++ b/lib/security/serviceAuth.ts
@@ -64,6 +64,15 @@ function extractAuthorizationToken(authorization: string | null): string | null 
   return raw.length > 0 ? raw : null;
 }
 
+function extractCandidateTokens(request: NextRequest): string[] {
+  const tokens = [
+    extractAuthorizationToken(request.headers.get('authorization')),
+    extractAuthorizationToken(request.headers.get('x-cron-secret')),
+    extractAuthorizationToken(request.headers.get('x-mobius-service-secret')),
+  ];
+  return tokens.filter((value): value is string => typeof value === 'string' && value.length > 0);
+}
+
 export function serviceAuthorizationHeaderValue(): string | null {
   const material = outboundBearerMaterial();
   return material ? `Bearer ${material}` : null;
@@ -115,12 +124,10 @@ export function getServiceAuthError(request: NextRequest): NextResponse | null {
     );
   }
 
-  const rawToken = extractAuthorizationToken(request.headers.get('authorization'));
-  const token =
-    rawToken !== null ? normalizeServiceSecretMaterial(rawToken) : null;
-  const authorized =
-    token !== null &&
-    secrets.some(({ value }) => token === value);
+  const candidateTokens = extractCandidateTokens(request);
+  const authorized = candidateTokens
+    .map((token) => normalizeServiceSecretMaterial(token))
+    .some((token) => token !== null && secrets.some(({ value }) => token === value));
 
   if (!authorized) {
     return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });


### PR DESCRIPTION
### Motivation

- Stop legacy automations from hanging by ensuring requests targeting the historical model-backed pipeline endpoint execute the canonical cycle-based synthesis route instead. 
- Reduce spurious `401` failures when automations send secrets in non-canonical headers or formats so KV seeding and other automations succeed. 
- Make agents status responses less prone to stale-cache behavior in production.

### Description

- Convert `POST /api/eve/pipeline-synthesize` into a compatibility alias that forwards POSTs to `/api/eve/cycle-synthesize` and returns the upstream response, while preserving Authorization and JSON body forwarding (`app/api/eve/pipeline-synthesize/route.ts`).
- Use the EVE-specific auth check (`getEveSynthesisAuthError`) for the alias route so cron invocations remain allowed (`app/api/eve/pipeline-synthesize/route.ts`).
- Harden service auth parsing to accept token material from `authorization`, `x-cron-secret`, and `x-mobius-service-secret` headers and normalize candidate tokens before matching against configured secrets (`lib/security/serviceAuth.ts`).
- Mark `/api/agents/status` as fully dynamic (`export const dynamic = 'force-dynamic'` and `export const revalidate = 0`) to avoid stale-cache responses for agent liveness (`app/api/agents/status/route.ts`).

### Testing

- `npx tsc --noEmit` completed successfully (TypeScript check passed).
- `npm run lint` could not complete in this environment because `next lint` invoked an interactive ESLint setup prompt, so linting was not finished here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d28b6b6a28832db1342d357804af71)