### PR TITLE
feat(journal): archive agent journals to Mobius-Substrate repo and merge on read [C-274]

### DIFF
--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -3,6 +3,7 @@ import { getServiceAuthError } from '@/lib/security/serviceAuth';
 import { appendJournalLaneEntry, getJournalRedisClient } from '@/lib/agents/journalLane';
 import { writeToSubstrate } from '@/lib/substrate/client';
 import { getOperatorSession } from '@/lib/auth/session';
+import { readJournalEntriesFromArchive, writeJournalEntryToArchive } from '@/lib/agents/journalArchive';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -220,7 +221,6 @@ async function seedGenesisEntries(redis: NonNullable<ReturnType<typeof getJourna
 
 export async function GET(request: NextRequest) {
   const redis = getJournalRedisClient();
-  let entries = await loadEntries(redis);
 
   const { searchParams } = request.nextUrl;
   const agentFilter = asString(searchParams.get('agent')).toUpperCase();
@@ -228,12 +228,24 @@ export async function GET(request: NextRequest) {
   const limitRaw = Number(searchParams.get('limit') ?? '20');
   const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(Math.floor(limitRaw), 100) : 20;
 
-  if (entries.length === 0 && redis) {
+  let kvEntries = await loadEntries(redis);
+  if (kvEntries.length === 0 && redis) {
     await seedGenesisEntries(redis, cycleFilter || 'C-272');
-    entries = await loadEntries(redis);
+    kvEntries = await loadEntries(redis);
   }
 
-  const filtered = entries
+  const archiveEntries = await readJournalEntriesFromArchive(agentFilter || undefined, 10).catch((error) => {
+    console.error('[journal] archive read error', error);
+    return [];
+  });
+
+  const deduped = new Map<string, AgentJournalEntry>();
+  for (const entry of [...kvEntries, ...archiveEntries]) {
+    if (!deduped.has(entry.id)) deduped.set(entry.id, entry);
+  }
+
+  const filtered = Array.from(deduped.values())
+    .sort((a, b) => b.timestamp.localeCompare(a.timestamp))
     .filter((entry) => (agentFilter ? entry.agent.toUpperCase() === agentFilter : true))
     .filter((entry) => (cycleFilter ? entry.cycle === cycleFilter : true))
     .slice(0, limit);
@@ -292,6 +304,10 @@ export async function POST(request: NextRequest) {
     tags: entry.tags,
   }).catch((error) => {
     console.error('[ledger] journal attest error', error);
+  });
+
+  void writeJournalEntryToArchive(entry).catch((error) => {
+    console.error('[journal] archive write error', error);
   });
 
   const redis = getJournalRedisClient();

--- a/lib/agents/journalArchive.ts
+++ b/lib/agents/journalArchive.ts
@@ -1,0 +1,116 @@
+interface JournalArchiveEntry {
+  id: string;
+  agent: string;
+  cycle: string;
+  timestamp: string;
+  scope: string;
+  observation: string;
+  inference: string;
+  recommendation: string;
+  confidence: number;
+  derivedFrom: string[];
+  status: 'draft' | 'committed' | 'contested' | 'verified';
+  category: 'observation' | 'inference' | 'alert' | 'recommendation' | 'close';
+  severity: 'nominal' | 'elevated' | 'critical';
+  source: 'agent-journal';
+  agentOrigin: string;
+  tags?: string[];
+}
+
+interface GitHubContentFile {
+  type: 'file' | 'dir';
+  name: string;
+  path: string;
+  download_url: string | null;
+}
+
+const REPO_OWNER = 'kaizencycle';
+const REPO_NAME = 'Mobius-Substrate';
+const REPO_BRANCH = 'main';
+const API_BASE = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}`;
+const RAW_BASE = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${REPO_BRANCH}`;
+
+function toAgentSlug(agent: string): string {
+  return agent.trim().toLowerCase();
+}
+
+function buildGitHubHeaders(): HeadersInit {
+  const headers: HeadersInit = {
+    Accept: 'application/vnd.github+json',
+  };
+
+  const token = process.env.GITHUB_TOKEN;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+export async function writeJournalEntryToArchive(entry: JournalArchiveEntry): Promise<void> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) return;
+
+  const agentSlug = toAgentSlug(entry.agent);
+  const safeTimestamp = new Date(entry.timestamp).toISOString().replace(/[.:]/g, '-');
+  const filename = `docs/catalog/${agentSlug}/${safeTimestamp}-journal.json`;
+
+  const response = await fetch(`${API_BASE}/contents/${filename}`, {
+    method: 'PUT',
+    headers: buildGitHubHeaders(),
+    body: JSON.stringify({
+      message: `${agentSlug}: journal entry · ${entry.cycle} [skip ci]`,
+      content: Buffer.from(JSON.stringify(entry, null, 2)).toString('base64'),
+      branch: REPO_BRANCH,
+      committer: {
+        name: entry.agent,
+        email: `${agentSlug}@mobius.systems`,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`GitHub archive write failed (${response.status}): ${errorText}`);
+  }
+}
+
+async function listPath(path: string): Promise<GitHubContentFile[]> {
+  const listResponse = await fetch(`${API_BASE}/contents/${path}?ref=${REPO_BRANCH}`, {
+    headers: buildGitHubHeaders(),
+    next: { revalidate: 0 },
+  });
+
+  if (!listResponse.ok) return [];
+  return (await listResponse.json()) as GitHubContentFile[];
+}
+
+export async function readJournalEntriesFromArchive(agent?: string, limit = 10): Promise<JournalArchiveEntry[]> {
+  const safeLimit = Math.max(1, Math.min(limit, 25));
+  let files: GitHubContentFile[] = [];
+
+  if (agent) {
+    const agentItems = await listPath(`docs/catalog/${toAgentSlug(agent)}`);
+    files = agentItems.filter((item) => item.type === 'file' && item.name.endsWith('-journal.json'));
+  } else {
+    const rootItems = await listPath('docs/catalog');
+    const directories = rootItems.filter((item) => item.type === 'dir');
+    const batches = await Promise.all(directories.map((dir) => listPath(dir.path)));
+    files = batches
+      .flat()
+      .filter((item) => item.type === 'file' && item.name.endsWith('-journal.json'));
+  }
+
+  const recent = files.sort((a, b) => b.name.localeCompare(a.name)).slice(0, safeLimit);
+
+  const entries = await Promise.all(
+    recent.map(async (file) => {
+      const rawUrl = file.download_url ?? `${RAW_BASE}/${file.path}`;
+      const response = await fetch(rawUrl, { next: { revalidate: 0 } });
+      if (!response.ok) return null;
+      const payload = (await response.json()) as JournalArchiveEntry;
+      return payload;
+    }),
+  );
+
+  return entries.filter((entry): entry is JournalArchiveEntry => entry !== null);
+}


### PR DESCRIPTION
### Motivation

- Provide a permanent, public archive for agent journal entries in the Mobius Substrate repo so agent reasoning trails are readable and discoverable outside the fast KV cache.
- Keep KV as the fast, primary read source while enabling the terminal and consumers to surface older/permanent journal files from the repo.
- Ensure archive writes/reads never block normal journal flow by making GitHub interactions fire-and-forget and non-fatal on failure.

### Description

- Add `lib/agents/journalArchive.ts` which implements `writeJournalEntryToArchive` and `readJournalEntriesFromArchive` using the GitHub Contents API and raw file URLs to store and fetch `docs/catalog/{agent}/*-journal.json` files.
- Update `POST /api/agents/journal` to asynchronously call `writeJournalEntryToArchive(entry)` (fire-and-forget) in addition to the existing ledger attest (`writeToSubstrate`) and KV append flows.
- Update `GET /api/agents/journal` to call `readJournalEntriesFromArchive(...)`, merge archive entries with KV entries, deduplicate by `id`, sort by `timestamp`, then apply agent/cycle/limit filters before returning results.
- Archive operations use `process.env.GITHUB_TOKEN` when present and are logged on failure but do not change response semantics or block KV/ledger behavior.

### Testing

- Ran `npm run lint` which could not complete non-interactively due to `next lint` prompting for ESLint configuration, so lint did not finish successfully in this environment.
- Ran `npx tsc --noEmit` which failed with existing project type resolution errors (missing `next-auth` types) that are unrelated to this patch, so typecheck did not fully pass here.
- Verified runtime behavior locally by exercising the journal `GET` and `POST` handlers in this environment (archive reads/writes are non-blocking and errors are logged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d510929eb8832dbee227709859cb1b)