### PR TITLE
Add Redis KV bridge + agent SDK and terminal API base fallback

### DIFF
--- a/api/redis_bridge.py
+++ b/api/redis_bridge.py
@@ -1,0 +1,461 @@
+import asyncio
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, AsyncGenerator, Dict, Optional
+
+import redis.asyncio as redis
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+
+app = FastAPI(title="Mobius Redis Bridge")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # tighten in production
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+redis_client: Optional[redis.Redis] = None
+
+
+KEY_PATTERNS = {
+    "agent": "mobius:agent:{agent_id}",
+    "agent_status": "mobius:agent:{agent_id}:status",
+    "agent_heartbeat": "mobius:agent:{agent_id}:heartbeat",
+    "epicon": "mobius:epicon:{event_id}",
+    "epicon_timeline": "mobius:epicon:timeline",
+    "signal_stream": "mobius:signal:stream",
+    "gi_current": "mobius:gi:current",
+}
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def parse_iso_timestamp(raw: Optional[str]) -> datetime:
+    if not raw:
+        return datetime.now(timezone.utc)
+
+    try:
+        normalized = raw.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except ValueError:
+        return datetime.now(timezone.utc)
+
+
+async def get_redis() -> redis.Redis:
+    global redis_client
+    if redis_client is None:
+        redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
+        redis_client = redis.from_url(redis_url, decode_responses=True)
+    return redis_client
+
+
+@app.get("/api/v1/agents/status")
+async def get_agents_status():
+    r = await get_redis()
+
+    agent_keys: list[str] = []
+    async for key in r.scan_iter(match="mobius:agent:*:status"):
+        agent_keys.append(key)
+
+    agents = []
+    for key in agent_keys:
+        raw = await r.get(key)
+        if not raw:
+            continue
+        try:
+            agent = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+        heartbeat_key = key.replace(":status", ":heartbeat")
+        heartbeat = await r.get(heartbeat_key)
+        if heartbeat:
+            agent["last_seen"] = heartbeat
+        agents.append(agent)
+
+    timestamp = now_iso()
+    return {
+        "success": True,
+        "source": "redis_kv",
+        "count": len(agents),
+        "data": agents,
+        # Terminal compatibility fields
+        "cycle": "live",
+        "timestamp": timestamp,
+        "agents": agents,
+    }
+
+
+@app.get("/api/v1/agents/{agent_id}")
+async def get_agent_detail(agent_id: str):
+    r = await get_redis()
+
+    status_key = KEY_PATTERNS["agent_status"].format(agent_id=agent_id)
+    heartbeat_key = KEY_PATTERNS["agent_heartbeat"].format(agent_id=agent_id)
+    state_key = KEY_PATTERNS["agent"].format(agent_id=agent_id)
+
+    status_data = await r.get(status_key)
+    if not status_data:
+        raise HTTPException(status_code=404, detail=f"Agent {agent_id} not found")
+
+    heartbeat = await r.get(heartbeat_key)
+    state_data = await r.get(state_key)
+    events_raw = await r.lrange(f"mobius:agent:{agent_id}:events", 0, 49)
+
+    agent = json.loads(status_data)
+    agent["heartbeat"] = heartbeat
+    agent["state"] = json.loads(state_data) if state_data else {}
+    agent["recent_events"] = [json.loads(item) for item in events_raw]
+
+    return {"success": True, "data": agent}
+
+
+@app.get("/api/v1/epicon/feed")
+async def get_epicon_feed(limit: int = 50, agent: Optional[str] = None):
+    r = await get_redis()
+
+    rows = await r.zrevrange(KEY_PATTERNS["epicon_timeline"], 0, max(0, limit - 1), withscores=False)
+
+    items = []
+    for row in rows:
+        try:
+            event = json.loads(row)
+        except json.JSONDecodeError:
+            continue
+        if agent and agent not in event.get("agent_trace", []):
+            continue
+        items.append(event)
+
+    timestamp = now_iso()
+    return {
+        "success": True,
+        "count": len(items),
+        "data": items,
+        # Terminal compatibility fields
+        "cycle": "live",
+        "timestamp": timestamp,
+        "items": items,
+    }
+
+
+async def calculate_gi_from_signals() -> Dict[str, Any]:
+    r = await get_redis()
+    signals = await r.lrange(KEY_PATTERNS["signal_stream"], 0, 99)
+
+    if not signals:
+        return {
+            "score": 0.5,
+            "delta": 0,
+            "institutional_trust": 0.5,
+            "info_reliability": 0.5,
+            "consensus_stability": 0.5,
+            "weekly": [0.5] * 7,
+            "factors": {
+                "source_reliability": 0.5,
+                "institutional_trust": 0.5,
+                "consensus_stability": 0.5,
+                "narrative_divergence": 0.5,
+            },
+            "calculated_at": now_iso(),
+            "source": "fallback",
+        }
+
+    factors: Dict[str, list[float]] = {
+        "source_reliability": [],
+        "institutional_trust": [],
+        "consensus_stability": [],
+        "narrative_divergence": [],
+    }
+
+    for raw in signals:
+        try:
+            signal = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+        for factor in factors:
+            value = signal.get(factor)
+            if isinstance(value, (int, float)):
+                factors[factor].append(float(value))
+
+    avg_factors = {
+        name: (sum(values) / len(values) if values else 0.5)
+        for name, values in factors.items()
+    }
+
+    score = sum(avg_factors.values()) / len(avg_factors)
+
+    return {
+        "score": round(score, 4),
+        "delta": 0,
+        "institutional_trust": round(avg_factors["institutional_trust"], 4),
+        "info_reliability": round(avg_factors["source_reliability"], 4),
+        "consensus_stability": round(avg_factors["consensus_stability"], 4),
+        "weekly": [round(score, 4)] * 7,
+        "factors": avg_factors,
+        "calculated_at": now_iso(),
+        "source": "redis_aggregated",
+        "sample_size": len(signals),
+    }
+
+
+@app.get("/api/v1/integrity/current")
+async def get_integrity_current():
+    r = await get_redis()
+
+    raw = await r.get(KEY_PATTERNS["gi_current"])
+    if raw:
+        gi = json.loads(raw)
+    else:
+        gi = await calculate_gi_from_signals()
+
+    return {
+        "success": True,
+        "data": gi,
+        # Terminal compatibility fields
+        "cycle": "live",
+        "timestamp": now_iso(),
+        "gi": gi,
+    }
+
+
+@app.get("/api/v1/tripwires/active")
+async def get_tripwires():
+    r = await get_redis()
+
+    keys: list[str] = []
+    async for key in r.scan_iter(match="mobius:tripwire:active:*"):
+        keys.append(key)
+
+    tripwires = []
+    for key in keys:
+        raw = await r.get(key)
+        if not raw:
+            continue
+        try:
+            tripwires.append(json.loads(raw))
+        except json.JSONDecodeError:
+            continue
+
+    return {
+        "success": True,
+        "data": tripwires,
+        # Terminal compatibility fields
+        "cycle": "live",
+        "timestamp": now_iso(),
+        "tripwires": tripwires,
+    }
+
+
+async def event_stream() -> AsyncGenerator[str, None]:
+    r = await get_redis()
+    pubsub = r.pubsub()
+
+    await pubsub.subscribe(
+        "mobius:events",
+        "mobius:agent:updates",
+        "mobius:epicon:new",
+        "mobius:tripwire:triggered",
+    )
+
+    yield f"event: heartbeat\ndata: {json.dumps({'type': 'heartbeat', 'cycle': 'live', 'timestamp': now_iso(), 'message': 'connected'})}\n\n"
+
+    channel_to_event = {
+        "mobius:events": "integrity",
+        "mobius:agent:updates": "agents",
+        "mobius:epicon:new": "epicon",
+        "mobius:tripwire:triggered": "tripwire",
+    }
+
+    try:
+        async for message in pubsub.listen():
+            if message.get("type") != "message":
+                continue
+
+            channel = message.get("channel")
+            data = message.get("data")
+
+            try:
+                payload = json.loads(data)
+            except (TypeError, json.JSONDecodeError):
+                continue
+
+            event_name = channel_to_event.get(channel, "heartbeat")
+            yield f"event: {event_name}\ndata: {json.dumps(payload)}\n\n"
+    except asyncio.CancelledError:
+        await pubsub.unsubscribe()
+        await pubsub.close()
+        raise
+
+
+@app.get("/api/v1/stream/events")
+async def stream_events():
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        },
+    )
+
+
+@app.post("/api/v1/agents/{agent_id}/heartbeat")
+async def agent_heartbeat(agent_id: str, status: Dict[str, Any]):
+    r = await get_redis()
+
+    status_key = KEY_PATTERNS["agent_status"].format(agent_id=agent_id)
+    heartbeat_key = KEY_PATTERNS["agent_heartbeat"].format(agent_id=agent_id)
+
+    enriched = {
+        **status,
+        "id": agent_id,
+        "last_updated": now_iso(),
+    }
+
+    await r.set(status_key, json.dumps(enriched))
+    await r.set(heartbeat_key, now_iso())
+
+    await r.publish(
+        "mobius:agent:updates",
+        json.dumps(
+            {
+                "type": "agents",
+                "cycle": "live",
+                "timestamp": now_iso(),
+                "agents": [enriched],
+            }
+        ),
+    )
+
+    return {"success": True}
+
+
+@app.post("/api/v1/epicon/publish")
+async def publish_epicon(event: Dict[str, Any]):
+    r = await get_redis()
+
+    event_id = event.get("id", f"ep-{datetime.now(timezone.utc).timestamp()}")
+    timestamp = parse_iso_timestamp(event.get("timestamp"))
+    score = timestamp.timestamp()
+
+    await r.zadd(KEY_PATTERNS["epicon_timeline"], {json.dumps(event): score})
+    await r.zremrangebyrank(KEY_PATTERNS["epicon_timeline"], 0, -1001)
+
+    for agent in event.get("agent_trace", []):
+        await r.lpush(f"mobius:agent:{agent}:events", json.dumps(event))
+        await r.ltrim(f"mobius:agent:{agent}:events", 0, 99)
+
+    await r.publish(
+        "mobius:epicon:new",
+        json.dumps(
+            {
+                "type": "epicon",
+                "cycle": "live",
+                "timestamp": now_iso(),
+                "item": event,
+                "event_id": event_id,
+            }
+        ),
+    )
+
+    return {"success": True, "event_id": event_id}
+
+
+@app.post("/api/v1/signals/publish")
+async def publish_signal(signal: Dict[str, Any]):
+    r = await get_redis()
+
+    payload = {
+        **signal,
+        "received_at": now_iso(),
+    }
+
+    await r.lpush(KEY_PATTERNS["signal_stream"], json.dumps(payload))
+    await r.ltrim(KEY_PATTERNS["signal_stream"], 0, 999)
+
+    await r.publish(
+        "mobius:events",
+        json.dumps(
+            {
+                "type": "integrity",
+                "cycle": "live",
+                "timestamp": now_iso(),
+                "gi": await calculate_gi_from_signals(),
+            }
+        ),
+    )
+
+    return {"success": True}
+
+
+@app.post("/api/v1/tripwire/trigger")
+async def trigger_tripwire(alert: Dict[str, Any]):
+    r = await get_redis()
+
+    tripwire_id = alert.get("id", f"tw-{datetime.now(timezone.utc).timestamp()}")
+    key = f"mobius:tripwire:active:{tripwire_id}"
+
+    tripwire = {
+        **alert,
+        "id": tripwire_id,
+        "triggered_at": now_iso(),
+        "status": "active",
+    }
+
+    await r.set(key, json.dumps(tripwire))
+    await r.expire(key, 86400)
+
+    current_tripwires = []
+    async for tw_key in r.scan_iter(match="mobius:tripwire:active:*"):
+        raw = await r.get(tw_key)
+        if raw:
+            current_tripwires.append(json.loads(raw))
+
+    await r.publish(
+        "mobius:tripwire:triggered",
+        json.dumps(
+            {
+                "type": "tripwire",
+                "cycle": "live",
+                "timestamp": now_iso(),
+                "tripwires": current_tripwires,
+            }
+        ),
+    )
+
+    return {"success": True, "tripwire_id": tripwire_id}
+
+
+@app.get("/health")
+async def health_check():
+    try:
+        r = await get_redis()
+        await r.ping()
+        return {
+            "status": "healthy",
+            "redis": "connected",
+            "timestamp": now_iso(),
+        }
+    except Exception as exc:
+        return {
+            "status": "unhealthy",
+            "redis": str(exc),
+            "timestamp": now_iso(),
+        }
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.30.6
 pydantic==2.9.2
 python-dotenv==1.0.1
 sse-starlette==2.1.3
+redis==5.2.1

--- a/lib/terminal/api.ts
+++ b/lib/terminal/api.ts
@@ -8,7 +8,7 @@ import { transformAgent, transformEpicon, transformTripwire } from './transforms
 
 const API_BASE =
   (typeof window !== 'undefined'
-    ? process.env.NEXT_PUBLIC_MOBIUS_API_BASE
+    ? process.env.NEXT_PUBLIC_MOBIUS_API_BASE ?? process.env.NEXT_PUBLIC_TERMINAL_API_BASE
     : ''
   )?.replace(/\/$/, '') || '';
 

--- a/lib/terminal/stream.ts
+++ b/lib/terminal/stream.ts
@@ -10,7 +10,7 @@ export type StreamMessage =
 
 const API_BASE =
   (typeof window !== 'undefined'
-    ? process.env.NEXT_PUBLIC_MOBIUS_API_BASE
+    ? process.env.NEXT_PUBLIC_MOBIUS_API_BASE ?? process.env.NEXT_PUBLIC_TERMINAL_API_BASE
     : ''
   )?.replace(/\/$/, '') || '';
 

--- a/sdk/mobius_agent.py
+++ b/sdk/mobius_agent.py
@@ -1,0 +1,117 @@
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class MobiusAgent:
+    """SDK for publishing agent data to Mobius Redis Bridge."""
+
+    def __init__(self, agent_id: str, agent_name: str, api_base: Optional[str] = None):
+        self.agent_id = agent_id
+        self.agent_name = agent_name
+        base = api_base or os.getenv("MOBIUS_API_BASE", "http://localhost:8000/api/v1")
+        self.api_base = base.rstrip("/")
+
+    @staticmethod
+    def _now_iso() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def heartbeat(
+        self,
+        status: str = "active",
+        confidence: float = 0.5,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        payload = {
+            "name": self.agent_name,
+            "status": status,
+            "confidence": confidence,
+            "metadata": metadata or {},
+        }
+
+        try:
+            response = requests.post(
+                f"{self.api_base}/agents/{self.agent_id}/heartbeat",
+                json=payload,
+                timeout=5,
+            )
+            response.raise_for_status()
+            return response.json()
+        except Exception as exc:
+            print(f"[{self.agent_name}] Heartbeat failed: {exc}")
+            return None
+
+    def publish_epicon(
+        self,
+        content: Dict[str, Any],
+        source: str,
+        confidence: float = 0.5,
+    ) -> Optional[Dict[str, Any]]:
+        event = {
+            "id": f"ep-{self.agent_id}-{datetime.now(timezone.utc).timestamp()}",
+            "timestamp": self._now_iso(),
+            "source": source,
+            "agent_trace": [self.agent_name],
+            "confidence_score": confidence,
+            "content": content,
+            "status": "pending",
+        }
+
+        try:
+            response = requests.post(
+                f"{self.api_base}/epicon/publish",
+                json=event,
+                timeout=5,
+            )
+            response.raise_for_status()
+            return response.json()
+        except Exception as exc:
+            print(f"[{self.agent_name}] EPICON publish failed: {exc}")
+            return None
+
+    def publish_signal(self, signal_type: str, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        signal = {
+            "type": signal_type,
+            "agent": self.agent_name,
+            "timestamp": self._now_iso(),
+            **data,
+        }
+
+        try:
+            response = requests.post(
+                f"{self.api_base}/signals/publish",
+                json=signal,
+                timeout=5,
+            )
+            response.raise_for_status()
+            return response.json()
+        except Exception as exc:
+            print(f"[{self.agent_name}] Signal publish failed: {exc}")
+            return None
+
+    def trigger_tripwire(
+        self,
+        level: str,
+        message: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        alert = {
+            "level": level,
+            "message": message,
+            "source_agent": self.agent_name,
+            "metadata": metadata or {},
+        }
+
+        try:
+            response = requests.post(
+                f"{self.api_base}/tripwire/trigger",
+                json=alert,
+                timeout=5,
+            )
+            response.raise_for_status()
+            return response.json()
+        except Exception as exc:
+            print(f"[{self.agent_name}] Tripwire trigger failed: {exc}")
+            return None


### PR DESCRIPTION
### Motivation
- Provide a canonical Redis-backed bridge so agents can persist state and emit real-time events that the Terminal UI can consume. 
- Fix the broken Redis KV → Terminal pipeline by offering HTTP publish endpoints and SSE pub/sub compatibility for live UI updates.
- Make the web client able to point at the new bridge without changing existing environment variables.

### Description
- Add a FastAPI Redis bridge service at `api/redis_bridge.py` that exposes read endpoints (`/api/v1/agents/status`, `/api/v1/epicon/feed`, `/api/v1/integrity/current`, `/api/v1/tripwires/active`), agent publish endpoints (`/api/v1/agents/{id}/heartbeat`, `/api/v1/epicon/publish`, `/api/v1/signals/publish`, `/api/v1/tripwire/trigger`), an SSE stream at `/api/v1/stream/events`, and a `/health` check; the bridge persists to Redis and publishes to channels compatible with the Terminal stream. 
- Add a lightweight Python agent SDK at `sdk/mobius_agent.py` to let agents post heartbeats, epicon events, signals, and tripwires to the bridge API. 
- Add `redis==5.2.1` to `api/requirements.txt` for the async Redis client. 
- Update terminal client code (`lib/terminal/api.ts`, `lib/terminal/stream.ts`) to accept either `NEXT_PUBLIC_MOBIUS_API_BASE` or the new `NEXT_PUBLIC_TERMINAL_API_BASE` as the API base so the UI can connect to the bridge without env churn. 

### Testing
- Ran Python static compile checks with `python -m py_compile api/redis_bridge.py sdk/mobius_agent.py`, which succeeded. 
- Attempted to run Next lint (`npm run -s lint -- lib/terminal/api.ts lib/terminal/stream.ts`), which failed in this environment due to `next lint` requiring a `pages`/`app` directory. 
- Attempted `npx eslint lib/terminal/api.ts lib/terminal/stream.ts`, which failed because the repository does not provide the ESLint flat config expected by ESLint v9 in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2e95ca148832d8e86dee7eeba8ae9)