### PR TITLE
fix(ledger): add idempotent live journal writes for agent commits

### DIFF
--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -1,6 +1,6 @@
-import { Redis } from '@upstash/redis';
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceAuthError } from '@/lib/security/serviceAuth';
+import { appendJournalLaneEntry, getJournalRedisClient } from '@/lib/agents/journalLane';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -46,12 +46,6 @@ function randomToken(length: number): string {
   return Array.from(bytes, (byte) => alphabet[byte % alphabet.length]).join('');
 }
 
-function getRedisClient(): Redis | null {
-  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) return null;
-  return new Redis({ url, token });
-}
 
 function asRecord(input: unknown): Record<string, unknown> | null {
   if (!input || typeof input !== 'object') return null;
@@ -157,7 +151,7 @@ function buildEntry(input: AgentJournalCreateInput): AgentJournalEntry | null {
   return entry;
 }
 
-async function loadEntries(redis: Redis | null): Promise<AgentJournalEntry[]> {
+async function loadEntries(redis: ReturnType<typeof getJournalRedisClient>): Promise<AgentJournalEntry[]> {
   if (!redis) return [];
 
   try {
@@ -178,7 +172,7 @@ async function loadEntries(redis: Redis | null): Promise<AgentJournalEntry[]> {
   }
 }
 
-async function seedGenesisEntries(redis: Redis, cycle: string): Promise<void> {
+async function seedGenesisEntries(redis: NonNullable<ReturnType<typeof getJournalRedisClient>>, cycle: string): Promise<void> {
   const timestamp = new Date().toISOString();
   for (const agent of GENESIS_AGENTS) {
     const entry: AgentJournalEntry = {
@@ -209,7 +203,7 @@ async function seedGenesisEntries(redis: Redis, cycle: string): Promise<void> {
 }
 
 export async function GET(request: NextRequest) {
-  const redis = getRedisClient();
+  const redis = getJournalRedisClient();
   let entries = await loadEntries(redis);
 
   const { searchParams } = request.nextUrl;
@@ -267,18 +261,20 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const redis = getRedisClient();
+  const redis = getJournalRedisClient();
   if (!redis) {
     return NextResponse.json({ ok: false, error: 'Redis not configured' }, { status: 503 });
   }
 
-  const agentKey = `journal:${entry.agent.toLowerCase()}`;
-  const packed = JSON.stringify(entry);
+  const writeResult = await appendJournalLaneEntry(redis, {
+    ...entry,
+    id: entry.id,
+    timestamp: entry.timestamp,
+  });
 
-  await redis.lpush(KEY_ALL, packed);
-  await redis.ltrim(KEY_ALL, 0, MAX_LIST_ENTRIES - 1);
-  await redis.lpush(agentKey, packed);
-  await redis.ltrim(agentKey, 0, MAX_LIST_ENTRIES - 1);
+  if (!writeResult.written) {
+    return NextResponse.json({ ok: true, duplicate: true, token: writeResult.token });
+  }
 
-  return NextResponse.json({ ok: true, entryId: entry.id, timestamp: entry.timestamp });
+  return NextResponse.json({ ok: true, entryId: writeResult.entry.id, timestamp: writeResult.entry.timestamp });
 }

--- a/app/api/epicon/promote/route.ts
+++ b/app/api/epicon/promote/route.ts
@@ -9,6 +9,7 @@ import type { EpiconLedgerFeedEntry } from '@/lib/epicon/ledgerFeedTypes';
 import type { EpiconItem } from '@/lib/terminal/types';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { defaultPromotionState, getPromotionState, savePromotionState } from '@/lib/epicon/promotion';
+import { appendJournalLaneEntry, getJournalRedisClient } from '@/lib/agents/journalLane';
 
 export const dynamic = 'force-dynamic';
 
@@ -101,6 +102,38 @@ function buildCommit(agent: Agent, epicon: EpiconItem, cycleId: string, seq: num
     status: 'committed',
     agentOrigin: agent,
   };
+}
+
+
+function toJournalSeverity(level: EpiconLedgerFeedEntry['severity']): 'nominal' | 'elevated' | 'critical' {
+  if (level === 'high') return 'critical';
+  if (level === 'medium') return 'elevated';
+  return 'nominal';
+}
+
+async function writeCommitJournalEntry(commit: EpiconLedgerFeedEntry, epicon: EpiconItem): Promise<void> {
+  const redis = getJournalRedisClient();
+  if (!redis) return;
+
+  const agent = (commit.agentOrigin || commit.author || 'ZEUS').toUpperCase();
+  const cycle = commit.cycle || currentCycleId();
+  const derived = [commit.derivedFrom || epicon.id];
+
+  await appendJournalLaneEntry(redis, {
+    agent,
+    cycle,
+    scope: `${agent} reasoning lane`,
+    observation: `${agent} committed ${epicon.id} (${epicon.category}) at confidence tier ${epicon.confidenceTier}.`,
+    inference: `${agent} judged the event suitable for ledger-level publication in ${cycle}.`,
+    recommendation: `Track downstream corroboration and GI impact for ${epicon.id}.`,
+    confidence: Math.max(0.5, Math.min(0.96, 0.55 + epicon.confidenceTier * 0.1)),
+    derivedFrom: derived,
+    status: 'committed',
+    category: 'observation',
+    severity: toJournalSeverity(commit.severity),
+    agentOrigin: agent,
+    tags: ['agent-commit', epicon.category, epicon.id],
+  });
 }
 
 function parsePendingLedgerEntry(row: EpiconLedgerFeedEntry): EpiconItem | null {
@@ -286,6 +319,7 @@ async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: stri
 
         const commit = buildCommit(agent, epicon, cycleId, seq++);
         await pushLedgerEntry(commit);
+        await writeCommitJournalEntry(commit, epicon);
         existing.committed_entries.push(commit.id);
         committed += 1;
       }

--- a/lib/agents/journalLane.ts
+++ b/lib/agents/journalLane.ts
@@ -1,0 +1,99 @@
+import { Redis } from '@upstash/redis';
+
+const KEY_ALL = 'journal:all';
+const MAX_LIST_ENTRIES = 200;
+const IDEMPOTENCY_TTL_SECONDS = 60 * 60 * 24 * 14;
+
+export type AgentJournalLaneEntry = {
+  id: string;
+  agent: string;
+  cycle: string;
+  timestamp: string;
+  scope: string;
+  observation: string;
+  inference: string;
+  recommendation: string;
+  confidence: number;
+  derivedFrom: string[];
+  status: 'draft' | 'committed' | 'contested' | 'verified';
+  category: 'observation' | 'inference' | 'alert' | 'recommendation' | 'close';
+  severity: 'nominal' | 'elevated' | 'critical';
+  source: 'agent-journal';
+  agentOrigin: string;
+  tags?: string[];
+};
+
+export type AgentJournalLaneInput = Omit<AgentJournalLaneEntry, 'id' | 'timestamp' | 'source'> & {
+  id?: string;
+  timestamp?: string;
+};
+
+export function getJournalRedisClient(): Redis | null {
+  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  return new Redis({ url, token });
+}
+
+function normalizeDerivedFrom(derivedFrom: string[]): string[] {
+  return [...new Set(derivedFrom.map((value) => value.trim()).filter(Boolean))].sort((a, b) => a.localeCompare(b));
+}
+
+function asReasoningToken(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9._-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+}
+
+function idempotencyToken(agent: string, cycle: string, derivedFrom: string[]): string {
+  const normalized = normalizeDerivedFrom(derivedFrom);
+  const payload = normalized.join('|') || 'none';
+  return `${asReasoningToken(agent)}:${asReasoningToken(cycle)}:${asReasoningToken(payload)}`;
+}
+
+function compactToken(input: string): string {
+  return input.replace(/[^a-zA-Z0-9]/g, '').slice(0, 36) || 'auto';
+}
+
+export async function appendJournalLaneEntry(
+  redis: Redis,
+  input: AgentJournalLaneInput,
+): Promise<{ written: true; entry: AgentJournalLaneEntry } | { written: false; reason: 'duplicate'; token: string }> {
+  const agent = input.agent.trim().toUpperCase();
+  const cycle = input.cycle.trim();
+  const derivedFrom = normalizeDerivedFrom(input.derivedFrom);
+  const token = idempotencyToken(agent, cycle, derivedFrom);
+  const markerKey = `journal:idempotency:${token}`;
+  const inserted = await redis.set(markerKey, '1', { nx: true, ex: IDEMPOTENCY_TTL_SECONDS });
+
+  if (inserted !== 'OK') {
+    return { written: false, reason: 'duplicate', token };
+  }
+
+  const entry: AgentJournalLaneEntry = {
+    id: input.id?.trim() || `journal-${agent}-${cycle}-${compactToken(token)}`,
+    agent,
+    cycle,
+    timestamp: input.timestamp?.trim() || new Date().toISOString(),
+    scope: input.scope.trim(),
+    observation: input.observation.trim(),
+    inference: input.inference.trim(),
+    recommendation: input.recommendation.trim(),
+    confidence: Math.max(0, Math.min(1, input.confidence)),
+    derivedFrom,
+    status: input.status,
+    category: input.category,
+    severity: input.severity,
+    source: 'agent-journal',
+    agentOrigin: input.agentOrigin.trim().toUpperCase(),
+    tags: input.tags,
+  };
+
+  const packed = JSON.stringify(entry);
+  const agentKey = `journal:${agent.toLowerCase()}`;
+
+  await redis.lpush(KEY_ALL, packed);
+  await redis.ltrim(KEY_ALL, 0, MAX_LIST_ENTRIES - 1);
+  await redis.lpush(agentKey, packed);
+  await redis.ltrim(agentKey, 0, MAX_LIST_ENTRIES - 1);
+
+  return { written: true, entry };
+}


### PR DESCRIPTION
### Motivation
- The EPICON/agent commit lane was actively writing committed ledger rows but the separate journal lane (`journal:all` / `journal:<agent>`) was not receiving live reasoning entries, leaving the Ledger Journal view empty even when Events had recent commits. 
- Agent commits need a compact, idempotent writer so reasoning rows are emitted into the journal KV lane whenever an `agent_commit` is published.

### Description
- Added `lib/agents/journalLane.ts`, a shared journal-lane helper that writes to `journal:all` and `journal:<agent>` lists and enforces idempotency via a Redis marker key `journal:idempotency:<token>` with a 14-day TTL. 
- Reworked the journal API at `app/api/agents/journal/route.ts` to use the shared `appendJournalLaneEntry` writer and to return a dup/ok response when an idempotency marker prevents duplicate writes. 
- Updated the promoter flow in `app/api/epicon/promote/route.ts` to call a new `writeCommitJournalEntry` helper after each successful `pushLedgerEntry`, converting ledger severity into a journal severity and emitting compact reasoning entries derived from the commit. 
- Kept journal writes scoped to `agent + cycle + derivedFrom` for idempotency and preserved list trimming behavior (`MAX_LIST_ENTRIES`) on both global and per-agent lanes.

### Testing
- `npx tsc --noEmit` completed successfully with no TypeScript errors. 
- `npm run lint` could not be completed non-interactively in this environment because `next lint` prompts for ESLint setup, so lint was not validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2ff186d88832d9135a5ca15a8fc30)