### PR TITLE
fix(terminal): agents KV heartbeat + journal route cache + EVE KV feed [C-272]

### DIFF
--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServiceAuthError } from '@/lib/security/serviceAuth';
 
 export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
 type AgentJournalStatus = 'draft' | 'committed' | 'contested' | 'verified';
 type AgentJournalCategory = 'observation' | 'inference' | 'alert' | 'recommendation' | 'close';
@@ -193,13 +194,20 @@ export async function GET(request: NextRequest) {
 
   const agents = Array.from(new Set(filtered.map((entry) => entry.agent)));
 
-  return NextResponse.json({
-    ok: true,
-    count: filtered.length,
-    entries: filtered,
-    agents,
-    timestamp: new Date().toISOString(),
-  });
+  return NextResponse.json(
+    {
+      ok: true,
+      count: filtered.length,
+      entries: filtered,
+      agents,
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    },
+  );
 }
 
 export async function POST(request: NextRequest) {

--- a/app/api/agents/status/route.ts
+++ b/app/api/agents/status/route.ts
@@ -36,17 +36,17 @@ const AGENT_BASE = [
 
 let staleSnapshot: { cycle: string; timestamp: string } | null = null;
 
-function toAgentStatus(status: 'alive' | 'unknown') {
+function toAgentStatus(status: 'active' | 'unknown') {
   return AGENT_BASE.map((agent) => ({
     ...agent,
     status,
     detail:
-      status === 'alive'
+      status === 'active'
         ? 'Live heartbeat observed from KV.'
         : 'Heartbeat is stale; agent state is currently unknown.',
-    heartbeat_ok: status === 'alive',
+    heartbeat_ok: status === 'active',
     last_action:
-      status === 'alive'
+      status === 'active'
         ? 'Live heartbeat received'
         : 'Awaiting fresh runtime heartbeat',
   }));
@@ -80,15 +80,17 @@ export async function GET() {
       return NextResponse.json({
         ok: true,
         ...liveEnvelope(timestamp),
+        source: 'kv-heartbeat',
         cycle,
         timestamp,
-        agents: toAgentStatus('alive'),
+        agents: toAgentStatus('active'),
       });
     }
 
     return NextResponse.json({
       ok: true,
       ...staleCacheEnvelope(timestamp, 'Heartbeat stale'),
+      source: 'stale-cache',
       cycle,
       timestamp,
       agents: toAgentStatus('unknown'),
@@ -101,6 +103,7 @@ export async function GET() {
       return NextResponse.json({
         ok: true,
         ...staleCacheEnvelope(staleSnapshot.timestamp, 'Heartbeat stale'),
+        source: 'stale-cache',
         cycle: staleSnapshot.cycle,
         timestamp: staleSnapshot.timestamp,
         agents: toAgentStatus('unknown'),

--- a/app/api/epicon/feed/route.ts
+++ b/app/api/epicon/feed/route.ts
@@ -371,16 +371,37 @@ async function fromEveSynthesisRedis(): Promise<EpiconEntry[]> {
   if (!redis) return [];
 
   try {
-    const rows = await redis.lrange<string>('epicon:eve-synthesis', 0, 99);
+    const rows = await redis.lrange<string>('epicon:eve-synthesis', 0, 19);
     return rows
-      .map((entry) => {
+      .map((entry, index) => {
         try {
-          const parsed = JSON.parse(entry) as EpiconEntry;
+          const parsed = JSON.parse(entry) as Partial<EpiconEntry> & {
+            id?: string;
+            timestamp?: string;
+            created_at?: string;
+            createdAt?: string;
+            summary?: string;
+          };
+          const timestamp = parsed.timestamp ?? parsed.created_at ?? parsed.createdAt ?? new Date().toISOString();
+          const title = typeof parsed.title === 'string' ? parsed.title : parsed.summary ?? 'EVE synthesis';
+          const id =
+            typeof parsed.id === 'string' && parsed.id.trim().length > 0
+              ? parsed.id
+              : `eve-synthesis-${timestamp}-${index}`;
+
           return coerceLedgerEntrySource({
             ...parsed,
+            id,
+            timestamp,
+            title,
             source: 'eve-synthesis',
             author: 'eve',
             agentOrigin: 'EVE',
+            type: parsed.type ?? 'epicon',
+            severity: (typeof parsed.severity === 'string' && isEpiconSeverity(parsed.severity)
+              ? parsed.severity
+              : 'info') as EpiconSeverity,
+            verified: Boolean(parsed.verified),
             tags: Array.isArray(parsed.tags) ? Array.from(new Set([...parsed.tags, 'eve'])) : ['eve'],
           });
         } catch {


### PR DESCRIPTION
### Motivation
- Flip the UI OFFLINE badge to ONLINE by making the agents status API consume the live `HEARTBEAT` value from KV when present and fresh.
- Ensure the agents journal polling path is reliably live so the UI does not get blocked by cached 404s.
- Surface EVE-generated synthesis rows into the EPICON feed so EVE entries appear in the ledger and the integrity feed.

### Description
- Updated `app/api/agents/status/route.ts` to treat fresh heartbeat-backed state as `active`, include an explicit `source` field (`kv-heartbeat` when fresh, `stale-cache` when stale/fallback), and preserve the existing stale/mock fallback behavior. 
- Updated `app/api/agents/journal/route.ts` to export `revalidate = 0` and return `Cache-Control: no-store` on `GET` responses so the 30s polling path always receives live data. 
- Updated `app/api/epicon/feed/route.ts` to read `epicon:eve-synthesis` from KV using a 20-item window (`lrange 0,19`), normalize incomplete payloads (fallbacks for `id`, `timestamp`, `title`, and severity), coerce the source/author metadata for EVE rows, and keep existing dedupe/merge logic. 

### Testing
- Ran `npm run build`, which completed successfully. 
- Ran `npm run lint`, which triggers an interactive Next.js/ESLint setup prompt in this repo and did not complete in non-interactive mode (note: lint requires repository ESLint configuration to be completed interactively).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2ccefc544832d93d3fe69440305e6)