### PR TITLE
fix(epicon): terminal KV feed reads Vercel KV env vars

### DIFF
--- a/app/api/epicon/feed/route.ts
+++ b/app/api/epicon/feed/route.ts
@@ -70,8 +70,8 @@ type GitHubCommit = {
 };
 
 function getRedisClient(): Redis | null {
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
   if (!url || !token) return null;
 
   try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The EPICON feed route (`/api/epicon/feed`) built its Upstash Redis client using only `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN`. Vercel KV and the rest of the stack (including `lib/kv/store.ts` and `writeEpiconEntry` in `lib/epicon-writer.ts`) prefer `KV_REST_API_URL` / `KV_REST_API_TOKEN`.

On deployments where only the Vercel KV variables are set, ledger writes could succeed while the feed route treated Redis as unconfigured, skipped `lrange`, and reported `sources.kv: 0`—so the terminal showed no KV-sourced entries.

## Change

- Align `getRedisClient()` in `app/api/epicon/feed/route.ts` with `lib/kv/store.ts`: `KV_REST_API_*` first, then `UPSTASH_REDIS_REST_*`.

## Tests

- `pnpm exec tsc --no-store` — pass
- `pnpm lint` — blocked by interactive Next.js ESLint migration prompt in this environment (no ESLint config migration run)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5537c39-5cae-4776-af46-3f62708d7167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5537c39-5cae-4776-af46-3f62708d7167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

