### PR TITLE
Add substrate_status/open_lab commands, substrate client, and UI improvements

### DIFF
--- a/app/api/substrate/status/route.ts
+++ b/app/api/substrate/status/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { getSubstrateStatusSummary } from '@/lib/substrate/client';
+
+export async function GET() {
+  const status = await getSubstrateStatusSummary();
+  const degraded = status.services.some((service) => !service.ok);
+
+  return NextResponse.json({
+    ok: true,
+    degraded,
+    ...status,
+  });
+}
+

--- a/components/terminal/AgentCortexPanel.tsx
+++ b/components/terminal/AgentCortexPanel.tsx
@@ -96,7 +96,7 @@ export default function AgentCortexPanel({
       : 'border-amber-500/20 bg-amber-500/5 text-amber-200';
   }
 
-  function sourceTone(status: SourceHealth) {
+function sourceTone(status: SourceHealth) {
     switch (status) {
       case 'ok':
         return 'border-emerald-500/20 bg-emerald-500/10 text-emerald-300';
@@ -109,6 +109,15 @@ export default function AgentCortexPanel({
         return 'border-rose-500/20 bg-rose-500/10 text-rose-300';
     }
   }
+
+  const statusBadgeText: Record<Agent['status'], string> = {
+    idle: '■ IDLE',
+    listening: '◉ LISTENING',
+    verifying: '✓ VERIFYING',
+    routing: '⇄ ROUTING',
+    analyzing: '≈ ANALYZING',
+    alert: '⚠ ALERT',
+  };
 
   return (
     <section
@@ -193,62 +202,72 @@ export default function AgentCortexPanel({
         </div>
       ) : null}
 
-      <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3 xl:grid-cols-4">
-        {visibleAgents.map((agent) => (
-          <button
-            key={agent.id}
-            onClick={() => onSelect?.(agent)}
-            className={cn(
-              'rounded-lg border p-3 text-left transition',
-              selectedId === agent.id
-                ? 'border-sky-500/40 bg-sky-500/10'
-                : 'border-slate-800 bg-slate-950/60 hover:border-slate-700 hover:bg-slate-900',
-            )}
-          >
-            <div className="flex items-center justify-between">
-              <div className="text-sm font-mono font-semibold text-white">
-                {agent.name}
+      {visibleAgents.length === 0 ? (
+        <div className="mt-3 rounded-lg border border-dashed border-slate-800 bg-slate-950/50 px-4 py-6 text-center">
+          <p className="text-sm font-mono text-slate-300">No agents available for this identity.</p>
+          <p className="mt-1 text-xs text-slate-500">
+            Check identity permissions or substrate connection to load the Cortex roster.
+          </p>
+        </div>
+      ) : (
+        <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          {visibleAgents.map((agent) => (
+            <button
+              key={agent.id}
+              onClick={() => onSelect?.(agent)}
+              className={cn(
+                'rounded-lg border p-3 text-left transition',
+                selectedId === agent.id
+                  ? 'border-sky-500/40 bg-sky-500/10'
+                  : 'border-slate-800 bg-slate-950/60 hover:border-slate-700 hover:bg-slate-900',
+              )}
+              aria-label={`${agent.name} ${statusBadgeText[agent.status]}`}
+            >
+              <div className="flex items-center justify-between">
+                <div className="text-sm font-mono font-semibold text-white">
+                  {agent.name}
+                </div>
+                <div className={cn(
+                  'h-2.5 w-2.5 rounded-full',
+                  agent.color,
+                  agent.status !== 'idle' && 'agent-glow',
+                )} />
               </div>
-              <div className={cn(
-                'h-2.5 w-2.5 rounded-full',
-                agent.color,
-                agent.status !== 'idle' && 'agent-glow',
-              )} />
-            </div>
-            <div className="mt-1 text-xs font-sans text-slate-400">
-              {agent.role}
-            </div>
+              <div className="mt-1 text-xs font-sans text-slate-400">
+                {agent.role}
+              </div>
 
-            <div className="mt-3 flex items-center gap-2">
-              <div
-                className={cn(
-                  'h-2 w-2 rounded-full',
-                  statusColor(agent.status),
-                  agent.status !== 'idle' && 'agent-pulse',
-                )}
-              />
-              <span className="text-xs font-mono uppercase tracking-[0.15em] text-slate-300">
-                {agent.status}
-              </span>
-            </div>
+              <div className="mt-3 flex items-center gap-2">
+                <div
+                  className={cn(
+                    'h-2 w-2 rounded-full',
+                    statusColor(agent.status),
+                    agent.status !== 'idle' && 'agent-pulse',
+                  )}
+                />
+                <span className="rounded border border-slate-700/80 bg-slate-900 px-1.5 py-0.5 text-[10px] font-mono uppercase tracking-[0.12em] text-slate-300">
+                  {statusBadgeText[agent.status]}
+                </span>
+              </div>
 
-            <div className="mt-3 text-xs font-sans text-slate-400">
-              {agent.lastAction}
-            </div>
+              <div className="mt-3 text-xs font-sans text-slate-400">
+                {agent.lastAction}
+              </div>
 
-            <div className="mt-3 flex items-center justify-between text-[11px] font-mono">
-              <span className="text-slate-500">Heartbeat</span>
-              <span
-                className={
-                  agent.heartbeatOk ? 'text-emerald-300' : 'text-red-300'
-                }
-              >
-                {agent.heartbeatOk ? 'OK' : 'FAIL'}
-              </span>
-            </div>
-          </button>
-        ))}
-      </div>
+              <div className="mt-3 flex items-center justify-between text-[11px] font-mono">
+                <span className="text-slate-500">Heartbeat</span>
+                <span
+                  className={
+                    agent.heartbeatOk ? 'text-emerald-300' : 'text-red-300'
+                  }
+                >
+                  {agent.heartbeatOk ? 'OK' : 'FAIL'}
+                </span>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
       {degraded ? (
         <div className="mt-3 text-xs text-amber-300">
           Showing mock/cached data — live source offline

--- a/components/terminal/CommandInput.tsx
+++ b/components/terminal/CommandInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { commandRegistry } from '@/lib/commands/registry';
 import type { TerminalCommandResult } from '@/lib/commands/types';
 
@@ -11,6 +11,22 @@ export default function CommandInput({
 }) {
   const [value, setValue] = useState('');
   const [loading, setLoading] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const normalizedInput = value.trim().toLowerCase();
+  const suggestions = useMemo(() => {
+    if (!normalizedInput) return commandRegistry;
+    return commandRegistry.filter((command) =>
+      command.name.toLowerCase().includes(normalizedInput),
+    );
+  }, [normalizedInput]);
+
+  const selectedSuggestion = suggestions[selectedIndex] ?? null;
+
+  function applySuggestion(name: string) {
+    setValue(name);
+    setSelectedIndex(0);
+  }
 
   async function handleRun() {
     if (!value.trim()) return;
@@ -27,6 +43,7 @@ export default function CommandInput({
       const json = await res.json();
       onResult(json.result);
       setValue('');
+      setSelectedIndex(0);
     } catch {
       onResult({
         command: value,
@@ -45,15 +62,38 @@ export default function CommandInput({
       <div className="text-[11px] uppercase tracking-[0.2em] text-slate-500">
         Command Interface
       </div>
+      <div className="mt-1 text-[11px] text-slate-600">
+        Shortcut: <kbd className="rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5 font-mono">↑</kbd>/<kbd className="rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5 font-mono">↓</kbd> to browse • <kbd className="rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5 font-mono">Enter</kbd> to run
+      </div>
 
       <div className="mt-3 flex gap-2 max-sm:flex-col">
         <input
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={(e) => {
+            if (e.key === 'ArrowDown') {
+              e.preventDefault();
+              if (suggestions.length === 0) return;
+              setSelectedIndex((prev) => (prev + 1) % suggestions.length);
+              return;
+            }
+
+            if (e.key === 'ArrowUp') {
+              e.preventDefault();
+              if (suggestions.length === 0) return;
+              setSelectedIndex((prev) => (prev - 1 + suggestions.length) % suggestions.length);
+              return;
+            }
+
+            if (e.key === 'Tab' && selectedSuggestion) {
+              e.preventDefault();
+              applySuggestion(selectedSuggestion.name);
+              return;
+            }
+
             if (e.key === 'Enter') handleRun();
           }}
-          placeholder="Enter command: weekly_digest"
+          placeholder="Try: substrate_status or open_lab oaa"
           className="flex-1 rounded-xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm text-white outline-none placeholder:text-slate-500"
         />
 
@@ -67,14 +107,27 @@ export default function CommandInput({
       </div>
 
       <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-500">
-        <span>Available:</span>
-        {commandRegistry.map((command) => (
-          <span
-            key={command.name}
-            className="rounded-md border border-slate-800 bg-slate-950 px-2 py-1 font-mono text-slate-400"
-          >
-            {command.name}
+        <span>{normalizedInput ? 'Matches:' : 'Available:'}</span>
+        {suggestions.length === 0 ? (
+          <span className="rounded-md border border-slate-800 bg-slate-950 px-2 py-1 font-mono text-amber-300">
+            No commands found
           </span>
+        ) : suggestions.map((command, index) => (
+          <button
+            type="button"
+            key={command.name}
+            onClick={() => applySuggestion(command.name)}
+            className={`cursor-pointer rounded-md border px-2 py-1 font-mono transition ${
+              index === selectedIndex
+                ? 'border-sky-500/40 bg-sky-500/10 text-sky-200'
+                : 'border-slate-800 bg-slate-950 text-slate-400 hover:border-slate-700 hover:text-slate-300'
+            }`}
+          >
+            <span>{command.name}</span>
+            <span className="ml-2 hidden text-[10px] text-slate-500 md:inline">
+              {command.description}
+            </span>
+          </button>
         ))}
       </div>
     </div>

--- a/lib/commands/registry.ts
+++ b/lib/commands/registry.ts
@@ -13,6 +13,14 @@ export const commandRegistry: TerminalCommandDefinition[] = [
     name: 'agent_status',
     description: 'Return current Mobius agent status grid data.',
   },
+  {
+    name: 'substrate_status',
+    description: 'Probe Mobius Substrate services (ledger, GI, MIC, broker, OAA).',
+  },
+  {
+    name: 'open_lab',
+    description: 'Resolve Browser Shell lab URL. Usage: open_lab <oaa|reflections|shield|hive|jade>',
+  },
 ];
 
 export const commandRegistryByName: Record<TerminalCommandName, TerminalCommandDefinition> =

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -1,6 +1,11 @@
 import { agentStatus } from '@/lib/mock/agentStatus';
 import { integrityStatus } from '@/lib/mock/integrityStatus';
 import { buildWeeklyDigest } from '@/lib/digest/weekly';
+import {
+  getLabLaunchUrl,
+  getSubstrateStatusSummary,
+  type LabId,
+} from '@/lib/substrate/client';
 import { commandRegistryByName } from './registry';
 import type { TerminalCommandName, TerminalCommandResult } from './types';
 
@@ -12,6 +17,8 @@ export async function runTerminalCommand(
   rawInput: string,
 ): Promise<TerminalCommandResult> {
   const input = rawInput.trim();
+  const [commandName, ...argParts] = input.split(/\s+/);
+  const args = argParts.join(' ').trim();
 
   if (!input) {
     return {
@@ -23,21 +30,21 @@ export async function runTerminalCommand(
     };
   }
 
-  if (!isTerminalCommandName(input)) {
+  if (!isTerminalCommandName(commandName)) {
     return {
       command: input,
       ok: false,
       title: 'Unknown Command',
-      error: `Command not recognized: ${input}`,
+      error: `Command not recognized: ${commandName}`,
       timestamp: new Date().toISOString(),
     };
   }
 
-  switch (input) {
+  switch (commandName) {
     case 'weekly_digest': {
       const digest = buildWeeklyDigest();
       return {
-        command: input,
+        command: commandName,
         ok: true,
         title: 'Mobius Weekly Situation Digest',
         summary: digest.summary,
@@ -47,7 +54,7 @@ export async function runTerminalCommand(
     }
     case 'gi_status':
       return {
-        command: input,
+        command: commandName,
         ok: true,
         title: 'Global Integrity Status',
         summary: integrityStatus.summary,
@@ -56,12 +63,47 @@ export async function runTerminalCommand(
       };
     case 'agent_status':
       return {
-        command: input,
+        command: commandName,
         ok: true,
         title: 'Mobius Agent Status',
         summary: 'Canonical agent role and state surface.',
         data: agentStatus,
         timestamp: new Date().toISOString(),
       };
+    case 'substrate_status': {
+      const summary = await getSubstrateStatusSummary();
+      const healthy = summary.services.filter((service) => service.ok).length;
+      return {
+        command: commandName,
+        ok: true,
+        title: 'Mobius Substrate Service Status',
+        summary: `${healthy}/${summary.services.length} services healthy`,
+        data: summary,
+        timestamp: new Date().toISOString(),
+      };
+    }
+    case 'open_lab': {
+      const target = args.toLowerCase();
+      const supported: LabId[] = ['oaa', 'reflections', 'shield', 'hive', 'jade'];
+      if (!supported.includes(target as LabId)) {
+        return {
+          command: commandName,
+          ok: false,
+          title: 'Lab Target Required',
+          error: `Usage: open_lab <${supported.join('|')}>`,
+          timestamp: new Date().toISOString(),
+        };
+      }
+
+      const url = getLabLaunchUrl(target as LabId);
+      return {
+        command: commandName,
+        ok: true,
+        title: `Shell Lab URL (${target})`,
+        summary: 'Resolved Browser Shell lab endpoint.',
+        data: { lab: target, url },
+        timestamp: new Date().toISOString(),
+      };
+    }
   }
 }

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -1,7 +1,9 @@
 export type TerminalCommandName =
   | 'weekly_digest'
   | 'gi_status'
-  | 'agent_status';
+  | 'agent_status'
+  | 'substrate_status'
+  | 'open_lab';
 
 export type TerminalCommandResult = {
   command: TerminalCommandName | string;

--- a/lib/substrate/client.ts
+++ b/lib/substrate/client.ts
@@ -1,0 +1,97 @@
+export type SubstrateServiceKey = 'ledger' | 'gi' | 'mic' | 'broker' | 'oaa';
+
+export type SubstrateServiceStatus = {
+  service: SubstrateServiceKey;
+  url: string;
+  ok: boolean;
+  status: number | null;
+  latencyMs: number | null;
+  error?: string;
+};
+
+export type SubstrateStatusSummary = {
+  timestamp: string;
+  services: SubstrateServiceStatus[];
+};
+
+type ServiceConfig = Record<SubstrateServiceKey, string>;
+
+export function getSubstrateServiceConfig(): ServiceConfig {
+  return {
+    ledger: process.env.MOBIUS_LEDGER_URL || 'http://localhost:3000',
+    gi: process.env.MOBIUS_GI_URL || 'http://localhost:3001',
+    mic: process.env.MOBIUS_MIC_URL || 'http://localhost:4002',
+    broker: process.env.MOBIUS_BROKER_URL || 'http://localhost:4005',
+    oaa: process.env.MOBIUS_OAA_URL || 'http://localhost:3004',
+  };
+}
+
+function healthPathFor(service: SubstrateServiceKey) {
+  switch (service) {
+    case 'ledger':
+    case 'gi':
+    case 'mic':
+    case 'broker':
+    case 'oaa':
+      return '/health';
+  }
+}
+
+export async function probeSubstrateService(
+  service: SubstrateServiceKey,
+  baseUrl: string,
+): Promise<SubstrateServiceStatus> {
+  const start = Date.now();
+  const healthPath = healthPathFor(service);
+
+  try {
+    const response = await fetch(`${baseUrl}${healthPath}`, { cache: 'no-store' });
+    return {
+      service,
+      url: `${baseUrl}${healthPath}`,
+      ok: response.ok,
+      status: response.status,
+      latencyMs: Date.now() - start,
+      error: response.ok ? undefined : `Health probe failed (${response.status})`,
+    };
+  } catch (error) {
+    return {
+      service,
+      url: `${baseUrl}${healthPath}`,
+      ok: false,
+      status: null,
+      latencyMs: Date.now() - start,
+      error: error instanceof Error ? error.message : 'Request failed',
+    };
+  }
+}
+
+export async function getSubstrateStatusSummary(): Promise<SubstrateStatusSummary> {
+  const config = getSubstrateServiceConfig();
+  const services = await Promise.all(
+    (Object.keys(config) as SubstrateServiceKey[]).map((service) =>
+      probeSubstrateService(service, config[service]),
+    ),
+  );
+
+  return {
+    timestamp: new Date().toISOString(),
+    services,
+  };
+}
+
+export type LabId = 'oaa' | 'reflections' | 'shield' | 'hive' | 'jade';
+
+const LAB_PATHS: Record<LabId, string> = {
+  oaa: '/lab/oaa',
+  reflections: '/lab/reflections',
+  shield: '/lab/shield',
+  hive: '/lab/hive',
+  jade: '/lab/jade',
+};
+
+export function getLabLaunchUrl(labId: LabId): string {
+  const base = process.env.MOBIUS_SHELL_URL || 'http://localhost:3002';
+  return `${base}${LAB_PATHS[labId]}`;
+}
+


### PR DESCRIPTION
### Motivation
- Provide a way to probe Mobius substrate services and resolve Browser Shell lab URLs from the in-app terminal and API.
- Improve the terminal experience with command suggestions and keyboard navigation.
- Improve the Agent Cortex UI to surface empty-state messaging and richer agent status badges.

### Description
- Added a substrate client at `lib/substrate/client.ts` with `getSubstrateStatusSummary`, `probeSubstrateService`, `getLabLaunchUrl`, and service configuration to probe `ledger`, `gi`, `mic`, `broker`, and `oaa` health endpoints.
- Exposed a new API route `app/api/substrate/status/route.ts` that returns the substrate status summary and a `degraded` flag.
- Extended the terminal command registry and types to include `substrate_status` and `open_lab`, and implemented handling in `lib/commands/run.ts` to return a service summary or resolved lab URL.
- Enhanced the `CommandInput` component to provide command suggestions, keyboard navigation (`ArrowUp`, `ArrowDown`, `Tab` to complete), inline descriptions, and an updated placeholder/shortcut hint.
- Updated `AgentCortexPanel` to show a friendly empty state when no agents are visible, add a compact status badge mapping, include aria labels for agent buttons, and minor layout and styling improvements.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2e2183ddc832da06a1f63117b84d0)