### PR TITLE
Improve ledger/operator truthfulness in terminal chamber

### DIFF
--- a/app/terminal/TerminalPageClient.tsx
+++ b/app/terminal/TerminalPageClient.tsx
@@ -396,6 +396,21 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
   });
   const giScore = gi?.score ?? 0;
   const giDelta = gi?.delta ?? 0;
+  const committedEventRows = useMemo(
+    () => (epiconFeed?.items ?? []).filter((item) => (item.status ?? '').toLowerCase() === 'committed'),
+    [epiconFeed?.items],
+  );
+  const committedAgentRowsThisCycle = useMemo(
+    () => committedEventRows.filter((item) => AGENT_ORDER.includes((item.agentOrigin ?? '').toUpperCase() as (typeof AGENT_ORDER)[number])).length,
+    [committedEventRows],
+  );
+  const journalEntriesThisCycle = journalFeed.filter((entry) => entry.cycle === cycleId).length;
+
+  useEffect(() => {
+    if (committedAgentRowsThisCycle > 0) {
+      setLedgerView('events');
+    }
+  }, [cycleId, committedAgentRowsThisCycle]);
 
   const statCards: Array<{ label: string; value: string; trend: number; icon: string; subtitle: string; nav: NavKey }> = [
     { label: 'Global Integrity', value: giScore.toFixed(3), trend: giDelta, icon: '◎', subtitle: 'GI stable', nav: 'pulse' },
@@ -612,6 +627,13 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
                 Journal
               </button>
             </div>
+          </div>
+          <div className="mb-3 flex flex-wrap items-center gap-2 rounded-md border border-slate-800 bg-slate-950/60 px-2 py-1.5 text-[10px] font-mono uppercase tracking-[0.12em] text-slate-400">
+            <span>Committed agent rows this cycle: <span className="text-sky-300">{committedAgentRowsThisCycle}</span></span>
+            <span className="text-slate-600">•</span>
+            <span>Journal entries this cycle: <span className="text-fuchsia-300">{journalEntriesThisCycle}</span></span>
+            <span className="text-slate-600">•</span>
+            <span>Current view: <span className={ledgerView === 'events' ? 'text-sky-300' : 'text-fuchsia-300'}>{ledgerView}</span></span>
           </div>
           {ledgerView === 'events' ? (
             <EventScreener
@@ -920,8 +942,16 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
             <section className="rounded-lg border border-slate-800 bg-slate-900/50 p-4">
               <div className="text-[10px] font-mono uppercase tracking-[0.16em] text-slate-300">Command Surface</div>
               <div className="mt-1 text-lg font-semibold text-slate-100">{commandSurfaceTitle}</div>
-              <div className="mt-2 text-sm text-slate-300">GI stable. {allTripwires.length} tripwires active. {filteredEpicon.length} signals in feed. {allTripwires.filter((t) => t.severity.toLowerCase() === 'high').length} alerts.</div>
-              <div className="mt-2 text-[10px] font-mono uppercase tracking-[0.14em] text-sky-300">TERMINAL LIVE · AWAITING OPERATOR ACTION</div>
+              <div className="mt-2 text-sm text-slate-300">
+                GI stable. {allTripwires.length} tripwires active. {filteredEpicon.length} signals in feed. {allTripwires.filter((t) => t.severity.toLowerCase() === 'high').length} alerts.
+              </div>
+              <div className="mt-1 text-[11px] text-slate-400">
+                Breaker posture: <span className="font-mono uppercase text-slate-200">{breaker.stage}</span>
+                {selectedNav === 'ledger' ? ` · Ledger view: ${ledgerView} · Committed rows: ${committedAgentRowsThisCycle}` : ''}
+              </div>
+              <div className="mt-2 text-[10px] font-mono uppercase tracking-[0.14em] text-sky-300">
+                TERMINAL LIVE · {selectedNav === 'ledger' ? `${ledgerView.toUpperCase()} VIEW ACTIVE` : 'AWAITING OPERATOR ACTION'}
+              </div>
               <div className="mt-3 flex flex-wrap gap-2">
                 {commandSurfaceButtons.map((action) => (
                   <button key={action.label} onClick={() => setSelectedNav(action.nav)} className="rounded-md border border-slate-600 px-3 py-1.5 text-xs">
@@ -1113,7 +1143,7 @@ function JournalView({ entries, cycleId }: { entries: AgentJournalEntry[]; cycle
   if (entries.length === 0) {
     return (
       <div className="rounded-md border border-dashed border-slate-700 bg-slate-950/60 p-4 text-center text-xs text-slate-400">
-        No committed journal entries for {cycleId} yet. Agent reasoning will appear here as cycles run.
+        No journal reasoning entries for {cycleId} yet. Live committed event rows may still be present in Events.
       </div>
     );
   }

--- a/components/terminal/EventScreener.tsx
+++ b/components/terminal/EventScreener.tsx
@@ -34,6 +34,7 @@ interface EventScreenerProps {
 const PAGE_SIZE = 12;
 type TypeFilter = 'all' | 'merge' | 'heartbeat' | 'catalog' | 'epicon' | 'zeus-verify';
 type AuthorFilter = 'all' | 'kaizencycle' | 'mobius-bot' | 'cursor-agent';
+type LaneFilter = 'all' | 'eve-governance';
 
 const TYPE_LABELS: Record<TypeFilter, string> = {
   all: 'All',
@@ -70,6 +71,14 @@ const AGENT_BADGE_STYLES: Record<string, string> = {
   kaizencycle: 'border-blue-500/30 bg-blue-500/10 text-blue-300',
   'mobius-bot': 'border-purple-500/30 bg-purple-500/10 text-purple-300',
   'cursor-agent': 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+  eve: 'border-rose-500/30 bg-rose-500/10 text-rose-300',
+  atlas: 'border-sky-500/30 bg-sky-500/10 text-sky-300',
+  zeus: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+  hermes: 'border-orange-500/30 bg-orange-500/10 text-orange-300',
+  aurea: 'border-yellow-500/30 bg-yellow-500/10 text-yellow-300',
+  jade: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+  daedalus: 'border-stone-500/30 bg-stone-500/10 text-stone-300',
+  echo: 'border-slate-500/30 bg-slate-500/10 text-slate-300',
 };
 
 const SEVERITY_STYLES: Record<string, string> = {
@@ -153,6 +162,7 @@ export default function EventScreener({
 }: EventScreenerProps) {
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
   const [authorFilter, setAuthorFilter] = useState<AuthorFilter>('all');
+  const [laneFilter, setLaneFilter] = useState<LaneFilter>('all');
   const [page, setPage] = useState(0);
   const [openId, setOpenId] = useState<string | null>(null);
   const [localSearchQuery, setLocalSearchQuery] = useState('');
@@ -242,11 +252,19 @@ export default function EventScreener({
     const filtered = externallySorted.filter((item) => {
       if (typeFilter !== 'all' && item.type !== typeFilter) return false;
       if (authorFilter !== 'all' && item.author !== authorFilter) return false;
+      if (laneFilter === 'eve-governance') {
+        const isEveOrigin = (item.agentOrigin ?? '').toUpperCase() === 'EVE' || (item.author ?? '').toLowerCase() === 'eve';
+        const hasGovernanceTag = (item.tags ?? []).some((tag) => {
+          const normalized = tag.toLowerCase();
+          return normalized.includes('governance') || normalized.includes('ethic') || normalized.includes('civic');
+        });
+        if (!isEveOrigin && item.source !== 'eve-synthesis' && !hasGovernanceTag) return false;
+      }
       return true;
     });
 
     return filtered;
-  }, [authorFilter, list, searchQuery, sortBy, sortDir, typeFilter]);
+  }, [authorFilter, laneFilter, list, searchQuery, sortBy, sortDir, typeFilter]);
 
   useEffect(() => {
     onResultCountChange?.(filteredAndSorted.length);
@@ -344,6 +362,34 @@ export default function EventScreener({
           <option value="mobius-bot">mobius-bot</option>
           <option value="cursor-agent">cursor-agent</option>
         </select>
+        <div className="inline-flex items-center gap-1 rounded border border-slate-800 bg-slate-900 p-0.5">
+          <button
+            type="button"
+            onClick={() => {
+              setLaneFilter('all');
+              setPage(0);
+            }}
+            className={cn(
+              'rounded px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em]',
+              laneFilter === 'all' ? 'bg-slate-800 text-slate-200' : 'text-slate-500',
+            )}
+          >
+            All lanes
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setLaneFilter('eve-governance');
+              setPage(0);
+            }}
+            className={cn(
+              'rounded px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em]',
+              laneFilter === 'eve-governance' ? 'bg-rose-500/20 text-rose-200' : 'text-slate-500',
+            )}
+          >
+            EVE governance
+          </button>
+        </div>
       </div>
 
       <div className="rounded-md border border-slate-800">
@@ -351,6 +397,7 @@ export default function EventScreener({
           {pagedRows.map((item) => {
             const isOpen = openId === item.id;
             const isEve = item.source === 'eve-synthesis';
+            const rowAgent = (item.agentOrigin || item.author || '').toLowerCase();
             const dotClass = TYPE_DOT_STYLES[item.type] ?? 'bg-slate-500';
             return (
               <div key={item.id} className={cn('transition hover:bg-slate-900/40', isOpen && 'bg-sky-500/5')}>
@@ -380,10 +427,12 @@ export default function EventScreener({
                             label="Agent"
                             value={(
                               <div className="flex items-center gap-1.5">
-                                <span className={cn('inline-flex h-5 w-5 items-center justify-center rounded-full border text-[10px] font-mono uppercase', AGENT_BADGE_STYLES[item.author] ?? 'border-slate-700 bg-slate-800 text-slate-300')}>
-                                  {initialsForAgent(item.author)}
+                                <span className={cn('inline-flex h-5 w-5 items-center justify-center rounded-full border text-[10px] font-mono uppercase', AGENT_BADGE_STYLES[rowAgent] ?? AGENT_BADGE_STYLES[item.author] ?? 'border-slate-700 bg-slate-800 text-slate-300')}>
+                                  {initialsForAgent(item.agentOrigin || item.author)}
                                 </span>
-                                <span className={cn(AUTHOR_STYLES[item.author] ?? 'text-slate-300')}>{item.author}</span>
+                                <span className={cn(AUTHOR_STYLES[item.author] ?? 'text-slate-300')}>
+                                  {item.agentOrigin || item.author}
+                                </span>
                               </div>
                             )}
                           />


### PR DESCRIPTION
### Motivation

- Operators were landing in a psychologically empty `Journal` view while live committed event rows existed in `Events`, causing a UI truthfulness mismatch. 
- The command surface lacked immediate context about which ledger lane was active and how many committed rows or journal entries existed for the cycle. 
- EVE-authored governance synthesis rows were present in feeds but not surfaced strongly in the Events lane, reducing legibility for governance signals. 

### Description

- Default the Ledger chamber to `Events` when committed agent event rows for the active cycle exist and introduce `committedAgentRowsThisCycle` and `journalEntriesThisCycle` counters in `app/terminal/TerminalPageClient.tsx`. 
- Add a Ledger truth bar under the Events/Journal toggle that shows `Committed agent rows this cycle`, `Journal entries this cycle`, and `Current view` for immediate operator clarity. 
- Update Journal empty-state copy to `No journal reasoning entries for {cycleId} yet. Live committed event rows may still be present in Events.` to avoid implying the ledger is empty. 
- Enhance `components/terminal/EventScreener.tsx` with an `EVE governance` lane filter and prefer `agentOrigin` for agent badges/labels so EVE-authored rows are visually first-class; expand badge styles for agents. 
- Surface breaker posture and ledger-specific context in the Command Surface so the terminal posture and active ledger mode are explicit. 

### Testing

- Type-check: `npx tsc --noEmit` completed successfully. 
- Lint: `npm run lint` could not run non-interactively in this environment because `next lint` triggered an interactive ESLint setup prompt, so automated linting was not completed. 
- No automated UI screenshot or end-to-end tests were executed as part of this change in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2fc8ce2c8832da5d49ea9c7c19692)