### PR TITLE
fix(terminal): harden bootstrap and normalize data/breaker flows

### DIFF
--- a/app/api/epicon/promote/route.ts
+++ b/app/api/epicon/promote/route.ts
@@ -307,21 +307,11 @@ async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: stri
   return { pending, promoted, committed, failed, trace: postRun.trace };
 }
 
-export async function GET(request: NextRequest) {
-  const runCycle = request.nextUrl.searchParams.get('trigger') === '1';
-  const maxItems = Number.parseInt(request.nextUrl.searchParams.get('maxItems') ?? '5', 10);
-  const boundedMaxItems = Number.isFinite(maxItems) ? Math.min(Math.max(maxItems, 1), 10) : 5;
+export async function GET() {
   const nowIso = new Date().toISOString();
   const cycleId = currentCycleId();
   const state = await getPromotionState();
-  let lastRunAt: string | null = null;
-  let promotedIdsThisCycle: string[] = [];
-  if (runCycle) {
-    const run = await runPromotionCycle(boundedMaxItems, nowIso, cycleId, state);
-    lastRunAt = nowIso;
-    promotedIdsThisCycle = run.trace.promoted_ids_this_cycle;
-  }
-  const promotable = await getPromotablePending(state, nowIso, promotedIdsThisCycle);
+  const promotable = await getPromotablePending(state, nowIso);
   const pending = promotable.pending;
 
   let promotedThisCycle = 0;
@@ -359,7 +349,7 @@ export async function GET(request: NextRequest) {
     },
     diagnostics: {
       ...promotable.trace,
-      last_promotion_run_at: lastRunAt,
+      last_promotion_run_at: promotable.trace.last_promotion_run_at,
     },
     items: pending.map((item) => {
       const entry = state[item.id] ?? defaultPromotionState(nowIso);

--- a/app/api/epicon/promotion-status/route.ts
+++ b/app/api/epicon/promotion-status/route.ts
@@ -1,0 +1,1 @@
+export { dynamic, GET } from '../promote/route';

--- a/app/terminal/TerminalPageClient.tsx
+++ b/app/terminal/TerminalPageClient.tsx
@@ -3,8 +3,8 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import HardHalt from '@/components/modals/HardHalt';
 import { WalletProvider } from '@/contexts/WalletContext';
-import { useTerminalData } from '@/hooks/useTerminalData';
-import { checkCovenantCompliance } from '@/lib/integrity-check';
+import { useTerminalData, type TerminalBootstrapSeed } from '@/hooks/useTerminalData';
+import { evaluateCircuitBreaker } from '@/lib/integrity-check';
 import { cn } from '@/lib/utils';
 import type { LedgerEntry, NavKey } from '@/lib/terminal/types';
 import type { AgentJournalEntry } from '@/lib/terminal/types';
@@ -91,15 +91,19 @@ const TABS: Array<{ key: NavKey; label: string }> = [
 
 const TERMINAL_PREFS_KEY = 'mobius-terminal-prefs-v1';
 
-export default function TerminalPageWrapper() {
+type TerminalPageWrapperProps = {
+  bootstrap?: TerminalBootstrapSeed;
+};
+
+export default function TerminalPageWrapper({ bootstrap }: TerminalPageWrapperProps) {
   return (
     <WalletProvider>
-      <TerminalPage />
+      <TerminalPage bootstrap={bootstrap} />
     </WalletProvider>
   );
 }
 
-function TerminalPage() {
+function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
   type SortField = 'time' | 'agent' | 'type' | 'severity' | 'gi' | 'status' | 'source';
   type SortDirection = 'asc' | 'desc';
 
@@ -132,7 +136,15 @@ function TerminalPage() {
   const [hydrated, setHydrated] = useState(false);
   const agentSearchRef = useRef<HTMLInputElement>(null);
 
-  const { allTripwires, filteredEpicon, gi, integrityStatus, mergedLedger } = useTerminalData(selectedNav);
+  const {
+    allTripwires,
+    dominantTripwireState,
+    filteredEpicon,
+    gi,
+    integrityStatus,
+    mergedLedger,
+    semanticDriftDetected,
+  } = useTerminalData(selectedNav, bootstrap);
   const cycleId = integrityStatus?.cycle ?? 'C-271';
 
   useEffect(() => {
@@ -377,7 +389,11 @@ function TerminalPage() {
     };
   }, []);
 
-  const covenantStatus = checkCovenantCompliance(gi?.score ?? 0);
+  const breaker = evaluateCircuitBreaker({
+    giScore: gi?.score ?? 0,
+    tripwireState: dominantTripwireState,
+    semanticDriftDetected,
+  });
   const giScore = gi?.score ?? 0;
   const giDelta = gi?.delta ?? 0;
 
@@ -717,7 +733,7 @@ function TerminalPage() {
 
   return (
     <div className="min-h-screen bg-[#020617] text-slate-100">
-      <HardHalt isOpen={covenantStatus.status === 'HALT'} giScore={gi.score} reason="Semantic drift detected in active civic signal lanes." />
+      <HardHalt isOpen={breaker.stage === 'halt'} giScore={gi.score} reason={breaker.message} />
 
       <header className="sticky top-0 z-40 border-b border-slate-800 bg-slate-950/80 backdrop-blur">
         <div className="mx-auto max-w-[1800px] px-4 py-3">
@@ -745,6 +761,18 @@ function TerminalPage() {
                   <span className="flex items-center gap-2 rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-slate-300">
                     <span className={cn('h-2 w-2 rounded-full', runtimeBadge === 'online' ? 'bg-emerald-500' : 'bg-amber-500')} />
                     {runtimeBadge.toUpperCase()}
+                  </span>
+                  <span className={cn(
+                    'rounded-md border px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em]',
+                    breaker.stage === 'nominal'
+                      ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200'
+                      : breaker.stage === 'guarded'
+                        ? 'border-amber-500/40 bg-amber-500/10 text-amber-200'
+                        : breaker.stage === 'containment'
+                          ? 'border-orange-500/40 bg-orange-500/10 text-orange-200'
+                          : 'border-rose-500/40 bg-rose-500/10 text-rose-200',
+                  )}>
+                    {breaker.stage.toUpperCase()}
                   </span>
                   <span className="hidden rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-slate-400 xl:inline">
                     {clock}

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -1,7 +1,9 @@
 import TerminalPageClient from './TerminalPageClient';
+import { getTerminalBootstrapSnapshot } from '@/lib/terminal/bootstrap';
 
 export const dynamic = 'force-dynamic';
 
-export default function TerminalPage() {
-  return <TerminalPageClient />;
+export default async function TerminalPage() {
+  const bootstrap = await getTerminalBootstrapSnapshot();
+  return <TerminalPageClient bootstrap={bootstrap} />;
 }

--- a/hooks/useTerminalData.ts
+++ b/hooks/useTerminalData.ts
@@ -38,6 +38,7 @@ import {
 } from '@/lib/terminal/stream';
 import type { StreamStatus } from '@/components/terminal/TopStatusBar';
 import type { MobiusCivicIntegritySignal } from '@/lib/integrity-signal';
+import type { TerminalBootstrapSnapshot } from '@/lib/terminal/bootstrap-types';
 
 const CATEGORY_MAP: Partial<Record<NavKey, EpiconItem['category']>> = {
   markets: 'market',
@@ -67,15 +68,33 @@ function resolveInitialInspectorTarget(
   return null;
 }
 
-export function useTerminalData(selectedNav: NavKey) {
-  const [agents, setAgents] = useState<Agent[]>([]);
-  const [epicon, setEpicon] = useState<EpiconItem[]>([]);
-  const [gi, setGi] = useState<GISnapshot | null>(null);
-  const [tripwires, setTripwires] = useState<Tripwire[]>([]);
-  const [integrityStatus, setIntegrityStatus] = useState<IntegrityStatusResponse | null>(null);
+export type TerminalBootstrapSeed = TerminalBootstrapSnapshot;
+
+const DEFAULT_PROMOTION_COUNTERS = {
+  pending_promotable_count: 0,
+  promoted_this_cycle_count: 0,
+  committed_agent_count: 0,
+  failed_promotion_count: 0,
+  diagnostics: {
+    last_promotion_run_at: null as string | null,
+    promoter_input_count: 0,
+    promoter_eligible_count: 0,
+    promoter_excluded_reasons: {} as Record<string, number>,
+    promoted_ids_this_cycle: [] as string[],
+  },
+};
+
+export function useTerminalData(selectedNav: NavKey, initialData?: TerminalBootstrapSeed) {
+  const [agents, setAgents] = useState<Agent[]>(() => initialData?.agents ?? []);
+  const [epicon, setEpicon] = useState<EpiconItem[]>(() => initialData?.epicon ?? []);
+  const [gi, setGi] = useState<GISnapshot | null>(() =>
+    initialData?.integrityStatus ? integrityStatusToGISnapshot(initialData.integrityStatus) : null,
+  );
+  const [tripwires, setTripwires] = useState<Tripwire[]>(() => initialData?.tripwires ?? []);
+  const [integrityStatus, setIntegrityStatus] = useState<IntegrityStatusResponse | null>(() => initialData?.integrityStatus ?? null);
   const [backfillLedger, setBackfillLedger] = useState<LedgerEntry[]>([]);
   const [integritySignal, setIntegritySignal] = useState<MobiusCivicIntegritySignal | null>(null);
-  const [feedLedgerRows, setFeedLedgerRows] = useState<LedgerEntry[]>([]);
+  const [feedLedgerRows, setFeedLedgerRows] = useState<LedgerEntry[]>(() => initialData?.feedLedgerRows ?? []);
   const [inspectorTarget, setInspectorTarget] = useState<InspectorTarget | null>(null);
   const [streamStatus, setStreamStatus] = useState<StreamStatus>(isLiveAPI ? 'reconnecting' : 'offline');
   const [echoLedger, setEchoLedger] = useState<LedgerEntry[]>([]);
@@ -84,18 +103,12 @@ export function useTerminalData(selectedNav: NavKey) {
   const [showCreateEpicon, setShowCreateEpicon] = useState(false);
   const [operatorMessage, setOperatorMessage] = useState('Terminal live. Awaiting operator action.');
   const [duplicateSuppressedCount, setDuplicateSuppressedCount] = useState(0);
-  const [promotionCounters, setPromotionCounters] = useState({
-    pending_promotable_count: 0,
-    promoted_this_cycle_count: 0,
-    committed_agent_count: 0,
-    failed_promotion_count: 0,
-    diagnostics: {
-      last_promotion_run_at: null as string | null,
-      promoter_input_count: 0,
-      promoter_eligible_count: 0,
-      promoter_excluded_reasons: {} as Record<string, number>,
-      promoted_ids_this_cycle: [] as string[],
-    },
+  const [promotionCounters, setPromotionCounters] = useState(() => {
+    if (!initialData?.promotion) return DEFAULT_PROMOTION_COUNTERS;
+    return {
+      ...initialData.promotion.counters,
+      diagnostics: initialData.promotion.diagnostics ?? DEFAULT_PROMOTION_COUNTERS.diagnostics,
+    };
   });
 
   const mergedLedger = useMemo(() => {
@@ -234,13 +247,7 @@ export function useTerminalData(selectedNav: NavKey) {
       if (promotion) {
         setPromotionCounters({
           ...promotion.counters,
-          diagnostics: promotion.diagnostics ?? {
-            last_promotion_run_at: null,
-            promoter_input_count: 0,
-            promoter_eligible_count: 0,
-            promoter_excluded_reasons: {},
-            promoted_ids_this_cycle: [],
-          },
+          diagnostics: promotion.diagnostics ?? DEFAULT_PROMOTION_COUNTERS.diagnostics,
         });
         const promotionMap = new Map((promotion.items ?? []).map((item) => [item.epicon_id, item]));
         setEpicon((prev) => prev.map((item) => {
@@ -306,6 +313,12 @@ export function useTerminalData(selectedNav: NavKey) {
     return 'stable' as const;
   }, [allTripwires]);
 
+  const semanticDriftDetected = useMemo(() => {
+    const driftScore = integritySignal?.layers?.geo_layer?.semantic_drift;
+    if (typeof driftScore !== 'number') return false;
+    return driftScore >= 0.7;
+  }, [integritySignal]);
+
   const submitEpiconDraft = async (draft: SubmitDraft): Promise<CommandResult> => {
     const sources = [draft.source1, draft.source2, draft.source3].map((source) => source.trim()).filter(Boolean);
     const tags = draft.tags.split(',').map((tag) => tag.trim()).filter(Boolean);
@@ -347,6 +360,7 @@ export function useTerminalData(selectedNav: NavKey) {
     agents,
     dataRef,
     dominantTripwireState,
+    semanticDriftDetected,
     echoAlerts,
     echoIntegrity,
     echoLedger,

--- a/lib/terminal/api.ts
+++ b/lib/terminal/api.ts
@@ -38,6 +38,12 @@ async function fetchInternalJson(path: string): Promise<any | null> {
   }
 }
 
+async function fetchWithNormalizedFallback(internalPath: string, externalPath?: string): Promise<any | null> {
+  const internal = await fetchInternalJson(internalPath);
+  if (internal) return internal;
+  return fetchJson(externalPath ?? internalPath);
+}
+
 export function integrityStatusToGISnapshot(
   status: IntegrityStatusResponse,
   previousScore?: number,
@@ -170,11 +176,27 @@ function backfillEntryToLedger(entry: LedgerBackfillEntry): LedgerEntry {
 }
 
 export async function getAgents(): Promise<Agent[]> {
-  const raw = await fetchJson('/agents/status');
-  if (!raw) return mockAgents;
-  const agents = raw.agents;
+  const raw = await fetchWithNormalizedFallback('/api/agents/status', '/agents/status');
+  if (!raw || typeof raw !== 'object') return mockAgents;
+  const agents = (raw as { agents?: unknown }).agents;
   if (!Array.isArray(agents)) return mockAgents;
-  return agents.map(transformAgent);
+  return agents.map((agent) => {
+    if (!agent || typeof agent !== 'object') return null;
+    const transformed = transformAgent(agent);
+    const status = (agent as { status?: unknown }).status;
+    const normalizedStatus =
+      transformed.status === 'idle' ||
+      transformed.status === 'listening' ||
+      transformed.status === 'verifying' ||
+      transformed.status === 'routing' ||
+      transformed.status === 'analyzing' ||
+      transformed.status === 'alert'
+        ? transformed.status
+        : status === 'active'
+          ? 'listening'
+          : 'idle';
+    return { ...transformed, status: normalizedStatus };
+  }).filter((agent): agent is Agent => agent !== null);
 }
 
 export type EpiconFeedBundle = {
@@ -183,9 +205,7 @@ export type EpiconFeedBundle = {
 };
 
 export async function getEpiconFeed(): Promise<EpiconFeedBundle> {
-  const raw = API_BASE
-    ? await fetchJson('/epicon/feed')
-    : await fetchInternalJson('/api/epicon/feed');
+  const raw = await fetchWithNormalizedFallback('/api/epicon/feed', '/epicon/feed');
   if (!raw || typeof raw !== 'object') {
     return { epicon: mockEpicon, ledgerRows: [] };
   }
@@ -207,7 +227,7 @@ export async function getEpiconFeed(): Promise<EpiconFeedBundle> {
 }
 
 export async function getIntegrityStatus(): Promise<IntegrityStatusResponse> {
-  const raw = await fetchInternalJson('/api/integrity-status');
+  const raw = await fetchWithNormalizedFallback('/api/integrity-status');
   if (!raw || typeof raw !== 'object' || !(raw as Record<string, unknown>).ok) return integrityStatus;
   return raw as IntegrityStatusResponse;
 }
@@ -218,11 +238,38 @@ export async function getGISnapshot(): Promise<GISnapshot> {
 }
 
 export async function getTripwires(): Promise<Tripwire[]> {
-  const raw = await fetchJson('/tripwires/active');
-  if (!raw) return mockTripwires;
-  const tripwires = raw.tripwires;
-  if (!Array.isArray(tripwires)) return mockTripwires;
-  return tripwires.map(transformTripwire);
+  const raw = await fetchWithNormalizedFallback('/api/tripwire/status', '/tripwires/active');
+  if (!raw || typeof raw !== 'object') return mockTripwires;
+
+  const tripwireStatus = (raw as { tripwire?: unknown }).tripwire;
+  if (tripwireStatus && typeof tripwireStatus === 'object') {
+    const tripwire = tripwireStatus as Record<string, unknown>;
+    const active = Boolean(tripwire.active);
+    if (!active) return [];
+
+    const severity = tripwire.level === 'high' || tripwire.level === 'medium' || tripwire.level === 'low'
+      ? tripwire.level
+      : 'medium';
+
+    return [{
+      id: 'runtime-tripwire',
+      label: typeof tripwire.reason === 'string' && tripwire.reason ? tripwire.reason : 'Runtime tripwire active',
+      severity,
+      owner:
+        typeof tripwire.triggeredBy === 'string' && tripwire.triggeredBy.trim()
+          ? tripwire.triggeredBy
+          : 'operator',
+      openedAt:
+        typeof tripwire.last_updated === 'string' && tripwire.last_updated
+          ? tripwire.last_updated
+          : new Date().toISOString(),
+      action: 'Investigate and keep write lanes constrained until resolved.',
+    }];
+  }
+
+  const externalTripwires = (raw as { tripwires?: unknown }).tripwires;
+  if (Array.isArray(externalTripwires)) return externalTripwires.map(transformTripwire);
+  return mockTripwires;
 }
 
 export async function getLedgerBackfill(): Promise<LedgerEntry[]> {
@@ -288,7 +335,7 @@ export async function getEchoFeed(): Promise<EchoFeedData | null> {
 }
 
 export async function getPromotionStatus(): Promise<PromotionStatus | null> {
-  const raw = await fetchInternalJson('/api/epicon/promote?trigger=1');
+  const raw = await fetchInternalJson('/api/epicon/promotion-status');
   if (!raw || typeof raw !== 'object') return null;
   const counters = (raw as { counters?: unknown }).counters;
   if (!counters || typeof counters !== 'object') return null;

--- a/lib/terminal/bootstrap-types.ts
+++ b/lib/terminal/bootstrap-types.ts
@@ -1,0 +1,12 @@
+import type { IntegrityStatusResponse } from '@/lib/mock/integrityStatus';
+import type { PromotionStatus } from '@/lib/terminal/api';
+import type { Agent, EpiconItem, LedgerEntry, Tripwire } from '@/lib/terminal/types';
+
+export type TerminalBootstrapSnapshot = {
+  agents: Agent[];
+  epicon: EpiconItem[];
+  feedLedgerRows: LedgerEntry[];
+  integrityStatus: IntegrityStatusResponse;
+  tripwires: Tripwire[];
+  promotion: PromotionStatus | null;
+};

--- a/lib/terminal/bootstrap.ts
+++ b/lib/terminal/bootstrap.ts
@@ -1,0 +1,138 @@
+import { headers } from 'next/headers';
+import { integrityStatus as mockIntegrityStatus, type IntegrityStatusResponse } from '@/lib/mock/integrityStatus';
+import { mockAgents, mockEpicon, mockTripwires } from '@/lib/terminal/mock';
+import { transformAgent, transformEpicon } from '@/lib/terminal/transforms';
+import type { Agent, EpiconItem, LedgerEntry, Tripwire } from '@/lib/terminal/types';
+import type { PromotionStatus } from '@/lib/terminal/api';
+import type { TerminalBootstrapSnapshot } from '@/lib/terminal/bootstrap-types';
+
+type JsonRecord = Record<string, unknown>;
+
+function buildBaseUrl(headerBag: Headers): string {
+  if (process.env.NEXT_PUBLIC_SITE_URL) return process.env.NEXT_PUBLIC_SITE_URL.replace(/\/$/, '');
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  const host = headerBag.get('x-forwarded-host') ?? headerBag.get('host');
+  const proto = headerBag.get('x-forwarded-proto') ?? 'https';
+  return host ? `${proto}://${host}` : 'http://localhost:3000';
+}
+
+async function fetchInternal<T>(baseUrl: string, path: string): Promise<T | null> {
+  try {
+    const res = await fetch(`${baseUrl}${path}`, { cache: 'no-store' });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+function epiconFeedRowToLedger(raw: JsonRecord): LedgerEntry | null {
+  if (raw.type !== 'epicon' || raw.verified !== true) return null;
+  const id = typeof raw.id === 'string' ? raw.id : '';
+  if (!id) return null;
+  const timestamp = typeof raw.timestamp === 'string' ? raw.timestamp : new Date().toISOString();
+  const summary = typeof raw.body === 'string' ? raw.body : typeof raw.title === 'string' ? raw.title : '';
+  const category = raw.category;
+  return {
+    id,
+    cycleId: typeof raw.cycle === 'string' && raw.cycle ? raw.cycle : 'C-0',
+    type: 'epicon',
+    agentOrigin: typeof raw.agentOrigin === 'string' && raw.agentOrigin ? raw.agentOrigin : 'operator',
+    timestamp,
+    title: typeof raw.title === 'string' ? raw.title : undefined,
+    summary,
+    integrityDelta: 0,
+    status: 'committed',
+    category:
+      category === 'geopolitical' ||
+      category === 'market' ||
+      category === 'governance' ||
+      category === 'infrastructure' ||
+      category === 'narrative' ||
+      category === 'ethics' ||
+      category === 'civic-risk'
+        ? category
+        : undefined,
+    confidenceTier: typeof raw.confidenceTier === 'number' ? raw.confidenceTier : undefined,
+    tags: Array.isArray(raw.tags) ? raw.tags.filter((tag): tag is string => typeof tag === 'string') : undefined,
+    source: 'echo',
+  };
+}
+
+function parseTripwires(raw: JsonRecord | null): Tripwire[] {
+  if (!raw) return mockTripwires;
+  const runtimeTripwire = raw.tripwire;
+  if (runtimeTripwire && typeof runtimeTripwire === 'object') {
+    const tripwire = runtimeTripwire as JsonRecord;
+    if (!tripwire.active) return [];
+    return [{
+      id: 'runtime-tripwire',
+      label: typeof tripwire.reason === 'string' ? tripwire.reason : 'Runtime tripwire active',
+      severity: tripwire.level === 'high' || tripwire.level === 'medium' || tripwire.level === 'low' ? tripwire.level : 'medium',
+      owner: typeof tripwire.triggeredBy === 'string' ? tripwire.triggeredBy : 'operator',
+      openedAt: typeof tripwire.last_updated === 'string' ? tripwire.last_updated : new Date().toISOString(),
+      action: 'Investigate and keep write lanes constrained until resolved.',
+    }];
+  }
+
+  const list = raw.tripwires;
+  if (!Array.isArray(list)) return mockTripwires;
+  return list
+    .filter((item): item is JsonRecord => item !== null && typeof item === 'object')
+    .map((item) => ({
+      id: typeof item.id === 'string' ? item.id : 'tripwire',
+      label: typeof item.label === 'string' ? item.label : 'Tripwire active',
+      severity: item.severity === 'high' || item.severity === 'medium' || item.severity === 'low' ? item.severity : 'medium',
+      owner: typeof item.owner === 'string' ? item.owner : 'operator',
+      openedAt: typeof item.opened_at === 'string' ? item.opened_at : new Date().toISOString(),
+      action: typeof item.action === 'string' ? item.action : 'Inspect tripwire state.',
+    }));
+}
+
+export async function getTerminalBootstrapSnapshot(): Promise<TerminalBootstrapSnapshot> {
+  const baseUrl = buildBaseUrl(await headers());
+  const [agentsRaw, feedRaw, integrityRaw, tripwiresRaw, promotionRaw] = await Promise.all([
+    fetchInternal<JsonRecord>(baseUrl, '/api/agents/status'),
+    fetchInternal<JsonRecord>(baseUrl, '/api/epicon/feed'),
+    fetchInternal<JsonRecord>(baseUrl, '/api/integrity-status'),
+    fetchInternal<JsonRecord>(baseUrl, '/api/tripwire/status'),
+    fetchInternal<PromotionStatus>(baseUrl, '/api/epicon/promotion-status'),
+  ]);
+
+  const agentsList = Array.isArray(agentsRaw?.agents)
+    ? agentsRaw.agents
+      .filter((item): item is JsonRecord => item !== null && typeof item === 'object')
+      .map((agent) => {
+        const transformed = transformAgent(agent);
+        return {
+          ...transformed,
+          status:
+            transformed.status === 'idle' ||
+            transformed.status === 'listening' ||
+            transformed.status === 'verifying' ||
+            transformed.status === 'routing' ||
+            transformed.status === 'analyzing' ||
+            transformed.status === 'alert'
+              ? transformed.status
+              : 'idle',
+        };
+      })
+    : mockAgents;
+
+  const feedItems = Array.isArray(feedRaw?.items)
+    ? feedRaw.items.filter((item): item is JsonRecord => item !== null && typeof item === 'object')
+    : [];
+
+  const epicon = feedItems.length > 0 ? feedItems.map(transformEpicon) : mockEpicon;
+  const feedLedgerRows = feedItems.map(epiconFeedRowToLedger).filter((entry): entry is LedgerEntry => entry !== null);
+  const integrityStatus = integrityRaw && integrityRaw.ok ? (integrityRaw as IntegrityStatusResponse) : mockIntegrityStatus;
+
+  return {
+    agents: agentsList,
+    epicon,
+    feedLedgerRows,
+    integrityStatus,
+    tripwires: parseTripwires(tripwiresRaw),
+    promotion: promotionRaw && typeof promotionRaw === 'object' ? promotionRaw : null,
+  };
+}


### PR DESCRIPTION
### Motivation
- Stabilize the `/terminal` startup by shipping a server-side bootstrap snapshot so the client hydrates from live state instead of falling back to the resilient shell on hydrate failures.
- Remove browser-driven side effects from promotion polling so status reads do not implicitly trigger promotions.
- Make all terminal data adapters follow a consistent internal-first fallback model to avoid half-live UI surfaces.
- Wire the richer staged circuit-breaker model into the client so the UI respects `guarded` / `containment` / `halt` stages instead of a binary check.

### Description
- Add a server bootstrap pipeline and types in `lib/terminal/bootstrap.ts` and `lib/terminal/bootstrap-types.ts`, and fetch it from the server page in `app/terminal/page.tsx` then pass the snapshot into the client as `bootstrap` props to `TerminalPageClient`.
- Update `useTerminalData` to accept an optional `TerminalBootstrapSeed`, initialize key state (agents, EPICON feed, integrity/GI snapshot, tripwires, feed ledger rows, promotion counters) from the seed, and surface `semanticDriftDetected` and `dominantTripwireState` signals for breaker logic.
- Normalize adapters in `lib/terminal/api.ts` by adding `fetchWithNormalizedFallback(internalPath, externalPath)` to try internal `/api/...` first, then external `API_BASE`, then mocks; apply this to `getAgents()`, `getEpiconFeed()`, `getIntegrityStatus()`, and `getTripwires()` and normalize agent/tripwire shapes/statuses.
- Split promotion status from promotion trigger by making `GET /api/epicon/promote` status-only (no `trigger=1` side effect) and adding `GET /api/epicon/promotion-status` as an alias, while keeping `POST /api/epicon/promote` for explicit execution.
- Wire the staged breaker into the client by replacing `checkCovenantCompliance(...)` with `evaluateCircuitBreaker(...)` (feeding `gi.score`, `dominantTripwireState`, and semantic drift), render breaker stage in the header, and keep `HardHalt` bound to the real `halt` stage.

### Testing
- Ran TypeScript checks with `npx tsc --noEmit`, which succeeded.
- Performed a production build with `npm run build`, which completed successfully and reported compiled pages.
- Attempted `npm run lint`, but the repository's Next.js lint step prompts an interactive ESLint setup in this environment and is not runnable non-interactively, so lint was not executed to completion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2f9702fd8832d986fa7f047d4662c)