### PR TITLE
feat(gaia): add NASA EONET natural events as GAIA signal source

### DIFF
--- a/lib/agents/micro/gaia.ts
+++ b/lib/agents/micro/gaia.ts
@@ -1,7 +1,7 @@
 // ============================================================================
 // GAIA — Environment Micro Sub-Agent
 //
-// Polls Open-Meteo (weather), OpenAQ-compatible AQI, and USGS earthquake API.
+// Polls Open-Meteo (weather), USGS earthquake API, and NASA EONET events.
 // All free, no API key required.
 // CC0 Public Domain
 // ============================================================================
@@ -15,12 +15,13 @@ import {
   normalizeDirect,
   safeFetch,
 } from './core';
+import { fetchEonetEvents, scoreEonetEvents } from '@/lib/signals/eonet';
 
 export const GAIA_CONFIG: MicroAgentConfig = {
   name: 'GAIA',
-  description: 'Ecological integrity — weather extremes, air quality, seismic activity',
+  description: 'Ecological integrity — weather extremes, natural hazards, seismic activity',
   pollIntervalMs: 5 * 60 * 1000, // 5 minutes
-  sources: ['Open-Meteo', 'USGS Earthquake'],
+  sources: ['Open-Meteo', 'USGS Earthquake', 'NASA EONET'],
 };
 
 // ── Open-Meteo: current weather for NYC (Merrick, LI area) ────────────────
@@ -109,18 +110,45 @@ async function pollEarthquakes(): Promise<MicroSignal | null> {
   };
 }
 
+async function pollEonet(): Promise<MicroSignal | null> {
+  return fetchEonetEvents(7)
+    .then((events) => {
+      const storms = events.filter((event) => event.categories.some((category) => category.id === 'severeStorms')).length;
+      const fires = events.filter((event) => event.categories.some((category) => category.id === 'wildfires')).length;
+
+      return {
+        agentName: 'GAIA',
+        source: 'NASA EONET',
+        timestamp: new Date().toISOString(),
+        value: scoreEonetEvents(events),
+        label: `EONET: ${events.length} open natural events (${storms} storms, ${fires} fires)`,
+        severity: events.length > 30 ? 'elevated' : 'nominal',
+        raw: {
+          count: events.length,
+          topEvent: events[0]?.title ?? null,
+          severeStorms: storms,
+          wildfires: fires,
+        },
+      } satisfies MicroSignal;
+    })
+    .catch(() => null);
+}
+
 // ── Poll all GAIA sources ─────────────────────────────────────────────────
 export async function pollGaia(): Promise<AgentPollResult> {
   const errors: string[] = [];
   const signals: MicroSignal[] = [];
 
-  const weather = await pollWeather();
+  const [weather, quakes, eonet] = await Promise.all([pollWeather(), pollEarthquakes(), pollEonet()]);
+
   if (weather) signals.push(weather);
   else errors.push('Open-Meteo weather fetch failed');
 
-  const quakes = await pollEarthquakes();
   if (quakes) signals.push(quakes);
   else errors.push('USGS earthquake fetch failed');
+
+  if (eonet) signals.push(eonet);
+  else errors.push('NASA EONET fetch failed');
 
   return {
     agentName: 'GAIA',

--- a/lib/agents/micro/index.ts
+++ b/lib/agents/micro/index.ts
@@ -44,9 +44,33 @@ export async function pollAllMicroAgents(): Promise<MicroAgentSweepResult> {
 
   const allSignals = agents.flatMap((a) => a.signals);
 
-  // Composite: weighted average of all signal values
-  const composite = allSignals.length > 0
-    ? Number((allSignals.reduce((sum, s) => sum + s.value, 0) / allSignals.length).toFixed(3))
+  // Composite: average by agent, with GAIA source-aware weighting.
+  const compositeByAgent = agents.map((agent) => {
+    if (agent.signals.length === 0) return 0.5;
+
+    if (agent.agentName === 'GAIA') {
+      const weather = agent.signals.find((signal) => signal.source === 'Open-Meteo')?.value;
+      const quakes = agent.signals.find((signal) => signal.source === 'USGS Earthquake')?.value;
+      const eonet = agent.signals.find((signal) => signal.source === 'NASA EONET')?.value;
+
+      const weights = [
+        { value: quakes, weight: 0.4 },
+        { value: weather, weight: 0.3 },
+        { value: eonet, weight: 0.3 },
+      ].filter((entry): entry is { value: number; weight: number } => typeof entry.value === 'number');
+
+      if (weights.length > 0) {
+        const weightedTotal = weights.reduce((sum, entry) => sum + entry.value * entry.weight, 0);
+        const totalWeight = weights.reduce((sum, entry) => sum + entry.weight, 0);
+        return Number((weightedTotal / totalWeight).toFixed(3));
+      }
+    }
+
+    return Number((agent.signals.reduce((sum, signal) => sum + signal.value, 0) / agent.signals.length).toFixed(3));
+  });
+
+  const composite = compositeByAgent.length > 0
+    ? Number((compositeByAgent.reduce((sum, value) => sum + value, 0) / compositeByAgent.length).toFixed(3))
     : 0.5;
 
   // Anomalies: anything elevated or critical

--- a/lib/signals/eonet.ts
+++ b/lib/signals/eonet.ts
@@ -1,0 +1,48 @@
+const EONET_BASE = 'https://eonet.gsfc.nasa.gov/api/v3';
+
+export interface EonetEvent {
+  id: string;
+  title: string;
+  categories: { id: string; title: string }[];
+  geometry: { date: string; type: string; coordinates: number[] | number[][][] }[];
+  closed: string | null;
+}
+
+type EonetEventsResponse = {
+  events?: EonetEvent[];
+};
+
+export async function fetchEonetEvents(days = 7): Promise<EonetEvent[]> {
+  const url = `${EONET_BASE}/events?status=open&days=${days}&limit=50`;
+  const res = await fetch(url, { signal: AbortSignal.timeout(5000), cache: 'no-store' });
+  if (!res.ok) throw new Error(`EONET ${res.status}`);
+  const data = (await res.json()) as EonetEventsResponse;
+  return data.events ?? [];
+}
+
+// Normalize open event count to 0-1 signal value
+// More open events = lower value (higher stress)
+export function scoreEonetEvents(events: EonetEvent[]): number {
+  const count = events.length;
+  if (count === 0) return 1.0; // no events = nominal
+  if (count <= 5) return 0.9; // quiet
+  if (count <= 15) return 0.75; // moderate activity
+  if (count <= 30) return 0.55; // elevated
+  if (count <= 50) return 0.35; // high
+  return 0.2; // extreme
+}
+
+// Score by specific high-impact categories
+export function scoreEonetByCategory(events: EonetEvent[]): Record<string, number> {
+  const cats = ['severeStorms', 'wildfires', 'volcanoes', 'floods', 'drought'];
+  const result: Record<string, number> = {};
+  for (const cat of cats) {
+    const count = events.filter((event) => event.categories.some((category) => category.id === cat)).length;
+    result[cat] = count === 0 ? 1.0
+      : count <= 3 ? 0.8
+        : count <= 8 ? 0.6
+          : count <= 15 ? 0.4
+            : 0.2;
+  }
+  return result;
+}


### PR DESCRIPTION
### Motivation
- Provide GAIA with near-real-time, open NASA EONET natural event data to expand environmental coverage across multiple disaster categories that impact civic integrity. 
- Ensure GAIA composite reflects multi-source risk signals by weighting seismic, weather, and event feeds so compound hazards suppress GI appropriately.

### Description
- Add `lib/signals/eonet.ts` with a typed `EonetEvent` model, `fetchEonetEvents` using `AbortSignal.timeout(5000)` and `cache: 'no-store'`, and scoring helpers `scoreEonetEvents` and `scoreEonetByCategory` for 0–1 normalization. 
- Integrate EONET into `lib/agents/micro/gaia.ts` by introducing `pollEonet()`, adding `NASA EONET` to `GAIA_CONFIG.sources`, returning a `MicroSignal` with enriched `label` and `raw` metadata, and degrading gracefully on failure (`.catch(() => null)`). 
- Update `lib/agents/micro/index.ts` composite calculation to compute a per-agent average and apply GAIA source-aware weighting (USGS 40%, Open-Meteo 30%, EONET 30%) while preserving safe fallbacks when one or more GAIA sources are missing. 
- Maintain strict TypeScript typing and avoid adding any new npm dependencies.

### Testing
- Ran `npx tsc --noEmit`, which completed successfully. 
- Attempted `npm run lint`, but it could not complete non-interactively due to an ESLint setup prompt in this environment. 
- No additional automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2b9e62540832d82dafdfcc7fec7e3)