### PR TITLE
feat(agents): scope manifests + EPICON reasoning journal [C-271]

### DIFF
--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { isValidCronSecretBearer } from '@/lib/security/serviceAuth';
+import {
+  appendAgentJournalEntry,
+  getAgentJournalEntries,
+  parseAgentJournalEntry,
+} from '@/lib/agents/journal';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const agent = searchParams.get('agent');
+  const cycle = searchParams.get('cycle');
+  const category = searchParams.get('category');
+
+  const entries = await getAgentJournalEntries({
+    agent,
+    cycle,
+    category,
+    status: 'committed',
+  });
+
+  return NextResponse.json({
+    ok: true,
+    entries,
+    count: entries.length,
+    filters: {
+      agent: agent ?? null,
+      cycle: cycle ?? null,
+      category: category ?? null,
+      status: 'committed',
+    },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  if (!isValidCronSecretBearer(request.headers.get('authorization'))) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: unknown = null;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const parsed = parseAgentJournalEntry(body);
+  if (!parsed) {
+    return NextResponse.json({ ok: false, error: 'Invalid AgentJournalEntry payload' }, { status: 400 });
+  }
+
+  const stored = await appendAgentJournalEntry(parsed);
+
+  return NextResponse.json({
+    ok: true,
+    entry: stored,
+  });
+}

--- a/app/api/aurea/oversee/route.ts
+++ b/app/api/aurea/oversee/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 import { buildAureaOversightReport } from '@/lib/aurea/oversee';
+import { appendAgentJournalEntry } from '@/lib/agents/journal';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
 
 export const dynamic = 'force-dynamic';
 
@@ -69,6 +71,22 @@ export async function GET() {
       },
     ],
   });
+
+  void appendAgentJournalEntry({
+    agent: 'AUREA',
+    cycle: currentCycleId(),
+    observation: `AUREA oversight ran across ${report.adapter_health.total} sources with ${report.adapter_health.degraded} degraded lanes.`,
+    inference: `Candidate backlog is ${report.pending_epicon_backlog.status} with ${report.pending_epicon_backlog.count} pending items.`,
+    recommendation: report.pending_epicon_backlog.status === 'nominal'
+      ? 'Maintain current operating posture and continue routine close checks.'
+      : 'Review degraded adapter lanes and prioritize verification queue before daily close.',
+    confidence: report.pending_epicon_backlog.status === 'nominal' ? 0.88 : 0.76,
+    derivedFrom: ['aurea:oversight', 'adapter-health', 'source-reliability'],
+    relatedAgents: ['ATLAS', 'ZEUS', 'ECHO'],
+    status: 'committed',
+    category: 'close',
+    severity: report.pending_epicon_backlog.status === 'nominal' ? 'nominal' : 'elevated',
+  }).catch(() => {});
 
   return NextResponse.json({
     ok: true,

--- a/app/api/cron/watchdog/route.ts
+++ b/app/api/cron/watchdog/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceAuthError, serviceAuthorizationHeaderValue } from '@/lib/security/serviceAuth';
+import { appendAgentJournalEntry } from '@/lib/agents/journal';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
 
 export const dynamic = 'force-dynamic';
 
@@ -87,6 +89,23 @@ export async function GET(request: NextRequest) {
     source: 'watchdog',
   };
   console.info('[watchdog] daily run', logResult);
+
+  const failed = actions.filter((action) => action.includes('fail')).length;
+  void appendAgentJournalEntry({
+    agent: 'ATLAS',
+    cycle: currentCycleId(),
+    observation: `Sentinel watchdog ran checks: ${actions.join(', ')}.`,
+    inference: failed === 0 ? 'System integrity checks passed in this cycle.' : `${failed} watchdog checks failed and require operator review.`,
+    recommendation: failed === 0
+      ? 'Continue scheduled watch cadence.'
+      : 'Inspect failed watchdog actions and confirm CRON_SECRET / KV health before next run.',
+    confidence: failed === 0 ? 0.9 : 0.62,
+    derivedFrom: ['watchdog:kv-health', 'watchdog:seed-kv', 'watchdog:integrity-status'],
+    relatedAgents: ['DAEDALUS', 'ZEUS'],
+    status: 'committed',
+    category: failed === 0 ? 'observation' : 'alert',
+    severity: failed === 0 ? 'nominal' : 'elevated',
+  }).catch(() => {});
 
   return NextResponse.json({
     ok: kvHealth.ok && seedResult.ok && giResult.ok,

--- a/app/api/eve/cycle-synthesize/route.ts
+++ b/app/api/eve/cycle-synthesize/route.ts
@@ -20,6 +20,7 @@ import {
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { getEveSynthesisAuthError, isVercelCronInvocation } from '@/lib/security/serviceAuth';
 import { runSignalEngine } from '@/lib/signals/engine';
+import { appendAgentJournalEntry } from '@/lib/agents/journal';
 
 export const dynamic = 'force-dynamic';
 
@@ -29,6 +30,29 @@ type CycleBody = {
   mode?: unknown;
   reason?: unknown;
 };
+
+function inferEveConfidence(payload: unknown): number {
+  if (payload && typeof payload === 'object') {
+    const row = payload as Record<string, unknown>;
+    const c = row.confidence;
+    if (typeof c === 'number' && Number.isFinite(c)) return Math.max(0, Math.min(1, c));
+    const score = row.qualityScore;
+    if (typeof score === 'number' && Number.isFinite(score)) return Math.max(0, Math.min(1, score));
+    const promoted = row.promotedCount;
+    if (typeof promoted === 'number' && promoted > 0) return 0.82;
+  }
+  return 0.74;
+}
+
+function inferEveSeverity(payload: unknown): 'nominal' | 'elevated' | 'critical' {
+  if (payload && typeof payload === 'object') {
+    const row = payload as Record<string, unknown>;
+    if (row.mode === 'escalation') return 'critical';
+    const contested = row.contestedCount;
+    if (typeof contested === 'number' && contested > 0) return 'elevated';
+  }
+  return 'nominal';
+}
 
 function parseCycleBody(body: unknown): {
   cycleId: string | null;
@@ -95,6 +119,20 @@ export async function POST(request: NextRequest) {
     mode === 'escalation'
       ? await processEveEscalationSynthesis(cycleId, force, reason)
       : await processEveCycleWindowSynthesis(cycleId, force);
+
+  void appendAgentJournalEntry({
+    agent: 'EVE',
+    cycle: cycleId,
+    observation: `EVE ${mode} synthesis executed${reason ? ` for reason ${reason}` : ''}.`,
+    inference: mode === 'escalation' ? 'Civic risk required escalation-class synthesis output.' : 'Cycle-window synthesis completed and staged for EPICON flow.',
+    recommendation: mode === 'escalation' ? 'Prioritize ZEUS verification and ATLAS oversight checks.' : 'Continue normal verification cadence across ZEUS and ATLAS.',
+    confidence: inferEveConfidence(payload),
+    derivedFrom: ['signal-engine:run', `eve-synthesis:${cycleId}`],
+    relatedAgents: ['ZEUS', 'ATLAS'],
+    status: 'committed',
+    category: mode === 'escalation' ? 'alert' : 'inference',
+    severity: inferEveSeverity(payload),
+  }).catch(() => {});
 
   return NextResponse.json(payload);
 }

--- a/app/api/zeus/verify/route.ts
+++ b/app/api/zeus/verify/route.ts
@@ -19,6 +19,8 @@ import {
   type EpiconCandidate,
 } from '@/lib/eve/synthesis-pipeline-store';
 import { getServiceAuthError } from '@/lib/security/serviceAuth';
+import { appendAgentJournalEntry } from '@/lib/agents/journal';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
 
 type VerifyRequest = {
   epiconId: string;
@@ -86,6 +88,20 @@ function verifyEveSynthesisCandidateRecord(
     };
     updatePipelineCandidate(id, patch);
   }
+  void appendAgentJournalEntry({
+    agent: 'ZEUS',
+    cycle: currentCycleId(),
+    observation: `Candidate ${id} reviewed with ${candidate.flags.length} flags at severity ${candidate.severity}.`,
+    inference: `ZEUS verdict: ${verdict}. Candidate transitioned to ${nextStatus}.`,
+    recommendation: verdict === 'contested' ? 'Escalate to ATLAS review before broad promotion.' : 'Proceed with standard ledger promotion checks.',
+    confidence: zeusScore,
+    derivedFrom: [id, `pipeline:candidate:${id}`],
+    relatedAgents: ['EVE', 'ATLAS'],
+    status: 'committed',
+    verifiedBy: verdict === 'contested' ? undefined : 'ZEUS',
+    category: 'inference',
+    severity: verdict === 'contested' ? 'elevated' : 'nominal',
+  }).catch(() => {});
   return NextResponse.json({
     ok: true,
     candidateId: id,
@@ -183,6 +199,21 @@ export async function POST(request: NextRequest) {
       verified: true,
       verifiedBy: 'ZEUS',
       tags: ['zeus', 'verification', confirmed ? 'confirmed' : 'flagged'],
+    }).catch(() => {});
+
+    void appendAgentJournalEntry({
+      agent: 'ZEUS',
+      cycle: currentCycleId(),
+      observation: `EPICON ${body.epiconId} verification completed with outcome ${body.outcome}.`,
+      inference: `Final status set to ${body.finalStatus} at tier ${body.finalConfidenceTier}.`,
+      recommendation: body.outcome === 'miss' ? 'Route contradicted item to operator follow-up.' : 'Allow downstream publication routines.',
+      confidence: zeusScoreForTier(body.finalConfidenceTier),
+      derivedFrom: [body.epiconId, `verification:${body.outcome}`],
+      relatedAgents: ['ECHO', 'ATLAS'],
+      status: 'committed',
+      verifiedBy: 'ZEUS',
+      category: 'recommendation',
+      severity: body.outcome === 'miss' ? 'elevated' : 'nominal',
     }).catch(() => {});
 
     return NextResponse.json({

--- a/app/terminal/TerminalPageClient.tsx
+++ b/app/terminal/TerminalPageClient.tsx
@@ -8,6 +8,8 @@ import { useTerminalData } from '@/hooks/useTerminalData';
 import { checkCovenantCompliance } from '@/lib/integrity-check';
 import { cn } from '@/lib/utils';
 import type { LedgerEntry, NavKey } from '@/lib/terminal/types';
+import type { AgentJournalEntry } from '@/lib/terminal/types';
+import { AGENT_MANIFESTS, AGENT_ORDER } from '@/lib/agents/manifests';
 import AgentGrid from '@/components/agents/AgentGrid';
 import EventScreener, { type EpiconFeedItem } from '@/components/terminal/EventScreener';
 import TripwirePanel from '@/components/tripwire/TripwirePanel';
@@ -47,6 +49,11 @@ type EpiconFeedResponse = {
   summary: { latestGI?: number; degradedCount?: number; lastHeartbeat?: string };
   items: EpiconFeedItem[];
 };
+type AgentJournalResponse = {
+  ok: boolean;
+  count: number;
+  entries: AgentJournalEntry[];
+};
 
 const TABS: Array<{ key: NavKey; label: string }> = [
   { key: 'pulse', label: 'Pulse' },
@@ -81,12 +88,15 @@ function TerminalPage() {
   const [kvLatency, setKvLatency] = useState<number | null>(null);
   const [ledgerExpanded, setLedgerExpanded] = useState(false);
   const [epiconFeed, setEpiconFeed] = useState<EpiconFeedResponse | null>(null);
+  const [journalFeed, setJournalFeed] = useState<AgentJournalEntry[]>([]);
+  const [ledgerView, setLedgerView] = useState<'events' | 'journal'>('events');
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<'time-desc' | 'time-asc' | 'type' | 'author' | 'gi-desc' | 'severity'>('time-desc');
   const [resultCount, setResultCount] = useState(0);
   const agentSearchRef = useRef<HTMLInputElement>(null);
 
   const { allTripwires, filteredEpicon, gi, integrityStatus, mergedLedger, streamStatus } = useTerminalData(selectedNav);
+  const cycleId = integrityStatus?.cycle ?? 'C-271';
 
   useEffect(() => {
     const timer = window.setInterval(() => {
@@ -95,6 +105,29 @@ function TerminalPage() {
     setClock(new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC');
     return () => window.clearInterval(timer);
   }, []);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadJournal() {
+      try {
+        const response = await fetch(`/api/agents/journal?cycle=${encodeURIComponent(cycleId)}`, { cache: 'no-store' });
+        const json = (await response.json()) as AgentJournalResponse;
+        if (mounted && json.ok) {
+          setJournalFeed(json.entries ?? []);
+        }
+      } catch {
+        if (mounted) setJournalFeed([]);
+      }
+    }
+
+    loadJournal();
+    const poll = window.setInterval(loadJournal, 30000);
+    return () => {
+      mounted = false;
+      window.clearInterval(poll);
+    };
+  }, [cycleId]);
 
   // Optimization 6: persist operator preferences across refreshes/session reconnects.
   useEffect(() => {
@@ -197,7 +230,6 @@ function TerminalPage() {
   }, []);
 
   const covenantStatus = checkCovenantCompliance(gi?.score ?? 0);
-  const cycleId = integrityStatus?.cycle ?? 'C-271';
   const giScore = gi?.score ?? 0;
   const giDelta = gi?.delta ?? 0;
 
@@ -265,15 +297,39 @@ function TerminalPage() {
     if (selectedNav === 'ledger') {
       return (
         <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-3">
-          <EventScreener
-            items={epiconFeed?.items}
-            summary={epiconFeed?.summary ?? {}}
-            sources={epiconFeed?.sources ?? { github: 0, kv: 0 }}
-            total={epiconFeed?.total ?? 0}
-            searchQuery={searchQuery}
-            sortBy={sortBy}
-            onResultCountChange={setResultCount}
-          />
+          <div className="mb-3 flex items-center justify-between border-b border-slate-800 pb-3">
+            <div>
+              <div className="text-sm font-semibold">Ledger Chamber</div>
+              <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-400">{cycleId} · Events and reasoning journal</div>
+            </div>
+            <div className="inline-flex rounded-md border border-slate-700 bg-slate-950 p-0.5 text-[10px] font-mono uppercase tracking-[0.12em]">
+              <button
+                onClick={() => setLedgerView('events')}
+                className={cn('rounded px-2 py-1', ledgerView === 'events' ? 'bg-sky-500/20 text-sky-200' : 'text-slate-400')}
+              >
+                Events
+              </button>
+              <button
+                onClick={() => setLedgerView('journal')}
+                className={cn('rounded px-2 py-1', ledgerView === 'journal' ? 'bg-fuchsia-500/20 text-fuchsia-200' : 'text-slate-400')}
+              >
+                Journal
+              </button>
+            </div>
+          </div>
+          {ledgerView === 'events' ? (
+            <EventScreener
+              items={epiconFeed?.items}
+              summary={epiconFeed?.summary ?? {}}
+              sources={epiconFeed?.sources ?? { github: 0, kv: 0 }}
+              total={epiconFeed?.total ?? 0}
+              searchQuery={searchQuery}
+              sortBy={sortBy}
+              onResultCountChange={setResultCount}
+            />
+          ) : (
+            <JournalView entries={journalFeed} cycleId={cycleId} />
+          )}
         </section>
       );
     }
@@ -639,6 +695,99 @@ const StatCard = memo(function StatCard({ label, value, trend, icon, subtitle, o
     </button>
   );
 });
+
+const AGENT_COLOR: Record<string, string> = {
+  ATLAS: 'border-sky-500/35 text-sky-200 bg-sky-500/10',
+  ZEUS: 'border-indigo-500/35 text-indigo-200 bg-indigo-500/10',
+  EVE: 'border-fuchsia-500/35 text-fuchsia-200 bg-fuchsia-500/10',
+  HERMES: 'border-violet-500/35 text-violet-200 bg-violet-500/10',
+  AUREA: 'border-amber-500/35 text-amber-200 bg-amber-500/10',
+  JADE: 'border-emerald-500/35 text-emerald-200 bg-emerald-500/10',
+  DAEDALUS: 'border-cyan-500/35 text-cyan-200 bg-cyan-500/10',
+  ECHO: 'border-teal-500/35 text-teal-200 bg-teal-500/10',
+};
+
+function JournalView({ entries, cycleId }: { entries: AgentJournalEntry[]; cycleId: string }) {
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const byAgent = useMemo(() => {
+    const grouped = new Map<string, AgentJournalEntry[]>();
+    for (const entry of entries) {
+      const lane = grouped.get(entry.agent) ?? [];
+      lane.push(entry);
+      grouped.set(entry.agent, lane);
+    }
+    return grouped;
+  }, [entries]);
+
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-slate-700 bg-slate-950/60 p-4 text-center text-xs text-slate-400">
+        No committed journal entries for {cycleId} yet. Agent reasoning will appear here as cycles run.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {AGENT_ORDER.map((agent) => {
+        const rows = byAgent.get(agent) ?? [];
+        const manifest = AGENT_MANIFESTS[agent];
+        return (
+          <div key={agent} className="rounded-md border border-slate-800 bg-slate-950/40">
+            <div className="flex items-center justify-between border-b border-slate-800 px-3 py-2">
+              <div className="flex items-center gap-2">
+                <span className={cn('rounded border px-1.5 py-0.5 text-[10px] font-mono uppercase', AGENT_COLOR[agent] ?? 'border-slate-700 text-slate-300')}>
+                  {agent}
+                </span>
+                <span className="text-[11px] text-slate-400">{manifest.scope}</span>
+              </div>
+              <span className="text-[10px] font-mono text-slate-500">{rows.length} entries</span>
+            </div>
+            <div className="space-y-2 p-2">
+              {rows.length === 0 ? (
+                <div className="rounded border border-dashed border-slate-700 bg-slate-950 p-2 text-[11px] text-slate-500">No entries yet.</div>
+              ) : (
+                rows.map((entry) => {
+                  const isOpen = expanded[entry.id] === true;
+                  return (
+                    <div key={entry.id} className="rounded border border-slate-800 bg-slate-950/70">
+                      <button
+                        onClick={() => setExpanded((prev) => ({ ...prev, [entry.id]: !isOpen }))}
+                        className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left"
+                      >
+                        <div>
+                          <div className="text-xs font-medium text-slate-200">{entry.category} · {entry.timestamp.slice(11, 16)} UTC</div>
+                          <div className="text-[11px] text-slate-400">{entry.inference}</div>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <span className="rounded border border-slate-700 px-1.5 py-0.5 text-[10px] font-mono uppercase text-slate-300">{entry.status}</span>
+                          {entry.contestedBy?.length ? (
+                            <span className="rounded border border-rose-500/40 bg-rose-500/10 px-1.5 py-0.5 text-[10px] font-mono uppercase text-rose-300">contested</span>
+                          ) : null}
+                          {entry.verifiedBy ? (
+                            <span className="rounded border border-emerald-500/40 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-mono uppercase text-emerald-300">verified</span>
+                          ) : null}
+                        </div>
+                      </button>
+                      {isOpen ? (
+                        <div className="space-y-2 border-t border-slate-800 px-3 py-2 text-[11px] text-slate-300">
+                          <div><span className="text-slate-500">Observation:</span> {entry.observation}</div>
+                          <div><span className="text-slate-500">Inference:</span> {entry.inference}</div>
+                          <div><span className="text-slate-500">Recommendation:</span> {entry.recommendation}</div>
+                          <div className="text-[10px] font-mono text-slate-500">confidence {(entry.confidence * 100).toFixed(0)}% · severity {entry.severity}</div>
+                        </div>
+                      ) : null}
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
 
 function MiniChart({ points }: { points: number[] }) {
   const normalized = points.length > 1 ? points : [0.5, 0.52, 0.49, 0.53, 0.55, 0.56, 0.57];

--- a/lib/agents/journal.ts
+++ b/lib/agents/journal.ts
@@ -1,0 +1,218 @@
+import { kvGet, kvSet } from '@/lib/kv/store';
+import { AGENT_MANIFESTS, AGENT_ORDER, type AgentName } from '@/lib/agents/manifests';
+import type { AgentJournalCategory, AgentJournalEntry, AgentJournalSeverity, AgentJournalStatus } from '@/lib/terminal/types';
+
+const INDEX_KEY = 'journal:index';
+const MAX_ENTRIES_PER_AGENT = 100;
+const MAX_INDEX_ROWS = 500;
+
+type JournalIndexRow = {
+  agent: AgentName;
+  cycle: string;
+  key: string;
+  updatedAt: string;
+};
+
+type NewJournalEntryInput = Omit<AgentJournalEntry, 'id' | 'timestamp' | 'scope' | 'source' | 'agentOrigin'> & {
+  id?: string;
+  timestamp?: string;
+  scope?: string;
+  source?: 'agent-journal';
+  agentOrigin?: string;
+};
+
+const VALID_STATUS: AgentJournalStatus[] = ['draft', 'committed', 'contested', 'verified'];
+const VALID_CATEGORY: AgentJournalCategory[] = ['observation', 'inference', 'alert', 'recommendation', 'close'];
+const VALID_SEVERITY: AgentJournalSeverity[] = ['nominal', 'elevated', 'critical'];
+
+function isAgentName(value: string): value is AgentName {
+  return value in AGENT_MANIFESTS;
+}
+
+function keyFor(agent: AgentName, cycle: string): string {
+  return `journal:${agent}:${cycle}`;
+}
+
+function clampConfidence(input: number): number {
+  return Math.max(0, Math.min(1, input));
+}
+
+function normalizeStringList(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  return input.filter((item): item is string => typeof item === 'string' && item.trim().length > 0).map((v) => v.trim());
+}
+
+function asRecord(input: unknown): Record<string, unknown> | null {
+  if (input === null || typeof input !== 'object') return null;
+  return input as Record<string, unknown>;
+}
+
+function makeJournalId(agent: AgentName, cycle: string): string {
+  const seq = Math.floor(Math.random() * 10_000)
+    .toString()
+    .padStart(4, '0');
+  return `journal-${agent}-${cycle}-${seq}`;
+}
+
+export function parseAgentJournalEntry(input: unknown): AgentJournalEntry | null {
+  const row = asRecord(input);
+  if (!row) return null;
+
+  const agent = row.agent;
+  const cycle = row.cycle;
+  const timestamp = row.timestamp;
+  const scope = row.scope;
+  const observation = row.observation;
+  const inference = row.inference;
+  const recommendation = row.recommendation;
+  const confidence = row.confidence;
+  const status = row.status;
+  const category = row.category;
+  const severity = row.severity;
+  const source = row.source;
+  const agentOrigin = row.agentOrigin;
+  const id = row.id;
+
+  if (typeof id !== 'string' || !id.trim()) return null;
+  if (typeof agent !== 'string' || !isAgentName(agent)) return null;
+  if (typeof cycle !== 'string' || !cycle.trim()) return null;
+  if (typeof timestamp !== 'string' || !timestamp.trim()) return null;
+  if (typeof scope !== 'string' || !scope.trim()) return null;
+  if (typeof observation !== 'string' || !observation.trim()) return null;
+  if (typeof inference !== 'string' || !inference.trim()) return null;
+  if (typeof recommendation !== 'string' || !recommendation.trim()) return null;
+  if (typeof confidence !== 'number' || Number.isNaN(confidence)) return null;
+  if (typeof status !== 'string' || !VALID_STATUS.includes(status as AgentJournalStatus)) return null;
+  if (typeof category !== 'string' || !VALID_CATEGORY.includes(category as AgentJournalCategory)) return null;
+  if (typeof severity !== 'string' || !VALID_SEVERITY.includes(severity as AgentJournalSeverity)) return null;
+  if (source !== 'agent-journal') return null;
+  if (typeof agentOrigin !== 'string' || !isAgentName(agentOrigin)) return null;
+
+  const contestedBy = normalizeStringList(row.contestedBy);
+  const verifiedBy = typeof row.verifiedBy === 'string' && row.verifiedBy.trim() ? row.verifiedBy.trim() : undefined;
+
+  return {
+    id: id.trim(),
+    agent,
+    cycle: cycle.trim(),
+    timestamp: timestamp.trim(),
+    scope: scope.trim(),
+    observation: observation.trim(),
+    inference: inference.trim(),
+    recommendation: recommendation.trim(),
+    confidence: clampConfidence(confidence),
+    derivedFrom: normalizeStringList(row.derivedFrom),
+    relatedAgents: normalizeStringList(row.relatedAgents),
+    status: status as AgentJournalStatus,
+    contestedBy: contestedBy.length > 0 ? contestedBy : undefined,
+    verifiedBy,
+    category: category as AgentJournalCategory,
+    severity: severity as AgentJournalSeverity,
+    source: 'agent-journal',
+    agentOrigin,
+  };
+}
+
+export function buildAgentJournalEntry(input: NewJournalEntryInput): AgentJournalEntry {
+  if (!isAgentName(input.agent)) {
+    throw new Error(`Unknown agent: ${input.agent}`);
+  }
+  if (!VALID_STATUS.includes(input.status)) {
+    throw new Error(`Invalid status: ${input.status}`);
+  }
+  if (!VALID_CATEGORY.includes(input.category)) {
+    throw new Error(`Invalid category: ${input.category}`);
+  }
+  if (!VALID_SEVERITY.includes(input.severity)) {
+    throw new Error(`Invalid severity: ${input.severity}`);
+  }
+  const cycle = input.cycle.trim();
+  if (!cycle) {
+    throw new Error('cycle is required');
+  }
+
+  return {
+    id: input.id?.trim() || makeJournalId(input.agent, cycle),
+    agent: input.agent,
+    cycle,
+    timestamp: input.timestamp?.trim() || new Date().toISOString(),
+    scope: input.scope?.trim() || AGENT_MANIFESTS[input.agent].scope,
+    observation: input.observation.trim(),
+    inference: input.inference.trim(),
+    recommendation: input.recommendation.trim(),
+    confidence: clampConfidence(input.confidence),
+    derivedFrom: input.derivedFrom,
+    relatedAgents: input.relatedAgents,
+    status: input.status,
+    contestedBy: input.contestedBy,
+    verifiedBy: input.verifiedBy,
+    category: input.category,
+    severity: input.severity,
+    source: 'agent-journal',
+    agentOrigin: input.agentOrigin?.trim() || input.agent,
+  };
+}
+
+async function upsertIndex(agent: AgentName, cycle: string): Promise<void> {
+  const key = keyFor(agent, cycle);
+  const rows = (await kvGet<JournalIndexRow[]>(INDEX_KEY)) ?? [];
+  const existing = rows.filter((row) => !(row.agent === agent && row.cycle === cycle));
+  existing.unshift({ agent, cycle, key, updatedAt: new Date().toISOString() });
+  await kvSet(INDEX_KEY, existing.slice(0, MAX_INDEX_ROWS));
+}
+
+export async function appendAgentJournalEntry(input: NewJournalEntryInput): Promise<AgentJournalEntry> {
+  const entry = buildAgentJournalEntry(input);
+  const agent = entry.agent as AgentName;
+  const key = keyFor(agent, entry.cycle);
+  const existing = (await kvGet<AgentJournalEntry[]>(key)) ?? [];
+  const next = [...existing, entry].slice(-MAX_ENTRIES_PER_AGENT);
+  await kvSet(key, next);
+  await upsertIndex(agent, entry.cycle);
+  return entry;
+}
+
+export async function getAgentJournalEntries(filters?: {
+  agent?: string | null;
+  cycle?: string | null;
+  category?: string | null;
+  status?: AgentJournalStatus | null;
+}): Promise<AgentJournalEntry[]> {
+  const agentFilter = typeof filters?.agent === 'string' && filters.agent.trim() ? filters.agent.trim().toUpperCase() : null;
+  const cycleFilter = typeof filters?.cycle === 'string' && filters.cycle.trim() ? filters.cycle.trim() : null;
+  const categoryFilter = typeof filters?.category === 'string' && filters.category.trim() ? filters.category.trim() : null;
+  const statusFilter = filters?.status ?? 'committed';
+
+  const keys = new Set<string>();
+
+  if (agentFilter && cycleFilter && isAgentName(agentFilter)) {
+    keys.add(keyFor(agentFilter, cycleFilter));
+  } else {
+    const rows = (await kvGet<JournalIndexRow[]>(INDEX_KEY)) ?? [];
+    for (const row of rows) {
+      if (agentFilter && row.agent !== agentFilter) continue;
+      if (cycleFilter && row.cycle !== cycleFilter) continue;
+      keys.add(row.key);
+    }
+    if (keys.size === 0 && cycleFilter) {
+      for (const agent of AGENT_ORDER) {
+        if (agentFilter && agent !== agentFilter) continue;
+        keys.add(keyFor(agent, cycleFilter));
+      }
+    }
+  }
+
+  const out: AgentJournalEntry[] = [];
+  for (const key of keys) {
+    const rows = (await kvGet<AgentJournalEntry[]>(key)) ?? [];
+    for (const raw of rows) {
+      const entry = parseAgentJournalEntry(raw);
+      if (!entry) continue;
+      if (statusFilter && entry.status !== statusFilter) continue;
+      if (categoryFilter && entry.category !== categoryFilter) continue;
+      out.push(entry);
+    }
+  }
+
+  return out.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+}

--- a/lib/agents/manifests.ts
+++ b/lib/agents/manifests.ts
@@ -1,0 +1,110 @@
+export type AgentName = 'ATLAS' | 'ZEUS' | 'EVE' | 'HERMES' | 'AUREA' | 'JADE' | 'DAEDALUS' | 'ECHO';
+
+export type AgentManifest = {
+  scope: string;
+  watchList: string[];
+  journalTone: string;
+  triggerConditions: string[];
+};
+
+export const AGENT_ORDER: AgentName[] = ['ATLAS', 'ZEUS', 'EVE', 'HERMES', 'AUREA', 'JADE', 'DAEDALUS', 'ECHO'];
+
+export const AGENT_MANIFESTS: Record<AgentName, AgentManifest> = {
+  ATLAS: {
+    scope: 'System integrity, operator accountability, sentinel oversight',
+    watchList: [
+      'GI composite',
+      'heartbeat freshness',
+      'EPICON commit chain',
+      'operator action trail',
+      'agent consensus divergence',
+    ],
+    journalTone: 'Measured, authoritative, constitutional',
+    triggerConditions: ['GI drops', 'heartbeat gaps', 'unverified entries aging > 6h'],
+  },
+  ZEUS: {
+    scope: 'Verification and contested claims',
+    watchList: [
+      'Unverified EPICON candidates',
+      'source credibility',
+      'cross-agent consensus',
+      'tripwire threshold breaches',
+    ],
+    journalTone: 'Evidentiary, precise, skeptical by default',
+    triggerConditions: [
+      'Any entry pending verification > 2h',
+      'ATLAS/EVE disagreement',
+      'source conflict',
+    ],
+  },
+  EVE: {
+    scope: 'Governance, ethics, civic risk, narrative patterns',
+    watchList: [
+      'External events',
+      'institutional behavior',
+      'civic radar',
+      'narrative overreach',
+      'bias indicators',
+      'power concentration',
+    ],
+    journalTone: 'Observational, cautionary, futures-oriented',
+    triggerConditions: ['Civic alert threshold', 'GI drops', 'narrative cluster spikes'],
+  },
+  HERMES: {
+    scope: 'Signal routing, message prioritization, information flow',
+    watchList: [
+      'Signal latency',
+      'feed freshness',
+      'agent communication gaps',
+      'routing failures',
+      'priority queue depth',
+    ],
+    journalTone: 'Technical, operational, terse',
+    triggerConditions: ['Feed staleness > 30min', 'routing failures', 'queue depth'],
+  },
+  AUREA: {
+    scope: 'Strategic synthesis, long arc patterns, system posture',
+    watchList: [
+      'Multi-cycle GI trends',
+      'agent activity patterns',
+      'EPICON entry density',
+      'system maturity indicators',
+    ],
+    journalTone: 'Strategic, reflective, long-horizon',
+    triggerConditions: ['Daily close', 'weekly arc', 'major threshold crossings'],
+  },
+  JADE: {
+    scope: 'Constitutional annotation, memory framing, precedent',
+    watchList: [
+      'EPICON entries for constitutional relevance',
+      'operator intent alignment',
+      'covenant adherence',
+    ],
+    journalTone: 'Constitutional, archival, precise',
+    triggerConditions: ['Entries touching Three Covenants', 'novel precedents'],
+  },
+  DAEDALUS: {
+    scope: 'Infrastructure health, system build integrity',
+    watchList: [
+      'API health',
+      'KV freshness',
+      'deployment state',
+      'dependency versions',
+      'self-ping latency',
+    ],
+    journalTone: 'Engineering, diagnostic, factual',
+    triggerConditions: ['401 errors', 'KV misses', 'build failures'],
+  },
+  ECHO: {
+    scope: 'Event memory, deduplication, ingestion integrity',
+    watchList: [
+      'Feed dedup rate',
+      'ingestion volume',
+      'memory coherence',
+      'duplicate events',
+      'source overlap',
+    ],
+    journalTone: 'Archival, inventory-style, precise',
+    triggerConditions: ['Dedup spikes', 'volume anomalies', 'memory gaps'],
+  },
+};

--- a/lib/terminal/types.ts
+++ b/lib/terminal/types.ts
@@ -150,6 +150,31 @@ export type LedgerEntry = {
   source?: 'mock' | 'echo' | 'backfill' | 'eve-synthesis' | 'agent_commit';
 };
 
+export type AgentJournalStatus = 'draft' | 'committed' | 'contested' | 'verified';
+export type AgentJournalCategory = 'observation' | 'inference' | 'alert' | 'recommendation' | 'close';
+export type AgentJournalSeverity = 'nominal' | 'elevated' | 'critical';
+
+export interface AgentJournalEntry {
+  id: string;
+  agent: string;
+  cycle: string;
+  timestamp: string;
+  scope: string;
+  observation: string;
+  inference: string;
+  recommendation: string;
+  confidence: number;
+  derivedFrom: string[];
+  relatedAgents: string[];
+  status: AgentJournalStatus;
+  contestedBy?: string[];
+  verifiedBy?: string;
+  category: AgentJournalCategory;
+  severity: AgentJournalSeverity;
+  source: 'agent-journal';
+  agentOrigin: string;
+}
+
 export type MFSShard = {
   id: string;
   citizenId: string;


### PR DESCRIPTION
### Motivation
- Make EPICON a ledger of minds by recording agent-scoped reasoning traces so operators can see who noticed what, why, and with what confidence. 
- Provide a canonical manifest for each core agent (scope, watch list, tone, triggers) to drive UI and automation behavior.
- Surface cross-agent dissent/verification by storing journal state (draft/committed/contested/verified) alongside events.

### Description
- Added canonical agent manifests in `lib/agents/manifests.ts` exporting `AGENT_MANIFESTS` and `AGENT_ORDER` for the eight agents (`ATLAS`, `ZEUS`, `EVE`, `HERMES`, `AUREA`, `JADE`, `DAEDALUS`, `ECHO`).
- Introduced typed journal types in `lib/terminal/types.ts`: `AgentJournalEntry` plus `status`, `category`, and `severity` unions to keep strict TypeScript typing.
- Implemented append-only KV-backed journal infra in `lib/agents/journal.ts` with parsing/validation (`parseAgentJournalEntry` / `buildAgentJournalEntry`), per-agent-per-cycle keys `journal:{agent}:{cycle}`, an index for retrieval, and retention capped at 100 entries per agent-cycle.
- Exposed `GET` and `POST` endpoints at `app/api/agents/journal/route.ts`; `GET` supports `?agent=&cycle=&category=` and returns committed entries, and `POST` requires `Authorization: Bearer CRON_SECRET` (validated via `isValidCronSecretBearer`) and validates payloads before appending.
- Hooked journaling calls into automations so agents write reasoning after runs: `ATLAS` watchdog (`/api/cron/watchdog`), `EVE` cycle synthesis (`/api/eve/cycle-synthesize`), `ZEUS` verification (`/api/zeus/verify`), and `AUREA` oversight (`/api/aurea/oversee`).
- Added a Journal view in the Terminal ledger UI (`app/terminal/TerminalPageClient.tsx`) with an `Events | Journal` toggle, per-agent collapsible sections, expandable entry rows showing `observation` / `inference` / `recommendation`, agent color badges, and consensus chips (`contested`, `verified`).
- Implementation notes: TypeScript strict typing preserved, KV writes are append-only, journal reads fallback to empty state so rendering is non-blocking, and no new npm deps were introduced.

### Testing
- `npx tsc --noEmit` passed successfully against the updated codebase.
- `npm run lint` (Next.js `next lint`) could not be completed non-interactively in this environment because it triggers the interactive ESLint bootstrap prompt; no new lint infra was added and lint remains to be run in CI or an interactive dev environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2c3492930832d8b11b21e5d5c3e7e)