### PR TITLE
Add Mobius Terminal gateway (FastAPI) + frontend client and Render blueprint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,18 @@
 NEXT_PUBLIC_MOBIUS_API_BASE=http://localhost:8000/api/v1
+NEXT_PUBLIC_MOBIUS_GATEWAY_URL=http://localhost:8000/api/v1
+
+# Fallback service URLs
+NEXT_PUBLIC_THOUGHT_BROKER_URL=https://thought-broker.onrender.com
+NEXT_PUBLIC_CIVIC_LEDGER_URL=https://civic-protocol-core-ledger.onrender.com
+NEXT_PUBLIC_GIC_INDEXER_URL=https://gic-indexer-api.onrender.com
+NEXT_PUBLIC_MIC_WALLET_URL=https://mobius-mic-wallet-service.onrender.com
+NEXT_PUBLIC_IDENTITY_URL=https://mobius-identity-service.onrender.com
+NEXT_PUBLIC_OAA_API_URL=https://oaa-api-library.onrender.com
+NEXT_PUBLIC_LAB4_URL=https://lab4-proof.onrender.com
+NEXT_PUBLIC_LAB6_URL=https://lab6-proof.onrender.com
+NEXT_PUBLIC_LAB7_URL=https://lab7-proof.onrender.com
+
+# Legacy render aliases retained for compatibility
 RENDER_IDENTITY_URL=https://mobius-identity-service.onrender.com
 RENDER_MIC_URL=https://mobius-mic-wallet-service.onrender.com
 RENDER_LEDGER_URL=https://civic-protocol-core.onrender.com

--- a/gateway.py
+++ b/gateway.py
@@ -1,0 +1,275 @@
+import asyncio
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, AsyncGenerator, Optional
+
+import httpx
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+app = FastAPI(title="Mobius Terminal Gateway")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["https://mobius-civic-ai-terminal.vercel.app", "http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+SERVICES = {
+    "thought_broker": os.getenv("THOUGHT_BROKER_URL", "http://localhost:4005"),
+    "civic_ledger": os.getenv("CIVIC_LEDGER_URL", "http://localhost:3000"),
+    "gic_indexer": os.getenv("GIC_INDEXER_URL", "http://localhost:4002"),
+    "mic_wallet": os.getenv("MIC_WALLET_URL", "http://localhost:3002"),
+    "identity": os.getenv("IDENTITY_URL", "http://localhost:3003"),
+    "oaa_api": os.getenv("OAA_API_URL", "http://localhost:3004"),
+    "lab4": os.getenv("LAB4_URL", "http://localhost:3005"),
+    "lab6": os.getenv("LAB6_URL", "http://localhost:3006"),
+    "lab7": os.getenv("LAB7_URL", "http://localhost:3007"),
+}
+
+http_client = httpx.AsyncClient(timeout=10.0)
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    await http_client.aclose()
+
+
+@app.get("/api/v1/agents/status")
+async def get_all_agents() -> dict[str, Any]:
+    try:
+        broker_resp = await http_client.get(f"{SERVICES['thought_broker']}/sentinels/status")
+        broker_data = broker_resp.json() if broker_resp.status_code == 200 else {}
+
+        ledger_resp = await http_client.get(f"{SERVICES['civic_ledger']}/agents/activity")
+        ledger_data = ledger_resp.json() if ledger_resp.status_code == 200 else {}
+
+        agents = []
+        for agent in broker_data.get("sentinels", []):
+            agent_id = agent.get("id")
+            ledger_activity = ledger_data.get("agents", {}).get(agent_id, {})
+
+            agents.append(
+                {
+                    "id": agent_id,
+                    "name": agent.get("name"),
+                    "status": agent.get("status", "unknown"),
+                    "confidence": agent.get("confidence", 0.5),
+                    "last_seen": agent.get("last_seen"),
+                    "consensus_participation": agent.get("vote_participation", 0),
+                    "recent_epicons": ledger_activity.get("recent_events", 0),
+                    "provider": agent.get("provider"),
+                }
+            )
+
+        return {"success": True, "data": agents, "source": "aggregated"}
+
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=503, detail=f"Service aggregation failed: {exc}") from exc
+
+
+@app.get("/api/v1/agents/{agent_id}")
+async def get_agent_detail(agent_id: str) -> dict[str, Any]:
+    try:
+        responses = await asyncio.gather(
+            http_client.get(f"{SERVICES['thought_broker']}/sentinels/{agent_id}"),
+            http_client.get(f"{SERVICES['civic_ledger']}/agents/{agent_id}/history"),
+            http_client.get(f"{SERVICES['gic_indexer']}/agents/{agent_id}/contributions"),
+            return_exceptions=True,
+        )
+
+        broker_data = (
+            responses[0].json()
+            if isinstance(responses[0], httpx.Response) and responses[0].status_code == 200
+            else {}
+        )
+        ledger_data = (
+            responses[1].json()
+            if isinstance(responses[1], httpx.Response) and responses[1].status_code == 200
+            else {}
+        )
+        gic_data = (
+            responses[2].json()
+            if isinstance(responses[2], httpx.Response) and responses[2].status_code == 200
+            else {}
+        )
+
+        return {
+            "success": True,
+            "data": {
+                "profile": broker_data,
+                "activity": ledger_data,
+                "contributions": gic_data,
+            },
+        }
+
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@app.get("/api/v1/epicon/feed")
+async def get_epicon_feed(limit: int = 50, agent: Optional[str] = None) -> dict[str, Any]:
+    try:
+        params: dict[str, Any] = {"limit": limit}
+        if agent:
+            params["agent"] = agent
+
+        resp = await http_client.get(f"{SERVICES['civic_ledger']}/epicon/feed", params=params)
+        return resp.json()
+
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@app.get("/api/v1/integrity/current")
+async def get_integrity() -> dict[str, Any]:
+    try:
+        resp = await http_client.get(f"{SERVICES['gic_indexer']}/gi/current")
+        return resp.json()
+
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@app.get("/api/v1/mic/wallet/{user_id}")
+async def get_wallet(user_id: str) -> dict[str, Any]:
+    try:
+        resp = await http_client.get(f"{SERVICES['mic_wallet']}/wallet/{user_id}")
+        return resp.json()
+
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@app.get("/api/v1/labs/{lab_id}/status")
+async def get_lab_status(lab_id: str) -> dict[str, Any]:
+    lab_urls = {
+        "oaa": SERVICES["lab7"],
+        "reflections": SERVICES["lab4"],
+        "shield": SERVICES["lab6"],
+    }
+
+    if lab_id not in lab_urls:
+        raise HTTPException(status_code=404, detail=f"Lab {lab_id} not found")
+
+    try:
+        resp = await http_client.get(f"{lab_urls[lab_id]}/health")
+        return {
+            "success": True,
+            "lab": lab_id,
+            "status": "healthy" if resp.status_code == 200 else "degraded",
+            "details": resp.json() if resp.status_code == 200 else {},
+        }
+
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "success": False,
+            "lab": lab_id,
+            "status": "offline",
+            "error": str(exc),
+        }
+
+
+async def aggregated_event_stream() -> AsyncGenerator[str, None]:
+    async with httpx.AsyncClient() as client:
+        async with client.stream(
+            "GET",
+            f"{SERVICES['thought_broker']}/stream/events",
+            timeout=None,
+        ) as broker_stream:
+            yield (
+                "data: "
+                + json.dumps({"type": "connected", "services": list(SERVICES.keys())})
+                + "\n\n"
+            )
+
+            async for line in broker_stream.aiter_lines():
+                if line.startswith("data: "):
+                    try:
+                        event = json.loads(line[6:])
+                        yield f"data: {json.dumps(event)}\\n\\n"
+                    except json.JSONDecodeError:
+                        yield f"{line}\\n\\n"
+
+
+@app.get("/api/v1/stream/events")
+async def stream_events() -> StreamingResponse:
+    return StreamingResponse(
+        aggregated_event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        },
+    )
+
+
+class IntentRequest(BaseModel):
+    agent_id: str
+    intent: str
+    spec: str
+    expected_outcome: str
+    divergence_tolerance: float = 0.1
+
+
+@app.post("/api/v1/intent/submit")
+async def submit_intent(request: IntentRequest) -> dict[str, Any]:
+    try:
+        resp = await http_client.post(
+            f"{SERVICES['oaa_api']}/intent",
+            json=request.model_dump(),
+        )
+        return resp.json()
+
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@app.get("/health")
+async def health_check() -> dict[str, Any]:
+    health: dict[str, str] = {}
+
+    for name, url in SERVICES.items():
+        try:
+            resp = await http_client.get(f"{url}/health", timeout=2.0)
+            health[name] = "healthy" if resp.status_code == 200 else "degraded"
+        except Exception:  # noqa: BLE001
+            health[name] = "unreachable"
+
+    return {
+        "status": "healthy" if any(v == "healthy" for v in health.values()) else "degraded",
+        "services": health,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@app.get("/api/v1/system/discovery")
+async def discover_services() -> dict[str, Any]:
+    return {
+        "services": {
+            name: {
+                "url": url,
+                "endpoints": [
+                    "/health",
+                    "/api/v1/agents/status",
+                    "/api/v1/epicon/feed",
+                    "/api/v1/integrity/current",
+                    "/api/v1/stream/events",
+                ]
+                if name == "thought_broker"
+                else ["/health"],
+            }
+            for name, url in SERVICES.items()
+        }
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/lib/mobiusClient.ts
+++ b/lib/mobiusClient.ts
@@ -1,0 +1,117 @@
+export interface Agent {
+  id: string;
+  name?: string;
+  status?: string;
+  confidence?: number;
+  last_seen?: string;
+  consensus_participation?: number;
+  recent_epicons?: number;
+  provider?: string;
+}
+
+export interface AgentDetail {
+  profile: Record<string, unknown>;
+  activity: Record<string, unknown>;
+  contributions: Record<string, unknown>;
+}
+
+export interface EPICONEvent {
+  id?: string;
+  [key: string]: unknown;
+}
+
+export interface GlobalIntegrity {
+  [key: string]: unknown;
+}
+
+export interface MICWallet {
+  [key: string]: unknown;
+}
+
+export interface LabStatus {
+  success: boolean;
+  lab: string;
+  status: 'healthy' | 'degraded' | 'offline';
+  details?: Record<string, unknown>;
+  error?: string;
+}
+
+export interface IntentRequest {
+  agent_id: string;
+  intent: string;
+  spec: string;
+  expected_outcome: string;
+  divergence_tolerance?: number;
+}
+
+export interface HealthStatus {
+  status: 'healthy' | 'degraded';
+  services: Record<string, string>;
+  timestamp: string;
+}
+
+const GATEWAY_URL = process.env.NEXT_PUBLIC_MOBIUS_GATEWAY_URL;
+
+export class MobiusGatewayClient {
+  private readonly baseUrl: string;
+
+  constructor() {
+    this.baseUrl = GATEWAY_URL || 'http://localhost:8000/api/v1';
+  }
+
+  async getAgents(): Promise<Agent[]> {
+    const res = await fetch(`${this.baseUrl}/agents/status`);
+    const data = await res.json();
+    return data.data;
+  }
+
+  async getAgentDetail(agentId: string): Promise<AgentDetail> {
+    const res = await fetch(`${this.baseUrl}/agents/${agentId}`);
+    const data = await res.json();
+    return data.data;
+  }
+
+  async getEPICONFeed(limit = 50, agent?: string): Promise<EPICONEvent[]> {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (agent) params.set('agent', agent);
+
+    const res = await fetch(`${this.baseUrl}/epicon/feed?${params}`);
+    const data = await res.json();
+    return data.data;
+  }
+
+  async getGI(): Promise<GlobalIntegrity> {
+    const res = await fetch(`${this.baseUrl}/integrity/current`);
+    const data = await res.json();
+    return data.data;
+  }
+
+  async getWallet(userId: string): Promise<MICWallet> {
+    const res = await fetch(`${this.baseUrl}/mic/wallet/${userId}`);
+    const data = await res.json();
+    return data.data;
+  }
+
+  async getLabStatus(labId: 'oaa' | 'reflections' | 'shield'): Promise<LabStatus> {
+    const res = await fetch(`${this.baseUrl}/labs/${labId}/status`);
+    return res.json();
+  }
+
+  async submitIntent(intent: IntentRequest): Promise<{ success: boolean }> {
+    const res = await fetch(`${this.baseUrl}/intent/submit`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(intent),
+    });
+    return res.json();
+  }
+
+  connectEventStream(): EventSource {
+    return new EventSource(`${this.baseUrl}/stream/events`);
+  }
+
+  async checkHealth(): Promise<HealthStatus> {
+    const res = await fetch(`${this.baseUrl.replace('/api/v1', '')}/health`);
+    return res.json();
+  }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,56 @@
+services:
+  - type: web
+    name: mobius-terminal-gateway
+    runtime: python
+    plan: starter
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn gateway:app --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: PYTHON_VERSION
+        value: 3.11.0
+      - key: THOUGHT_BROKER_URL
+        fromService:
+          name: thought-broker
+          type: web
+          property: host
+      - key: CIVIC_LEDGER_URL
+        fromService:
+          name: Civic-Protocol-Core Ledger API
+          type: web
+          property: host
+      - key: GIC_INDEXER_URL
+        fromService:
+          name: GIC Indexer API
+          type: web
+          property: host
+      - key: MIC_WALLET_URL
+        fromService:
+          name: mobius-mic-wallet-service
+          type: web
+          property: host
+      - key: IDENTITY_URL
+        fromService:
+          name: mobius-identity-service
+          type: web
+          property: host
+      - key: OAA_API_URL
+        fromService:
+          name: OAA-API-Library API
+          type: web
+          property: host
+      - key: LAB4_URL
+        fromService:
+          name: lab4-proof API
+          type: web
+          property: host
+      - key: LAB6_URL
+        fromService:
+          name: lab6-proof API
+          type: web
+          property: host
+      - key: LAB7_URL
+        fromService:
+          name: lab7-proof API
+          type: web
+          property: host
+      - fromGroup: mobius.sys

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.8
+uvicorn[standard]==0.34.0
+httpx==0.28.1
+pydantic==2.11.1


### PR DESCRIPTION
### Motivation
- Provide a single, unified API gateway so the Terminal can securely aggregate and proxy data and real-time events from the nine deployed Mobius services.  
- Expose a small, typed frontend client surface and environment defaults to simplify Vercel/local configuration and integration.  

### Description
- Add `render.yaml` to declare a `mobius-terminal-gateway` Render blueprint with `fromService` bindings to existing services and the shared env group.  
- Implement `gateway.py`, a FastAPI app that aggregates endpoints and SSE streaming, including `/api/v1/agents/status`, `/api/v1/agents/{agent_id}`, `/api/v1/epicon/feed`, `/api/v1/integrity/current`, `/api/v1/mic/wallet/{user_id}`, `/api/v1/labs/{lab_id}/status`, `/api/v1/intent/submit`, `/api/v1/stream/events`, plus `/health` and `/api/v1/system/discovery`.  
- Add `requirements.txt` with pinned runtime deps (`fastapi`, `uvicorn`, `httpx`, `pydantic`) and add `lib/mobiusClient.ts` which exports `MobiusGatewayClient` and related types for the frontend to consume the gateway.  
- Update `.env.example` with `NEXT_PUBLIC_MOBIUS_GATEWAY_URL` and per-service fallback URLs, and ensure `gateway.py` closes the `httpx` client on shutdown and includes basic error handling and SSE passthrough.  

### Testing
- Ran `python3 -m py_compile gateway.py` which completed successfully.  
- Ran `npx tsc --noEmit` which completed successfully (TypeScript compile check passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2ea82fbf0832d8b2f64a8b5ee21ba)