### PR TITLE
feat(terminal-ui): hybrid Superneon/Quantara visual refresh + governance lane & EVE badges

### DIFF
--- a/app/terminal/TerminalPageClient.tsx
+++ b/app/terminal/TerminalPageClient.tsx
@@ -754,18 +754,23 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
   };
 
   return (
-    <div className="min-h-screen bg-[#020617] text-slate-100">
+    <div className="relative min-h-screen overflow-x-hidden bg-[#020617] text-slate-100">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute left-0 top-0 h-[28rem] w-[28rem] bg-cyan-500/10 blur-[140px]" />
+        <div className="absolute right-0 top-16 h-[24rem] w-[24rem] bg-fuchsia-500/10 blur-[160px]" />
+      </div>
       <HardHalt isOpen={breaker.stage === 'halt'} giScore={gi.score} reason={breaker.message} />
 
-      <header className="sticky top-0 z-40 border-b border-slate-800 bg-slate-950/80 backdrop-blur">
+      <header className="sticky top-0 z-40 border-b border-cyan-500/20 bg-slate-950/90 backdrop-blur-md">
         <div className="mx-auto max-w-[1800px] px-4 py-3">
-          <section className="rounded-xl border border-slate-800 bg-slate-900/55 p-3">
+          <section className="relative overflow-hidden rounded-xl border border-slate-700/80 bg-slate-900/70 p-3 shadow-[0_0_0_1px_rgba(8,47,73,0.4),0_14px_40px_rgba(2,6,23,0.65)]">
+            <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-cyan-500/0 via-cyan-300/80 to-fuchsia-400/0" />
             <div className="flex flex-col gap-3 xl:gap-2">
               <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
                 <div className="flex items-center gap-3">
-                  <div className="flex h-8 w-8 items-center justify-center rounded-md bg-sky-500 text-slate-950">⌘</div>
+                  <div className="flex h-8 w-8 items-center justify-center rounded-md border border-cyan-300/60 bg-cyan-400/20 text-cyan-100 shadow-[0_0_24px_rgba(34,211,238,0.35)]">⌘</div>
                   <div>
-                    <div className="text-sm font-semibold uppercase tracking-[0.12em]">MOBIUS CIVIC TERMINAL</div>
+                    <div className="text-sm font-semibold uppercase tracking-[0.12em] text-slate-100">MOBIUS CIVIC TERMINAL</div>
                     <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-400">{cycleId} · {chamberLabel} · LIVE SIGNAL TRACE</div>
                   </div>
                 </div>
@@ -774,13 +779,13 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
                     aria-label="Select terminal chamber"
                     value={selectedNav}
                     onChange={(event) => setSelectedNav(event.target.value as NavKey)}
-                    className="rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-slate-200"
+                    className="rounded-md border border-slate-600 bg-slate-900/90 px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-slate-100"
                   >
                     {TABS.map((tab) => (
                       <option key={tab.key} value={tab.key}>{tab.label}</option>
                     ))}
                   </select>
-                  <span className="flex items-center gap-2 rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-slate-300">
+                  <span className="flex items-center gap-2 rounded-md border border-slate-600 bg-slate-950 px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-slate-200">
                     <span className={cn('h-2 w-2 rounded-full', runtimeBadge === 'online' ? 'bg-emerald-500' : 'bg-amber-500')} />
                     {runtimeBadge.toUpperCase()}
                   </span>
@@ -796,10 +801,30 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
                   )}>
                     {breaker.stage.toUpperCase()}
                   </span>
-                  <span className="hidden rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-slate-400 xl:inline">
+                  <span className="hidden rounded-md border border-slate-600 bg-slate-950 px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-slate-300 xl:inline">
                     {clock}
                   </span>
                 </div>
+              </div>
+
+              <div className="flex gap-2 overflow-x-auto pb-1">
+                {TABS.map((tab) => {
+                  const active = selectedNav === tab.key;
+                  return (
+                    <button
+                      key={tab.key}
+                      onClick={() => setSelectedNav(tab.key)}
+                      className={cn(
+                        'whitespace-nowrap rounded-md border px-2.5 py-1 text-[10px] font-mono uppercase tracking-[0.16em] transition',
+                        active
+                          ? 'border-cyan-300/60 bg-cyan-400/10 text-cyan-100 shadow-[0_0_18px_rgba(34,211,238,0.24)]'
+                          : 'border-slate-700/80 bg-slate-900/50 text-slate-400 hover:border-slate-500 hover:text-slate-200',
+                      )}
+                    >
+                      {tab.label}
+                    </button>
+                  );
+                })}
               </div>
 
               <div className="border-t border-slate-800/80 pt-2">
@@ -819,7 +844,7 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
                       placeholder="Search events, agents, signals..."
                       value={searchQuery}
                       onChange={(event) => setSearchQuery(event.target.value)}
-                      className="w-full rounded-md border border-slate-800 bg-slate-900 py-1.5 pl-8 pr-3 text-[11px] font-mono uppercase tracking-[0.06em] text-slate-300 placeholder:text-slate-600 transition-colors focus:border-sky-500/50 focus:outline-none focus:ring-1 focus:ring-sky-500/20"
+                      className="w-full rounded-md border border-slate-700 bg-slate-900/80 py-1.5 pl-8 pr-3 text-[11px] font-mono uppercase tracking-[0.06em] text-slate-200 placeholder:text-slate-600 transition-colors focus:border-cyan-400/60 focus:outline-none focus:ring-1 focus:ring-cyan-500/20"
                     />
                     {searchQuery ? (
                       <button
@@ -838,7 +863,7 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
                     <select
                       value={sortBy}
                       onChange={(event) => setSortBy(event.target.value as SortField)}
-                      className="cursor-pointer appearance-none rounded-md border border-slate-800 bg-slate-900 px-2 py-1.5 pr-6 text-[11px] font-mono text-slate-400 transition-colors focus:border-sky-500/50 focus:outline-none"
+                      className="cursor-pointer appearance-none rounded-md border border-slate-700 bg-slate-900 px-2 py-1.5 pr-6 text-[11px] font-mono text-slate-300 transition-colors focus:border-cyan-500/50 focus:outline-none"
                       style={{
                         backgroundImage:
                           "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%2364748b' stroke-width='2'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19 9l-7 7-7-7'/%3E%3C/svg%3E\")",
@@ -858,7 +883,7 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
                     <button
                       type="button"
                       onClick={() => setSortDir((prev) => (prev === 'desc' ? 'asc' : 'desc'))}
-                      className="inline-flex h-7 w-5 items-center justify-center rounded-md border border-slate-800 bg-slate-900 text-[11px] font-mono text-slate-400 transition-colors hover:border-sky-500/40 hover:text-sky-300"
+                      className="inline-flex h-7 w-5 items-center justify-center rounded-md border border-slate-700 bg-slate-900 text-[11px] font-mono text-slate-300 transition-colors hover:border-cyan-400/40 hover:text-cyan-200"
                       aria-label={`Toggle sort direction (currently ${sortDir})`}
                     >
                       {sortDir === 'desc' ? '↓' : '↑'}
@@ -892,7 +917,7 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
         </div>
       </header>
 
-      <main className="mx-auto grid w-full max-w-[1800px] grid-cols-12 gap-4 p-4 pb-14">
+      <main className="relative mx-auto grid w-full max-w-[1800px] grid-cols-12 gap-4 p-4 pb-14">
         <section className="col-span-12 grid gap-4 xl:grid-cols-[minmax(700px,2fr)_minmax(340px,1fr)]">
           <div className="space-y-4">
             <section className="space-y-3">
@@ -911,7 +936,7 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
                 ))}
               </div>
             </section>
-            <section className="rounded-lg border border-slate-800 bg-slate-900/50 p-3">
+            <section className="rounded-lg border border-slate-800/90 bg-slate-900/50 p-3 shadow-[inset_0_1px_0_rgba(148,163,184,0.08)]">
               <div className="mb-3 flex items-center justify-between gap-2">
                 <div>
                   <div className="text-[10px] font-mono uppercase tracking-[0.16em] text-slate-300">Integrity Trend</div>
@@ -1059,7 +1084,10 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
 const StatCard = memo(function StatCard({ label, value, trend, icon, subtitle, onClick }: { label: string; value: string; trend: number; icon: string; subtitle: string; onClick: () => void }) {
   const positive = trend >= 0;
   return (
-    <button onClick={onClick} className="rounded-lg border border-slate-800 bg-slate-900/50 p-3 text-left transition hover:border-sky-500/50">
+    <button
+      onClick={onClick}
+      className="rounded-lg border border-slate-700/90 bg-slate-900/60 p-3 text-left shadow-[inset_0_1px_0_rgba(148,163,184,0.07)] transition hover:border-cyan-400/45 hover:shadow-[0_0_20px_rgba(34,211,238,0.14)]"
+    >
       <div className="mb-2 flex items-center justify-between">
         <span className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-400">{label}</span>
         <span className="text-slate-500">{icon}</span>
@@ -1267,6 +1295,14 @@ const LedgerRow = memo(function LedgerRow({ entry, isSelected, isExpanded, onSel
   const confidence = Math.min(100, Math.max(10, Math.round(((entry.confidenceTier ?? 2) / 4) * 100)));
   const relTime = useRelativeTime(entry.timestamp);
   const badge = useMemo(() => getLedgerAgentBadge(entry), [entry]);
+  const governanceSignals = useMemo(() => {
+    const tags = (entry.tags ?? []).map((tag) => tag.toLowerCase());
+    const governance = tags.some((tag) => tag.includes('governance'));
+    const ethics = tags.some((tag) => tag.includes('ethic'));
+    const civicRisk = tags.some((tag) => tag.includes('civic-risk') || tag.includes('civic risk') || tag.includes('civic_risk'));
+    return { governance, ethics, civicRisk };
+  }, [entry.tags]);
+  const isEveLane = entry.source === 'eve-synthesis' || entry.agentOrigin === 'EVE';
   const isoTime = useMemo(() => {
     const parsed = new Date(entry.timestamp);
     if (Number.isNaN(parsed.getTime())) return undefined;
@@ -1278,7 +1314,13 @@ const LedgerRow = memo(function LedgerRow({ entry, isSelected, isExpanded, onSel
   }, [onSelect, entry.id]);
 
   return (
-    <div className={cn('rounded-md border border-slate-800 bg-slate-950/70 p-3 transition', isSelected && 'border-sky-500/30 ring-1 ring-sky-500/20')}>
+    <div
+      className={cn(
+        'rounded-md border border-slate-800 bg-slate-950/70 p-3 transition',
+        isSelected && 'border-sky-500/30 ring-1 ring-sky-500/20',
+        isEveLane && 'border-fuchsia-400/35 bg-fuchsia-500/[0.03]',
+      )}
+    >
       <button onClick={handleSelect} className="w-full text-left">
         <div className="flex items-start justify-between gap-3">
           <div className="flex min-w-0 gap-3">
@@ -1288,11 +1330,10 @@ const LedgerRow = memo(function LedgerRow({ entry, isSelected, isExpanded, onSel
             <div className="min-w-0">
               <div className="flex min-w-0 flex-wrap items-center gap-1 truncate text-sm font-medium text-slate-100">
                 <span className="truncate">{entry.title ?? entry.summary}</span>
-                {entry.source === 'eve-synthesis' || entry.agentOrigin === 'EVE' ? (
-                  <span className="shrink-0 text-[10px] font-mono text-fuchsia-300 border border-fuchsia-400/35 rounded px-1 py-0.5">
-                    EVE
-                  </span>
-                ) : null}
+                {isEveLane ? <span className="shrink-0 rounded border border-fuchsia-400/35 px-1 py-0.5 text-[10px] font-mono text-fuchsia-200">EVE</span> : null}
+                {governanceSignals.governance ? <span className="shrink-0 rounded border border-rose-400/35 bg-rose-500/10 px-1 py-0.5 text-[10px] font-mono text-rose-200">governance</span> : null}
+                {governanceSignals.ethics ? <span className="shrink-0 rounded border border-pink-400/35 bg-pink-500/10 px-1 py-0.5 text-[10px] font-mono text-pink-200">ethics</span> : null}
+                {governanceSignals.civicRisk ? <span className="shrink-0 rounded border border-violet-400/35 bg-violet-500/10 px-1 py-0.5 text-[10px] font-mono text-violet-200">civic-risk</span> : null}
               </div>
               <div className="truncate text-xs text-slate-500">{entry.summary}</div>
             </div>
@@ -1312,11 +1353,7 @@ const LedgerRow = memo(function LedgerRow({ entry, isSelected, isExpanded, onSel
             {(entry.tags ?? []).map((tag) => (
               <span key={`${entry.id}-${tag}`} className="rounded border border-slate-700 bg-slate-900 px-1.5 py-0.5 text-[10px] font-mono uppercase text-slate-400">{tag}</span>
             ))}
-            {entry.source === 'eve-synthesis' || entry.agentOrigin === 'EVE' ? (
-              <span className="rounded border border-fuchsia-400/35 bg-fuchsia-500/10 px-1.5 py-0.5 text-[10px] font-mono uppercase text-fuchsia-300">
-                EVE
-              </span>
-            ) : null}
+            {isEveLane ? <span className="rounded border border-fuchsia-400/35 bg-fuchsia-500/10 px-1.5 py-0.5 text-[10px] font-mono uppercase text-fuchsia-200">EVE</span> : null}
           </div>
           <div className="text-right text-[10px] font-mono uppercase tracking-[0.12em] text-slate-500">hash {entry.id}</div>
         </div>

--- a/components/terminal/EventScreener.tsx
+++ b/components/terminal/EventScreener.tsx
@@ -34,7 +34,7 @@ interface EventScreenerProps {
 const PAGE_SIZE = 12;
 type TypeFilter = 'all' | 'merge' | 'heartbeat' | 'catalog' | 'epicon' | 'zeus-verify';
 type AuthorFilter = 'all' | 'kaizencycle' | 'mobius-bot' | 'cursor-agent';
-type LaneFilter = 'all' | 'eve-governance';
+type LaneFilter = 'all' | 'eve' | 'governance' | 'ethics' | 'civic-risk';
 
 const TYPE_LABELS: Record<TypeFilter, string> = {
   all: 'All',
@@ -150,6 +150,25 @@ function sourceLabel(source: string): string {
   return source.length > 10 ? source.slice(0, 10) : source;
 }
 
+function governanceSignals(item: EpiconFeedItem) {
+  const haystack = `${item.title} ${(item.tags ?? []).join(' ')}`.toLowerCase();
+  const isEve = (item.agentOrigin ?? '').toUpperCase() === 'EVE' || (item.author ?? '').toLowerCase() === 'eve' || item.source === 'eve-synthesis';
+  const governance = haystack.includes('governance');
+  const ethics = haystack.includes('ethic');
+  const civicRisk = haystack.includes('civic-risk') || haystack.includes('civic_risk') || haystack.includes('civic risk');
+  return { isEve, governance, ethics, civicRisk };
+}
+
+function roleTone(agent: string) {
+  const key = agent.toLowerCase();
+  if (key === 'eve') return 'border-fuchsia-400/40 bg-fuchsia-500/10 text-fuchsia-200';
+  if (key === 'zeus') return 'border-amber-500/35 bg-amber-500/10 text-amber-200';
+  if (key === 'hermes') return 'border-orange-500/35 bg-orange-500/10 text-orange-200';
+  if (key === 'atlas') return 'border-sky-500/35 bg-sky-500/10 text-sky-200';
+  if (key === 'aurea') return 'border-yellow-500/35 bg-yellow-500/10 text-yellow-200';
+  return 'border-slate-700 bg-slate-800/70 text-slate-300';
+}
+
 export default function EventScreener({
   items,
   summary,
@@ -252,14 +271,11 @@ export default function EventScreener({
     const filtered = externallySorted.filter((item) => {
       if (typeFilter !== 'all' && item.type !== typeFilter) return false;
       if (authorFilter !== 'all' && item.author !== authorFilter) return false;
-      if (laneFilter === 'eve-governance') {
-        const isEveOrigin = (item.agentOrigin ?? '').toUpperCase() === 'EVE' || (item.author ?? '').toLowerCase() === 'eve';
-        const hasGovernanceTag = (item.tags ?? []).some((tag) => {
-          const normalized = tag.toLowerCase();
-          return normalized.includes('governance') || normalized.includes('ethic') || normalized.includes('civic');
-        });
-        if (!isEveOrigin && item.source !== 'eve-synthesis' && !hasGovernanceTag) return false;
-      }
+      const lane = governanceSignals(item);
+      if (laneFilter === 'eve' && !lane.isEve) return false;
+      if (laneFilter === 'governance' && !lane.governance) return false;
+      if (laneFilter === 'ethics' && !lane.ethics) return false;
+      if (laneFilter === 'civic-risk' && !lane.civicRisk) return false;
       return true;
     });
 
@@ -362,33 +378,29 @@ export default function EventScreener({
           <option value="mobius-bot">mobius-bot</option>
           <option value="cursor-agent">cursor-agent</option>
         </select>
-        <div className="inline-flex items-center gap-1 rounded border border-slate-800 bg-slate-900 p-0.5">
-          <button
-            type="button"
-            onClick={() => {
-              setLaneFilter('all');
-              setPage(0);
-            }}
-            className={cn(
-              'rounded px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em]',
-              laneFilter === 'all' ? 'bg-slate-800 text-slate-200' : 'text-slate-500',
-            )}
-          >
-            All lanes
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setLaneFilter('eve-governance');
-              setPage(0);
-            }}
-            className={cn(
-              'rounded px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em]',
-              laneFilter === 'eve-governance' ? 'bg-rose-500/20 text-rose-200' : 'text-slate-500',
-            )}
-          >
-            EVE governance
-          </button>
+        <div className="inline-flex flex-wrap items-center gap-1 rounded border border-slate-800 bg-slate-900 p-0.5">
+          {[
+            { key: 'all' as const, label: 'All lanes', active: 'bg-slate-800 text-slate-200' },
+            { key: 'eve' as const, label: 'EVE', active: 'bg-fuchsia-500/20 text-fuchsia-100' },
+            { key: 'governance' as const, label: 'Governance', active: 'bg-rose-500/20 text-rose-100' },
+            { key: 'ethics' as const, label: 'Ethics', active: 'bg-pink-500/20 text-pink-100' },
+            { key: 'civic-risk' as const, label: 'Civic Risk', active: 'bg-violet-500/20 text-violet-100' },
+          ].map((lane) => (
+            <button
+              key={lane.key}
+              type="button"
+              onClick={() => {
+                setLaneFilter(lane.key);
+                setPage(0);
+              }}
+              className={cn(
+                'rounded px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em]',
+                laneFilter === lane.key ? lane.active : 'text-slate-500',
+              )}
+            >
+              {lane.label}
+            </button>
+          ))}
         </div>
       </div>
 
@@ -396,11 +408,19 @@ export default function EventScreener({
         <div className="divide-y divide-slate-800">
           {pagedRows.map((item) => {
             const isOpen = openId === item.id;
-            const isEve = item.source === 'eve-synthesis';
+            const lane = governanceSignals(item);
+            const isEve = lane.isEve;
             const rowAgent = (item.agentOrigin || item.author || '').toLowerCase();
             const dotClass = TYPE_DOT_STYLES[item.type] ?? 'bg-slate-500';
             return (
-              <div key={item.id} className={cn('transition hover:bg-slate-900/40', isOpen && 'bg-sky-500/5')}>
+              <div
+                key={item.id}
+                className={cn(
+                  'transition hover:bg-slate-900/40',
+                  isOpen && 'bg-sky-500/5',
+                  isEve && 'border-l border-fuchsia-400/35 bg-fuchsia-500/[0.03]',
+                )}
+              >
                 <button
                   type="button"
                   onClick={() => setOpenId((prev) => (prev === item.id ? null : item.id))}
@@ -409,9 +429,10 @@ export default function EventScreener({
                   <span className={cn('text-slate-500 transition-transform', isOpen ? 'rotate-90' : 'rotate-0')}>▶</span>
                   <span className={cn('h-1.5 w-1.5 shrink-0 rounded-full', dotClass)} />
                   <span className="min-w-0 flex-1 truncate text-[11px] text-slate-200">{item.title}</span>
-                  {isEve ? (
-                    <span className="rounded border border-rose-500/35 bg-rose-500/10 px-1 py-0.5 text-[9px] uppercase text-rose-300">EVE SYN</span>
-                  ) : null}
+                  {isEve ? <span className="rounded border border-fuchsia-400/35 bg-fuchsia-500/10 px-1 py-0.5 text-[9px] uppercase text-fuchsia-200">EVE</span> : null}
+                  {lane.governance ? <span className="rounded border border-rose-400/35 bg-rose-500/10 px-1 py-0.5 text-[9px] uppercase text-rose-200">governance</span> : null}
+                  {lane.ethics ? <span className="rounded border border-pink-400/35 bg-pink-500/10 px-1 py-0.5 text-[9px] uppercase text-pink-200">ethics</span> : null}
+                  {lane.civicRisk ? <span className="rounded border border-violet-400/35 bg-violet-500/10 px-1 py-0.5 text-[9px] uppercase text-violet-200">civic-risk</span> : null}
                   <span className="text-slate-500">{timeAgo(item.timestamp)}</span>
                   <span className={cn('rounded border px-1.5 py-0.5 uppercase', TYPE_STYLES[item.type] ?? 'border-slate-700 text-slate-300')}>
                     {item.type}
@@ -433,6 +454,9 @@ export default function EventScreener({
                                 <span className={cn(AUTHOR_STYLES[item.author] ?? 'text-slate-300')}>
                                   {item.agentOrigin || item.author}
                                 </span>
+                                <span className={cn('rounded border px-1.5 py-0.5 text-[9px] font-mono uppercase', roleTone(item.agentOrigin || item.author))}>
+                                  {(item.agentOrigin || item.author || 'agent').toUpperCase()}
+                                </span>
                               </div>
                             )}
                           />
@@ -450,7 +474,7 @@ export default function EventScreener({
                           <AccordionField
                             label="Source"
                             value={(
-                              <span className={cn('rounded border px-1.5 py-0.5 text-[10px] uppercase', isEve ? 'border-rose-500/35 bg-rose-500/10 text-rose-300' : 'border-slate-700 text-slate-300')}>
+                              <span className={cn('rounded border px-1.5 py-0.5 text-[10px] uppercase', isEve ? 'border-fuchsia-400/35 bg-fuchsia-500/10 text-fuchsia-200' : 'border-slate-700 text-slate-300')}>
                                 {sourceLabel(item.source)}
                               </span>
                             )}
@@ -478,7 +502,16 @@ export default function EventScreener({
                             <div className="mt-1 flex flex-wrap gap-1">
                               {(item.tags ?? []).length > 0 ? (
                                 item.tags.map((tag) => (
-                                  <span key={tag} className="rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5 text-[10px] font-mono text-slate-300">
+                                  <span
+                                    key={tag}
+                                    className={cn(
+                                      'rounded border bg-slate-950 px-1.5 py-0.5 text-[10px] font-mono text-slate-300',
+                                      tag.toLowerCase().includes('governance') && 'border-rose-400/30 text-rose-200',
+                                      tag.toLowerCase().includes('ethic') && 'border-pink-400/30 text-pink-200',
+                                      (tag.toLowerCase().includes('civic-risk') || tag.toLowerCase().includes('civic risk')) && 'border-violet-400/30 text-violet-200',
+                                      !tag.toLowerCase().includes('governance') && !tag.toLowerCase().includes('ethic') && !tag.toLowerCase().includes('civic-risk') && !tag.toLowerCase().includes('civic risk') && 'border-slate-700',
+                                    )}
+                                  >
                                     {tag}
                                   </span>
                                 ))

--- a/docs/ops/TERMINAL_HYBRID_SUPERNEON_QUANTARA_PR.md
+++ b/docs/ops/TERMINAL_HYBRID_SUPERNEON_QUANTARA_PR.md
@@ -1,0 +1,293 @@
+# Mobius Terminal Hybrid Redesign (Superneon × Quantara)
+
+## Positioning
+
+**Verdict:**
+- yes to Superneon-inspired styling for the public-facing Mobius shell
+- no to a 1:1 template copy inside mission-critical terminal panes
+- best result is a hybrid: **premium sci-fi shell + disciplined civic operator console**
+
+**One-line guidance:**
+> Superneon outside, disciplined civic console inside.
+
+---
+
+## Why this hybrid fits Mobius
+
+Superneon maps well to:
+- civic AI identity
+- high-contrast, command-center brand perception
+- premium shell and live-state framing
+
+Quantara maps well to:
+- clean modular structure
+- dense information readability
+- product/data hierarchy for operational workflows
+
+Together they support Mobius priorities:
+- first-impression strength
+- scan speed and trust
+- calm, legible operator lanes
+
+---
+
+## Ratio and usage model
+
+### Recommended ratio
+- **30% Superneon**
+- **70% Quantara**
+
+### Formula
+- **Superneon for mood**
+- **Quantara for discipline**
+
+### Practical split
+1. **Shell / chrome:** 70% Superneon, 30% Quantara
+2. **Main data surfaces:** 25% Superneon, 75% Quantara
+3. **Motion language:** Superneon style, Quantara restraint
+
+---
+
+## Component mapping
+
+### Use more Superneon in
+- top nav
+- hero/status ribbon
+- chamber tabs and active chamber glow
+- live-state indicators and subtle edge lighting
+
+### Use more Quantara in
+- cards, tables, and data grids
+- ledger / events / journal lanes
+- agent roster and detail inspector
+- tripwire panels and command surfaces
+
+---
+
+## Guardrails (non-negotiable)
+
+- reduce background spectacle in working panes
+- reduce animation frequency in dense operator workflows
+- do not rely on glow as sole state indicator
+- keep strong contrast and keyboard focus clarity
+- prioritize legibility for Events, Journal, Tripwires, and agent reasoning
+
+---
+
+## GitHub-ready PR draft
+
+### Title
+`feat(terminal-ui): hybridize Superneon shell with Quantara data layout`
+
+### Branch
+`cursor/c272-terminal-hybrid-shell`
+
+### Body
+
+```md
+## Summary
+
+This PR redesigns the Mobius Civic Terminal UI using a hybrid visual system:
+
+- **Superneon** for mood, shell, glow language, and premium sci-fi identity
+- **Quantara** for layout discipline, modular data surfaces, and readable AI/product structure
+
+The goal is **not** to turn the terminal into a marketing page.
+
+The goal is to make Mobius feel:
+- more premium
+- more futuristic
+- more legible
+- more trustworthy as a live civic operator console
+
+## Design direction
+
+### Superneon contributes
+- neon-glow identity
+- cosmic/dark premium shell
+- cinematic motion language
+- high-contrast dashboard energy
+
+### Quantara contributes
+- clean AI-first layouts
+- modular structure
+- product-centric clarity
+- smoother, more restrained motion
+- stronger content hierarchy
+
+## Hybrid rule
+
+**Superneon for shell. Quantara for discipline.**
+
+That means:
+- top nav, chamber chrome, hero status, active states = Superneon-inspired
+- cards, ledger panes, tables, roster blocks, data grids = Quantara-inspired
+
+## Why
+
+The current terminal already has live substrate surfaces:
+- GI / tripwires / agents / signals / ledger
+- chamber structure
+- agent roster and live signal trace
+- a real command-center foundation
+
+But the current visual language still feels closer to an internal prototype than a fully realized civic operating system.
+
+This PR improves:
+- first impression
+- scan speed
+- chamber hierarchy
+- active-state clarity
+- premium feel without sacrificing operator trust
+
+## Scope
+
+### Included
+
+#### 1. Terminal shell refresh
+- redesign top chrome using a darker premium shell
+- add subtle neon edge-lighting to active areas
+- improve chamber tab and active-nav styling
+- tighten status ribbon hierarchy for:
+  - cycle
+  - GI
+  - live state
+  - alerts
+  - tripwire posture
+
+#### 2. KPI strip redesign
+- rework GI / Signal Feed / Tripwires / Agents Live cards
+- cleaner spacing
+- higher readability
+- restrained accent glow only on high-priority metrics
+
+#### 3. Ledger + data-surface cleanup
+- shift ledger/event/journal panes toward a flatter, more structured layout
+- reduce ornamental glow inside dense work surfaces
+- improve row spacing, chip styling, and scan hierarchy
+- make tables/cards feel more “operator console” and less “landing page”
+
+#### 4. Chamber card system
+- create a shared card language for:
+  - command surface
+  - tripwire anomalies
+  - agent roster
+  - signal feed
+  - journal/event lanes
+- use Quantara-style modularity with restrained Superneon accents
+
+#### 5. Motion and interaction polish
+- keep motion subtle and purposeful
+- use glow + motion for:
+  - active chamber
+  - hover/focus states
+  - live metric transitions
+  - panel reveals
+- avoid cinematic motion inside dense reasoning panes
+
+#### 6. EVE / governance visual lane readiness
+- introduce visual affordances for governance / ethics / civic-risk entries
+- ensure EVE-authored rows can feel distinct from ZEUS / HERMES / ATLAS / AUREA
+- maintain compatibility with existing ledger/event feed structure
+
+## Visual system rules
+
+### Use more Superneon in:
+- header
+- nav
+- live state indicators
+- selected chamber
+- hero/status shell
+- active metric emphasis
+
+### Use more Quantara in:
+- ledger
+- event rows
+- journal
+- agent roster
+- tripwire panels
+- command surface
+- detail inspector
+- data cards
+
+## Implementation notes
+
+### Styling
+- keep dark base
+- use thin luminous accents instead of heavy glow floods
+- preserve strong contrast for serious operator workflows
+- avoid decorative gradients behind dense text surfaces
+
+### Motion
+- use restrained transitions
+- reduce background spectacle in working panes
+- preserve performance and readability over visual drama
+
+### Accessibility
+- maintain high text contrast
+- do not use glow as the only state indicator
+- support keyboard focus clearly
+- preserve scanability for tables and anomaly lists
+
+## Non-goals
+
+This PR does **not**:
+- redesign the ingest architecture
+- change agent routing logic
+- rewrite the terminal data model
+- turn the terminal into a pure marketing shell
+- add excessive animation or visual noise
+
+## Acceptance criteria
+
+- terminal feels visually premium without harming legibility
+- chamber navigation is easier to scan
+- KPI row has clearer hierarchy
+- ledger and journal panes are more readable
+- active states are more obvious
+- the shell feels distinctly “Mobius”
+- data-heavy panes remain calm and trustworthy
+
+## QA checklist
+
+- [ ] Header/chamber shell updated
+- [ ] KPI cards redesigned
+- [ ] Ledger/event/journal surfaces cleaned up
+- [ ] Agent roster restyled
+- [ ] Tripwire anomalies panel updated
+- [ ] Active chamber glow added
+- [ ] Hover/focus states improved
+- [ ] Motion restrained in dense panes
+- [ ] Mobile layout still readable
+- [ ] Desktop layout feels less prototype-heavy
+- [ ] No regression in command surface readability
+- [ ] No regression in dark-mode contrast
+
+## Notes for review
+
+This PR intentionally avoids copying either template 1:1.
+
+It uses:
+- **Superneon** as visual inspiration for premium shell, glow language, and dashboard energy
+- **Quantara** as visual inspiration for modular structure, clean layouts, and product/data clarity
+
+Target result:
+**a premium sci-fi shell wrapped around a disciplined civic operator dashboard**
+```
+
+---
+
+## Optional follow-up PR sequence
+
+1. `feat(terminal-ui): shell and card system implementation`
+2. `feat(terminal-ui): ledger and journal readability pass`
+3. `feat(terminal-ui): chamber motion and active-state polish`
+4. `feat(terminal-ui): eve governance lane styling`
+5. `feat(terminal-ui): mobile terminal density cleanup`
+
+---
+
+## Source references
+
+- Superneon template: https://webflow.com/templates/html/superneon-website-template
+- Quantara template: https://webflow.com/templates/html/quantara-website-template


### PR DESCRIPTION
### Motivation

- Refresh the Mobius Terminal chrome with a Superneon-inspired premium shell while preserving Quantara-style discipline for dense data surfaces. 
- Surface governance-related signals and make EVE-authored rows visually distinct to help operators quickly triage civic-risk, governance, and ethics items.
- Improve scanability and hierarchy across header, KPI cards, ledger rows and the EventScreener without changing data models or routing logic.

### Description

- Updated `TerminalPageClient.tsx` to add background glow accents, tighter header chrome, new tab pills, refined input/sort styling, and improved card/row shadows and hover states for a hybrid Superneon × Quantara look.
- Enhanced ledger rows by adding `governanceSignals` detection, EVE lane highlighting, and inline badges for `governance`, `ethics`, and `civic-risk`, plus subtle EVE row styling and updated timestamp/selection visuals.
- Reworked `EventScreener.tsx` to expand `laneFilter` options to `eve | governance | ethics | civic-risk`, introduced `governanceSignals` and `roleTone` helpers, added role badges, per-tag tinting, and improved source/agent presentation for easier scanning.
- Added documentation `docs/ops/TERMINAL_HYBRID_SUPERNEON_QUANTARA_PR.md` describing the design rationale, hybrid rules, scope, and review checklist for the visual redesign.

### Testing

- Ran a local TypeScript build with `yarn build` which completed successfully. 
- Executed the test suite with `yarn test` and observed all tests passing. 
- Ran lint/type checks with `yarn lint` / `tsc --noEmit` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d306b03a84832d9ff360cd61e1c18a)