### PR TITLE
feat(hermes): integrate Perplexity Sonar live intelligence lane for HERMES + EVE

### DIFF
--- a/app/api/kv/health/route.ts
+++ b/app/api/kv/health/route.ts
@@ -28,6 +28,7 @@ export async function GET() {
     ok: health.available,
     ...health,
     keys,
+    perplexity: Boolean(process.env.PERPLEXITY_API_KEY),
     timestamp: new Date().toISOString(),
   }, {
     headers: {

--- a/lib/agents/micro/hermes.ts
+++ b/lib/agents/micro/hermes.ts
@@ -1,8 +1,7 @@
 // ============================================================================
 // HERMES-µ — News/Information Velocity Micro Sub-Agent
 //
-// Polls Hacker News API and Wikipedia recent changes.
-// Both free, no API key required.
+// Polls Hacker News API, Wikipedia recent changes, and optional Perplexity Sonar.
 // CC0 Public Domain
 // ============================================================================
 
@@ -15,12 +14,13 @@ import {
   normalizeInverse,
   safeFetch,
 } from './core';
+import { querySonarForLane } from '@/lib/signals/perplexity-sonar';
 
 export const HERMES_CONFIG: MicroAgentConfig = {
   name: 'HERMES-µ',
   description: 'Information velocity — tech news flow, encyclopedic edit rate',
   pollIntervalMs: 5 * 60 * 1000,
-  sources: ['Hacker News', 'Wikipedia Recent Changes'],
+  sources: ['Hacker News', 'Wikipedia Recent Changes', 'Perplexity Sonar'],
 };
 
 // ── Hacker News: top story velocity ───────────────────────────────────────
@@ -119,6 +119,31 @@ async function pollWikipedia(): Promise<MicroSignal | null> {
   };
 }
 
+
+async function pollSonar(): Promise<MicroSignal | null> {
+  const result = await querySonarForLane(
+    'HERMES',
+    'Major technology, governance, and civic events globally in the last 24 hours. List top 5 developments.',
+    'day',
+  );
+
+  if (!result) return null;
+
+  return {
+    agentName: 'HERMES-µ',
+    source: 'Perplexity Sonar',
+    timestamp: result.timestamp,
+    value: 0.8,
+    label: `Sonar: ${result.sources.length} cited sources · ${result.answer.slice(0, 80)}...`,
+    severity: 'nominal',
+    raw: {
+      answer: result.answer,
+      sourceCount: result.sources.length,
+      topSource: result.sources[0]?.title ?? null,
+    },
+  };
+}
+
 // ── Poll all HERMES-µ sources ─────────────────────────────────────────────
 export async function pollHermes(): Promise<AgentPollResult> {
   const errors: string[] = [];
@@ -131,6 +156,10 @@ export async function pollHermes(): Promise<AgentPollResult> {
   const wiki = await pollWikipedia();
   if (wiki) signals.push(wiki);
   else errors.push('Wikipedia API fetch failed');
+
+  const sonar = await pollSonar();
+  if (sonar) signals.push(sonar);
+  else errors.push('Perplexity Sonar unavailable or not configured');
 
   return {
     agentName: 'HERMES-µ',

--- a/lib/eve/governance-synthesis.ts
+++ b/lib/eve/governance-synthesis.ts
@@ -8,6 +8,8 @@ import { Redis } from '@upstash/redis';
 import type { EveNewsItem, EveSynthesis, NewsCategory, Severity } from '@/lib/eve/global-news';
 import { fetchEveGlobalNews } from '@/lib/eve/global-news';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
+import type { SonarSignal } from '@/lib/signals/perplexity-sonar';
+import { querySonarForLane } from '@/lib/signals/perplexity-sonar';
 import { getEchoAlerts, getEchoEpicon } from '@/lib/echo/store';
 import type { EpiconLedgerFeedEntry } from '@/lib/epicon/ledgerFeedTypes';
 import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
@@ -44,6 +46,7 @@ export type EveGovernanceSynthesisInput = {
   narrativeClusterCount: number;
   externalDegraded: boolean;
   externalEnrichment: string | null;
+  sonarCivic: SonarSignal | null;
 };
 
 export type EveGovernanceCategory = 'governance' | 'ethics' | 'civic-risk';
@@ -198,6 +201,15 @@ async function tryExternalEnrichment(): Promise<{ line: string | null; degraded:
   }
 }
 
+function formatSonarExternalContext(sonar: SonarSignal | null): string | null {
+  if (!sonar || !sonar.answer.trim()) return null;
+  const sourceLine =
+    sonar.sources.length > 0
+      ? `Sources: ${sonar.sources.slice(0, 5).map((s) => s.url).join(', ')}`
+      : 'Sources: none returned';
+  return `external_context: ${sonar.answer.trim()}\n${sourceLine}`;
+}
+
 function parseLedgerTimestampMs(row: EpiconLedgerFeedEntry): number {
   const t = Date.parse(row.timestamp);
   return Number.isNaN(t) ? 0 : t;
@@ -264,6 +276,13 @@ export async function gatherEveGovernanceSynthesisInput(
   const narrativeClusterCount = echoEpicon.length;
 
   const ext = await tryExternalEnrichment();
+  const sonarCivic = await querySonarForLane(
+    'EVE',
+    'Civic risk, democratic accountability, and institutional governance news today. Focus on verified events.',
+    'day',
+    resolvedCycle,
+  );
+  const sonarContext = formatSonarExternalContext(sonarCivic);
 
   return {
     cycleId: resolvedCycle,
@@ -278,7 +297,8 @@ export async function gatherEveGovernanceSynthesisInput(
     treasuryAlertCount,
     narrativeClusterCount,
     externalDegraded: ext.degraded,
-    externalEnrichment: ext.line,
+    externalEnrichment: [ext.line, sonarContext].filter((line): line is string => typeof line === 'string').join('\n\n') || null,
+    sonarCivic,
   };
 }
 
@@ -356,6 +376,9 @@ export function buildEveGovernanceSynthesisOutput(input: EveGovernanceSynthesisI
   }
   if (input.tripwire.level !== 'none') {
     derivedFrom.push(`tripwire:${input.tripwire.level}`);
+  }
+  for (const source of input.sonarCivic?.sources ?? []) {
+    derivedFrom.push(source.url);
   }
 
   const governanceSummary =
@@ -679,7 +702,7 @@ export async function publishEveGovernanceSynthesis(
     severity: ledgerSeverity,
     gi: input.gi,
     tags,
-    source: EVE_SYNTHESIS_SOURCE,
+    source: input.sonarCivic ? 'eve-synthesis+sonar' : EVE_SYNTHESIS_SOURCE,
     verified: true,
     verifiedBy: 'ZEUS',
     cycle: input.cycleId,

--- a/lib/signals/perplexity-sonar.ts
+++ b/lib/signals/perplexity-sonar.ts
@@ -1,0 +1,127 @@
+import { currentCycleId } from '@/lib/eve/cycle-engine';
+
+export type SonarRecency = 'hour' | 'day' | 'week' | 'month';
+
+export interface SonarSource {
+  title: string;
+  url: string;
+}
+
+export interface SonarSignal {
+  query: string;
+  answer: string;
+  sources: SonarSource[];
+  recency: SonarRecency;
+  timestamp: string;
+}
+
+type SonarLane = 'HERMES' | 'EVE';
+
+const SONAR_TIMEOUT_MS = 8000;
+const SONAR_WINDOW_MS = 4 * 60 * 60 * 1000;
+
+const sonarWindowCache = new Map<string, Promise<SonarSignal | null>>();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function cycleWindowBucket(nowMs: number): string {
+  return String(Math.floor(nowMs / SONAR_WINDOW_MS));
+}
+
+function cacheKey(lane: SonarLane, cycleId: string, recency: SonarRecency): string {
+  return `${lane}|${cycleId}|${cycleWindowBucket(Date.now())}|${recency}`;
+}
+
+function normalizeSource(value: unknown): SonarSource | null {
+  if (!isRecord(value)) return null;
+  const urlRaw = value.url;
+  const titleRaw = value.title;
+  const url = typeof urlRaw === 'string' ? urlRaw.trim() : '';
+  if (!url) return null;
+  const title = typeof titleRaw === 'string' && titleRaw.trim() ? titleRaw.trim() : url;
+  return { title, url };
+}
+
+function parseSonarResponse(payload: unknown): { answer: string; sources: SonarSource[] } {
+  if (!isRecord(payload)) return { answer: '', sources: [] };
+
+  const choicesRaw = payload.choices;
+  let answer = '';
+  if (Array.isArray(choicesRaw) && choicesRaw[0] && isRecord(choicesRaw[0])) {
+    const firstChoice = choicesRaw[0];
+    const messageRaw = firstChoice.message;
+    if (isRecord(messageRaw)) {
+      const content = messageRaw.content;
+      if (typeof content === 'string') answer = content.trim();
+    }
+  }
+
+  const citationsRaw = payload.citations;
+  const sources = Array.isArray(citationsRaw)
+    ? citationsRaw
+        .map((item) => (typeof item === 'string' ? { title: item, url: item } : normalizeSource(item)))
+        .filter((item): item is SonarSource => item !== null)
+    : [];
+
+  return { answer, sources };
+}
+
+export async function querySonar(
+  prompt: string,
+  recency: SonarRecency = 'day',
+): Promise<SonarSignal> {
+  const apiKey = process.env.PERPLEXITY_API_KEY;
+  if (!apiKey) {
+    throw new Error('PERPLEXITY_API_KEY is not configured');
+  }
+
+  const res = await fetch('https://api.perplexity.ai/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    signal: AbortSignal.timeout(SONAR_TIMEOUT_MS),
+    body: JSON.stringify({
+      model: 'sonar',
+      messages: [{ role: 'user', content: prompt }],
+      search_recency_filter: recency,
+    }),
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    throw new Error(`Perplexity Sonar request failed (${res.status})`);
+  }
+
+  const json = (await res.json()) as unknown;
+  const parsed = parseSonarResponse(json);
+
+  return {
+    query: prompt,
+    answer: parsed.answer,
+    sources: parsed.sources,
+    recency,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function querySonarForLane(
+  lane: SonarLane,
+  prompt: string,
+  recency: SonarRecency = 'day',
+  cycleId = currentCycleId(),
+): Promise<SonarSignal | null> {
+  const key = cacheKey(lane, cycleId, recency);
+  const existing = sonarWindowCache.get(key);
+  if (existing) return existing;
+
+  const pending = querySonar(prompt, recency)
+    .then((result) => result)
+    .catch(() => null);
+
+  sonarWindowCache.set(key, pending);
+  return pending;
+}


### PR DESCRIPTION
### Motivation
- Provide a live, cited web-intelligence lane using Perplexity Sonar so HERMES and EVE can enrich synthesis with real-time, sourced web context while remaining substrate-first and non-blocking.

### Description
- Add `lib/signals/perplexity-sonar.ts` implementing a typed Sonar client (`querySonar`) with `AbortSignal.timeout(8000)`, answer/citation parsing, and per-lane/per-cycle/window idempotent caching via `querySonarForLane`.
- Extend HERMES (`lib/agents/micro/hermes.ts`) to poll Sonar once per window (`pollSonar`) and emit a non-blocking micro-signal; Sonar is listed as an optional source and degrades gracefully when unavailable.
- Enrich EVE input path (`lib/eve/governance-synthesis.ts`) by querying Sonar for civic/governance context, folding `sonarCivic` into `externalEnrichment`, including Sonar URLs in `derivedFrom`, and marking ledger entries as `eve-synthesis+sonar` when Sonar data is present.
- Surface Perplexity readiness in the health endpoint by adding a `perplexity` flag to `GET /api/kv/health` (`Boolean(process.env.PERPLEXITY_API_KEY)`).

### Testing
- Type check: `npx tsc --noEmit` passed successfully.
- Dependency install: attempted `npm install @ai-sdk/perplexity ai` but package fetch failed in this environment with a registry 403, so the implementation uses a direct fetch-based client to Perplexity API instead (fallback to graceful degradation when the API key is not set).
- Lint: `npm run lint` could not be executed non-interactively because Next.js prompted to initialize ESLint config, so automated linting was not completed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2d1ce2d58832d8259319f496f16d9)