### PR TITLE
Add integrity signal ingestion primitives (MobiusDataClient, processors, hook)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,36 @@ The system tracks a **Global Integrity Score (GI)** that measures information he
 
 Without a configured API, the terminal falls back to mock data automatically.
 
+## Integrity Signal Ingestion Layer
+
+To support broader Mobius ecosystem ingestion, the terminal now includes a normalized ingestion stack:
+
+- `lib/ingestion/MobiusDataClient.ts` — registers terminal and substrate data sources, connects via SSE/polling, and emits standardized integrity signals through an in-app signal bus.
+- `lib/ingestion/processors/EPICONProcessor.ts` — maps EPICON events into confidence tiers, provenance status, threat indicators, sentiment metadata, and GI deltas.
+- `lib/ingestion/processors/AgentProcessor.ts` — computes agent health, constitutional compliance, activity velocity, and integrity contribution.
+- `hooks/useIntegritySignals.ts` — React hook for subscribing to all processed signals, retrieving filtered subsets, and computing an aggregated GI trend.
+
+This ingestion layer is additive and can be used by new dashboard modules without replacing existing `useTerminalData` flows.
+
+### Ingestion Environment Variables
+
+```bash
+# Terminal API (primary)
+NEXT_PUBLIC_TERMINAL_API_BASE=http://localhost:8000/api/v1
+
+# Mobius-Substrate Services
+NEXT_PUBLIC_LEDGER_URL=http://localhost:3000
+NEXT_PUBLIC_GI_URL=http://localhost:3001
+NEXT_PUBLIC_MIC_URL=http://localhost:4002
+NEXT_PUBLIC_BROKER_URL=http://localhost:4005
+NEXT_PUBLIC_OAA_URL=http://localhost:3004
+
+# Ingestion Settings
+NEXT_PUBLIC_SSE_RECONNECT_MS=5000
+NEXT_PUBLIC_POLL_INTERVAL_MS=30000
+NEXT_PUBLIC_MAX_SIGNAL_HISTORY=1000
+```
+
 ---
 
 ## Boot Modes

--- a/hooks/useIntegritySignals.ts
+++ b/hooks/useIntegritySignals.ts
@@ -1,0 +1,93 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { MobiusDataClient } from '@/lib/ingestion/MobiusDataClient';
+import type { IngestedSignal } from '@/lib/ingestion/types';
+
+const MAX_SIGNAL_HISTORY = Number(process.env.NEXT_PUBLIC_MAX_SIGNAL_HISTORY ?? 1000);
+
+function calculateTrend(signals: IngestedSignal[]): 'up' | 'down' | 'flat' {
+  if (signals.length < 2) return 'flat';
+
+  const newest = signals[0]?.processed.giContribution ?? 0;
+  const oldest = signals[signals.length - 1]?.processed.giContribution ?? newest;
+  const delta = newest - oldest;
+
+  if (delta > 0.02) return 'up';
+  if (delta < -0.02) return 'down';
+
+  return 'flat';
+}
+
+export function useIntegritySignals() {
+  const [client] = useState(() => new MobiusDataClient());
+  const [signals, setSignals] = useState<IngestedSignal[]>([]);
+  const [signalCounts, setSignalCounts] = useState<Record<string, number>>({});
+  const [isConnected, setIsConnected] = useState(false);
+
+  useEffect(() => {
+    const handleSignal = (event: Event) => {
+      const customEvent = event as CustomEvent<IngestedSignal>;
+      const signal = customEvent.detail;
+
+      setSignals((previous) => [signal, ...previous].slice(0, MAX_SIGNAL_HISTORY));
+      setSignalCounts((previous) => ({
+        ...previous,
+        [signal.type]: (previous[signal.type] ?? 0) + 1,
+        total: (previous.total ?? 0) + 1,
+      }));
+    };
+
+    client.signalBus.addEventListener('signal', handleSignal);
+
+    void client.connectAll().then(() => {
+      setIsConnected(true);
+    });
+
+    return () => {
+      client.signalBus.removeEventListener('signal', handleSignal);
+      client.disconnectAll();
+    };
+  }, [client]);
+
+  const getSignalsByType = useCallback(
+    (type: string) => signals.filter((signal) => signal.type === type),
+    [signals],
+  );
+
+  const getLatestSignal = useCallback(
+    (type?: string) => {
+      if (!type) return signals[0];
+      return signals.find((signal) => signal.type === type);
+    },
+    [signals],
+  );
+
+  const getAggregatedGI = useCallback(() => {
+    const integritySignals = getSignalsByType('integrity');
+    if (integritySignals.length === 0) return null;
+
+    const latest = integritySignals[0].processed;
+
+    return {
+      current: latest.giContribution,
+      factors: {
+        sourceReliability: latest.sourceReliability,
+        institutionalTrust: latest.institutionalTrust,
+        consensusStability: latest.consensusStability,
+        narrativeDivergence: latest.narrativeDivergence,
+      },
+      trend: calculateTrend(integritySignals.slice(0, 24)),
+    };
+  }, [getSignalsByType]);
+
+  return {
+    signals,
+    signalCounts,
+    isConnected,
+    getSignalsByType,
+    getLatestSignal,
+    getAggregatedGI,
+    client,
+  };
+}

--- a/lib/ingestion/MobiusDataClient.ts
+++ b/lib/ingestion/MobiusDataClient.ts
@@ -1,0 +1,256 @@
+import {
+  type DataSourceConfig,
+  type IngestedSignal,
+  type IntegritySignal,
+  type SignalType,
+} from '@/lib/ingestion/types';
+
+const DEFAULT_SSE_RECONNECT_MS = Number(process.env.NEXT_PUBLIC_SSE_RECONNECT_MS ?? 5000);
+const DEFAULT_POLL_INTERVAL_MS = Number(process.env.NEXT_PUBLIC_POLL_INTERVAL_MS ?? 30000);
+
+export class MobiusDataClient {
+  private readonly sources: Map<string, DataSourceConfig> = new Map();
+  private readonly eventSources: Map<string, EventSource> = new Map();
+  private readonly pollingIntervals: Map<string, ReturnType<typeof setInterval>> = new Map();
+
+  public readonly signalBus = new EventTarget();
+
+  constructor() {
+    this.registerDefaultSources();
+  }
+
+  private registerDefaultSources() {
+    this.registerSource({
+      name: 'terminal-api',
+      baseUrl: process.env.NEXT_PUBLIC_TERMINAL_API_BASE ?? 'http://localhost:8000/api/v1',
+      type: 'sse',
+      retryConfig: { maxRetries: 5, backoffMs: DEFAULT_SSE_RECONNECT_MS },
+    });
+
+    this.registerSource({
+      name: 'civic-ledger',
+      baseUrl: process.env.NEXT_PUBLIC_LEDGER_URL ?? 'http://localhost:3000',
+      type: 'rest',
+      retryConfig: { maxRetries: 3, backoffMs: 500 },
+    });
+
+    this.registerSource({
+      name: 'gi-aggregator',
+      baseUrl: process.env.NEXT_PUBLIC_GI_URL ?? 'http://localhost:3001',
+      type: 'poll',
+      retryConfig: { maxRetries: 3, backoffMs: 500 },
+    });
+
+    this.registerSource({
+      name: 'thought-broker',
+      baseUrl: process.env.NEXT_PUBLIC_BROKER_URL ?? 'http://localhost:4005',
+      type: 'sse',
+      retryConfig: { maxRetries: 5, backoffMs: DEFAULT_SSE_RECONNECT_MS },
+    });
+  }
+
+  registerSource(config: DataSourceConfig) {
+    this.sources.set(config.name, config);
+  }
+
+  async connectAll() {
+    for (const [name, config] of this.sources.entries()) {
+      await this.connectSource(name, config);
+    }
+  }
+
+  private async connectSource(name: string, config: DataSourceConfig) {
+    switch (config.type) {
+      case 'sse':
+        this.connectSSE(name, config);
+        break;
+      case 'rest':
+        this.startPolling(name, config, 5000);
+        break;
+      case 'poll':
+        this.startPolling(name, config, DEFAULT_POLL_INTERVAL_MS);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private connectSSE(name: string, config: DataSourceConfig, attempts = 0) {
+    const url = this.getStreamUrl(name, config);
+    const eventSource = new EventSource(url);
+
+    eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data) as unknown;
+        this.processSignal(name, data);
+      } catch (error) {
+        console.error(`[${name}] Parse error`, error);
+      }
+    };
+
+    eventSource.onerror = () => {
+      eventSource.close();
+
+      if (attempts >= config.retryConfig.maxRetries) {
+        console.error(`[${name}] SSE retry limit reached`);
+        return;
+      }
+
+      window.setTimeout(
+        () => this.connectSSE(name, config, attempts + 1),
+        config.retryConfig.backoffMs,
+      );
+    };
+
+    this.eventSources.set(name, eventSource);
+  }
+
+  private startPolling(name: string, config: DataSourceConfig, intervalMs: number) {
+    const poll = async () => {
+      try {
+        const endpoints = this.getEndpointsForSource(name);
+        for (const endpoint of endpoints) {
+          const response = await fetch(`${config.baseUrl}${endpoint}`);
+          if (!response.ok) continue;
+
+          const data = (await response.json()) as unknown;
+          this.processSignal(name, data, endpoint);
+        }
+      } catch (error) {
+        console.error(`[${name}] Poll error`, error);
+      }
+    };
+
+    void poll();
+    const interval = setInterval(() => {
+      void poll();
+    }, intervalMs);
+    this.pollingIntervals.set(name, interval);
+  }
+
+  private getStreamUrl(name: string, config: DataSourceConfig): string {
+    if (name === 'terminal-api') {
+      return `${config.baseUrl}/stream/events`;
+    }
+
+    return `${config.baseUrl}/stream/events`;
+  }
+
+  private getEndpointsForSource(name: string): string[] {
+    const endpointMap: Record<string, string[]> = {
+      'terminal-api': ['/agents/status', '/epicon/feed', '/integrity/current', '/tripwires/active'],
+      'civic-ledger': ['/epicon/record', '/epicon/attestations', '/ledger/history'],
+      'gi-aggregator': ['/gi/current', '/gi/factors'],
+      'thought-broker': ['/sentinels/status', '/consensus/active'],
+    };
+
+    return endpointMap[name] ?? ['/'];
+  }
+
+  private processSignal(source: string, raw: unknown, endpoint?: string) {
+    const signal: IngestedSignal = {
+      id: `${source}-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+      timestamp: new Date(),
+      source,
+      type: this.classifySignal(endpoint),
+      raw,
+      processed: this.transformToIntegritySignal(source, raw),
+      confidence: this.calculateConfidence(source),
+    };
+
+    this.signalBus.dispatchEvent(new CustomEvent<IngestedSignal>('signal', { detail: signal }));
+    this.signalBus.dispatchEvent(new CustomEvent<IngestedSignal>(`signal:${signal.type}`, { detail: signal }));
+  }
+
+  private classifySignal(endpoint?: string): SignalType {
+    if (endpoint?.includes('epicon')) return 'epicon';
+    if (endpoint?.includes('agent')) return 'agent';
+    if (endpoint?.includes('integrity') || endpoint?.includes('gi')) return 'integrity';
+    if (endpoint?.includes('tripwire')) return 'threat';
+    if (endpoint?.includes('sentinel') || endpoint?.includes('consensus')) return 'consensus';
+    if (endpoint?.includes('wallet') || endpoint?.includes('mic')) return 'economy';
+
+    return 'sentiment';
+  }
+
+  private transformToIntegritySignal(source: string, raw: unknown): IntegritySignal {
+    const payload = (typeof raw === 'object' && raw !== null ? raw : {}) as Record<string, unknown>;
+
+    const sourceReliability = this.numberOrDefault(payload.sourceReliability ?? payload.confidence, 0.5);
+    const institutionalTrust = this.numberOrDefault(payload.institutionalTrust ?? payload.trustScore, 0.5);
+    const consensusStability = this.numberOrDefault(payload.consensusStability ?? payload.consensus, 0.5);
+    const narrativeDivergence = this.numberOrDefault(payload.narrativeDivergence ?? payload.divergence, 0);
+
+    return {
+      sourceReliability,
+      institutionalTrust,
+      consensusStability,
+      narrativeDivergence,
+      giContribution: this.calculateGIContribution({
+        sourceReliability,
+        institutionalTrust,
+        consensusStability,
+        narrativeDivergence,
+      }),
+      provenance: {
+        source,
+        timestamp: new Date(),
+        rawHash: this.hashRawData(raw),
+      },
+    };
+  }
+
+  private calculateGIContribution(input: {
+    sourceReliability: number;
+    institutionalTrust: number;
+    consensusStability: number;
+    narrativeDivergence: number;
+  }) {
+    const weights = {
+      sourceReliability: 0.3,
+      institutionalTrust: 0.3,
+      consensusStability: 0.25,
+      narrativeDivergence: 0.15,
+    };
+
+    return (
+      input.sourceReliability * weights.sourceReliability +
+      input.institutionalTrust * weights.institutionalTrust +
+      input.consensusStability * weights.consensusStability +
+      (1 - input.narrativeDivergence) * weights.narrativeDivergence
+    );
+  }
+
+  private calculateConfidence(source: string): number {
+    const sourceConfidence: Record<string, number> = {
+      'terminal-api': 0.9,
+      'civic-ledger': 0.95,
+      'gi-aggregator': 0.92,
+      'thought-broker': 0.88,
+      external: 0.6,
+    };
+
+    return sourceConfidence[source] ?? 0.5;
+  }
+
+  private hashRawData(raw: unknown): string {
+    const serialized = JSON.stringify(raw);
+
+    if (typeof window !== 'undefined' && typeof window.btoa === 'function') {
+      return window.btoa(serialized).slice(0, 16);
+    }
+
+    return Buffer.from(serialized).toString('base64').slice(0, 16);
+  }
+
+  private numberOrDefault(value: unknown, fallback: number): number {
+    return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+  }
+
+  disconnectAll() {
+    this.eventSources.forEach((source) => source.close());
+    this.pollingIntervals.forEach((interval) => clearInterval(interval));
+    this.eventSources.clear();
+    this.pollingIntervals.clear();
+  }
+}

--- a/lib/ingestion/processors/AgentProcessor.ts
+++ b/lib/ingestion/processors/AgentProcessor.ts
@@ -1,0 +1,60 @@
+import type { ProcessedAgentSignal } from '@/lib/ingestion/types';
+
+type AgentStatus = {
+  id: string;
+  name: string;
+  status?: string;
+  lastSeen?: string;
+  confidence?: number;
+  voteParticipation?: number;
+  dvaViolations?: unknown[];
+  dvaWarnings?: unknown[];
+  recentEvents?: Array<{ timestamp: string }>;
+};
+
+export class AgentProcessor {
+  process(agentStatus: AgentStatus): ProcessedAgentSignal {
+    return {
+      agentId: agentStatus.id,
+      name: agentStatus.name,
+      healthScore: this.calculateHealth(agentStatus),
+      consensusParticipation: agentStatus.voteParticipation ?? 0,
+      constitutionalCompliance: this.checkDVACompliance(agentStatus),
+      eventVelocity: this.calculateVelocity(agentStatus.recentEvents),
+      integrityScore: agentStatus.confidence ?? 0.5,
+    };
+  }
+
+  private calculateHealth(status: AgentStatus): number {
+    const factors = {
+      online: status.status === 'active' ? 1 : 0.5,
+      responsive: status.lastSeen
+        ? Date.now() - new Date(status.lastSeen).getTime() < 60_000
+          ? 1
+          : 0.5
+        : 0,
+      confident: status.confidence ?? 0.5,
+    };
+
+    return (factors.online + factors.responsive + factors.confident) / 3;
+  }
+
+  private checkDVACompliance(status: AgentStatus): 'compliant' | 'warning' | 'violation' {
+    if ((status.dvaViolations?.length ?? 0) > 0) return 'violation';
+    if ((status.dvaWarnings?.length ?? 0) > 0) return 'warning';
+
+    return 'compliant';
+  }
+
+  private calculateVelocity(events?: Array<{ timestamp: string }>): 'high' | 'medium' | 'low' {
+    if (!events?.length) return 'low';
+
+    const oneHourAgo = Date.now() - 3_600_000;
+    const recentCount = events.filter((event) => new Date(event.timestamp).getTime() > oneHourAgo).length;
+
+    if (recentCount > 20) return 'high';
+    if (recentCount > 5) return 'medium';
+
+    return 'low';
+  }
+}

--- a/lib/ingestion/processors/EPICONProcessor.ts
+++ b/lib/ingestion/processors/EPICONProcessor.ts
@@ -1,0 +1,85 @@
+import type {
+  ProcessedEPICON,
+  SentimentAnalysis,
+  ThreatIndicator,
+} from '@/lib/ingestion/types';
+
+type EPICONEvent = {
+  id: string;
+  timestamp: string;
+  confidenceScore?: number;
+  sourceChain?: string[];
+  agentTrace?: string[];
+  content?: unknown;
+};
+
+export class EPICONProcessor {
+  process(event: EPICONEvent): ProcessedEPICON {
+    return {
+      id: event.id,
+      timestamp: new Date(event.timestamp),
+      confidenceTier: this.calculateConfidenceTier(event.confidenceScore ?? 0.5),
+      sourceChain: event.sourceChain,
+      agentTrace: event.agentTrace,
+      verificationStatus: this.verifyProvenance(event),
+      threatIndicators: this.extractThreats(event),
+      sentiment: this.analyzeSentiment(event.content),
+      giDelta: this.calculateGIDelta(event),
+    };
+  }
+
+  private calculateConfidenceTier(score: number): 'unverified' | 'low' | 'medium' | 'high' | 'confirmed' {
+    if (score > 0.95) return 'confirmed';
+    if (score > 0.8) return 'high';
+    if (score > 0.6) return 'medium';
+    if (score > 0.4) return 'low';
+
+    return 'unverified';
+  }
+
+  private verifyProvenance(event: EPICONEvent): 'verified' | 'questionable' | 'contradicted' {
+    const hasValidChain = Boolean(event.sourceChain && event.sourceChain.length > 0);
+    const hasAgentConsensus = Boolean(event.agentTrace && event.agentTrace.length >= 2);
+
+    if (hasValidChain && hasAgentConsensus) return 'verified';
+    if (hasValidChain || hasAgentConsensus) return 'questionable';
+
+    return 'contradicted';
+  }
+
+  private extractThreats(event: EPICONEvent): ThreatIndicator[] {
+    const threats: ThreatIndicator[] = [];
+    const contentText = JSON.stringify(event.content ?? '').toLowerCase();
+
+    if (contentText.includes('urgent') && (event.confidenceScore ?? 0) < 0.5) {
+      threats.push({ type: 'manipulation', severity: 'medium', reason: 'Low-confidence urgency pattern' });
+    }
+
+    if (event.sourceChain?.some((source) => source.includes('unverified'))) {
+      threats.push({ type: 'source_risk', severity: 'high', reason: 'Unverified source in chain' });
+    }
+
+    return threats;
+  }
+
+  private analyzeSentiment(content: unknown): SentimentAnalysis {
+    const text = JSON.stringify(content ?? '').toLowerCase();
+    const positive = ['good', 'great', 'excellent', 'success', 'verified'].some((word) => text.includes(word));
+    const negative = ['bad', 'fail', 'error', 'contradicted', 'false'].some((word) => text.includes(word));
+
+    return {
+      polarity: positive ? 'positive' : negative ? 'negative' : 'neutral',
+      intensity: positive || negative ? 'high' : 'low',
+      subjectivity: text.includes('i think') || text.includes('believe') ? 'high' : 'low',
+    };
+  }
+
+  private calculateGIDelta(event: EPICONEvent): number {
+    const baseImpact = event.confidenceScore ?? 0.5;
+    const sourceMultiplier = event.sourceChain?.length
+      ? Math.min(event.sourceChain.length * 0.1, 0.5)
+      : 0;
+
+    return baseImpact * 0.1 + sourceMultiplier;
+  }
+}

--- a/lib/ingestion/types.ts
+++ b/lib/ingestion/types.ts
@@ -1,0 +1,82 @@
+export type DataSourceType = 'rest' | 'sse' | 'websocket' | 'poll';
+
+export type SignalType =
+  | 'epicon'
+  | 'agent'
+  | 'integrity'
+  | 'threat'
+  | 'consensus'
+  | 'economy'
+  | 'sentiment'
+  | 'constitutional';
+
+export interface DataSourceConfig {
+  name: string;
+  baseUrl: string;
+  type: DataSourceType;
+  auth?: {
+    type: 'bearer' | 'apikey' | 'none';
+    token?: string;
+  };
+  retryConfig: {
+    maxRetries: number;
+    backoffMs: number;
+  };
+}
+
+export interface IntegritySignal {
+  sourceReliability: number;
+  institutionalTrust: number;
+  consensusStability: number;
+  narrativeDivergence: number;
+  giContribution: number;
+  provenance: {
+    source: string;
+    timestamp: Date;
+    rawHash: string;
+  };
+}
+
+export interface IngestedSignal {
+  id: string;
+  timestamp: Date;
+  source: string;
+  type: SignalType;
+  raw: unknown;
+  processed: IntegritySignal;
+  confidence: number;
+}
+
+export interface ThreatIndicator {
+  type: 'manipulation' | 'source_risk' | 'other';
+  severity: 'low' | 'medium' | 'high';
+  reason: string;
+}
+
+export interface SentimentAnalysis {
+  polarity: 'positive' | 'negative' | 'neutral';
+  intensity: 'high' | 'low';
+  subjectivity: 'high' | 'low';
+}
+
+export interface ProcessedEPICON {
+  id: string;
+  timestamp: Date;
+  confidenceTier: 'unverified' | 'low' | 'medium' | 'high' | 'confirmed';
+  sourceChain?: string[];
+  agentTrace?: string[];
+  verificationStatus: 'verified' | 'questionable' | 'contradicted';
+  threatIndicators: ThreatIndicator[];
+  sentiment: SentimentAnalysis;
+  giDelta: number;
+}
+
+export interface ProcessedAgentSignal {
+  agentId: string;
+  name: string;
+  healthScore: number;
+  consensusParticipation: number;
+  constitutionalCompliance: 'compliant' | 'warning' | 'violation';
+  eventVelocity: 'high' | 'medium' | 'low';
+  integrityScore: number;
+}


### PR DESCRIPTION
### Motivation

- Introduce a reusable ingestion layer to normalize diverse Mobius and external data sources into standardized integrity signals for UI consumption and downstream processing.
- Provide primitives that allow new dashboard modules to subscribe to processed signals without replacing existing `useTerminalData` flows.

### Description

- Add a typed ingestion domain model in `lib/ingestion/types.ts` (data source config, signal types, integrity signal and processor outputs). 
- Implement `MobiusDataClient` (`lib/ingestion/MobiusDataClient.ts`) that registers default terminal/substrate sources, connects via SSE and polling, classifies endpoints, transforms raw payloads to `IntegritySignal` dimensions, and emits events on an in-app `signalBus`.
- Add dedicated processors `EPICONProcessor` and `AgentProcessor` (`lib/ingestion/processors/*.ts`) that enrich incoming EPICON and agent payloads with confidence tiers, provenance checks, threat indicators, sentiment metadata, health/compliance scoring, velocity classification, and GI delta calculations.
- Add `useIntegritySignals` React hook (`hooks/useIntegritySignals.ts`) that subscribes to the signal bus, maintains a bounded signal history and counters, exposes typed selectors, and computes an aggregated GI trend for UI components; and update `README.md` with documentation and environment variables for the ingestion layer.

### Testing

- Type-checking with `npx tsc --noEmit` completed successfully.
- Running `npm run lint` could not be executed non-interactively in this environment because Next.js prompted for ESLint configuration (interactive setup), so linting was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2e6cf8a94832d867cc3b6bbf4fff1)