### PR TITLE
fix(eve): POST synthesis, normalize author field, surface KV entries in feed [C-272]

### DIFF
--- a/app/api/epicon/feed/route.ts
+++ b/app/api/epicon/feed/route.ts
@@ -330,11 +330,13 @@ function coerceLedgerEntrySource(entry: EpiconEntry): EpiconEntry {
   const governanceSynthTagged = entry.tags?.includes('eve-governance-synthesis') === true;
   const eveOrigin = entry.agentOrigin?.trim() === 'EVE';
   if (entry.source === 'eve-synthesis' || eveOrigin || governanceSynthTagged) {
+    const currentTags = Array.isArray(entry.tags) ? entry.tags : [];
     return {
       ...entry,
       source: 'eve-synthesis',
-      author: entry.author?.trim() ? entry.author : 'EVE',
+      author: 'eve',
       agentOrigin: entry.agentOrigin?.trim() ? entry.agentOrigin : 'EVE',
+      tags: currentTags.includes('eve') ? currentTags : [...currentTags, 'eve'],
     };
   }
   return entry;
@@ -354,6 +356,33 @@ async function fromRedis(): Promise<EpiconEntry[]> {
       .map((entry) => {
         try {
           return coerceLedgerEntrySource(JSON.parse(entry) as EpiconEntry);
+        } catch {
+          return null;
+        }
+      })
+      .filter((entry): entry is EpiconEntry => entry !== null);
+  } catch {
+    return [];
+  }
+}
+
+async function fromEveSynthesisRedis(): Promise<EpiconEntry[]> {
+  const redis = getRedisClient();
+  if (!redis) return [];
+
+  try {
+    const rows = await redis.lrange<string>('epicon:eve-synthesis', 0, 99);
+    return rows
+      .map((entry) => {
+        try {
+          const parsed = JSON.parse(entry) as EpiconEntry;
+          return coerceLedgerEntrySource({
+            ...parsed,
+            source: 'eve-synthesis',
+            author: 'eve',
+            agentOrigin: 'EVE',
+            tags: Array.isArray(parsed.tags) ? Array.from(new Set([...parsed.tags, 'eve'])) : ['eve'],
+          });
         } catch {
           return null;
         }
@@ -434,10 +463,11 @@ export async function GET(request: NextRequest) {
   const minGI = params.get('minGI');
   const minGiValue = minGI ? Number.parseFloat(minGI) : undefined;
 
-  const [{ entries: ledgerEntries, degraded: ledgerDegraded }, commits, kvEntries] = await Promise.all([
+  const [{ entries: ledgerEntries, degraded: ledgerDegraded }, commits, kvEntries, eveKvEntries] = await Promise.all([
     fetchRenderLedgerEntries(50),
     fetchGitHubCommits(80),
     fromRedis(),
+    fromEveSynthesisRedis(),
   ]);
   const commitEntries = commits.map(toEpiconEntry).filter((entry): entry is EpiconEntry => entry !== null);
   const memoryEntries = fromMemoryFeed();
@@ -446,6 +476,7 @@ export async function GET(request: NextRequest) {
   let entries = dedupeSort([
     ...ledgerEntries,
     ...kvEntries,
+    ...eveKvEntries,
     ...localLedgerEntries,
     ...commitEntries,
     ...memoryEntries,
@@ -470,6 +501,7 @@ export async function GET(request: NextRequest) {
         github: commitEntries.length,
         ledgerApi: ledgerEntries.length,
         kv: kvEntries.length,
+        eveKv: eveKvEntries.length,
         memory: memoryEntries.length,
         memoryLedger: localLedgerEntries.length,
         kvConfigured: !!getRedisClient(),

--- a/app/api/eve/cycle-synthesize/route.ts
+++ b/app/api/eve/cycle-synthesize/route.ts
@@ -88,7 +88,7 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json({
     ok: true,
-    info: 'POST with service Authorization to run EVE governance synthesis (live EPICON ledger). Vercel Cron GET runs cycle synthesis when scheduled.',
+    info: 'GET is preview-only and does not run synthesis (unless Vercel Cron headers are present). Use POST with service Authorization to execute EVE governance synthesis.',
     mode: 'cycle',
     currentCycle: cycleId,
     windowBucket,

--- a/lib/eve/governance-synthesis.ts
+++ b/lib/eve/governance-synthesis.ts
@@ -21,6 +21,7 @@ import { getTripwireState } from '@/lib/tripwire/store';
 
 export const EVE_GOVERNANCE_SYNTH_TAG = 'eve-governance-synthesis';
 export const EVE_SYNTHESIS_SOURCE = 'eve-synthesis' as const;
+const EVE_SYNTHESIS_KV_KEY = 'epicon:eve-synthesis';
 
 /** Align with EVE automation cadence (every 4h). */
 const CYCLE_WINDOW_MS = 4 * 60 * 60 * 1000;
@@ -658,6 +659,7 @@ export async function publishEveGovernanceSynthesis(
   const ledgerSeverity = ledgerSeverityFromSignals(output.severity);
 
   const tags = [
+    'eve',
     EVE_GOVERNANCE_SYNTH_TAG,
     idempotencyTag,
     output.category,
@@ -667,10 +669,10 @@ export async function publishEveGovernanceSynthesis(
   const derivedFromIds = output.derivedFrom.slice(0, 32);
   const derivedFromCompact = derivedFromIds.join('|').slice(0, 512);
 
-  await pushLedgerEntry({
+  const entry: EpiconLedgerFeedEntry = {
     id: entryId,
     timestamp,
-    author: 'EVE',
+    author: 'eve',
     title: output.title,
     body: output.body,
     type: 'epicon',
@@ -687,7 +689,16 @@ export async function publishEveGovernanceSynthesis(
     derivedFromIds,
     status: 'committed',
     agentOrigin: 'EVE',
-  });
+  };
+
+  await pushLedgerEntry(entry);
+
+  const redis = getRedisClient();
+  if (redis) {
+    const payload = JSON.stringify(entry);
+    await redis.lpush(EVE_SYNTHESIS_KV_KEY, payload);
+    await redis.ltrim(EVE_SYNTHESIS_KV_KEY, 0, 199);
+  }
 
   return { published: true, entryId, idempotencyTag, ledgerSeverity };
 }


### PR DESCRIPTION
### Motivation
- EVE synthesis was being written to KV but the public EPICON feed only read GitHub commits, and automations were calling the wrong HTTP method, causing EVE to show zero entries in the UI.
- Normalize author/agentOrigin and tag EVE outputs so the agent filter tabs (`author === 'eve'` or `agentOrigin === 'EVE'` or `tags` includes `'eve'`) will surface EVE rows.

### Description
- Publish-time normalization: EVE synthesis ledger entries are now built with `author: 'eve'`, `agentOrigin: 'EVE'`, and include an `'eve'` tag before being pushed to the ledger, and the `EVE` tag is added to the tags array; change made in `lib/eve/governance-synthesis.ts`.
- KV mirroring: committed EVE synthesis entries are mirrored into a dedicated Redis list `epicon:eve-synthesis` (trimmed), so the feed can read EVE-specific rows; implemented in `lib/eve/governance-synthesis.ts` using `EVE_SYNTHESIS_KV_KEY`.
- Feed ingestion: `/api/epicon/feed` now reads `epicon:eve-synthesis`, parses and normalizes those rows (sets `source: 'eve-synthesis'`, `author: 'eve'`, `agentOrigin: 'EVE'`, ensures `'eve'` tag), merges them with other sources, and deduplicates by `id`; it also exposes `sources.eveKv` in the response; changes in `app/api/epicon/feed/route.ts`.
- Coercion hardening: feed coercion now always maps EVE-origin rows to `author: 'eve'` and appends `'eve'` to tags to match UI filters.
- Automation guidance: clarified the `/api/eve/cycle-synthesize` GET response text to explicitly state GET is preview-only and that POST (with service auth or vercel cron headers) is required to execute synthesis; change in `app/api/eve/cycle-synthesize/route.ts`.

### Testing
- Type-check: ran `npx tsc --noEmit` and it completed successfully.
- Lint: ran `npm run lint` but the environment prompted for interactive ESLint setup so non-interactive lint verification could not complete (manual/CI lint recommended).
- Basic build/commit: changes were committed (`fix(eve): POST synthesis, normalize author field, surface KV entries in feed [C-272]`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2c806353c832db2de060fa730e9b1)