### PR TITLE
feat(ledger): multi-dimension sort control [C-272]

### DIFF
--- a/app/terminal/TerminalPageClient.tsx
+++ b/app/terminal/TerminalPageClient.tsx
@@ -74,6 +74,9 @@ export default function TerminalPageWrapper() {
 }
 
 function TerminalPage() {
+  type SortField = 'time' | 'agent' | 'type' | 'severity' | 'gi' | 'status' | 'source';
+  type SortDirection = 'asc' | 'desc';
+
   const [selectedNav, setSelectedNav] = useState<NavKey>('pulse');
   const [selectedLedgerId, setSelectedLedgerId] = useState<string | null>(null);
   const [expandedLedgerId, setExpandedLedgerId] = useState<string | null>(null);
@@ -91,7 +94,8 @@ function TerminalPage() {
   const [journalFeed, setJournalFeed] = useState<AgentJournalEntry[]>([]);
   const [ledgerView, setLedgerView] = useState<'events' | 'journal'>('events');
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState<'time-desc' | 'time-asc' | 'type' | 'author' | 'gi-desc' | 'severity'>('time-desc');
+  const [sortBy, setSortBy] = useState<SortField>('time');
+  const [sortDir, setSortDir] = useState<SortDirection>('desc');
   const [resultCount, setResultCount] = useState(0);
   const [runtimeBadge, setRuntimeBadge] = useState<'online' | 'degraded' | 'offline'>('offline');
   const agentSearchRef = useRef<HTMLInputElement>(null);
@@ -387,6 +391,7 @@ function TerminalPage() {
               total={epiconFeed?.total ?? 0}
               searchQuery={searchQuery}
               sortBy={sortBy}
+              sortDir={sortDir}
               onResultCountChange={setResultCount}
             />
           ) : (
@@ -438,7 +443,11 @@ function TerminalPage() {
           {agentTabs.map((agent) => (
             <button
               key={agent}
-              onClick={() => setAgentFilter(agent)}
+              onClick={() => {
+                setAgentFilter(agent);
+                setSortBy('time');
+                setSortDir('desc');
+              }}
               className={cn('rounded-md border px-2 py-1 text-[10px] font-mono uppercase tracking-[0.14em]', getAgentTabClass(agent, agentFilter === agent))}
             >
               {agent}
@@ -549,7 +558,7 @@ function TerminalPage() {
                     <span className="text-[9px] font-mono uppercase tracking-widest text-slate-600">Sort</span>
                     <select
                       value={sortBy}
-                      onChange={(event) => setSortBy(event.target.value as typeof sortBy)}
+                      onChange={(event) => setSortBy(event.target.value as SortField)}
                       className="cursor-pointer appearance-none rounded-md border border-slate-800 bg-slate-900 px-2 py-1.5 pr-6 text-[11px] font-mono text-slate-400 transition-colors focus:border-sky-500/50 focus:outline-none"
                       style={{
                         backgroundImage:
@@ -559,13 +568,22 @@ function TerminalPage() {
                         backgroundSize: '10px',
                       }}
                     >
-                      <option value="time-desc">Newest first</option>
-                      <option value="time-asc">Oldest first</option>
-                      <option value="type">By type</option>
-                      <option value="author">By author</option>
-                      <option value="gi-desc">GI high → low</option>
-                      <option value="severity">By severity</option>
+                      <option value="time">Time</option>
+                      <option value="agent">Agent</option>
+                      <option value="type">Type</option>
+                      <option value="severity">Severity</option>
+                      <option value="gi">GI score</option>
+                      <option value="status">Status</option>
+                      <option value="source">Source</option>
                     </select>
+                    <button
+                      type="button"
+                      onClick={() => setSortDir((prev) => (prev === 'desc' ? 'asc' : 'desc'))}
+                      className="inline-flex h-7 w-5 items-center justify-center rounded-md border border-slate-800 bg-slate-900 text-[11px] font-mono text-slate-400 transition-colors hover:border-sky-500/40 hover:text-sky-300"
+                      aria-label={`Toggle sort direction (currently ${sortDir})`}
+                    >
+                      {sortDir === 'desc' ? '↓' : '↑'}
+                    </button>
                   </div>
 
                   {searchQuery ? (

--- a/components/terminal/EventScreener.tsx
+++ b/components/terminal/EventScreener.tsx
@@ -13,9 +13,11 @@ export interface EpiconFeedItem {
   severity: string;
   tags: string[];
   source: string;
+  status?: string;
   verified: boolean;
   sha?: string;
   gi?: number;
+  agentOrigin?: string;
 }
 
 interface EventScreenerProps {
@@ -24,13 +26,12 @@ interface EventScreenerProps {
   sources: { github: number; kv: number };
   total: number;
   searchQuery?: string;
-  sortBy?: 'time-desc' | 'time-asc' | 'type' | 'author' | 'gi-desc' | 'severity';
+  sortBy?: 'time' | 'agent' | 'type' | 'severity' | 'gi' | 'status' | 'source';
+  sortDir?: 'asc' | 'desc';
   onResultCountChange?: (count: number) => void;
 }
 
 const PAGE_SIZE = 12;
-
-type SortColumn = 'time' | 'type' | 'author' | 'gi';
 type TypeFilter = 'all' | 'merge' | 'heartbeat' | 'catalog' | 'epicon' | 'zeus-verify';
 type AuthorFilter = 'all' | 'kaizencycle' | 'mobius-bot' | 'cursor-agent';
 
@@ -147,12 +148,11 @@ export default function EventScreener({
   total,
   searchQuery: externalSearchQuery,
   sortBy,
+  sortDir,
   onResultCountChange,
 }: EventScreenerProps) {
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
   const [authorFilter, setAuthorFilter] = useState<AuthorFilter>('all');
-  const [sortCol, setSortCol] = useState<SortColumn>('time');
-  const [sortDir, setSortDir] = useState<1 | -1>(-1);
   const [page, setPage] = useState(0);
   const [openId, setOpenId] = useState<string | null>(null);
   const [localSearchQuery, setLocalSearchQuery] = useState('');
@@ -163,7 +163,32 @@ export default function EventScreener({
 
   const filteredAndSorted = useMemo(() => {
     const needle = searchQuery.trim().toLowerCase();
-    const severityRank: Record<string, number> = { critical: 0, elevated: 1, nominal: 2 };
+    const direction = sortDir === 'asc' ? 1 : -1;
+    const activeSortBy = sortBy ?? 'time';
+
+    const agentPriority = ['atlas', 'zeus', 'eve', 'hermes', 'aurea', 'jade', 'daedalus', 'echo', 'kaizencycle', 'mobius-bot', 'cursor-agent'];
+    const typePriority = ['heartbeat', 'epicon', 'zeus-verify', 'merge', 'catalog'];
+    const severityPriority = ['critical', 'elevated', 'degraded', 'nominal', 'info'];
+    const statusPriority = ['committed', 'pending', 'unknown'];
+
+    const rankFor = (value: string, ordered: string[]) => {
+      const idx = ordered.indexOf(value.toLowerCase());
+      return idx >= 0 ? idx : ordered.length;
+    };
+
+    const timeValue = (value: string) => {
+      const parsed = new Date(value).getTime();
+      return Number.isFinite(parsed) ? parsed : 0;
+    };
+
+    const compareNullableNumbers = (a: number | undefined, b: number | undefined) => {
+      const aMissing = typeof a !== 'number';
+      const bMissing = typeof b !== 'number';
+      if (aMissing && bMissing) return 0;
+      if (aMissing) return 1;
+      if (bMissing) return -1;
+      return a - b;
+    };
 
     const externallyFiltered = list.filter((item) => {
       if (!needle) return true;
@@ -176,12 +201,42 @@ export default function EventScreener({
     });
 
     const externallySorted = [...externallyFiltered].sort((a, b) => {
-      if (sortBy === 'time-asc') return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
-      if (sortBy === 'type') return (a.type ?? '').localeCompare(b.type ?? '');
-      if (sortBy === 'author') return (a.author ?? '').localeCompare(b.author ?? '');
-      if (sortBy === 'gi-desc') return (b.gi ?? -1) - (a.gi ?? -1);
-      if (sortBy === 'severity') return (severityRank[a.severity?.toLowerCase()] ?? Number.MAX_SAFE_INTEGER) - (severityRank[b.severity?.toLowerCase()] ?? Number.MAX_SAFE_INTEGER);
-      return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+      const compare = (() => {
+        if (activeSortBy === 'time') return timeValue(a.timestamp) - timeValue(b.timestamp);
+        if (activeSortBy === 'agent') {
+          const agentA = (a.author || a.agentOrigin || '').toLowerCase();
+          const agentB = (b.author || b.agentOrigin || '').toLowerCase();
+          const rankDiff = rankFor(agentA, agentPriority) - rankFor(agentB, agentPriority);
+          if (rankDiff !== 0) return rankDiff;
+          return agentA.localeCompare(agentB);
+        }
+        if (activeSortBy === 'type') {
+          const typeA = (a.type || '').toLowerCase();
+          const typeB = (b.type || '').toLowerCase();
+          const rankDiff = rankFor(typeA, typePriority) - rankFor(typeB, typePriority);
+          if (rankDiff !== 0) return rankDiff;
+          return typeA.localeCompare(typeB);
+        }
+        if (activeSortBy === 'severity') {
+          const severityA = (a.severity || '').toLowerCase();
+          const severityB = (b.severity || '').toLowerCase();
+          const rankDiff = rankFor(severityA, severityPriority) - rankFor(severityB, severityPriority);
+          if (rankDiff !== 0) return rankDiff;
+          return severityA.localeCompare(severityB);
+        }
+        if (activeSortBy === 'gi') return compareNullableNumbers(a.gi, b.gi);
+        if (activeSortBy === 'status') {
+          const statusA = (a.status || 'unknown').toLowerCase();
+          const statusB = (b.status || 'unknown').toLowerCase();
+          const rankDiff = rankFor(statusA, statusPriority) - rankFor(statusB, statusPriority);
+          if (rankDiff !== 0) return rankDiff;
+          return statusA.localeCompare(statusB);
+        }
+        return (a.source || '').localeCompare(b.source || '');
+      })();
+
+      if (compare !== 0) return compare * direction;
+      return (timeValue(b.timestamp) - timeValue(a.timestamp)) * direction;
     });
 
     const filtered = externallySorted.filter((item) => {
@@ -190,19 +245,8 @@ export default function EventScreener({
       return true;
     });
 
-    return [...filtered].sort((a, b) => {
-      if (sortCol === 'time') {
-        return sortDir * (new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
-      }
-      if (sortCol === 'type') {
-        return sortDir * a.type.localeCompare(b.type);
-      }
-      if (sortCol === 'author') {
-        return sortDir * a.author.localeCompare(b.author);
-      }
-      return sortDir * ((a.gi ?? -1) - (b.gi ?? -1));
-    });
-  }, [authorFilter, list, searchQuery, sortBy, sortCol, sortDir, typeFilter]);
+    return filtered;
+  }, [authorFilter, list, searchQuery, sortBy, sortDir, typeFilter]);
 
   useEffect(() => {
     onResultCountChange?.(filteredAndSorted.length);
@@ -217,20 +261,6 @@ export default function EventScreener({
 
   const merges = list.filter((item) => item.type === 'merge').length;
   const heartbeats = list.filter((item) => item.type === 'heartbeat').length;
-
-  const handleSort = (col: SortColumn) => {
-    if (sortCol === col) {
-      setSortDir((prev) => (prev === 1 ? -1 : 1));
-      return;
-    }
-    setSortCol(col);
-    setSortDir(col === 'time' ? -1 : 1);
-  };
-
-  const sortIndicator = (col: SortColumn) => {
-    if (sortCol !== col) return '↕';
-    return sortDir === 1 ? '↑' : '↓';
-  };
 
   if (items == null) {
     return (
@@ -317,13 +347,6 @@ export default function EventScreener({
       </div>
 
       <div className="rounded-md border border-slate-800">
-        <div className="flex flex-wrap items-center gap-2 border-b border-slate-800 bg-slate-950/70 px-2 py-2 text-[10px] font-mono text-slate-500">
-          <span className="uppercase">Sort:</span>
-          <SortButton label="Time" onClick={() => handleSort('time')} indicator={sortIndicator('time')} active={sortCol === 'time'} />
-          <SortButton label="Type" onClick={() => handleSort('type')} indicator={sortIndicator('type')} active={sortCol === 'type'} />
-          <SortButton label="Author" onClick={() => handleSort('author')} indicator={sortIndicator('author')} active={sortCol === 'author'} />
-          <SortButton label="GI" onClick={() => handleSort('gi')} indicator={sortIndicator('gi')} active={sortCol === 'gi'} />
-        </div>
         <div className="divide-y divide-slate-800">
           {pagedRows.map((item) => {
             const isOpen = openId === item.id;
@@ -467,21 +490,6 @@ function StatCard({ label, value }: { label: string; value: string }) {
       <div className="text-[9px] font-mono uppercase tracking-widest text-slate-500">{label}</div>
       <div className="text-lg font-mono font-bold text-slate-100">{value}</div>
     </div>
-  );
-}
-
-function SortButton({ label, onClick, indicator, active }: { label: string; onClick: () => void; indicator: string; active: boolean }) {
-  return (
-    <button
-      onClick={onClick}
-      className={cn(
-        'inline-flex items-center gap-1 rounded border px-2 py-1 uppercase transition hover:text-slate-300',
-        active ? 'border-sky-500/30 bg-sky-500/10 text-sky-300' : 'border-slate-700 text-slate-500',
-      )}
-    >
-      {label}
-      <span>{indicator}</span>
-    </button>
   );
 }
 

--- a/components/terminal/TerminalShellFallback.tsx
+++ b/components/terminal/TerminalShellFallback.tsx
@@ -9,7 +9,8 @@ export default function TerminalShellFallback({
   statusLabel?: string;
 }) {
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState('time-desc');
+  const [sortBy, setSortBy] = useState<'time' | 'agent' | 'type' | 'severity' | 'gi' | 'status' | 'source'>('time');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
   const resultCount: number = 0;
   const [gi] = useState<number | null>(null);
 
@@ -63,7 +64,7 @@ export default function TerminalShellFallback({
             <span className="text-[9px] font-mono uppercase tracking-widest text-slate-600">Sort</span>
             <select
               value={sortBy}
-              onChange={(event) => setSortBy(event.target.value)}
+              onChange={(event) => setSortBy(event.target.value as typeof sortBy)}
               className="cursor-pointer appearance-none rounded-md border border-slate-800 bg-slate-900 px-2 py-1.5 pr-6 text-[11px] font-mono text-slate-400 transition-colors focus:border-sky-500/50 focus:outline-none"
               style={{
                 backgroundImage:
@@ -73,13 +74,22 @@ export default function TerminalShellFallback({
                 backgroundSize: '10px',
               }}
             >
-              <option value="time-desc">Newest first</option>
-              <option value="time-asc">Oldest first</option>
-              <option value="type">By type</option>
-              <option value="author">By author</option>
-              <option value="gi-desc">GI high → low</option>
-              <option value="severity">By severity</option>
+              <option value="time">Time</option>
+              <option value="agent">Agent</option>
+              <option value="type">Type</option>
+              <option value="severity">Severity</option>
+              <option value="gi">GI score</option>
+              <option value="status">Status</option>
+              <option value="source">Source</option>
             </select>
+            <button
+              type="button"
+              onClick={() => setSortDir((prev) => (prev === 'desc' ? 'asc' : 'desc'))}
+              className="inline-flex h-7 w-5 items-center justify-center rounded-md border border-slate-800 bg-slate-900 text-[11px] font-mono text-slate-400 transition-colors hover:border-sky-500/40 hover:text-sky-300"
+              aria-label={`Toggle sort direction (currently ${sortDir})`}
+            >
+              {sortDir === 'desc' ? '↓' : '↑'}
+            </button>
           </div>
 
           {searchQuery ? (


### PR DESCRIPTION
### Motivation
- Replace the single "Newest first" dropdown with a full sort control so operators can sort the ledger by meaningful dimensions (time, agent, type, severity, GI, status, source) and flip direction quickly.
- Ensure sort behavior is client-side, deterministic, and preserves the default newest-first view while enabling incident-focused views (e.g., low-GI first).

### Description
- Added `SortField` / `SortDirection` state (`sortBy`, `sortDir`) and replaced the single select with a two-part control (field select + direction toggle) in `TerminalPageClient` and the degraded `TerminalShellFallback` UI, defaulting to `time` + `desc`.
- Wired the new `sortBy`/`sortDir` into `EventScreener` props and implemented client-side sort logic for `time`, `agent`, `type`, `severity`, `gi`, `status`, and `source` with explicit priority/ranking rules and null-safe GI handling.
- Implemented agent-tab change behavior to reset sort to `time` / `desc` so each agent context opens fresh in newest-first order.
- Kept sorting purely client-side and preserved default behavior; no API changes were made.

### Testing
- Ran TypeScript compile: `npx tsc --noEmit` and it passed successfully.
- Verified the UI control and sorting logic build without type errors and the fallback/degraded shell mirrors the new control.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2d0699520832db1840ba3b5319016)