### PR TITLE
C-274: restore terminal runtime truth and expose snapshot lane health

### DIFF
--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -234,8 +234,10 @@ export async function GET(request: NextRequest) {
     kvEntries = await loadEntries(redis);
   }
 
+  let archiveError: string | null = null;
   const archiveEntries = await readJournalEntriesFromArchive(agentFilter || undefined, 10).catch((error) => {
     console.error('[journal] archive read error', error);
+    archiveError = error instanceof Error ? error.message : 'archive read failed';
     return [];
   });
 
@@ -252,6 +254,13 @@ export async function GET(request: NextRequest) {
 
   const agents = Array.from(new Set(filtered.map((entry) => entry.agent)));
 
+  const maxTs = (list: AgentJournalEntry[]) =>
+    list.reduce((acc, e) => Math.max(acc, new Date(e.timestamp).getTime() || 0), 0);
+  const kvMax = maxTs(kvEntries);
+  const archMax = maxTs(archiveEntries);
+  const archiveStale =
+    archiveEntries.length > 0 && kvMax > 0 && archMax > 0 && kvMax - archMax > 60 * 60 * 1000;
+
   return NextResponse.json(
     {
       ok: true,
@@ -259,6 +268,10 @@ export async function GET(request: NextRequest) {
       entries: filtered,
       agents,
       timestamp: new Date().toISOString(),
+      merged_from_archive: archiveEntries.length > 0,
+      archive_error: archiveError,
+      archive_fetched_count: archiveEntries.length,
+      archive_stale: archiveStale,
     },
     {
       headers: {

--- a/app/api/cron/watchdog/route.ts
+++ b/app/api/cron/watchdog/route.ts
@@ -3,6 +3,11 @@ import { getServiceAuthError, serviceAuthorizationHeaderValue } from '@/lib/secu
 import { appendAgentJournalEntry } from '@/lib/agents/journal';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 
+/**
+ * C-274: Runtime maintenance is currently once-daily (Vercel cron). If heartbeat,
+ * journal/archive merge, or promotion normalization need tighter cadence, extend
+ * this handler (or add schedules) in one place — avoid per-lane commit spam.
+ */
 export const dynamic = 'force-dynamic';
 
 type WatchdogActionResult = {

--- a/app/api/terminal/snapshot/route.ts
+++ b/app/api/terminal/snapshot/route.ts
@@ -10,10 +10,14 @@ import { GET as getSentiment } from '@/app/api/sentiment/composite/route';
 import { GET as getRuntime } from '@/app/api/runtime/status/route';
 import { GET as getPromotion } from '@/app/api/epicon/promotion-status/route';
 import { GET as getEve } from '@/app/api/eve/cycle-advance/route';
+import {
+  normalizeAllSnapshotLanes,
+  type SnapshotLaneKey,
+  type SnapshotLaneState,
+  type SnapshotLeaf,
+} from '@/lib/terminal/snapshotLanes';
 
 export const dynamic = 'force-dynamic';
-
-type SnapshotLeaf = { ok: boolean; status: number; data: unknown; error: string | null };
 
 async function callHandler(request: NextRequest, handler: (request: NextRequest) => Promise<NextResponse>): Promise<SnapshotLeaf> {
   try {
@@ -62,12 +66,34 @@ export async function GET(request: NextRequest) {
     callHandler(makeRequest(baseUrl, '/api/eve/cycle-advance'), getEve),
   ]);
 
+  const leaves: Record<SnapshotLaneKey, SnapshotLeaf> = {
+    integrity,
+    signals,
+    kvHealth,
+    agents,
+    epicon,
+    echo,
+    journal,
+    sentiment,
+    runtime,
+    promotion,
+    eve,
+  };
+
+  const lanes: SnapshotLaneState[] = normalizeAllSnapshotLanes(leaves);
+  const laneSummary = lanes.every((lane) => lane.state === 'healthy' || lane.state === 'empty');
+
   return NextResponse.json(
     {
-      ok: [integrity, signals, kvHealth, agents, epicon, echo, journal, sentiment, runtime, promotion, eve].every((row) => row.ok),
+      ok: laneSummary,
       cycle: cycle ?? null,
       include_catalog: includeCatalog === 'true',
       timestamp: new Date().toISOString(),
+      deployment: {
+        commit_sha: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+        environment: process.env.VERCEL_ENV ?? null,
+      },
+      lanes,
       integrity,
       signals,
       kvHealth,

--- a/app/terminal/TerminalPageClient.tsx
+++ b/app/terminal/TerminalPageClient.tsx
@@ -16,6 +16,10 @@ import TripwirePanel from '@/components/tripwire/TripwirePanel';
 import MICWalletPanel from '@/components/terminal/MICWalletPanel';
 import SentimentMap from '@/components/terminal/SentimentMap';
 import CommandSurface from '@/components/terminal/CommandSurface';
+import LaneHealthBadgeRow, { runtimeStateSummary } from '@/components/terminal/LaneHealthBadgeRow';
+import SnapshotDiagnostics from '@/components/terminal/SnapshotDiagnostics';
+import { formatRelativeAge, isoHoverTitle } from '@/lib/terminal/freshnessDisplay';
+import type { SnapshotLaneState } from '@/lib/terminal/snapshotLanes';
 
 type AgentStatusApi = {
   id: string;
@@ -86,8 +90,13 @@ type RuntimeStatusResponse = {
   degraded?: boolean;
   freshness?: { status?: string };
 };
+type SnapshotDeployment = { commit_sha: string | null; environment: string | null };
+
 type TerminalSnapshotResponse = {
   ok: boolean;
+  timestamp?: string;
+  deployment?: SnapshotDeployment;
+  lanes?: SnapshotLaneState[];
   integrity: { ok: boolean; status: number; data: unknown; error: string | null };
   signals: { ok: boolean; status: number; data: unknown; error: string | null };
   kvHealth: { ok: boolean; status: number; data: unknown; error: string | null };
@@ -115,6 +124,38 @@ const TERMINAL_PREFS_KEY = 'mobius-terminal-prefs-v1';
 type TerminalPageWrapperProps = {
   bootstrap?: TerminalBootstrapSeed;
 };
+
+function PanelLaneNotice({ lane, label }: { lane: SnapshotLaneState | undefined; label: string }) {
+  if (!lane || lane.state === 'healthy') return null;
+  const rel = formatRelativeAge(lane.lastUpdated);
+  const tone =
+    lane.state === 'offline'
+      ? 'border-rose-500/40 bg-rose-500/10 text-rose-100'
+      : lane.state === 'stale'
+        ? 'border-cyan-500/40 bg-cyan-500/10 text-cyan-100'
+        : lane.state === 'empty'
+          ? 'border-slate-600 bg-slate-800/60 text-slate-200'
+          : 'border-amber-500/40 bg-amber-500/10 text-amber-100';
+  return (
+    <div className={cn('mb-3 rounded-md border px-2.5 py-2 text-[11px] leading-snug', tone)} role="status">
+      <span className="font-mono uppercase tracking-[0.1em] text-[10px] opacity-90">{label}</span>
+      <div className="mt-0.5">{lane.message}</div>
+      <div className="mt-1 font-mono text-[10px] text-slate-400">
+        Lane: {lane.key} · {lane.state}
+        {lane.lastUpdated ? (
+          <>
+            {' '}
+            ·{' '}
+            <time dateTime={lane.lastUpdated} title={isoHoverTitle(lane.lastUpdated)}>
+              {rel}
+            </time>
+          </>
+        ) : null}
+        {lane.fallbackMode === 'cached' ? ' · cached view' : null}
+      </div>
+    </div>
+  );
+}
 
 export default function TerminalPageWrapper({ bootstrap }: TerminalPageWrapperProps) {
   return (
@@ -148,7 +189,7 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
   const [sentimentHistory, setSentimentHistory] = useState<
     Partial<Record<SentimentDomainKey, Array<{ timestamp: string; value: number | null; sourceLabel: string }>>>
   >({});
-  const [ledgerView, setLedgerView] = useState<'events' | 'journal'>('events');
+  const [ledgerView, setLedgerView] = useState<'events' | 'journal' | 'runtime'>('events');
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<SortField>('time');
   const [sortDir, setSortDir] = useState<SortDirection>('desc');
@@ -156,7 +197,19 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
   const [resultCount, setResultCount] = useState(0);
   const [runtimeBadge, setRuntimeBadge] = useState<'online' | 'degraded' | 'offline'>('offline');
   const [hydrated, setHydrated] = useState(false);
+  const [snapshotLanes, setSnapshotLanes] = useState<SnapshotLaneState[]>([]);
+  const [snapshotAt, setSnapshotAt] = useState<string | null>(null);
+  const [snapshotDeployment, setSnapshotDeployment] = useState<SnapshotDeployment | null>(null);
+  const [snapshotLoadError, setSnapshotLoadError] = useState<string | null>(null);
+  const [showLaneDiagnostics, setShowLaneDiagnostics] = useState(false);
+  const [giFreshAt, setGiFreshAt] = useState<string | null>(null);
   const agentSearchRef = useRef<HTMLInputElement>(null);
+  const laneByKeyRef = useRef<Record<string, SnapshotLaneState>>({});
+  const epiconFeedRef = useRef<EpiconFeedResponse | null>(null);
+  const journalFeedRef = useRef<AgentJournalEntry[]>([]);
+  const sentimentRef = useRef<SentimentCompositeResponse | null>(null);
+  const microRef = useRef<MicroSweepResponse | null>(null);
+  const agentRosterRef = useRef<AgentStatusApi[]>([]);
 
   const {
     allTripwires,
@@ -166,8 +219,25 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
     integrityStatus,
     mergedLedger,
     semanticDriftDetected,
+    promotionCounters,
   } = useTerminalData(selectedNav, bootstrap);
   const cycleId = integrityStatus?.cycle ?? 'C-271';
+
+  const laneByKey = useMemo(() => Object.fromEntries(snapshotLanes.map((lane) => [lane.key, lane])) as Record<string, SnapshotLaneState>, [snapshotLanes]);
+
+  const tripwireFreshAt = useMemo(() => {
+    let best = 0;
+    for (const tw of allTripwires) {
+      const t = new Date(tw.openedAt).getTime();
+      if (Number.isFinite(t) && t > best) best = t;
+    }
+    return best > 0 ? new Date(best).toISOString() : null;
+  }, [allTripwires]);
+
+  useEffect(() => {
+    const ts = integrityStatus?.timestamp;
+    if (ts) setGiFreshAt(ts);
+  }, [integrityStatus?.timestamp]);
 
   useEffect(() => {
     setHydrated(true);
@@ -280,6 +350,14 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
         const json = (await response.json()) as TerminalSnapshotResponse;
         if (!mounted || !json) return;
 
+        setSnapshotLoadError(null);
+        if (json.timestamp) setSnapshotAt(json.timestamp);
+        if (json.deployment) setSnapshotDeployment(json.deployment);
+        if (Array.isArray(json.lanes) && json.lanes.length > 0) {
+          setSnapshotLanes(json.lanes);
+          laneByKeyRef.current = Object.fromEntries(json.lanes.map((lane) => [lane.key, lane]));
+        }
+
         const runtime = json.runtime.data as RuntimeStatusResponse | null;
         if (!json.runtime.ok || !runtime?.ok) {
           setRuntimeBadge('offline');
@@ -290,30 +368,61 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
         }
 
         const agents = json.agents.data as AgentStatusResponse | null;
-        if (json.agents.ok && agents?.ok) setAgentRoster(agents.agents ?? []);
+        const agentsLane = json.lanes?.find((l) => l.key === 'agents');
+        if (json.agents.ok && agents?.ok) {
+          agentRosterRef.current = agents.agents ?? [];
+          setAgentRoster(agents.agents ?? []);
+        } else if (agentsLane?.fallbackMode === 'cached' && agentRosterRef.current.length > 0) {
+          setAgentRoster(agentRosterRef.current);
+        }
+
         setRosterLoaded(true);
 
         const microPayload = json.signals.data as MicroSweepResponse | null;
+        const signalsLane = json.lanes?.find((l) => l.key === 'signals');
         if (json.signals.ok && microPayload?.ok) {
-          const microJson = microPayload;
-          setMicro(microJson);
-          const time = new Date(microJson.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-          setMicroHistory((prev) => [...prev, { time, composite: microJson.composite }].slice(-12));
+          microRef.current = microPayload;
+          setMicro(microPayload);
+          const time = new Date(microPayload.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+          setMicroHistory((prev) => [...prev, { time, composite: microPayload.composite }].slice(-12));
+        } else if (signalsLane?.fallbackMode === 'cached' && microRef.current) {
+          setMicro(microRef.current);
         }
 
         const kvPayload = json.kvHealth.data as KvHealthResponse | null;
         if (kvPayload) setKvLatency(kvPayload.latencyMs ?? null);
 
         const epiconPayload = json.epicon.data as EpiconFeedResponse | null;
-        if (json.epicon.ok && epiconPayload?.ok) setEpiconFeed(epiconPayload);
+        const epiconLane = json.lanes?.find((l) => l.key === 'epicon');
+        if (json.epicon.ok && epiconPayload?.ok) {
+          epiconFeedRef.current = epiconPayload;
+          setEpiconFeed(epiconPayload);
+        } else if (epiconLane?.fallbackMode === 'cached' && epiconFeedRef.current) {
+          setEpiconFeed(epiconFeedRef.current);
+        }
 
         const journalPayload = json.journal.data as AgentJournalResponse | null;
-        if (json.journal.ok && journalPayload?.ok) setJournalFeed(journalPayload.entries ?? []);
+        const journalLane = json.lanes?.find((l) => l.key === 'journal');
+        if (json.journal.ok && journalPayload?.ok) {
+          journalFeedRef.current = journalPayload.entries ?? [];
+          setJournalFeed(journalPayload.entries ?? []);
+        } else if (journalLane?.fallbackMode === 'cached' && journalFeedRef.current.length > 0) {
+          setJournalFeed(journalFeedRef.current);
+        }
 
         const sentimentPayload = json.sentiment.data as SentimentCompositeResponse | null;
-        if (json.sentiment.ok && sentimentPayload?.ok) applySentiment(sentimentPayload);
-      } catch {
-        if (mounted) setRuntimeBadge('offline');
+        const sentimentLane = json.lanes?.find((l) => l.key === 'sentiment');
+        if (json.sentiment.ok && sentimentPayload?.ok) {
+          sentimentRef.current = sentimentPayload;
+          applySentiment(sentimentPayload);
+        } else if (sentimentLane?.fallbackMode === 'cached' && sentimentRef.current) {
+          applySentiment(sentimentRef.current);
+        }
+      } catch (err) {
+        if (mounted) {
+          setRuntimeBadge('offline');
+          setSnapshotLoadError(err instanceof Error ? err.message : 'Snapshot fetch failed');
+        }
       }
     }
 
@@ -348,14 +457,68 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
     }
   }, [cycleId, committedAgentRowsThisCycle]);
 
-  const statCards: Array<{ label: string; value: string; trend: number; icon: string; subtitle: string; nav: NavKey }> = [
-    { label: 'Global Integrity', value: giScore.toFixed(3), trend: giDelta, icon: '◎', subtitle: 'GI stable', nav: 'pulse' },
-    { label: 'Signal Feed', value: String(filteredEpicon.length), trend: filteredEpicon.length > 8 ? 0.08 : -0.04, icon: '∿', subtitle: 'live entries', nav: 'pulse' },
-    { label: 'Tripwires', value: String(allTripwires.length), trend: allTripwires.length > 0 ? -0.1 : 0.02, icon: '⚠', subtitle: '2 high / 4 medium', nav: 'infrastructure' },
-    { label: 'Agents Live', value: String(agentRoster.length), trend: agentRoster.length >= 6 ? 0.05 : -0.02, icon: '◉', subtitle: 'sentinels online', nav: 'agents' },
-  ];
+  const statCards = useMemo(() => {
+    const integ = laneByKey.integrity;
+    const sig = laneByKey.signals;
+    const ag = laneByKey.agents;
+    const highTw = allTripwires.filter((t) => t.severity.toLowerCase() === 'high').length;
+    const medTw = allTripwires.filter((t) => t.severity.toLowerCase() === 'medium').length;
+    const giSub =
+      integ?.lastUpdated != null
+        ? `updated ${formatRelativeAge(integ.lastUpdated)}${integ.state !== 'healthy' ? ` · ${integ.state}` : ''}`
+      : giFreshAt
+        ? `updated ${formatRelativeAge(giFreshAt)}`
+        : 'timestamp pending';
+    const sigSub =
+      sig?.lastUpdated != null
+        ? `sweep ${formatRelativeAge(sig.lastUpdated)}${sig.state !== 'healthy' ? ` · ${sig.state}` : ''}`
+      : micro?.timestamp
+        ? `sweep ${formatRelativeAge(micro.timestamp)}`
+        : 'micro lane pending';
+    const twSub =
+      tripwireFreshAt != null
+        ? `latest ${formatRelativeAge(tripwireFreshAt)} · ${highTw} high / ${medTw} medium`
+        : `${highTw} high / ${medTw} medium`;
+    const agSub =
+      ag?.lastUpdated != null
+        ? `roster ${formatRelativeAge(ag.lastUpdated)}${ag.state !== 'healthy' ? ` · ${ag.state}` : ''}`
+        : rosterLoaded
+          ? 'roster live'
+          : 'roster loading';
+
+    const cards: Array<{ label: string; value: string; trend: number; icon: string; subtitle: string; nav: NavKey }> = [
+      { label: 'Global Integrity', value: giScore.toFixed(3), trend: giDelta, icon: '◎', subtitle: giSub, nav: 'pulse' },
+      { label: 'Signal Feed', value: String(filteredEpicon.length), trend: filteredEpicon.length > 8 ? 0.08 : -0.04, icon: '∿', subtitle: sigSub, nav: 'pulse' },
+      { label: 'Tripwires', value: String(allTripwires.length), trend: allTripwires.length > 0 ? -0.1 : 0.02, icon: '⚠', subtitle: twSub, nav: 'infrastructure' },
+      { label: 'Agents Live', value: String(agentRoster.length), trend: agentRoster.length >= 6 ? 0.05 : -0.02, icon: '◉', subtitle: agSub, nav: 'agents' },
+    ];
+    return cards;
+  }, [
+    agentRoster.length,
+    allTripwires,
+    filteredEpicon.length,
+    giDelta,
+    giFreshAt,
+    giScore,
+    laneByKey.agents,
+    laneByKey.integrity,
+    laneByKey.signals,
+    micro?.timestamp,
+    rosterLoaded,
+    tripwireFreshAt,
+  ]);
   const chamberLabel = selectedNav === 'pulse' ? 'PULSE CHAMBER' : selectedNav === 'agents' ? 'AGENT CHAMBER' : selectedNav === 'ledger' ? 'CIVIC LEDGER CHAMBER' : selectedNav === 'infrastructure' ? 'TRIPWIRE CHAMBER' : selectedNav === 'sentiment' ? 'SENTIMENT CHAMBER' : 'MIC CHAMBER';
   const commandSurfaceTitle = selectedNav === 'wallet' ? 'Wallet Chamber' : selectedNav === 'agents' ? 'Agent Chamber' : selectedNav === 'ledger' ? 'Civic Ledger Chamber' : selectedNav === 'infrastructure' ? 'Tripwire Chamber' : selectedNav === 'sentiment' ? 'Sentiment Chamber' : 'Pulse Chamber';
+
+  const snapshotSummaryLine = useMemo(() => {
+    const parts: string[] = [];
+    if (snapshotAt) parts.push(`snapshot ${formatRelativeAge(snapshotAt)}`);
+    parts.push(runtimeStateSummary(snapshotLanes));
+    if (snapshotLoadError) parts.push(`fetch: ${snapshotLoadError}`);
+    return parts.join(' · ');
+  }, [snapshotAt, snapshotLanes, snapshotLoadError]);
+
+  const integrityDisplayTs = integrityStatus?.timestamp ?? giFreshAt;
   const commandSurfaceButtons: Array<{ label: string; nav: NavKey }> =
     selectedNav === 'wallet'
       ? [{ label: 'Inspect', nav: 'wallet' }, { label: 'Open Chamber', nav: 'wallet' }, { label: 'Review Signals', nav: 'pulse' }]
@@ -518,11 +681,20 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
     return (
       <div className="min-h-screen bg-slate-950 text-slate-200">
         <header className="border-b border-slate-800 bg-slate-950/95 px-4 py-3">
-          <div className="mx-auto flex w-full max-w-[1800px] items-center justify-between">
-            <div className="text-xs font-mono uppercase tracking-[0.14em] text-slate-400">Mobius Terminal</div>
-            <div className="rounded border border-slate-700 bg-slate-900 px-2 py-1 text-[10px] font-mono uppercase tracking-widest text-slate-300">
-              GI …
+          <div className="mx-auto flex w-full max-w-[1800px] flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <div className="text-xs font-mono uppercase tracking-[0.14em] text-slate-400">Mobius Terminal</div>
+              <div className="rounded border border-slate-700 bg-slate-900 px-2 py-1 text-[10px] font-mono uppercase tracking-widest text-slate-300">
+                Loading integrity layer…
+              </div>
             </div>
+            <p className="text-[11px] text-slate-500">
+              Fetching `/api/integrity-status` and ledger merge. Shell stays responsive; snapshot lane strip appears once the first bundle returns.
+            </p>
+            {snapshotLanes.length > 0 ? <LaneHealthBadgeRow lanes={snapshotLanes} /> : null}
+            {snapshotLoadError ? (
+              <div className="rounded border border-rose-500/30 bg-rose-500/10 px-2 py-1 text-[10px] font-mono text-rose-200">{snapshotLoadError}</div>
+            ) : null}
           </div>
         </header>
       </div>
@@ -537,6 +709,7 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
             <div className="text-sm font-semibold">Agent Roster</div>
             <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-400">{cycleId} · Live agent status</div>
           </div>
+          <PanelLaneNotice lane={laneByKey.agents} label="Agent status API" />
           <AgentGrid />
         </section>
       );
@@ -544,12 +717,14 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
     if (selectedNav === 'ledger') {
       return (
         <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-3">
-          <div className="mb-3 flex items-center justify-between border-b border-slate-800 pb-3">
+          <div className="mb-3 flex flex-col gap-2 border-b border-slate-800 pb-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <div className="text-sm font-semibold">Ledger Chamber</div>
-              <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-400">{cycleId} · Events and reasoning journal</div>
+              <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-400">
+                {cycleId} · Facts (events) · Reasoning (journals) · Runtime (promotion + lanes)
+              </div>
             </div>
-            <div className="inline-flex rounded-md border border-slate-700 bg-slate-950 p-0.5 text-[10px] font-mono uppercase tracking-[0.12em]">
+            <div className="inline-flex flex-wrap rounded-md border border-slate-700 bg-slate-950 p-0.5 text-[10px] font-mono uppercase tracking-[0.12em]">
               <button
                 onClick={() => setLedgerView('events')}
                 className={cn('rounded px-2 py-1', ledgerView === 'events' ? 'bg-sky-500/20 text-sky-200' : 'text-slate-400')}
@@ -560,7 +735,13 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
                 onClick={() => setLedgerView('journal')}
                 className={cn('rounded px-2 py-1', ledgerView === 'journal' ? 'bg-fuchsia-500/20 text-fuchsia-200' : 'text-slate-400')}
               >
-                Journal
+                Journals
+              </button>
+              <button
+                onClick={() => setLedgerView('runtime')}
+                className={cn('rounded px-2 py-1', ledgerView === 'runtime' ? 'bg-emerald-500/20 text-emerald-200' : 'text-slate-400')}
+              >
+                Runtime
               </button>
             </div>
           </div>
@@ -569,23 +750,78 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
             <span className="text-slate-600">•</span>
             <span>Journal entries this cycle: <span className="text-fuchsia-300">{journalEntriesThisCycle}</span></span>
             <span className="text-slate-600">•</span>
-            <span>Current view: <span className={ledgerView === 'events' ? 'text-sky-300' : 'text-fuchsia-300'}>{ledgerView}</span></span>
+            <span>
+              View:{' '}
+              <span
+                className={
+                  ledgerView === 'events' ? 'text-sky-300' : ledgerView === 'journal' ? 'text-fuchsia-300' : 'text-emerald-300'
+                }
+              >
+                {ledgerView}
+              </span>
+            </span>
           </div>
           {ledgerView === 'events' ? (
-            <EventScreener
-              items={epiconFeed?.items}
-              summary={epiconFeed?.summary ?? {}}
-              sources={epiconFeed?.sources ?? { github: 0, kv: 0 }}
-              total={epiconFeed?.total ?? 0}
-              searchQuery={searchQuery}
-              sortBy={sortBy}
-              sortDir={sortDir}
-              onResultCountChange={setResultCount}
-              includeCatalog={includeCatalog}
-              onIncludeCatalogChange={setIncludeCatalog}
-            />
+            <>
+              <PanelLaneNotice lane={laneByKey.epicon} label="EPICON / events lane" />
+              <EventScreener
+                items={epiconFeed?.items}
+                summary={epiconFeed?.summary ?? {}}
+                sources={epiconFeed?.sources ?? { github: 0, kv: 0 }}
+                total={epiconFeed?.total ?? 0}
+                searchQuery={searchQuery}
+                sortBy={sortBy}
+                sortDir={sortDir}
+                onResultCountChange={setResultCount}
+                includeCatalog={includeCatalog}
+                onIncludeCatalogChange={setIncludeCatalog}
+              />
+            </>
+          ) : ledgerView === 'journal' ? (
+            <>
+              <PanelLaneNotice lane={laneByKey.journal} label="Agent journal lane" />
+              <JournalView entries={journalFeed} cycleId={cycleId} />
+            </>
           ) : (
-            <JournalView entries={journalFeed} cycleId={cycleId} />
+            <>
+              <PanelLaneNotice lane={laneByKey.promotion} label="Promotion lane" />
+              <PanelLaneNotice lane={laneByKey.runtime} label="Deployment / GitHub heartbeat" />
+              <PanelLaneNotice lane={laneByKey.eve} label="Cycle engine (EVE)" />
+              <div className="space-y-3 rounded-md border border-slate-800 bg-slate-950/50 p-3 text-[11px] text-slate-300">
+                <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-slate-500">Promotion counters</div>
+                <ul className="grid gap-2 sm:grid-cols-2">
+                  <li className="rounded border border-slate-800 bg-slate-900/60 px-2 py-1.5">
+                    Pending promotable{' '}
+                    <span className="font-mono text-sky-300">{promotionCounters.pending_promotable_count}</span>
+                  </li>
+                  <li className="rounded border border-slate-800 bg-slate-900/60 px-2 py-1.5">
+                    Promoted this cycle{' '}
+                    <span className="font-mono text-emerald-300">{promotionCounters.promoted_this_cycle_count}</span>
+                  </li>
+                  <li className="rounded border border-slate-800 bg-slate-900/60 px-2 py-1.5">
+                    Committed agent rows{' '}
+                    <span className="font-mono text-slate-200">{promotionCounters.committed_agent_count}</span>
+                  </li>
+                  <li className="rounded border border-slate-800 bg-slate-900/60 px-2 py-1.5">
+                    Failed promotions{' '}
+                    <span className="font-mono text-rose-300">{promotionCounters.failed_promotion_count}</span>
+                  </li>
+                </ul>
+                {promotionCounters.diagnostics?.last_promotion_run_at ? (
+                  <div className="font-mono text-[10px] text-slate-500">
+                    Last promotion run{' '}
+                    <time
+                      dateTime={promotionCounters.diagnostics.last_promotion_run_at}
+                      title={isoHoverTitle(promotionCounters.diagnostics.last_promotion_run_at)}
+                    >
+                      {formatRelativeAge(promotionCounters.diagnostics.last_promotion_run_at)}
+                    </time>
+                  </div>
+                ) : (
+                  <div className="font-mono text-[10px] text-slate-500">No promotion run timestamp recorded yet.</div>
+                )}
+              </div>
+            </>
           )}
         </section>
       );
@@ -597,25 +833,30 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
             <div className="text-sm font-semibold">Tripwire Infrastructure</div>
             <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-400">{cycleId} · System tripwire status</div>
           </div>
+          <PanelLaneNotice lane={laneByKey.echo} label="ECHO ingest (feeds tripwire context)" />
           <TripwirePanel />
         </section>
       );
     }
     if (selectedNav === 'sentiment') {
       return (
-        <SentimentMap
-          cycleId={sentiment?.cycle ?? cycleId}
-          timestamp={sentiment?.timestamp ?? new Date().toISOString()}
-          gi={sentiment?.gi ?? gi.score}
-          overallSentiment={sentiment?.overall_sentiment ?? null}
-          domains={sentimentDomains}
-          history={sentimentHistory}
-          journalEntries={journalFeed}
-          onAskAgent={(agent, domain) => {
-            setSearchQuery(`${agent} ${domain}`);
-            setSelectedNav('agents');
-          }}
-        />
+        <>
+          <PanelLaneNotice lane={laneByKey.sentiment} label="Sentiment composite lane" />
+          <SentimentMap
+            cycleId={sentiment?.cycle ?? cycleId}
+            timestamp={sentiment?.timestamp ?? new Date().toISOString()}
+            sentimentTimestamp={sentiment?.timestamp ?? null}
+            gi={sentiment?.gi ?? gi.score}
+            overallSentiment={sentiment?.overall_sentiment ?? null}
+            domains={sentimentDomains}
+            history={sentimentHistory}
+            journalEntries={journalFeed}
+            onAskAgent={(agent, domain) => {
+              setSearchQuery(`${agent} ${domain}`);
+              setSelectedNav('agents');
+            }}
+          />
+        </>
       );
     }
     if (selectedNav === 'wallet') {
@@ -628,11 +869,13 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
     // default: pulse
     return (
       <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-3">
+        <PanelLaneNotice lane={laneByKey.integrity} label="Integrity / GI lane" />
+        <PanelLaneNotice lane={laneByKey.signals} label="Micro-signal sweep" />
         <div className="mb-3 flex items-center justify-between gap-2 border-b border-slate-800 pb-3">
           <div>
             <div className="text-sm font-semibold uppercase tracking-[0.08em]">Pulse Ledger</div>
             <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-400">{cycleId} · Live signal trace</div>
-            <div className="text-[10px] text-slate-500">Immutable event record — Mobius Substrate</div>
+            <div className="text-[10px] text-slate-500">Facts: merged ledger (EPICON + ECHO + backfill)</div>
           </div>
           <div className="text-xs font-mono text-slate-400">
             {agentFilter === 'ALL'
@@ -711,6 +954,17 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
                   <div>
                     <div className="text-sm font-semibold uppercase tracking-[0.12em] text-slate-100">MOBIUS CIVIC TERMINAL</div>
                     <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-400">{cycleId} · {chamberLabel} · LIVE SIGNAL TRACE</div>
+                    {integrityDisplayTs ? (
+                      <div className="mt-0.5 text-[10px] font-mono text-slate-500">
+                        GI layer{' '}
+                        <time dateTime={integrityDisplayTs} title={isoHoverTitle(integrityDisplayTs)} className="text-slate-400">
+                          {formatRelativeAge(integrityDisplayTs)}
+                        </time>
+                        {laneByKey.integrity && laneByKey.integrity.state !== 'healthy' ? (
+                          <span className="text-amber-400/90"> · {laneByKey.integrity.state}</span>
+                        ) : null}
+                      </div>
+                    ) : null}
                   </div>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
@@ -724,8 +978,15 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
                       <option key={tab.key} value={tab.key}>{tab.label}</option>
                     ))}
                   </select>
+                  <button
+                    type="button"
+                    onClick={() => setShowLaneDiagnostics((v) => !v)}
+                    className="rounded-md border border-slate-600 bg-slate-950 px-2 py-1 text-[10px] font-mono uppercase tracking-[0.12em] text-slate-300 hover:border-cyan-500/40 hover:text-cyan-200"
+                  >
+                    {showLaneDiagnostics ? 'Hide lanes' : 'Lane diag'}
+                  </button>
                   <span className="flex items-center gap-2 rounded-md border border-slate-600 bg-slate-950 px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-slate-200">
-                    <span className={cn('h-2 w-2 rounded-full', runtimeBadge === 'online' ? 'bg-emerald-500' : 'bg-amber-500')} />
+                    <span className={cn('h-2 w-2 rounded-full', runtimeBadge === 'online' ? 'bg-emerald-500' : runtimeBadge === 'offline' ? 'bg-rose-500' : 'bg-amber-500')} />
                     {runtimeBadge.toUpperCase()}
                   </span>
                   <span className={cn(
@@ -765,6 +1026,16 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
                   );
                 })}
               </div>
+
+              {snapshotLanes.length > 0 ? (
+                <div className="space-y-1">
+                  <div className="text-[9px] font-mono uppercase tracking-[0.16em] text-slate-500">Snapshot lanes</div>
+                  <LaneHealthBadgeRow lanes={snapshotLanes} />
+                </div>
+              ) : null}
+              {showLaneDiagnostics && snapshotLanes.length > 0 ? (
+                <SnapshotDiagnostics lanes={snapshotLanes} snapshotAt={snapshotAt} deployment={snapshotDeployment} />
+              ) : null}
 
               <div className="border-t border-slate-800/80 pt-2">
                 <div className="flex items-center gap-3">
@@ -907,14 +1178,16 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
               <div className="text-[10px] font-mono uppercase tracking-[0.16em] text-slate-300">Command Surface</div>
               <div className="mt-1 text-lg font-semibold text-slate-100">{commandSurfaceTitle}</div>
               <div className="mt-2 text-sm text-slate-300">
-                GI stable. {allTripwires.length} tripwires active. {filteredEpicon.length} signals in feed. {allTripwires.filter((t) => t.severity.toLowerCase() === 'high').length} alerts.
+                GI {giScore.toFixed(3)} ({breaker.stage}). {allTripwires.length} tripwire(s). {filteredEpicon.length} EPICON in model.{' '}
+                {allTripwires.filter((t) => t.severity.toLowerCase() === 'high').length} high-severity.
               </div>
               <div className="mt-1 text-[11px] text-slate-400">
                 Breaker posture: <span className="font-mono uppercase text-slate-200">{breaker.stage}</span>
-                {selectedNav === 'ledger' ? ` · Ledger view: ${ledgerView} · Committed rows: ${committedAgentRowsThisCycle}` : ''}
+                {selectedNav === 'ledger' ? ` · Ledger: ${ledgerView} · committed rows this cycle: ${committedAgentRowsThisCycle}` : ''}
               </div>
+              <div className="mt-1 text-[10px] font-mono text-slate-500 leading-snug">{snapshotSummaryLine}</div>
               <div className="mt-2 text-[10px] font-mono uppercase tracking-[0.14em] text-sky-300">
-                TERMINAL LIVE · {selectedNav === 'ledger' ? `${ledgerView.toUpperCase()} VIEW ACTIVE` : 'AWAITING OPERATOR ACTION'}
+                COMMAND SHELL ACTIVE · {selectedNav === 'ledger' ? `${ledgerView.toUpperCase()} SUBVIEW` : chamberLabel}
               </div>
               <div className="mt-3 flex flex-wrap gap-2">
                 {commandSurfaceButtons.map((action) => (
@@ -1004,16 +1277,30 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
 
       <CommandSurface onSwitchChamber={setSelectedNav} />
 
-      <footer className="fixed bottom-0 left-0 right-0 z-40 flex h-7 items-center justify-between border-t border-slate-800 bg-slate-950 px-4 text-[10px] font-mono uppercase tracking-[0.14em] text-slate-400">
-        <div className="flex items-center gap-3">
-          <span className="flex items-center gap-1"><span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />System Ready</span>
-          <span>CPU 27%</span>
-          <span>MEM 61%</span>
+      <footer className="fixed bottom-0 left-0 right-0 z-40 flex min-h-7 flex-wrap items-center justify-between gap-x-3 gap-y-1 border-t border-slate-800 bg-slate-950 px-4 py-1 text-[10px] font-mono uppercase tracking-[0.14em] text-slate-400">
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="flex items-center gap-1">
+            <span className={cn('h-1.5 w-1.5 rounded-full', runtimeBadge === 'online' ? 'bg-emerald-400' : runtimeBadge === 'offline' ? 'bg-rose-400' : 'bg-amber-400')} />
+            Runtime {runtimeBadge}
+          </span>
+          {snapshotDeployment?.commit_sha ? (
+            <span title={snapshotDeployment.commit_sha} className="normal-case text-slate-500">
+              build {snapshotDeployment.commit_sha.slice(0, 7)}
+            </span>
+          ) : null}
         </div>
-        <div className="flex items-center gap-3">
-          <span>Latency {kvLatency ?? '--'}ms</span>
-          <span>Uptime {micro?.healthy ? '99.98%' : 'degraded'}</span>
-          <span>Node MOBIUS-US-EAST-1</span>
+        <div className="flex flex-wrap items-center gap-3">
+          <span>
+            KV {kvLatency != null ? `${kvLatency}ms` : '—'}
+            {laneByKey.kvHealth && laneByKey.kvHealth.state !== 'healthy' ? ` · ${laneByKey.kvHealth.state}` : ''}
+          </span>
+          <span>
+            Signals {micro?.timestamp ? formatRelativeAge(micro.timestamp) : '—'}
+            {laneByKey.signals && laneByKey.signals.state === 'stale' ? ' · stale' : ''}
+          </span>
+          <span className="max-w-[14rem] truncate normal-case text-slate-500" title={snapshotSummaryLine}>
+            {snapshotLanes.length ? `${snapshotLanes.filter((l) => l.state !== 'healthy' && l.state !== 'empty').length} lane warn` : 'lanes —'}
+          </span>
         </div>
       </footer>
     </div>

--- a/components/terminal/LaneHealthBadgeRow.tsx
+++ b/components/terminal/LaneHealthBadgeRow.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import type { SnapshotLaneSemanticState, SnapshotLaneState } from '@/lib/terminal/snapshotLanes';
+import { laneStateAbbrev } from '@/lib/terminal/snapshotLanes';
+
+function toneForState(state: SnapshotLaneSemanticState): string {
+  switch (state) {
+    case 'healthy':
+      return 'border-emerald-500/35 bg-emerald-500/10 text-emerald-200';
+    case 'degraded':
+      return 'border-amber-500/35 bg-amber-500/10 text-amber-200';
+    case 'stale':
+      return 'border-cyan-500/35 bg-cyan-500/10 text-cyan-200';
+    case 'empty':
+      return 'border-slate-600 bg-slate-800/60 text-slate-300';
+    case 'offline':
+      return 'border-rose-500/40 bg-rose-500/10 text-rose-200';
+    default:
+      return 'border-slate-600 bg-slate-800/50 text-slate-300';
+  }
+}
+
+function formatLaneTitle(lane: SnapshotLaneState): string {
+  const iso = lane.lastUpdated ?? '';
+  return iso ? `${lane.message}\nLast update: ${iso}` : lane.message;
+}
+
+/** Compact operator-facing snapshot lane matrix (C-274). */
+export default function LaneHealthBadgeRow({ lanes, className }: { lanes: SnapshotLaneState[]; className?: string }) {
+  if (lanes.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        'flex gap-1.5 overflow-x-auto pb-0.5',
+        className,
+      )}
+      role="list"
+      aria-label="Terminal snapshot lane health"
+    >
+      {lanes.map((lane) => (
+        <span
+          key={lane.key}
+          role="listitem"
+          title={formatLaneTitle(lane)}
+          className={cn(
+            'inline-flex shrink-0 items-center gap-1 rounded border px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-[0.08em]',
+            toneForState(lane.state),
+          )}
+        >
+          <span className="text-slate-400">{lane.key}</span>
+          <span className="font-semibold">{laneStateAbbrev(lane.state)}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** One-line summary of unhealthy lanes for command surface / debugging. */
+export function runtimeStateSummary(lanes: SnapshotLaneState[]): string {
+  const bad = lanes.filter((l) => l.state !== 'healthy' && l.state !== 'empty');
+  if (bad.length === 0) {
+    const empty = lanes.filter((l) => l.state === 'empty');
+    if (empty.length === 0) return 'All snapshot lanes healthy.';
+    return `Snapshot ok · ${empty.map((l) => `${l.key} empty`).join('; ')}`;
+  }
+  return bad.map((l) => `${l.key} ${l.state}`).join(' · ');
+}

--- a/components/terminal/SentimentMap.tsx
+++ b/components/terminal/SentimentMap.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react';
 import { cn } from '@/lib/utils';
 import type { AgentJournalEntry } from '@/lib/terminal/types';
+import { formatRelativeAge, isoHoverTitle } from '@/lib/terminal/freshnessDisplay';
 
 type DomainKey = 'civic' | 'environ' | 'financial' | 'narrative' | 'infrastructure' | 'institutional';
 
@@ -25,6 +26,8 @@ type DomainReading = {
 type Props = {
   cycleId: string;
   timestamp: string;
+  /** ISO timestamp for composite snapshot freshness */
+  sentimentTimestamp?: string | null;
   gi: number;
   overallSentiment: number | null;
   domains: DomainSnapshot[];
@@ -57,6 +60,7 @@ function barTone(value: number | null): string {
 export default function SentimentMap({
   cycleId,
   timestamp,
+  sentimentTimestamp,
   gi,
   overallSentiment,
   domains,
@@ -84,8 +88,16 @@ export default function SentimentMap({
       <div className="mb-3 border-b border-slate-800 pb-3">
         <div className="text-sm font-semibold uppercase tracking-[0.08em]">Global Sentiment Map</div>
         <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-400">
-          {cycleId} · {timestamp.slice(11, 16)} UTC · GI {gi.toFixed(3)} · Overall {overallSentiment === null ? '--' : overallSentiment.toFixed(3)}
+          {cycleId} · sample {timestamp.slice(11, 16)} UTC · GI {gi.toFixed(3)} · Overall {overallSentiment === null ? '--' : overallSentiment.toFixed(3)}
         </div>
+        {sentimentTimestamp ? (
+          <div className="mt-1 text-[10px] font-mono text-slate-500">
+            Composite updated{' '}
+            <time dateTime={sentimentTimestamp} title={isoHoverTitle(sentimentTimestamp)} className="text-cyan-300/90">
+              {formatRelativeAge(sentimentTimestamp)}
+            </time>
+          </div>
+        ) : null}
       </div>
 
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">

--- a/components/terminal/SnapshotDiagnostics.tsx
+++ b/components/terminal/SnapshotDiagnostics.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import type { SnapshotLaneState } from '@/lib/terminal/snapshotLanes';
+import { formatRelativeAge, isoHoverTitle } from '@/lib/terminal/freshnessDisplay';
+
+type DeploymentInfo = { commit_sha: string | null; environment: string | null };
+
+/** Compact debug block for operators — normalized lanes + deploy identity (C-274). */
+export default function SnapshotDiagnostics({
+  lanes,
+  snapshotAt,
+  deployment,
+  className,
+}: {
+  lanes: SnapshotLaneState[];
+  snapshotAt: string | null;
+  deployment: DeploymentInfo | null;
+  className?: string;
+}) {
+  return (
+    <div className={cn('rounded-md border border-slate-800 bg-slate-950/70 p-3 text-[11px]', className)}>
+      <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-slate-400">Runtime diagnostics</div>
+      <div className="mb-3 space-y-1 font-mono text-slate-300">
+        <div>
+          <span className="text-slate-500">Snapshot</span>{' '}
+          <time dateTime={snapshotAt ?? undefined} title={isoHoverTitle(snapshotAt ?? undefined)} className="text-sky-300">
+            {snapshotAt ? formatRelativeAge(snapshotAt) : '—'}
+          </time>
+        </div>
+        <div>
+          <span className="text-slate-500">Deploy</span>{' '}
+          <span className="text-slate-200">
+            {deployment?.commit_sha ? `${deployment.commit_sha.slice(0, 7)}` : 'local / unknown'}
+            {deployment?.environment ? ` · ${deployment.environment}` : ''}
+          </span>
+        </div>
+      </div>
+      <ul className="max-h-48 space-y-1 overflow-y-auto font-mono text-[10px] text-slate-400">
+        {lanes.map((lane) => (
+          <li key={lane.key} className="flex flex-wrap gap-x-2 border-b border-slate-800/80 py-1 last:border-0">
+            <span className="shrink-0 uppercase text-slate-500">{lane.key}</span>
+            <span
+              className={cn(
+                lane.state === 'healthy' && 'text-emerald-300',
+                lane.state === 'empty' && 'text-slate-400',
+                lane.state === 'stale' && 'text-cyan-300',
+                lane.state === 'degraded' && 'text-amber-300',
+                lane.state === 'offline' && 'text-rose-300',
+              )}
+            >
+              {lane.state}
+            </span>
+            <span className="min-w-0 flex-1 text-slate-500" title={lane.message}>
+              {lane.message}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/terminal/TerminalShellFallback.tsx
+++ b/components/terminal/TerminalShellFallback.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { cn } from '@/lib/utils';
 
 export default function TerminalShellFallback({
-  statusLabel = 'Booting Mobius Terminal...',
+  statusLabel = 'Client shell loading; waiting for integrity bundle…',
 }: {
   statusLabel?: string;
 }) {
@@ -128,9 +128,9 @@ export default function TerminalShellFallback({
 
         <main className="col-span-7 border-r border-slate-800 p-4 max-md:border-r-0">
           <div className="rounded-xl border border-dashed border-slate-800 bg-slate-900/40 p-4">
-            <div className="text-xs font-mono uppercase tracking-[0.18em] text-sky-300">Resilient shell</div>
+            <div className="text-xs font-mono uppercase tracking-[0.18em] text-sky-300">Offline layout preview</div>
             <div className="mt-2 text-sm text-slate-400">
-              If live data is delayed, the terminal still explains what it does, shows freshness placeholders, and signals degraded or disconnected states instead of rendering a blank loading screen.
+              This surface is a static shell when the full terminal bundle is not mounted. On the live app, `/api/terminal/snapshot` drives lane health; use the production `/terminal` route for operator truth.
             </div>
           </div>
 
@@ -146,7 +146,7 @@ export default function TerminalShellFallback({
             <div className="text-xs font-mono uppercase tracking-[0.18em] text-slate-500">Inspector fallback</div>
             <div className="mt-2 h-56 rounded-lg border border-slate-800 bg-slate-950" />
             <div className="mt-3 text-xs text-slate-500">
-              Degraded mode keeps the operator context visible while live hydration completes.
+              Partial outages should mark specific lanes (EPICON, journal, sentiment, runtime) instead of blanking the whole console.
             </div>
           </div>
         </section>

--- a/lib/terminal/freshnessDisplay.ts
+++ b/lib/terminal/freshnessDisplay.ts
@@ -1,0 +1,23 @@
+/** Shared relative / ISO freshness strings for terminal surfaces (C-274). */
+
+export function formatRelativeAge(iso: string | null | undefined, nowMs = Date.now()): string {
+  if (!iso) return '—';
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return iso;
+  const sec = Math.floor((nowMs - t) / 1000);
+  if (sec < 0) return 'just now';
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 48) return `${hr}h ago`;
+  const d = Math.floor(hr / 24);
+  return `${d}d ago`;
+}
+
+export function isoHoverTitle(iso: string | null | undefined): string | undefined {
+  if (!iso) return undefined;
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return iso;
+  return new Date(t).toISOString();
+}

--- a/lib/terminal/snapshotLanes.ts
+++ b/lib/terminal/snapshotLanes.ts
@@ -1,0 +1,723 @@
+/**
+ * C-274: Normalized terminal snapshot lane health — single source of truth for
+ * `/api/terminal/snapshot` leaves and client render decisions.
+ */
+
+export type SnapshotLaneKey =
+  | 'integrity'
+  | 'signals'
+  | 'kvHealth'
+  | 'agents'
+  | 'epicon'
+  | 'echo'
+  | 'journal'
+  | 'sentiment'
+  | 'runtime'
+  | 'promotion'
+  | 'eve';
+
+export type SnapshotLaneSemanticState = 'healthy' | 'degraded' | 'offline' | 'stale' | 'empty';
+
+export type FallbackMode = 'live' | 'cached' | 'empty' | 'offline';
+
+export type SnapshotLaneState = {
+  key: SnapshotLaneKey;
+  ok: boolean;
+  state: SnapshotLaneSemanticState;
+  statusCode: number | null;
+  message: string;
+  lastUpdated: string | null;
+  fallbackMode: FallbackMode;
+};
+
+export type SnapshotLeaf = {
+  ok: boolean;
+  status: number;
+  data: unknown;
+  error: string | null;
+};
+
+const STALE_MS_SIGNALS = 5 * 60 * 1000;
+const STALE_MS_SENTIMENT = 10 * 60 * 1000;
+const STALE_MS_ECHO_INGEST = 2 * 60 * 60 * 1000;
+
+export const SNAPSHOT_LANE_KEYS: readonly SnapshotLaneKey[] = [
+  'integrity',
+  'signals',
+  'kvHealth',
+  'agents',
+  'epicon',
+  'echo',
+  'journal',
+  'sentiment',
+  'runtime',
+  'promotion',
+  'eve',
+] as const;
+
+function asRecord(data: unknown): Record<string, unknown> | null {
+  if (!data || typeof data !== 'object') return null;
+  return data as Record<string, unknown>;
+}
+
+function parseIsoMs(value: unknown): number | null {
+  if (typeof value !== 'string') return null;
+  const t = new Date(value).getTime();
+  return Number.isFinite(t) ? t : null;
+}
+
+function ageMs(lastUpdated: string | null): number | null {
+  if (!lastUpdated) return null;
+  const t = new Date(lastUpdated).getTime();
+  if (!Number.isFinite(t)) return null;
+  return Date.now() - t;
+}
+
+function classifyHttpFailure(status: number, error: string | null): { state: SnapshotLaneSemanticState; message: string } {
+  if (status === 401 || status === 403) {
+    return { state: 'offline', message: error ?? 'Lane blocked (auth or config)' };
+  }
+  if (status === 408 || status === 504) {
+    return { state: 'degraded', message: error ?? 'Upstream timeout' };
+  }
+  if (status >= 500) {
+    return { state: 'offline', message: error ?? 'Upstream error' };
+  }
+  if (status === 404) {
+    return { state: 'offline', message: error ?? 'Lane endpoint not found' };
+  }
+  return { state: 'degraded', message: error ?? `HTTP ${status}` };
+}
+
+/** Best-effort timestamp for a lane from normalized API payloads */
+export function extractLaneLastUpdated(key: SnapshotLaneKey, data: unknown): string | null {
+  const row = asRecord(data);
+  if (!row) return null;
+
+  const pick = (...keys: string[]): string | null => {
+    for (const k of keys) {
+      const v = row[k];
+      if (typeof v === 'string' && v.trim()) return v.trim();
+    }
+    return null;
+  };
+
+  switch (key) {
+    case 'integrity':
+      return pick('timestamp');
+    case 'signals':
+      return pick('timestamp');
+    case 'kvHealth':
+      return pick('timestamp');
+    case 'agents':
+      return pick('timestamp', 'asOf');
+    case 'epicon': {
+      const summary = asRecord(row.summary);
+      const hb = summary && typeof summary.lastHeartbeat === 'string' ? summary.lastHeartbeat : null;
+      return hb ?? pick('timestamp');
+    }
+    case 'echo': {
+      const status = asRecord(row.status);
+      return status ? (typeof status.lastIngest === 'string' ? status.lastIngest : null) : pick('timestamp');
+    }
+    case 'journal':
+      return pick('timestamp', 'asOf', 'lastArchiveWriteAt');
+    case 'sentiment':
+      return pick('timestamp', 'cachedAt');
+    case 'runtime':
+      return pick('freshAt', 'last_run', 'lastRun', 'timestamp');
+    case 'promotion': {
+      const diag = asRecord(row.diagnostics);
+      const d = diag && typeof diag.last_promotion_run_at === 'string' ? diag.last_promotion_run_at : null;
+      return d ?? pick('timestamp');
+    }
+    case 'eve':
+      return pick('timestamp');
+    default:
+      return null;
+  }
+}
+
+function normalizeEpiconLane(leaf: SnapshotLeaf): SnapshotLaneState {
+  const lastUpdated = extractLaneLastUpdated('epicon', leaf.data);
+  if (!leaf.ok) {
+    const { state, message } = classifyHttpFailure(leaf.status, leaf.error);
+    return {
+      key: 'epicon',
+      ok: false,
+      state,
+      statusCode: leaf.status,
+      message,
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const row = asRecord(leaf.data);
+  const innerOk = row?.ok === true;
+  if (!innerOk) {
+    return {
+      key: 'epicon',
+      ok: false,
+      state: 'degraded',
+      statusCode: leaf.status,
+      message: typeof row?.error === 'string' ? row.error : 'EPICON feed returned not ok',
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const items = row.items;
+  const count = Array.isArray(items) ? items.length : typeof row.count === 'number' ? row.count : 0;
+  const committed =
+    Array.isArray(items)
+      ? items.filter((item) => {
+          const r = asRecord(item);
+          return String(r?.status ?? '').toLowerCase() === 'committed';
+        }).length
+      : 0;
+  if (count === 0) {
+    return {
+      key: 'epicon',
+      ok: true,
+      state: 'empty',
+      statusCode: leaf.status,
+      message: 'EPICON feed returned no rows (empty dataset)',
+      lastUpdated,
+      fallbackMode: 'empty',
+    };
+  }
+  if (committed === 0) {
+    return {
+      key: 'epicon',
+      ok: true,
+      state: 'empty',
+      statusCode: leaf.status,
+      message: 'No committed EPICON rows in current feed',
+      lastUpdated,
+      fallbackMode: 'empty',
+    };
+  }
+  return {
+    key: 'epicon',
+    ok: true,
+    state: 'healthy',
+    statusCode: leaf.status,
+    message: `${committed} committed row(s) in feed`,
+    lastUpdated,
+    fallbackMode: 'live',
+  };
+}
+
+function normalizeJournalLane(leaf: SnapshotLeaf): SnapshotLaneState {
+  const lastUpdated = extractLaneLastUpdated('journal', leaf.data);
+  if (!leaf.ok) {
+    const { state, message } = classifyHttpFailure(leaf.status, leaf.error);
+    return {
+      key: 'journal',
+      ok: false,
+      state,
+      statusCode: leaf.status,
+      message,
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const row = asRecord(leaf.data);
+  if (row?.ok !== true) {
+    return {
+      key: 'journal',
+      ok: false,
+      state: row?.ok === false && leaf.status === 200 ? 'offline' : 'degraded',
+      statusCode: leaf.status,
+      message: typeof row?.error === 'string' ? row.error : 'Journal API not ok',
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const entries = row.entries;
+  const count = Array.isArray(entries) ? entries.length : typeof row.count === 'number' ? row.count : 0;
+  const merged = Boolean(row.merged_from_archive);
+  const archiveError = typeof row.archive_error === 'string' ? row.archive_error : null;
+  const archiveStale = Boolean(row.archive_stale);
+
+  let state: SnapshotLaneSemanticState = 'healthy';
+  let message = `${count} journal entr${count === 1 ? 'y' : 'ies'}${merged ? ' · hot + archive' : ' (hot lane)'}`;
+  let fallbackMode: FallbackMode = 'live';
+
+  if (count === 0) {
+    state = 'empty';
+    message = 'No journal rows for current filter';
+    fallbackMode = 'empty';
+  }
+  if (archiveError) {
+    state = 'degraded';
+    message = `Archive unreachable (${archiveError}); showing hot-lane only`;
+    fallbackMode = 'cached';
+  } else if (archiveStale) {
+    state = 'stale';
+    message = 'Archive merge may be stale; hot lane is authoritative';
+    fallbackMode = 'cached';
+  }
+
+  return {
+    key: 'journal',
+    ok: true,
+    state,
+    statusCode: leaf.status,
+    message,
+    lastUpdated,
+    fallbackMode,
+  };
+}
+
+function normalizeSentimentLane(leaf: SnapshotLeaf): SnapshotLaneState {
+  const lastUpdated = extractLaneLastUpdated('sentiment', leaf.data);
+  if (!leaf.ok) {
+    const { state, message } = classifyHttpFailure(leaf.status, leaf.error);
+    return {
+      key: 'sentiment',
+      ok: false,
+      state,
+      statusCode: leaf.status,
+      message,
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const row = asRecord(leaf.data);
+  if (row?.ok !== true) {
+    return {
+      key: 'sentiment',
+      ok: false,
+      state: 'degraded',
+      statusCode: leaf.status,
+      message: typeof row?.error === 'string' ? row.error : 'Sentiment composite not ok',
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const age = ageMs(lastUpdated);
+  let state: SnapshotLaneSemanticState = 'healthy';
+  if (age !== null && age > STALE_MS_SENTIMENT) state = 'stale';
+
+  const domains = row.domains;
+  const domainCount = Array.isArray(domains) ? domains.length : 0;
+  const nullScores =
+    Array.isArray(domains)
+      ? domains.filter((d) => asRecord(d)?.score === null || asRecord(d)?.score === undefined).length
+      : 0;
+
+  let message = `Composite · ${domainCount} domain(s)`;
+  if (state === 'stale') message = `Snapshot stale (${Math.round((age ?? 0) / 60000)}m); ${message.toLowerCase()}`;
+  if (domainCount > 0 && nullScores === domainCount) {
+    state = state === 'healthy' ? 'empty' : state;
+    message = 'All domain scores null (upstream sparse)';
+  }
+
+  return {
+    key: 'sentiment',
+    ok: true,
+    state,
+    statusCode: leaf.status,
+    message,
+    lastUpdated,
+    fallbackMode: state === 'stale' ? 'cached' : 'live',
+  };
+}
+
+function normalizeRuntimeLane(leaf: SnapshotLeaf): SnapshotLaneState {
+  const lastUpdated = extractLaneLastUpdated('runtime', leaf.data);
+  if (!leaf.ok) {
+    const { state, message } = classifyHttpFailure(leaf.status, leaf.error);
+    return {
+      key: 'runtime',
+      ok: false,
+      state,
+      statusCode: leaf.status,
+      message,
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const row = asRecord(leaf.data);
+  if (row?.ok !== true) {
+    return {
+      key: 'runtime',
+      ok: false,
+      state: 'offline',
+      statusCode: leaf.status,
+      message: typeof row?.error === 'string' ? row.error : 'Runtime status not ok',
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const degraded = Boolean(row.degraded);
+  const freshness = asRecord(row.freshness);
+  const status = typeof freshness?.status === 'string' ? freshness.status : '';
+  const seconds = typeof freshness?.seconds === 'number' ? freshness.seconds : null;
+
+  let state: SnapshotLaneSemanticState = 'healthy';
+  if (status === 'stale' || (seconds !== null && seconds > 3600)) state = 'stale';
+  if (status === 'degraded' || degraded) state = 'degraded';
+
+  const source = typeof row.source === 'string' ? row.source : '';
+  let message = `Runtime ${source || 'status'} · freshness ${status || 'unknown'}`;
+  if (row.mock === true || source === 'mock') {
+    message = 'GitHub heartbeat unavailable; mock envelope active';
+    state = state === 'healthy' ? 'degraded' : state;
+  }
+
+  return {
+    key: 'runtime',
+    ok: true,
+    state,
+    statusCode: leaf.status,
+    message,
+    lastUpdated,
+    fallbackMode: state === 'stale' || state === 'degraded' ? 'cached' : 'live',
+  };
+}
+
+function normalizeIntegrityLane(leaf: SnapshotLeaf): SnapshotLaneState {
+  const lastUpdated = extractLaneLastUpdated('integrity', leaf.data);
+  if (!leaf.ok) {
+    const { state, message } = classifyHttpFailure(leaf.status, leaf.error);
+    return {
+      key: 'integrity',
+      ok: false,
+      state,
+      statusCode: leaf.status,
+      message,
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const row = asRecord(leaf.data);
+  if (row?.ok !== true) {
+    return {
+      key: 'integrity',
+      ok: false,
+      state: 'degraded',
+      statusCode: leaf.status,
+      message: 'Integrity payload missing ok',
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const degraded = Boolean(row.degraded);
+  const source = typeof row.source === 'string' ? row.source : '';
+  let state: SnapshotLaneSemanticState = degraded || source === 'mock' ? 'degraded' : 'healthy';
+  if (source === 'cached') state = 'stale';
+  const message =
+    degraded || source === 'mock'
+      ? `GI live with degradation (source: ${source || 'unknown'})`
+      : source === 'cached'
+        ? 'GI from Redis cache (stale risk)'
+        : `Integrity nominal (source: ${source || 'live'})`;
+
+  return {
+    key: 'integrity',
+    ok: true,
+    state,
+    statusCode: leaf.status,
+    message,
+    lastUpdated,
+    fallbackMode: source === 'cached' ? 'cached' : 'live',
+  };
+}
+
+function normalizeSignalsLane(leaf: SnapshotLeaf): SnapshotLaneState {
+  const lastUpdated = extractLaneLastUpdated('signals', leaf.data);
+  if (!leaf.ok) {
+    const { state, message } = classifyHttpFailure(leaf.status, leaf.error);
+    return {
+      key: 'signals',
+      ok: false,
+      state,
+      statusCode: leaf.status,
+      message,
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const row = asRecord(leaf.data);
+  if (row?.ok !== true) {
+    return {
+      key: 'signals',
+      ok: false,
+      state: 'degraded',
+      statusCode: leaf.status,
+      message: typeof row?.error === 'string' ? row.error : 'Micro-signals not ok',
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const age = ageMs(lastUpdated);
+  let state: SnapshotLaneSemanticState = 'healthy';
+  if (age !== null && age > STALE_MS_SIGNALS) state = 'stale';
+  const healthy = row.healthy === true;
+  if (!healthy) state = state === 'healthy' ? 'degraded' : state;
+
+  return {
+    key: 'signals',
+    ok: true,
+    state,
+    statusCode: leaf.status,
+    message: healthy ? 'Micro-agent sweep healthy' : 'Micro-agent sweep reported unhealthy',
+    lastUpdated,
+    fallbackMode: state === 'stale' ? 'cached' : 'live',
+  };
+}
+
+function normalizeKvLane(leaf: SnapshotLeaf): SnapshotLaneState {
+  const lastUpdated = extractLaneLastUpdated('kvHealth', leaf.data);
+  if (!leaf.ok) {
+    const { state, message } = classifyHttpFailure(leaf.status, leaf.error);
+    return {
+      key: 'kvHealth',
+      ok: false,
+      state,
+      statusCode: leaf.status,
+      message,
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const row = asRecord(leaf.data);
+  const available = row?.ok === true;
+  return {
+    key: 'kvHealth',
+    ok: true,
+    state: available ? 'healthy' : 'degraded',
+    statusCode: leaf.status,
+    message: available ? 'KV reachable' : 'KV unavailable or misconfigured',
+    lastUpdated,
+    fallbackMode: available ? 'live' : 'offline',
+  };
+}
+
+function normalizeAgentsLane(leaf: SnapshotLeaf): SnapshotLaneState {
+  const lastUpdated = extractLaneLastUpdated('agents', leaf.data);
+  if (!leaf.ok) {
+    const { state, message } = classifyHttpFailure(leaf.status, leaf.error);
+    return {
+      key: 'agents',
+      ok: false,
+      state,
+      statusCode: leaf.status,
+      message,
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const row = asRecord(leaf.data);
+  if (row?.ok !== true) {
+    return {
+      key: 'agents',
+      ok: false,
+      state: 'degraded',
+      statusCode: leaf.status,
+      message: 'Agent status not ok',
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const agents = row.agents;
+  const n = Array.isArray(agents) ? agents.length : 0;
+  return {
+    key: 'agents',
+    ok: true,
+    state: n === 0 ? 'empty' : 'healthy',
+    statusCode: leaf.status,
+    message: n === 0 ? 'Roster empty' : `${n} agent(s) in roster`,
+    lastUpdated,
+    fallbackMode: n === 0 ? 'empty' : 'live',
+  };
+}
+
+function normalizeEchoLane(leaf: SnapshotLeaf): SnapshotLaneState {
+  const lastUpdated = extractLaneLastUpdated('echo', leaf.data);
+  if (!leaf.ok) {
+    const { state, message } = classifyHttpFailure(leaf.status, leaf.error);
+    return {
+      key: 'echo',
+      ok: false,
+      state,
+      statusCode: leaf.status,
+      message,
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const row = asRecord(leaf.data);
+  if (!row) {
+    return {
+      key: 'echo',
+      ok: false,
+      state: 'offline',
+      statusCode: leaf.status,
+      message: 'ECHO payload missing',
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const status = asRecord(row.status);
+  const lastIngest = status && typeof status.lastIngest === 'string' ? status.lastIngest : null;
+  const ingestAge = ageMs(lastIngest);
+  let state: SnapshotLaneSemanticState = 'healthy';
+  if (ingestAge !== null && ingestAge > STALE_MS_ECHO_INGEST) state = 'stale';
+
+  const epicon = row.epicon;
+  const n = Array.isArray(epicon) ? epicon.length : 0;
+  let message = `ECHO feed · ${n} epicon item(s)`;
+  if (state === 'stale') message = `Ingest stale; ${message.toLowerCase()}`;
+
+  return {
+    key: 'echo',
+    ok: true,
+    state,
+    statusCode: leaf.status,
+    message,
+    lastUpdated: lastIngest ?? lastUpdated,
+    fallbackMode: state === 'stale' ? 'cached' : 'live',
+  };
+}
+
+function normalizePromotionLane(leaf: SnapshotLeaf): SnapshotLaneState {
+  const lastUpdated = extractLaneLastUpdated('promotion', leaf.data);
+  if (!leaf.ok) {
+    const { state, message } = classifyHttpFailure(leaf.status, leaf.error);
+    return {
+      key: 'promotion',
+      ok: false,
+      state,
+      statusCode: leaf.status,
+      message,
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const row = asRecord(leaf.data);
+  if (row?.ok !== true) {
+    return {
+      key: 'promotion',
+      ok: false,
+      state: 'degraded',
+      statusCode: leaf.status,
+      message: 'Promotion status not ok',
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const counters = asRecord(row.counters);
+  const pending = typeof counters?.pending_promotable_count === 'number' ? counters.pending_promotable_count : 0;
+  return {
+    key: 'promotion',
+    ok: true,
+    state: 'healthy',
+    statusCode: leaf.status,
+    message: `Promotion lane · ${pending} pending promotable`,
+    lastUpdated,
+    fallbackMode: 'live',
+  };
+}
+
+function normalizeEveLane(leaf: SnapshotLeaf): SnapshotLaneState {
+  const lastUpdated = extractLaneLastUpdated('eve', leaf.data);
+  if (!leaf.ok) {
+    const { state, message } = classifyHttpFailure(leaf.status, leaf.error);
+    return {
+      key: 'eve',
+      ok: false,
+      state,
+      statusCode: leaf.status,
+      message,
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const row = asRecord(leaf.data);
+  if (!row) {
+    return {
+      key: 'eve',
+      ok: false,
+      state: 'offline',
+      statusCode: leaf.status,
+      message: 'EVE payload missing',
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const inSync = row.inSync === true;
+  const status = typeof row.status === 'string' ? row.status : '';
+  let state: SnapshotLaneSemanticState = 'healthy';
+  if (!inSync || status === 'drift_detected') state = 'degraded';
+
+  return {
+    key: 'eve',
+    ok: true,
+    state,
+    statusCode: leaf.status,
+    message: inSync ? 'Cycle engine in sync with transform' : 'Cycle drift: epoch vs transform mismatch',
+    lastUpdated,
+    fallbackMode: 'live',
+  };
+}
+
+export function normalizeSnapshotLane(key: SnapshotLaneKey, leaf: SnapshotLeaf): SnapshotLaneState {
+  switch (key) {
+    case 'integrity':
+      return normalizeIntegrityLane(leaf);
+    case 'signals':
+      return normalizeSignalsLane(leaf);
+    case 'kvHealth':
+      return normalizeKvLane(leaf);
+    case 'agents':
+      return normalizeAgentsLane(leaf);
+    case 'epicon':
+      return normalizeEpiconLane(leaf);
+    case 'echo':
+      return normalizeEchoLane(leaf);
+    case 'journal':
+      return normalizeJournalLane(leaf);
+    case 'sentiment':
+      return normalizeSentimentLane(leaf);
+    case 'runtime':
+      return normalizeRuntimeLane(leaf);
+    case 'promotion':
+      return normalizePromotionLane(leaf);
+    case 'eve':
+      return normalizeEveLane(leaf);
+    default:
+      return {
+        key,
+        ok: leaf.ok,
+        state: leaf.ok ? 'healthy' : 'offline',
+        statusCode: leaf.status,
+        message: leaf.error ?? (leaf.ok ? 'ok' : 'failed'),
+        lastUpdated: null,
+        fallbackMode: leaf.ok ? 'live' : 'offline',
+      };
+  }
+}
+
+export function normalizeAllSnapshotLanes(leaves: Record<SnapshotLaneKey, SnapshotLeaf>): SnapshotLaneState[] {
+  return SNAPSHOT_LANE_KEYS.map((key) => normalizeSnapshotLane(key, leaves[key]));
+}
+
+/** Short label for compact UI */
+export function laneStateAbbrev(state: SnapshotLaneSemanticState): string {
+  switch (state) {
+    case 'healthy':
+      return 'ok';
+    case 'degraded':
+      return 'deg';
+    case 'offline':
+      return 'off';
+    case 'stale':
+      return 'stale';
+    case 'empty':
+      return 'empty';
+    default:
+      return '?';
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       next:
         specifier: ^15.1.0
         version: 15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-auth:
+        specifier: ^5.0.0-beta.30
+        version: 5.0.0-beta.30(next@15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -66,6 +69,20 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@auth/core@0.41.0':
+    resolution: {integrity: sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^6.8.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -306,6 +323,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -586,6 +606,9 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -644,6 +667,22 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  next-auth@5.0.0-beta.30:
+    resolution: {integrity: sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      next: ^14.0.0-0 || ^15.0.0 || ^16.0.0
+      nodemailer: ^7.0.7
+      react: ^18.2.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
   next@15.5.14:
     resolution: {integrity: sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
@@ -671,6 +710,9 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  oauth4webapi@3.8.5:
+    resolution: {integrity: sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -752,6 +794,14 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -912,6 +962,14 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@auth/core@0.41.0':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.2.2
+      oauth4webapi: 3.8.5
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
   '@babel/runtime@7.29.2': {}
 
   '@emnapi/runtime@1.9.1':
@@ -1067,6 +1125,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@panva/hkdf@1.2.1': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -1310,6 +1370,8 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  jose@6.2.2: {}
+
   js-tokens@4.0.0: {}
 
   lilconfig@3.1.3: {}
@@ -1355,6 +1417,12 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  next-auth@5.0.0-beta.30(next@15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@auth/core': 0.41.0
+      next: 15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+
   next@15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 15.5.14
@@ -1381,6 +1449,8 @@ snapshots:
   node-releases@2.0.36: {}
 
   normalize-path@3.0.0: {}
+
+  oauth4webapi@3.8.5: {}
 
   object-assign@4.1.1: {}
 
@@ -1440,6 +1510,12 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
 
   prop-types@15.8.1:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

- Normalizes every `/api/terminal/snapshot` leaf into a single `SnapshotLaneState` model (`healthy` | `degraded` | `offline` | `stale` | `empty`) with `fallbackMode`, HTTP status, message, and `lastUpdated`.
- Extends the snapshot JSON with `lanes[]`, `deployment.commit_sha` / `environment` (from `VERCEL_*` when present), and fixes aggregate `ok` so empty-but-valid lanes do not mark the whole snapshot failed.
- Surfaces lane health in the terminal header (compact badge row + optional **Lane diag** panel) and adds relative/ISO freshness on GI, stat cards, sentiment composite, command surface summary, and footer.
- Makes degradation **panel-specific**: `PanelLaneNotice` per chamber; snapshot polling keeps last-good EPICON / journal / sentiment / micro / roster when `fallbackMode === 'cached'`.
- Ledger chamber: **Events** / **Journals** / **Runtime** tabs — Runtime shows promotion counters and lane notices for promotion, runtime heartbeat, and EVE cycle sync.
- Journal GET: `merged_from_archive`, `archive_error`, `archive_stale`, `archive_fetched_count` for archive vs hot-lane truth.
- Watchdog route: C-274 note on daily cron vs desired heartbeat cadence (no schedule change). `TerminalShellFallback` copy is explicit instead of “booting / resilient shell”.

## Production parity (Task 1)

This environment cannot read Vercel’s live deployment registry. **After merge**, compare public `GET /api/terminal/snapshot` → `deployment.commit_sha` to `main` on GitHub (and Vercel deployment list). If they diverge, the mismatch is deploy pipeline / branch config, not this diff.

## Tests

- `pnpm exec tsc --noEmit`
- `pnpm build`

## Screenshots

Screenshots of live `/terminal` and lane health should be captured from the deployed preview after this PR builds (not available from this agent run).

---

*Cycle: C-274 — optimize operator truth, not illusion.*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56428333-1b52-4945-9258-7f4e98328826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56428333-1b52-4945-9258-7f4e98328826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

