### PR TITLE
Fix terminal hydration UX, auto-seed agent journal, persist ECHO/TRIPWIRE KV, and preserve sort state

### DIFF
--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -38,6 +38,7 @@ type AgentJournalCreateInput = Omit<AgentJournalEntry, 'id' | 'timestamp' | 'sta
 const KEY_ALL = 'journal:all';
 const MAX_LIST_ENTRIES = 200;
 const MAX_READ = 100;
+const GENESIS_AGENTS = ['ATLAS', 'ZEUS', 'EVE', 'HERMES', 'AUREA', 'JADE', 'DAEDALUS', 'ECHO'] as const;
 
 function randomToken(length: number): string {
   const alphabet = '0123456789abcdefghijklmnopqrstuvwxyz';
@@ -177,15 +178,50 @@ async function loadEntries(redis: Redis | null): Promise<AgentJournalEntry[]> {
   }
 }
 
+async function seedGenesisEntries(redis: Redis, cycle: string): Promise<void> {
+  const timestamp = new Date().toISOString();
+  for (const agent of GENESIS_AGENTS) {
+    const entry: AgentJournalEntry = {
+      id: `journal-${agent}-${cycle}-genesis`,
+      agent,
+      cycle,
+      timestamp,
+      scope: 'agent-journal',
+      observation: `${agent} genesis observation initialized for ${cycle}.`,
+      inference: `${agent} baseline reasoning lane is active and ready for live cycle commits.`,
+      recommendation: `Continue cycle ${cycle} and replace genesis scaffolding with live entries.`,
+      confidence: 0.72,
+      derivedFrom: [],
+      status: 'committed',
+      category: 'observation',
+      severity: 'nominal',
+      source: 'agent-journal',
+      agentOrigin: agent,
+      tags: ['genesis', cycle.toLowerCase()],
+    };
+
+    const packed = JSON.stringify(entry);
+    await redis.lpush(KEY_ALL, packed);
+    await redis.ltrim(KEY_ALL, 0, MAX_LIST_ENTRIES - 1);
+    await redis.lpush(`journal:${agent.toLowerCase()}`, packed);
+    await redis.ltrim(`journal:${agent.toLowerCase()}`, 0, MAX_LIST_ENTRIES - 1);
+  }
+}
+
 export async function GET(request: NextRequest) {
   const redis = getRedisClient();
-  const entries = await loadEntries(redis);
+  let entries = await loadEntries(redis);
 
   const { searchParams } = request.nextUrl;
   const agentFilter = asString(searchParams.get('agent')).toUpperCase();
   const cycleFilter = asString(searchParams.get('cycle'));
   const limitRaw = Number(searchParams.get('limit') ?? '20');
   const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(Math.floor(limitRaw), 100) : 20;
+
+  if (entries.length === 0 && redis) {
+    await seedGenesisEntries(redis, cycleFilter || 'C-272');
+    entries = await loadEntries(redis);
+  }
 
   const filtered = entries
     .filter((entry) => (agentFilter ? entry.agent.toUpperCase() === agentFilter : true))

--- a/app/api/echo/ingest/route.ts
+++ b/app/api/echo/ingest/route.ts
@@ -16,6 +16,7 @@ import { fetchAllSources } from '@/lib/echo/sources';
 import { transformBatch } from '@/lib/echo/transform';
 import { pushIngestResult, getEchoStatus, getEchoEpicon, getEchoLedger, getEchoAlerts } from '@/lib/echo/store';
 import { writeSnapshot } from '@/lib/echo/snapshot-writer';
+import { saveEchoState } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
 
@@ -50,6 +51,19 @@ export async function POST() {
 
     // 3. Push to store
     pushIngestResult(result);
+    const status = getEchoStatus();
+    const dedupDenominator = Math.max(1, status.totalIngested + status.duplicateSuppressedCount);
+    const dedupRate = Number((status.duplicateSuppressedCount / dedupDenominator).toFixed(3));
+    await saveEchoState({
+      lastIngest: status.lastIngest,
+      cycleId: status.cycleId,
+      totalIngested: status.totalIngested,
+      epiconCount: status.counts.epicon,
+      ledgerCount: status.counts.ledger,
+      alertCount: status.counts.alerts,
+      timestamp: new Date().toISOString(),
+      dedupRate,
+    }).catch(() => {});
 
     // 4. Generate docs/echo/ snapshot (fire-and-forget, non-blocking)
     let snapshotWritten = false;

--- a/app/api/sentiment/composite/route.ts
+++ b/app/api/sentiment/composite/route.ts
@@ -75,6 +75,7 @@ export async function GET() {
     const hermesSignals = microByAgent.get('HERMES-µ')?.signals ?? [];
     const narrativeScore = mean(hermesSignals.map((signal) => signal.value));
     const hermesSources = hermesSignals.map((signal) => signal.source);
+    const sonarEnabled = Boolean(process.env.PERPLEXITY_API_KEY);
     const daedalusScore = mean((microByAgent.get('DAEDALUS-µ')?.signals ?? []).map((signal) => signal.value));
     const themisSignals = microByAgent.get('THEMIS')?.signals ?? [];
     const civicScore = mean(themisSignals.map((signal) => signal.value));
@@ -88,7 +89,13 @@ export async function GET() {
         label: 'NARRATIVE',
         agent: 'HERMES',
         score: narrativeScore,
-        sourceLabel: hermesSources.includes('GDELT') ? 'HN + Wikipedia + Sonar + GDELT' : 'HN + Wikipedia + Sonar',
+        sourceLabel: sonarEnabled
+          ? hermesSources.includes('GDELT')
+            ? 'HN + Wikipedia + Sonar + GDELT'
+            : 'HN + Wikipedia + Sonar'
+          : hermesSources.includes('GDELT')
+            ? 'HN + Wikipedia + GDELT (Sonar unavailable)'
+            : 'HN + Wikipedia (Sonar unavailable)',
       },
       { key: 'infrastructure', label: 'INFRASTR', agent: 'DAEDALUS', score: daedalusScore, sourceLabel: 'GitHub + npm + self-ping' },
       { key: 'institutional', label: 'INSTITUTIONAL', agent: 'JADE', score: civicScore, sourceLabel: 'data.gov + FRED (future)' },

--- a/app/api/tripwire/status/route.ts
+++ b/app/api/tripwire/status/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getTripwireState, setTripwireState, type RuntimeTripwireState } from '@/lib/tripwire/store';
 import { mockTripwire } from '@/lib/mock-data';
 import { liveEnvelope, mockEnvelope } from '@/lib/response-envelope';
+import { saveTripwireState } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
 
@@ -43,10 +44,18 @@ function parsePayload(value: unknown): TripwireUpdatePayload | null {
 
 export async function GET() {
   try {
+    const tripwire = getTripwireState();
+    await saveTripwireState({
+      active: tripwire.active,
+      level: tripwire.active ? 'elevated' : 'none',
+      reason: tripwire.reason,
+      last_updated: tripwire.last_updated,
+    }).catch(() => {});
+
     return NextResponse.json({
       ok: true,
       ...liveEnvelope(),
-      tripwire: getTripwireState(),
+      tripwire,
       last_updated: new Date().toISOString(),
       freshness: { status: 'fresh', seconds: 0 },
     });
@@ -93,6 +102,12 @@ export async function POST(request: NextRequest) {
       };
 
   setTripwireState(nextTripwire);
+  await saveTripwireState({
+    active: nextTripwire.active,
+    level: nextTripwire.active ? 'elevated' : 'none',
+    reason: nextTripwire.reason,
+    last_updated: nextTripwire.last_updated,
+  }).catch(() => {});
 
   return NextResponse.json({
     ok: true,

--- a/app/terminal/TerminalPageClient.tsx
+++ b/app/terminal/TerminalPageClient.tsx
@@ -2,7 +2,6 @@
 
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import HardHalt from '@/components/modals/HardHalt';
-import TerminalShellFallback from '@/components/terminal/TerminalShellFallback';
 import { WalletProvider } from '@/contexts/WalletContext';
 import { useTerminalData } from '@/hooks/useTerminalData';
 import { checkCovenantCompliance } from '@/lib/integrity-check';
@@ -130,10 +129,15 @@ function TerminalPage() {
   const [sortDir, setSortDir] = useState<SortDirection>('desc');
   const [resultCount, setResultCount] = useState(0);
   const [runtimeBadge, setRuntimeBadge] = useState<'online' | 'degraded' | 'offline'>('offline');
+  const [hydrated, setHydrated] = useState(false);
   const agentSearchRef = useRef<HTMLInputElement>(null);
 
   const { allTripwires, filteredEpicon, gi, integrityStatus, mergedLedger } = useTerminalData(selectedNav);
   const cycleId = integrityStatus?.cycle ?? 'C-271';
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
 
   useEffect(() => {
     let mounted = true;
@@ -232,7 +236,7 @@ function TerminalPage() {
             { key: 'civic', label: 'CIVIC', agent: 'EVE', sourceLabel: 'Federal Register + Sonar civic' },
             { key: 'environ', label: 'ENVIRON', agent: 'GAIA', sourceLabel: 'USGS + Open-Meteo + EONET' },
             { key: 'financial', label: 'FINANCIAL', agent: 'ECHO', sourceLabel: 'crypto prices composite' },
-            { key: 'narrative', label: 'NARRATIVE', agent: 'HERMES', sourceLabel: 'HN + Wikipedia + Sonar + GDELT' },
+            { key: 'narrative', label: 'NARRATIVE', agent: 'HERMES', sourceLabel: 'HN + Wikipedia + GDELT (Sonar lane conditional)' },
             { key: 'infrastructure', label: 'INFRASTR', agent: 'DAEDALUS', sourceLabel: 'GitHub + npm + self-ping' },
             { key: 'institutional', label: 'INSTITUTIONAL', agent: 'JADE', sourceLabel: 'data.gov + FRED (future)' },
           ];
@@ -543,7 +547,20 @@ function TerminalPage() {
     setExpandedLedgerId((prev) => (prev === id ? null : id));
   }, []);
 
-  if (!gi) return <TerminalShellFallback statusLabel="Booting Mobius Terminal · syncing integrity surfaces" />;
+  if (!hydrated || !gi) {
+    return (
+      <div className="min-h-screen bg-slate-950 text-slate-200">
+        <header className="border-b border-slate-800 bg-slate-950/95 px-4 py-3">
+          <div className="mx-auto flex w-full max-w-[1800px] items-center justify-between">
+            <div className="text-xs font-mono uppercase tracking-[0.14em] text-slate-400">Mobius Terminal</div>
+            <div className="rounded border border-slate-700 bg-slate-900 px-2 py-1 text-[10px] font-mono uppercase tracking-widest text-slate-300">
+              GI …
+            </div>
+          </div>
+        </header>
+      </div>
+    );
+  }
 
   const renderCenterContent = () => {
     if (selectedNav === 'agents') {
@@ -659,8 +676,6 @@ function TerminalPage() {
               key={agent}
               onClick={() => {
                 setAgentFilter(agent);
-                setSortBy('time');
-                setSortDir('desc');
               }}
               className={cn('rounded-md border px-2 py-1 text-[10px] font-mono uppercase tracking-[0.14em]', getAgentTabClass(agent, agentFilter === agent))}
             >

--- a/lib/kv/store.ts
+++ b/lib/kv/store.ts
@@ -227,6 +227,7 @@ export type EchoKVState = {
   epiconCount: number;
   ledgerCount: number;
   alertCount: number;
+  dedupRate?: number;
   timestamp: string;
 };
 


### PR DESCRIPTION
### Motivation
- Prevent the server-rendered terminal from flashing a misleading critical-looking GI (`GI --`) and full resilient shell before the client hydrates.  
- Ensure the agents' journal is not permanently empty on cold starts by seeding genesis entries when the KV is available but empty.  
- Avoid erasing operator sort preferences on simple agent tab switches and make sentiment provenance and KV health reporting honest about Perplexity/Sonar availability.  
- Surface ECHO and Tripwire runtime state into KV so the `ECHO_STATE` and `TRIPWIRE_STATE` health keys reflect real operational data.

### Description
- Add a client-side hydration gate (`hydrated` state) and render a minimal neutral header showing `GI …` until both hydration and the GI snapshot are available, removing the pre-hydration resilient skeleton that implied a critical state (`app/terminal/TerminalPageClient.tsx`).  
- Stop resetting sort state on agent tab clicks by removing the forced `setSortBy('time')`/`setSortDir('desc')` calls so operator-selected sort persists across tab switches (`app/terminal/TerminalPageClient.tsx`).  
- Make `GET /api/agents/journal` idempotently auto-seed eight genesis journal entries when Redis is configured but the journal list is empty, writing both global (`journal:all`) and per-agent lists (`app/api/agents/journal/route.ts`).  
- Make narrative sentiment source labeling conditional on `PERPLEXITY_API_KEY` so the `sourceLabel` no longer claims Sonar is active when the key is absent (`app/api/sentiment/composite/route.ts` and client defaults).  
- Persist ECHO ingest summary (counts and dedup rate) to KV during ingest cycles by calling `saveEchoState` after `pushIngestResult`, and extend `EchoKVState` with `dedupRate`; persist Tripwire evaluation and updates to KV by calling `saveTripwireState` on GET and POST, enabling `ECHO_STATE` and `TRIPWIRE_STATE` to reflect live activity (`app/api/echo/ingest/route.ts`, `app/api/tripwire/status/route.ts`, `lib/kv/store.ts`).

### Testing
- `npm run build` completed successfully and the production build compiled without type errors.  
- `npm run lint` could not be run non-interactively in this environment because Next.js prompted to configure ESLint interactively, so lint was not validated here.  
- Basic smoke validation performed by building and static route generation confirmed the modified routes and client component compile (no runtime tests were executed in this run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2de2940f0832da9cbe85afc5eb831)