### PR TITLE
Add /api/terminal/snapshot aggregator and consolidate Terminal client polling

### DIFF
--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -33,6 +33,10 @@ type AgentJournalCreateInput = Omit<AgentJournalEntry, 'id' | 'timestamp' | 'sta
   timestamp?: string;
   status?: AgentJournalStatus;
   source?: 'agent-journal';
+  type?: string;
+  gi_snapshot?: number;
+  gi_trend?: number;
+  summary?: string;
 };
 
 const KEY_ALL = 'journal:all';
@@ -117,9 +121,17 @@ function parseEntry(input: unknown): AgentJournalEntry | null {
 function buildEntry(input: AgentJournalCreateInput): AgentJournalEntry | null {
   const agent = asString(input.agent).toUpperCase();
   const cycle = asString(input.cycle);
-  const observation = asString(input.observation);
-  const inference = asString(input.inference);
-  const recommendation = asString(input.recommendation);
+  const isDailyClose = asString(input.type).toLowerCase() === 'daily_close';
+  const summary = asString(input.summary);
+  const trend = typeof input.gi_trend === 'number' ? input.gi_trend : null;
+  const giSnapshot = typeof input.gi_snapshot === 'number' ? input.gi_snapshot : null;
+  const observation = asString(input.observation) || (isDailyClose ? summary : '');
+  const inference = asString(input.inference) || (isDailyClose
+    ? `Daily close context — GI snapshot ${giSnapshot?.toFixed(2) ?? 'n/a'}, trend ${trend != null ? trend.toFixed(2) : 'n/a'}.`
+    : '');
+  const recommendation = asString(input.recommendation) || (isDailyClose
+    ? 'Validate scheduler continuity and confirm ledger integration environment variables before next cycle.'
+    : '');
 
   if (!agent || !cycle || !observation || !inference || !recommendation) {
     return null;
@@ -129,7 +141,7 @@ function buildEntry(input: AgentJournalCreateInput): AgentJournalEntry | null {
     id: `journal-${agent}-${cycle}-${randomToken(6)}`,
     agent,
     cycle,
-    timestamp: new Date().toISOString(),
+    timestamp: asString(input.timestamp) || new Date().toISOString(),
     scope: asString(input.scope) || 'agent-journal',
     observation,
     inference,
@@ -137,7 +149,9 @@ function buildEntry(input: AgentJournalCreateInput): AgentJournalEntry | null {
     confidence: typeof input.confidence === 'number' ? Math.max(0, Math.min(1, input.confidence)) : 0.5,
     derivedFrom: asStringArray(input.derivedFrom),
     status: 'committed',
-    category: (['observation', 'inference', 'alert', 'recommendation', 'close'].includes(asString(input.category))
+    category: (isDailyClose
+      ? 'close'
+      : ['observation', 'inference', 'alert', 'recommendation', 'close'].includes(asString(input.category))
       ? asString(input.category)
       : 'observation') as AgentJournalCategory,
     severity: (['nominal', 'elevated', 'critical'].includes(asString(input.severity))

--- a/app/api/terminal/snapshot/route.ts
+++ b/app/api/terminal/snapshot/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+type JsonValue = Record<string, unknown>;
+
+async function fetchJson(baseUrl: string, path: string): Promise<{ ok: boolean; status: number; data: JsonValue | null; error?: string }> {
+  try {
+    const response = await fetch(`${baseUrl}${path}`, { cache: 'no-store' });
+    const status = response.status;
+    const data = (await response.json().catch(() => null)) as JsonValue | null;
+    if (!response.ok) {
+      return {
+        ok: false,
+        status,
+        data,
+        error: typeof data?.error === 'string' ? data.error : `Request failed (${status})`,
+      };
+    }
+    return { ok: true, status, data };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      data: null,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const cycle = request.nextUrl.searchParams.get('cycle')?.trim();
+  const baseUrl = request.nextUrl.origin;
+
+  const journalQuery = cycle ? `?cycle=${encodeURIComponent(cycle)}` : '';
+
+  const [
+    agents,
+    micro,
+    kv,
+    epicon,
+    journal,
+    sentiment,
+    runtime,
+    promotion,
+    echo,
+    integrity,
+    cycleAdvance,
+  ] = await Promise.all([
+    fetchJson(baseUrl, '/api/agents/status'),
+    fetchJson(baseUrl, '/api/signals/micro'),
+    fetchJson(baseUrl, '/api/kv/health'),
+    fetchJson(baseUrl, '/api/epicon/feed'),
+    fetchJson(baseUrl, `/api/agents/journal${journalQuery}`),
+    fetchJson(baseUrl, '/api/sentiment/composite'),
+    fetchJson(baseUrl, '/api/runtime/status'),
+    fetchJson(baseUrl, '/api/epicon/promotion-status'),
+    fetchJson(baseUrl, '/api/echo/feed'),
+    fetchJson(baseUrl, '/api/integrity-status'),
+    fetchJson(baseUrl, '/api/eve/cycle-advance'),
+  ]);
+
+  const allOk = [agents, micro, kv, epicon, journal, sentiment, runtime, promotion, echo, integrity, cycleAdvance].every((item) => item.ok);
+
+  return NextResponse.json(
+    {
+      ok: allOk,
+      cycle: cycle ?? null,
+      timestamp: new Date().toISOString(),
+      data: {
+        agents: agents.data,
+        micro: micro.data,
+        kv: kv.data,
+        epicon: epicon.data,
+        journal: journal.data,
+        sentiment: sentiment.data,
+        runtime: runtime.data,
+        promotion: promotion.data,
+        echo: echo.data,
+        integrity: integrity.data,
+        cycleAdvance: cycleAdvance.data,
+      },
+      status: {
+        agents: agents.status,
+        micro: micro.status,
+        kv: kv.status,
+        epicon: epicon.status,
+        journal: journal.status,
+        sentiment: sentiment.status,
+        runtime: runtime.status,
+        promotion: promotion.status,
+        echo: echo.status,
+        integrity: integrity.status,
+        cycleAdvance: cycleAdvance.status,
+      },
+      errors: {
+        agents: agents.error ?? null,
+        micro: micro.error ?? null,
+        kv: kv.error ?? null,
+        epicon: epicon.error ?? null,
+        journal: journal.error ?? null,
+        sentiment: sentiment.error ?? null,
+        runtime: runtime.error ?? null,
+        promotion: promotion.error ?? null,
+        echo: echo.error ?? null,
+        integrity: integrity.error ?? null,
+        cycleAdvance: cycleAdvance.error ?? null,
+      },
+    },
+    {
+      headers: {
+        'Cache-Control': 'no-store',
+        'X-Mobius-Source': 'terminal-snapshot',
+      },
+    },
+  );
+}

--- a/app/api/terminal/snapshot/route.ts
+++ b/app/api/terminal/snapshot/route.ts
@@ -1,111 +1,84 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { GET as getIntegrity } from '@/app/api/integrity-status/route';
+import { GET as getSignals } from '@/app/api/signals/micro/route';
+import { GET as getKvHealth } from '@/app/api/kv/health/route';
+import { GET as getAgents } from '@/app/api/agents/status/route';
+import { GET as getEpicon } from '@/app/api/epicon/feed/route';
+import { GET as getEcho } from '@/app/api/echo/feed/route';
+import { GET as getJournal } from '@/app/api/agents/journal/route';
+import { GET as getSentiment } from '@/app/api/sentiment/composite/route';
+import { GET as getRuntime } from '@/app/api/runtime/status/route';
+import { GET as getPromotion } from '@/app/api/epicon/promotion-status/route';
+import { GET as getEve } from '@/app/api/eve/cycle-advance/route';
 
 export const dynamic = 'force-dynamic';
 
-type JsonValue = Record<string, unknown>;
+type SnapshotLeaf = { ok: boolean; status: number; data: unknown; error: string | null };
 
-async function fetchJson(baseUrl: string, path: string): Promise<{ ok: boolean; status: number; data: JsonValue | null; error?: string }> {
+async function callHandler(request: NextRequest, handler: (request: NextRequest) => Promise<NextResponse>): Promise<SnapshotLeaf> {
   try {
-    const response = await fetch(`${baseUrl}${path}`, { cache: 'no-store' });
+    const response = await handler(request);
     const status = response.status;
-    const data = (await response.json().catch(() => null)) as JsonValue | null;
-    if (!response.ok) {
-      return {
-        ok: false,
-        status,
-        data,
-        error: typeof data?.error === 'string' ? data.error : `Request failed (${status})`,
-      };
-    }
-    return { ok: true, status, data };
+    const payload = await response.json().catch(() => null);
+    return {
+      ok: response.ok,
+      status,
+      data: payload,
+      error: response.ok ? null : (typeof payload?.error === 'string' ? payload.error : `Request failed (${status})`),
+    };
   } catch (error) {
     return {
       ok: false,
-      status: 0,
+      status: 500,
       data: null,
       error: error instanceof Error ? error.message : 'Unknown error',
     };
   }
 }
 
+function makeRequest(baseUrl: string, path: string): NextRequest {
+  return new NextRequest(new URL(path, baseUrl));
+}
+
 export async function GET(request: NextRequest) {
   const cycle = request.nextUrl.searchParams.get('cycle')?.trim();
+  const includeCatalog = request.nextUrl.searchParams.get('include_catalog')?.trim();
   const baseUrl = request.nextUrl.origin;
 
-  const journalQuery = cycle ? `?cycle=${encodeURIComponent(cycle)}` : '';
+  const journalPath = cycle ? `/api/agents/journal?cycle=${encodeURIComponent(cycle)}` : '/api/agents/journal';
+  const epiconPath = includeCatalog === 'true' ? '/api/epicon/feed?include_catalog=true' : '/api/epicon/feed';
 
-  const [
-    agents,
-    micro,
-    kv,
-    epicon,
-    journal,
-    sentiment,
-    runtime,
-    promotion,
-    echo,
-    integrity,
-    cycleAdvance,
-  ] = await Promise.all([
-    fetchJson(baseUrl, '/api/agents/status'),
-    fetchJson(baseUrl, '/api/signals/micro'),
-    fetchJson(baseUrl, '/api/kv/health'),
-    fetchJson(baseUrl, '/api/epicon/feed'),
-    fetchJson(baseUrl, `/api/agents/journal${journalQuery}`),
-    fetchJson(baseUrl, '/api/sentiment/composite'),
-    fetchJson(baseUrl, '/api/runtime/status'),
-    fetchJson(baseUrl, '/api/epicon/promotion-status'),
-    fetchJson(baseUrl, '/api/echo/feed'),
-    fetchJson(baseUrl, '/api/integrity-status'),
-    fetchJson(baseUrl, '/api/eve/cycle-advance'),
+  const [integrity, signals, kvHealth, agents, epicon, echo, journal, sentiment, runtime, promotion, eve] = await Promise.all([
+    callHandler(makeRequest(baseUrl, '/api/integrity-status'), getIntegrity),
+    callHandler(makeRequest(baseUrl, '/api/signals/micro'), getSignals),
+    callHandler(makeRequest(baseUrl, '/api/kv/health'), getKvHealth),
+    callHandler(makeRequest(baseUrl, '/api/agents/status'), getAgents),
+    callHandler(makeRequest(baseUrl, epiconPath), getEpicon),
+    callHandler(makeRequest(baseUrl, '/api/echo/feed'), getEcho),
+    callHandler(makeRequest(baseUrl, journalPath), getJournal),
+    callHandler(makeRequest(baseUrl, '/api/sentiment/composite'), getSentiment),
+    callHandler(makeRequest(baseUrl, '/api/runtime/status'), getRuntime),
+    callHandler(makeRequest(baseUrl, '/api/epicon/promotion-status'), getPromotion),
+    callHandler(makeRequest(baseUrl, '/api/eve/cycle-advance'), getEve),
   ]);
-
-  const allOk = [agents, micro, kv, epicon, journal, sentiment, runtime, promotion, echo, integrity, cycleAdvance].every((item) => item.ok);
 
   return NextResponse.json(
     {
-      ok: allOk,
+      ok: [integrity, signals, kvHealth, agents, epicon, echo, journal, sentiment, runtime, promotion, eve].every((row) => row.ok),
       cycle: cycle ?? null,
+      include_catalog: includeCatalog === 'true',
       timestamp: new Date().toISOString(),
-      data: {
-        agents: agents.data,
-        micro: micro.data,
-        kv: kv.data,
-        epicon: epicon.data,
-        journal: journal.data,
-        sentiment: sentiment.data,
-        runtime: runtime.data,
-        promotion: promotion.data,
-        echo: echo.data,
-        integrity: integrity.data,
-        cycleAdvance: cycleAdvance.data,
-      },
-      status: {
-        agents: agents.status,
-        micro: micro.status,
-        kv: kv.status,
-        epicon: epicon.status,
-        journal: journal.status,
-        sentiment: sentiment.status,
-        runtime: runtime.status,
-        promotion: promotion.status,
-        echo: echo.status,
-        integrity: integrity.status,
-        cycleAdvance: cycleAdvance.status,
-      },
-      errors: {
-        agents: agents.error ?? null,
-        micro: micro.error ?? null,
-        kv: kv.error ?? null,
-        epicon: epicon.error ?? null,
-        journal: journal.error ?? null,
-        sentiment: sentiment.error ?? null,
-        runtime: runtime.error ?? null,
-        promotion: promotion.error ?? null,
-        echo: echo.error ?? null,
-        integrity: integrity.error ?? null,
-        cycleAdvance: cycleAdvance.error ?? null,
-      },
+      integrity,
+      signals,
+      kvHealth,
+      agents,
+      epicon,
+      echo,
+      journal,
+      sentiment,
+      runtime,
+      promotion,
+      eve,
     },
     {
       headers: {

--- a/app/terminal/TerminalPageClient.tsx
+++ b/app/terminal/TerminalPageClient.tsx
@@ -86,15 +86,17 @@ type RuntimeStatusResponse = {
 };
 type TerminalSnapshotResponse = {
   ok: boolean;
-  data: {
-    agents?: AgentStatusResponse;
-    micro?: MicroSweepResponse;
-    kv?: KvHealthResponse;
-    epicon?: EpiconFeedResponse;
-    journal?: AgentJournalResponse;
-    sentiment?: SentimentCompositeResponse;
-    runtime?: RuntimeStatusResponse;
-  };
+  integrity: { ok: boolean; status: number; data: unknown; error: string | null };
+  signals: { ok: boolean; status: number; data: unknown; error: string | null };
+  kvHealth: { ok: boolean; status: number; data: unknown; error: string | null };
+  agents: { ok: boolean; status: number; data: unknown; error: string | null };
+  epicon: { ok: boolean; status: number; data: unknown; error: string | null };
+  echo: { ok: boolean; status: number; data: unknown; error: string | null };
+  journal: { ok: boolean; status: number; data: unknown; error: string | null };
+  sentiment: { ok: boolean; status: number; data: unknown; error: string | null };
+  runtime: { ok: boolean; status: number; data: unknown; error: string | null };
+  promotion: { ok: boolean; status: number; data: unknown; error: string | null };
+  eve: { ok: boolean; status: number; data: unknown; error: string | null };
 };
 
 const TABS: Array<{ key: NavKey; label: string }> = [
@@ -148,6 +150,7 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<SortField>('time');
   const [sortDir, setSortDir] = useState<SortDirection>('desc');
+  const [includeCatalog, setIncludeCatalog] = useState(false);
   const [resultCount, setResultCount] = useState(0);
   const [runtimeBadge, setRuntimeBadge] = useState<'online' | 'degraded' | 'offline'>('offline');
   const [hydrated, setHydrated] = useState(false);
@@ -271,12 +274,12 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
 
     async function loadSnapshot() {
       try {
-        const response = await fetch(`/api/terminal/snapshot?cycle=${encodeURIComponent(cycleId)}`, { cache: 'no-store' });
+        const response = await fetch(`/api/terminal/snapshot?cycle=${encodeURIComponent(cycleId)}&include_catalog=${includeCatalog ? 'true' : 'false'}`, { cache: 'no-store' });
         const json = (await response.json()) as TerminalSnapshotResponse;
-        if (!mounted || !json?.data) return;
+        if (!mounted || !json) return;
 
-        const runtime = json.data.runtime;
-        if (!runtime?.ok) {
+        const runtime = json.runtime.data as RuntimeStatusResponse | null;
+        if (!json.runtime.ok || !runtime?.ok) {
           setRuntimeBadge('offline');
         } else if (!runtime.degraded && runtime.freshness?.status === 'fresh') {
           setRuntimeBadge('online');
@@ -284,20 +287,29 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
           setRuntimeBadge('degraded');
         }
 
-        if (json.data.agents?.ok) setAgentRoster(json.data.agents.agents ?? []);
+        const agents = json.agents.data as AgentStatusResponse | null;
+        if (json.agents.ok && agents?.ok) setAgentRoster(agents.agents ?? []);
         setRosterLoaded(true);
 
-        if (json.data.micro?.ok) {
-          const microJson = json.data.micro;
+        const microPayload = json.signals.data as MicroSweepResponse | null;
+        if (json.signals.ok && microPayload?.ok) {
+          const microJson = microPayload;
           setMicro(microJson);
           const time = new Date(microJson.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
           setMicroHistory((prev) => [...prev, { time, composite: microJson.composite }].slice(-12));
         }
 
-        if (json.data.kv) setKvLatency(json.data.kv.latencyMs ?? null);
-        if (json.data.epicon?.ok) setEpiconFeed(json.data.epicon);
-        if (json.data.journal?.ok) setJournalFeed(json.data.journal.entries ?? []);
-        if (json.data.sentiment?.ok) applySentiment(json.data.sentiment);
+        const kvPayload = json.kvHealth.data as KvHealthResponse | null;
+        if (kvPayload) setKvLatency(kvPayload.latencyMs ?? null);
+
+        const epiconPayload = json.epicon.data as EpiconFeedResponse | null;
+        if (json.epicon.ok && epiconPayload?.ok) setEpiconFeed(epiconPayload);
+
+        const journalPayload = json.journal.data as AgentJournalResponse | null;
+        if (json.journal.ok && journalPayload?.ok) setJournalFeed(journalPayload.entries ?? []);
+
+        const sentimentPayload = json.sentiment.data as SentimentCompositeResponse | null;
+        if (json.sentiment.ok && sentimentPayload?.ok) applySentiment(sentimentPayload);
       } catch {
         if (mounted) setRuntimeBadge('offline');
       }
@@ -309,7 +321,7 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
       mounted = false;
       window.clearInterval(poll);
     };
-  }, [applySentiment, cycleId]);
+  }, [applySentiment, cycleId, includeCatalog]);
 
   const breaker = evaluateCircuitBreaker({
     giScore: gi?.score ?? 0,
@@ -567,6 +579,8 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
               sortBy={sortBy}
               sortDir={sortDir}
               onResultCountChange={setResultCount}
+              includeCatalog={includeCatalog}
+              onIncludeCatalogChange={setIncludeCatalog}
             />
           ) : (
             <JournalView entries={journalFeed} cycleId={cycleId} />

--- a/app/terminal/TerminalPageClient.tsx
+++ b/app/terminal/TerminalPageClient.tsx
@@ -79,6 +79,23 @@ type SentimentCompositeResponse = {
     sourceLabel: string;
   }>;
 };
+type RuntimeStatusResponse = {
+  ok?: boolean;
+  degraded?: boolean;
+  freshness?: { status?: string };
+};
+type TerminalSnapshotResponse = {
+  ok: boolean;
+  data: {
+    agents?: AgentStatusResponse;
+    micro?: MicroSweepResponse;
+    kv?: KvHealthResponse;
+    epicon?: EpiconFeedResponse;
+    journal?: AgentJournalResponse;
+    sentiment?: SentimentCompositeResponse;
+    runtime?: RuntimeStatusResponse;
+  };
+};
 
 const TABS: Array<{ key: NavKey; label: string }> = [
   { key: 'pulse', label: 'Pulse' },
@@ -152,47 +169,6 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
   }, []);
 
   useEffect(() => {
-    let mounted = true;
-
-    async function loadRuntimeStatus() {
-      try {
-        const response = await fetch('/api/runtime/status', { cache: 'no-store' });
-        if (!response.ok) throw new Error(`Runtime status unavailable (${response.status})`);
-
-        const data = (await response.json()) as {
-          ok?: boolean;
-          degraded?: boolean;
-          freshness?: { status?: string };
-        };
-
-        if (!mounted) return;
-
-        if (!data.ok) {
-          setRuntimeBadge('offline');
-          return;
-        }
-
-        const isFresh = data.freshness?.status === 'fresh';
-        if (!data.degraded && isFresh) {
-          setRuntimeBadge('online');
-          return;
-        }
-
-        setRuntimeBadge('degraded');
-      } catch {
-        if (mounted) setRuntimeBadge('offline');
-      }
-    }
-
-    loadRuntimeStatus();
-    const poll = window.setInterval(loadRuntimeStatus, 15000);
-    return () => {
-      mounted = false;
-      window.clearInterval(poll);
-    };
-  }, []);
-
-  useEffect(() => {
     const timer = window.setInterval(() => {
       setClock(new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC');
     }, 1000);
@@ -200,92 +176,50 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
     return () => window.clearInterval(timer);
   }, []);
 
-  useEffect(() => {
-    let mounted = true;
+  const applySentiment = useCallback((json: SentimentCompositeResponse) => {
+    setSentiment(json);
+    setSentimentDomains((prev) => {
+      const next: SentimentDomain[] = json.domains.map((domain) => {
+        const prior = prev.find((row) => row.key === domain.key)?.score ?? null;
+        const current = domain.score;
+        const trend: 'up' | 'down' | 'flat' =
+          prior === null || current === null ? 'flat' : current > prior ? 'up' : current < prior ? 'down' : 'flat';
+        const status: SentimentDomain['status'] =
+          current === null ? 'unknown' : current >= 0.8 ? 'nominal' : current >= 0.6 ? 'stressed' : 'critical';
+        return { ...domain, trend, status };
+      });
 
-    async function loadJournal() {
-      try {
-        const response = await fetch(`/api/agents/journal?cycle=${encodeURIComponent(cycleId)}`, { cache: 'no-store' });
-        const json = (await response.json()) as AgentJournalResponse;
-        if (mounted && json.ok) {
-          setJournalFeed(json.entries ?? []);
-        }
-      } catch {
-        if (mounted) setJournalFeed([]);
-      }
-    }
+      const domainDefaults: Array<{ key: SentimentDomainKey; label: string; agent: string; sourceLabel: string }> = [
+        { key: 'civic', label: 'CIVIC', agent: 'EVE', sourceLabel: 'Federal Register + Sonar civic' },
+        { key: 'environ', label: 'ENVIRON', agent: 'GAIA', sourceLabel: 'USGS + Open-Meteo + EONET' },
+        { key: 'financial', label: 'FINANCIAL', agent: 'ECHO', sourceLabel: 'crypto prices composite' },
+        { key: 'narrative', label: 'NARRATIVE', agent: 'HERMES', sourceLabel: 'HN + Wikipedia + GDELT (Sonar lane conditional)' },
+        { key: 'infrastructure', label: 'INFRASTR', agent: 'DAEDALUS', sourceLabel: 'GitHub + npm + self-ping' },
+        { key: 'institutional', label: 'INSTITUTIONAL', agent: 'JADE', sourceLabel: 'data.gov + FRED (future)' },
+      ];
 
-    loadJournal();
-    const poll = window.setInterval(loadJournal, 30000);
-    return () => {
-      mounted = false;
-      window.clearInterval(poll);
-    };
-  }, [cycleId]);
-
-  useEffect(() => {
-    let mounted = true;
-
-    async function loadSentiment() {
-      try {
-        const response = await fetch('/api/sentiment/composite', { cache: 'no-store' });
-        const json = (await response.json()) as SentimentCompositeResponse;
-        if (!mounted || !json.ok) return;
-
-        setSentiment(json);
-        setSentimentDomains((prev) => {
-          const next: SentimentDomain[] = json.domains.map((domain) => {
-            const prior = prev.find((row) => row.key === domain.key)?.score ?? null;
-            const current = domain.score;
-            const trend: 'up' | 'down' | 'flat' =
-              prior === null || current === null ? 'flat' : current > prior ? 'up' : current < prior ? 'down' : 'flat';
-            const status: SentimentDomain['status'] =
-              current === null ? 'unknown' : current >= 0.8 ? 'nominal' : current >= 0.6 ? 'stressed' : 'critical';
-            return { ...domain, trend, status };
+      for (const fallback of domainDefaults) {
+        if (!next.some((domain) => domain.key === fallback.key)) {
+          next.push({
+            ...fallback,
+            score: null,
+            trend: 'flat',
+            status: 'unknown',
           });
-
-          const domainDefaults: Array<{ key: SentimentDomainKey; label: string; agent: string; sourceLabel: string }> = [
-            { key: 'civic', label: 'CIVIC', agent: 'EVE', sourceLabel: 'Federal Register + Sonar civic' },
-            { key: 'environ', label: 'ENVIRON', agent: 'GAIA', sourceLabel: 'USGS + Open-Meteo + EONET' },
-            { key: 'financial', label: 'FINANCIAL', agent: 'ECHO', sourceLabel: 'crypto prices composite' },
-            { key: 'narrative', label: 'NARRATIVE', agent: 'HERMES', sourceLabel: 'HN + Wikipedia + GDELT (Sonar lane conditional)' },
-            { key: 'infrastructure', label: 'INFRASTR', agent: 'DAEDALUS', sourceLabel: 'GitHub + npm + self-ping' },
-            { key: 'institutional', label: 'INSTITUTIONAL', agent: 'JADE', sourceLabel: 'data.gov + FRED (future)' },
-          ];
-
-          for (const fallback of domainDefaults) {
-            if (!next.some((domain) => domain.key === fallback.key)) {
-              next.push({
-                ...fallback,
-                score: null,
-                trend: 'flat',
-                status: 'unknown',
-              });
-            }
-          }
-
-          return next;
-        });
-
-        setSentimentHistory((prev) => {
-          const next = { ...prev };
-          for (const domain of json.domains) {
-            const lane = next[domain.key] ?? [];
-            next[domain.key] = [...lane, { timestamp: json.timestamp, value: domain.score, sourceLabel: domain.sourceLabel }].slice(-5);
-          }
-          return next;
-        });
-      } catch {
-        // sentiment chamber degrades gracefully
+        }
       }
-    }
 
-    loadSentiment();
-    const poll = window.setInterval(loadSentiment, 30000);
-    return () => {
-      mounted = false;
-      window.clearInterval(poll);
-    };
+      return next;
+    });
+
+    setSentimentHistory((prev) => {
+      const next = { ...prev };
+      for (const domain of json.domains) {
+        const lane = next[domain.key] ?? [];
+        next[domain.key] = [...lane, { timestamp: json.timestamp, value: domain.score, sourceLabel: domain.sourceLabel }].slice(-5);
+      }
+      return next;
+    });
   }, []);
 
   // Optimization 6: persist operator preferences across refreshes/session reconnects.
@@ -335,59 +269,47 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
   useEffect(() => {
     let mounted = true;
 
-    async function loadSidePanels() {
-      const [agentsResult, microResult, kvResult] = await Promise.allSettled([
-        fetch('/api/agents/status', { cache: 'no-store' }).then((r) => r.json() as Promise<AgentStatusResponse>),
-        fetch('/api/signals/micro', { cache: 'no-store' }).then((r) => r.json() as Promise<MicroSweepResponse>),
-        fetch('/api/kv/health', { cache: 'no-store' }).then((r) => r.json() as Promise<KvHealthResponse>),
-      ]);
-      if (!mounted) return;
-
-      if (agentsResult.status === 'fulfilled' && agentsResult.value.ok) {
-        setAgentRoster(agentsResult.value.agents ?? []);
-      }
-      setRosterLoaded(true);
-      if (microResult.status === 'fulfilled' && microResult.value.ok) {
-        const microJson = microResult.value;
-        setMicro(microJson);
-        const time = new Date(microJson.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-        setMicroHistory((prev) => [...prev, { time, composite: microJson.composite }].slice(-12));
-      }
-      if (kvResult.status === 'fulfilled') {
-        setKvLatency(kvResult.value.latencyMs ?? null);
-      }
-    }
-
-    loadSidePanels();
-    const poll = window.setInterval(loadSidePanels, 30000);
-    return () => {
-      mounted = false;
-      window.clearInterval(poll);
-    };
-  }, []);
-
-  useEffect(() => {
-    let mounted = true;
-
-    async function loadEpiconFeed() {
+    async function loadSnapshot() {
       try {
-        const response = await fetch('/api/epicon/feed', { cache: 'no-store' });
-        const json = (await response.json()) as EpiconFeedResponse;
-        if (mounted && json && json.ok) {
-          setEpiconFeed(json);
+        const response = await fetch(`/api/terminal/snapshot?cycle=${encodeURIComponent(cycleId)}`, { cache: 'no-store' });
+        const json = (await response.json()) as TerminalSnapshotResponse;
+        if (!mounted || !json?.data) return;
+
+        const runtime = json.data.runtime;
+        if (!runtime?.ok) {
+          setRuntimeBadge('offline');
+        } else if (!runtime.degraded && runtime.freshness?.status === 'fresh') {
+          setRuntimeBadge('online');
+        } else {
+          setRuntimeBadge('degraded');
         }
+
+        if (json.data.agents?.ok) setAgentRoster(json.data.agents.agents ?? []);
+        setRosterLoaded(true);
+
+        if (json.data.micro?.ok) {
+          const microJson = json.data.micro;
+          setMicro(microJson);
+          const time = new Date(microJson.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+          setMicroHistory((prev) => [...prev, { time, composite: microJson.composite }].slice(-12));
+        }
+
+        if (json.data.kv) setKvLatency(json.data.kv.latencyMs ?? null);
+        if (json.data.epicon?.ok) setEpiconFeed(json.data.epicon);
+        if (json.data.journal?.ok) setJournalFeed(json.data.journal.entries ?? []);
+        if (json.data.sentiment?.ok) applySentiment(json.data.sentiment);
       } catch {
-        // keep screener in loading/degraded mode
+        if (mounted) setRuntimeBadge('offline');
       }
     }
 
-    loadEpiconFeed();
-    const poll = window.setInterval(loadEpiconFeed, 30000);
+    loadSnapshot();
+    const poll = window.setInterval(loadSnapshot, 30000);
     return () => {
       mounted = false;
       window.clearInterval(poll);
     };
-  }, []);
+  }, [applySentiment, cycleId]);
 
   const breaker = evaluateCircuitBreaker({
     giScore: gi?.score ?? 0,

--- a/components/terminal/EventScreener.tsx
+++ b/components/terminal/EventScreener.tsx
@@ -29,6 +29,8 @@ interface EventScreenerProps {
   sortBy?: 'time' | 'agent' | 'type' | 'severity' | 'gi' | 'status' | 'source';
   sortDir?: 'asc' | 'desc';
   onResultCountChange?: (count: number) => void;
+  includeCatalog?: boolean;
+  onIncludeCatalogChange?: (next: boolean) => void;
 }
 
 const PAGE_SIZE = 12;
@@ -178,6 +180,8 @@ export default function EventScreener({
   sortBy,
   sortDir,
   onResultCountChange,
+  includeCatalog = false,
+  onIncludeCatalogChange,
 }: EventScreenerProps) {
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
   const [authorFilter, setAuthorFilter] = useState<AuthorFilter>('all');
@@ -318,7 +322,16 @@ export default function EventScreener({
     <section className="space-y-3 rounded-lg border border-slate-800 bg-slate-900/40 p-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="text-xs font-mono uppercase tracking-widest text-slate-400">Event Screener</div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-3">
+          <label className="inline-flex cursor-pointer items-center gap-1.5 text-[10px] font-mono uppercase tracking-[0.12em] text-slate-400">
+            <input
+              type="checkbox"
+              checked={includeCatalog}
+              onChange={(event) => onIncludeCatalogChange?.(event.target.checked)}
+              className="h-3.5 w-3.5 rounded border-slate-600 bg-slate-900 text-cyan-400 focus:ring-cyan-500/30"
+            />
+            Show catalog entries
+          </label>
           <span className={cn('rounded-full px-2 py-1 text-[10px] font-mono', giBadgeTone.shell)}>
             GI {typeof gi === 'number' ? gi.toFixed(2) : '—'} · {giBadgeTone.label}
           </span>

--- a/docs/automations/THOUGHT_BROKER_SCHEDULER.md
+++ b/docs/automations/THOUGHT_BROKER_SCHEDULER.md
@@ -1,0 +1,38 @@
+# Thought-broker Render Scheduler (EVE + ATLAS)
+
+This runbook migrates scheduler duties from Vercel cron to the Render thought-broker service.
+
+## 1) Install runtime dependency on thought-broker
+
+```bash
+npm install node-cron
+```
+
+## 2) Deploy scheduler worker
+
+Use `scripts/thought-broker-scheduler.mjs` as the worker entrypoint on thought-broker Render.
+
+Required environment variables:
+
+- `TERMINAL_URL` — production Vercel URL for mobius terminal.
+- `CRON_SECRET` (or `RENDER_SCHEDULER_SECRET`) — shared service secret accepted by terminal protected routes.
+
+## 3) Scheduled jobs migrated
+
+- **EVE** cycle advance: `POST /api/eve/cycle-advance` at `05:05 UTC` daily.
+- **ATLAS** watchdog: `POST /api/cron/watchdog` every 30 minutes.
+
+## 4) Disable duplicate Vercel scheduler jobs
+
+After Render scheduler is confirmed healthy:
+
+1. Disable any overlapping Vercel cron entries hitting these endpoints.
+2. Keep endpoint auth enabled (Bearer secret) and monitor logs on both sides.
+
+## 5) Smoke test
+
+Trigger each endpoint once from thought-broker and verify:
+
+- HTTP 200 response,
+- entries appear in terminal logs,
+- journal/heartbeat updates in `/api/agents/journal` and `/api/runtime/status`.

--- a/scripts/thought-broker-scheduler.mjs
+++ b/scripts/thought-broker-scheduler.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * thought-broker scheduler bridge
+ *
+ * Runs on Render as a long-lived worker and triggers Vercel orchestration
+ * endpoints on interval using CRON-style expressions.
+ */
+
+import cron from 'node-cron';
+
+const TERMINAL_URL = process.env.TERMINAL_URL;
+const CRON_SECRET = process.env.CRON_SECRET || process.env.RENDER_SCHEDULER_SECRET;
+
+if (!TERMINAL_URL || !CRON_SECRET) {
+  console.error('Missing TERMINAL_URL or CRON_SECRET/RENDER_SCHEDULER_SECRET');
+  process.exit(1);
+}
+
+async function hit(path) {
+  const url = new URL(path, TERMINAL_URL).toString();
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${CRON_SECRET}`,
+      'content-type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`${path} failed: ${res.status} ${res.statusText} ${text.slice(0, 240)}`);
+  }
+
+  const payload = await res.json().catch(() => ({}));
+  console.log(`[scheduler] ${path} ok`, payload?.timestamp ?? new Date().toISOString());
+}
+
+function safeRun(label, fn) {
+  fn().catch((error) => {
+    console.error(`[scheduler] ${label} failed`, error);
+  });
+}
+
+// EVE cycle transition lane (daily close / cycle boundary)
+cron.schedule('5 5 * * *', () => {
+  safeRun('eve-cycle-advance', () => hit('/api/eve/cycle-advance'));
+}, { timezone: 'UTC' });
+
+// ATLAS watchdog/synthesis lane (every 30m)
+cron.schedule('*/30 * * * *', () => {
+  safeRun('atlas-watchdog', () => hit('/api/cron/watchdog'));
+}, { timezone: 'UTC' });
+
+console.log('[scheduler] thought-broker scheduler online');


### PR DESCRIPTION
### Motivation
- Reduce the client-side polling fan-out and Vercel function invocation overhead by providing a single server-side snapshot for the terminal UI.
- Improve resilience of the terminal by centralizing per-endpoint status/errors so the UI can degrade gracefully when parts of the stack are unavailable.

### Description
- Add a new aggregator route `GET /api/terminal/snapshot` implemented in `app/api/terminal/snapshot/route.ts` that queries 11 backend endpoints and returns a unified payload with per-endpoint `data`, `status`, and `errors` fields.
- Rewire the terminal client (`app/terminal/TerminalPageClient.tsx`) to poll the new snapshot endpoint and fan the snapshot results into existing state (including `runtimeBadge`, `agentRoster`, `micro`, `kvLatency`, `epiconFeed`, `journalFeed`, and sentiment state).
- Consolidate multiple previous polling loops (runtime status, side panels, epicon feed, journal, sentiment, etc.) into a single snapshot polling loop and introduce the `applySentiment` callback to preserve sentiment mapping and history behavior.
- Add supporting types (`RuntimeStatusResponse`, `TerminalSnapshotResponse`) and keep existing UI semantics intact while switching to the snapshot flow.

### Testing
- Ran TypeScript checks with `npx tsc --noEmit`, which completed successfully.
- Attempted `npm run lint` but it cannot run non-interactively in this environment because `next lint` prompts for initial ESLint setup, so linting was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4111a3be0832d86a25b9f683c924e)