### PR TITLE
feat(scheduler): move cron load to Render — single Vercel daily watchdog [C-271]

### DIFF
--- a/app/api/cron/watchdog/route.ts
+++ b/app/api/cron/watchdog/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServiceAuthError, serviceAuthorizationHeaderValue } from '@/lib/security/serviceAuth';
+
+export const dynamic = 'force-dynamic';
+
+type WatchdogActionResult = {
+  ok: boolean;
+  status: number;
+  body: unknown;
+};
+
+function getInternalAuthorizationHeader(): string | null {
+  const outbound = serviceAuthorizationHeaderValue();
+  if (outbound) return outbound;
+
+  const candidates = [process.env.CRON_SECRET, process.env.RENDER_SCHEDULER_SECRET];
+  for (const raw of candidates) {
+    if (typeof raw === 'string' && raw.trim().length > 0) {
+      return `Bearer ${raw.trim()}`;
+    }
+  }
+  return null;
+}
+
+async function fetchWithTimeout(
+  request: NextRequest,
+  path: string,
+  init?: RequestInit,
+): Promise<WatchdogActionResult> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5_000);
+  const authorization = getInternalAuthorizationHeader();
+  const headers = new Headers(init?.headers);
+
+  if (authorization && !headers.has('authorization')) {
+    headers.set('authorization', authorization);
+  }
+
+  try {
+    const response = await fetch(new URL(path, request.nextUrl.origin), {
+      ...init,
+      headers,
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+
+    let body: unknown = null;
+    try {
+      body = await response.json();
+    } catch {
+      body = null;
+    }
+
+    return { ok: response.ok, status: response.status, body };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 500,
+      body: { error: error instanceof Error ? error.message : 'Unknown fetch error' },
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const authError = getServiceAuthError(request);
+  if (authError) return authError;
+
+  const actions: string[] = [];
+  const timestamp = new Date().toISOString();
+
+  const kvHealth = await fetchWithTimeout(request, '/api/kv/health');
+  actions.push(`kv-health:${kvHealth.ok ? 'ok' : `fail:${kvHealth.status}`}`);
+
+  const seedResult = await fetchWithTimeout(request, '/api/admin/seed-kv', { method: 'POST' });
+  actions.push(`seed-kv:${seedResult.ok ? 'ok' : `fail:${seedResult.status}`}`);
+
+  const giResult = await fetchWithTimeout(request, '/api/integrity-status');
+  actions.push(`integrity-status:${giResult.ok ? 'ok' : `fail:${giResult.status}`}`);
+
+  const logResult = {
+    seeded: seedResult.body,
+    gi: giResult.body,
+    kvHealth: kvHealth.body,
+    timestamp,
+    source: 'watchdog',
+  };
+  console.info('[watchdog] daily run', logResult);
+
+  return NextResponse.json({
+    ok: kvHealth.ok && seedResult.ok && giResult.ok,
+    actions,
+    timestamp,
+  });
+}

--- a/lib/security/serviceAuth.ts
+++ b/lib/security/serviceAuth.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-type ServiceSecretName = 'MOBIUS_SERVICE_SECRET' | 'CRON_SECRET' | 'BACKFILL_SECRET';
+type ServiceSecretName =
+  | 'MOBIUS_SERVICE_SECRET'
+  | 'CRON_SECRET'
+  | 'RENDER_SCHEDULER_SECRET'
+  | 'BACKFILL_SECRET';
 
 /**
  * Normalize secret material from env: trim, strip one layer of surrounding quotes,
@@ -33,6 +37,7 @@ function configuredSecrets(): Array<{ name: ServiceSecretName; value: string }> 
   const pairs: Array<{ name: ServiceSecretName; value: string | undefined }> = [
     { name: 'MOBIUS_SERVICE_SECRET', value: process.env.MOBIUS_SERVICE_SECRET },
     { name: 'CRON_SECRET', value: process.env.CRON_SECRET },
+    { name: 'RENDER_SCHEDULER_SECRET', value: process.env.RENDER_SCHEDULER_SECRET },
     { name: 'BACKFILL_SECRET', value: process.env.BACKFILL_SECRET },
   ];
 
@@ -46,7 +51,12 @@ function configuredSecrets(): Array<{ name: ServiceSecretName; value: string }> 
 
 /** First non-empty normalized secret for outbound Authorization (MOBIUS first so probes match sentinel / ops). */
 function outboundBearerMaterial(): string | null {
-  const order: ServiceSecretName[] = ['MOBIUS_SERVICE_SECRET', 'CRON_SECRET', 'BACKFILL_SECRET'];
+  const order: ServiceSecretName[] = [
+    'MOBIUS_SERVICE_SECRET',
+    'CRON_SECRET',
+    'RENDER_SCHEDULER_SECRET',
+    'BACKFILL_SECRET',
+  ];
   for (const name of order) {
     const normalized = normalizeServiceSecretMaterial(process.env[name]);
     if (normalized !== null) return normalized;

--- a/vercel.json
+++ b/vercel.json
@@ -7,32 +7,8 @@
   "ignoreCommand": "bash scripts/ignore-build.sh",
   "crons": [
     {
-      "path": "/api/eve/cycle-advance",
-      "schedule": "0 5 * * *"
-    },
-    {
-      "path": "/api/echo/ingest",
-      "schedule": "5 5 * * *"
-    },
-    {
-      "path": "/api/signals/micro",
-      "schedule": "10 5 * * *"
-    },
-    {
-      "path": "/api/integrity-status",
-      "schedule": "15 5 * * *"
-    },
-    {
-      "path": "/api/aurea/oversee",
-      "schedule": "35 5 * * *"
-    },
-    {
-      "path": "/api/runtime/heartbeat",
-      "schedule": "45 5 * * *"
-    },
-    {
-      "path": "/api/eve/cycle-synthesize",
-      "schedule": "0 */4 * * *"
+      "path": "/api/cron/watchdog",
+      "schedule": "0 0 * * *"
     }
   ],
   "installCommand": "pnpm install --no-frozen-lockfile"


### PR DESCRIPTION
### Motivation
- Conform to Vercel Hobby plan (1 cron/day) by moving frequent scheduling off Vercel and keeping a single daily watchdog route as a safety net.

### Description
- Replace multiple high-frequency entries in `vercel.json` with a single daily cron at ` /api/cron/watchdog` (`0 0 * * *`).
- Add `app/api/cron/watchdog/route.ts` which authenticates via service secrets, probes `/api/kv/health`, `POST /api/admin/seed-kv`, and `/api/integrity-status`, uses a 5000ms timeout for internal requests, logs a structured run, and returns `{ ok, actions, timestamp }`.
- Extend service auth in `lib/security/serviceAuth.ts` to accept `RENDER_SCHEDULER_SECRET` for inbound validation and include it in outbound bearer selection order.

### Testing
- Ran `npx tsc --noEmit` and it passed successfully.
- Attempted `pnpm lint`, but `next lint` triggered Next.js interactive ESLint setup so lint could not run non-interactively in the current repo configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d297dbd2cc832d922d86d2ed31e7b8)