### PR TITLE
feat(substrate): agent journal write/read via Mobius-Substrate journals/ [C-274]

### DIFF
--- a/.github/workflows/anti-nuke.yml
+++ b/.github/workflows/anti-nuke.yml
@@ -1,3 +1,5 @@
+# STEP 0 — Read shared world state (C-274): GET https://mobius-civic-ai-terminal.vercel.app/api/terminal/snapshot
+# (cycle, gi, anomalies, echo/epicon, sentiment, substrate.agents / substrate.latest). Do not duplicate USGS/CoinGecko/EONET fetches.
 # ═══════════════════════════════════════════════════════════════════════════════
 # Anti-Nuke Guardrail — Civic AI Terminal
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -1,3 +1,5 @@
+# STEP 0 — Read shared world state (C-274): GET https://mobius-civic-ai-terminal.vercel.app/api/terminal/snapshot
+# (cycle, gi, anomalies, echo/epicon, sentiment, substrate.agents / substrate.latest). Do not duplicate USGS/CoinGecko/EONET fetches.
 name: Mobius Catalog Update
 
 on:

--- a/.github/workflows/epicon-kv-sync.yml
+++ b/.github/workflows/epicon-kv-sync.yml
@@ -1,3 +1,5 @@
+# STEP 0 — Read shared world state (C-274): GET https://mobius-civic-ai-terminal.vercel.app/api/terminal/snapshot
+# (cycle, gi, anomalies, echo/epicon, sentiment, substrate.agents / substrate.latest). Do not duplicate USGS/CoinGecko/EONET fetches.
 # EPICON KV Sync — short-cycle keepalive for terminal UI KV reads
 # Class B at runtime: POST seed-kv + GET kv/health only (no repo writes).
 # Schedule: every 15 minutes UTC

--- a/.github/workflows/gi-gate.yml
+++ b/.github/workflows/gi-gate.yml
@@ -1,3 +1,5 @@
+# STEP 0 — Read shared world state (C-274): GET https://mobius-civic-ai-terminal.vercel.app/api/terminal/snapshot
+# (cycle, gi, anomalies, echo/epicon, sentiment, substrate.agents / substrate.latest). Do not duplicate USGS/CoinGecko/EONET fetches.
 # ═══════════════════════════════════════════════════════════════════════════════
 # GI Gate — Integrity Threshold Enforcement
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/.github/workflows/sentinel-heartbeat.yml
+++ b/.github/workflows/sentinel-heartbeat.yml
@@ -1,3 +1,5 @@
+# STEP 0 — Read shared world state (C-274): GET https://mobius-civic-ai-terminal.vercel.app/api/terminal/snapshot
+# (cycle, gi, anomalies, echo/epicon, sentiment, substrate.agents / substrate.latest). Do not duplicate USGS/CoinGecko/EONET fetches.
 # ═══════════════════════════════════════════════════════════════════════════════
 # Sentinel Heartbeat — Agent Health Attestation
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/.github/workflows/sentinel-review.yml
+++ b/.github/workflows/sentinel-review.yml
@@ -1,3 +1,5 @@
+# STEP 0 — Read shared world state (C-274): GET https://mobius-civic-ai-terminal.vercel.app/api/terminal/snapshot
+# (cycle, gi, anomalies, echo/epicon, sentiment, substrate.agents / substrate.latest). Do not duplicate USGS/CoinGecko/EONET fetches.
 # ═══════════════════════════════════════════════════════════════════════════════
 # Sentinel Review (AUREA + ATLAS) — Civic AI Terminal
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -3,8 +3,12 @@ import { getServiceAuthError } from '@/lib/security/serviceAuth';
 import { appendJournalLaneEntry, getJournalRedisClient } from '@/lib/agents/journalLane';
 import { writeToSubstrate } from '@/lib/substrate/client';
 import { getOperatorSession } from '@/lib/auth/session';
-import { writeJournalToSubstrate, type JournalEntry as SubstrateGithubJournalEntry } from '@/lib/substrate/github-journal';
-import { readAgentJournal, readAllAgentJournals } from '@/lib/substrate/github-reader';
+import {
+  writeJournalToSubstrate,
+  type SubstrateJournalEntry,
+  type SubstrateJournalWriteInput,
+} from '@/lib/substrate/github-journal';
+import { readAgentJournals } from '@/lib/substrate/github-reader';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -74,27 +78,7 @@ function asOptionalTags(input: unknown): string[] | undefined {
   return tags.length > 0 ? tags : undefined;
 }
 
-function toSubstrateGithubJournalEntry(entry: AgentJournalEntry): SubstrateGithubJournalEntry {
-  return {
-    id: entry.id,
-    agent: entry.agent,
-    agentOrigin: entry.agentOrigin,
-    cycle: entry.cycle,
-    scope: entry.scope,
-    category: entry.category,
-    severity: entry.severity,
-    observation: entry.observation,
-    inference: entry.inference,
-    recommendation: entry.recommendation,
-    confidence: entry.confidence,
-    derivedFrom: entry.derivedFrom,
-    source: entry.source,
-    tags: entry.tags ?? [],
-    status: entry.status,
-  };
-}
-
-function substrateRecordToAgentEntry(row: SubstrateGithubJournalEntry & { id: string; timestamp: string }): AgentJournalEntry | null {
+function substrateRecordToAgentEntry(row: SubstrateJournalEntry): AgentJournalEntry | null {
   const id = asString(row.id);
   const agent = asString(row.agent).toUpperCase();
   const cycle = asString(row.cycle);
@@ -103,7 +87,7 @@ function substrateRecordToAgentEntry(row: SubstrateGithubJournalEntry & { id: st
   const observation = asString(row.observation);
   const inference = asString(row.inference);
   const recommendation = asString(row.recommendation);
-  const status = asString(row.status) as AgentJournalStatus;
+  const status = (asString(row.status) || 'committed') as AgentJournalStatus;
   const category = asString(row.category) as AgentJournalCategory;
   const severity = asString(row.severity) as AgentJournalSeverity;
   const agentOrigin = asString(row.agentOrigin).toUpperCase();
@@ -302,26 +286,28 @@ export async function GET(request: NextRequest) {
 
   let substrateError: string | null = null;
   let substrateEntries: AgentJournalEntry[] = [];
-  try {
-    if (agentFilter) {
-      const rows = await readAgentJournal(agentFilter.toLowerCase(), 10);
+  if (agentFilter) {
+    try {
+      const substrateRead = readAgentJournals(agentFilter.toLowerCase(), 10);
+      const rows = await Promise.race([
+        substrateRead,
+        new Promise<SubstrateJournalEntry[]>((_, reject) =>
+          setTimeout(() => reject(new Error('substrate_timeout')), 5000),
+        ),
+      ]);
       for (const row of rows) {
         const mapped = substrateRecordToAgentEntry(row);
         if (mapped) substrateEntries.push(mapped);
       }
-    } else {
-      const byAgent = await readAllAgentJournals(3);
-      for (const rows of Object.values(byAgent)) {
-        for (const row of rows) {
-          const mapped = substrateRecordToAgentEntry(row);
-          if (mapped) substrateEntries.push(mapped);
-        }
-      }
+    } catch (error) {
+      console.error('[journal] substrate read error', error);
+      substrateError = error instanceof Error ? error.message : 'substrate read failed';
     }
-  } catch (error) {
-    console.error('[journal] substrate read error', error);
-    substrateError = error instanceof Error ? error.message : 'substrate read failed';
   }
+
+  const kvForSources = agentFilter
+    ? kvEntries.filter((e) => e.agent.toUpperCase() === agentFilter)
+    : kvEntries;
 
   const all = [...kvEntries, ...substrateEntries];
   const seen = new Set<string>();
@@ -342,7 +328,7 @@ export async function GET(request: NextRequest) {
 
   const maxTs = (list: AgentJournalEntry[]) =>
     list.reduce((acc, e) => Math.max(acc, new Date(e.timestamp).getTime() || 0), 0);
-  const kvMax = maxTs(kvEntries);
+  const kvMax = maxTs(kvForSources);
   const subMax = maxTs(substrateEntries);
   const archiveStale =
     substrateEntries.length > 0 && kvMax > 0 && subMax > 0 && kvMax - subMax > 60 * 60 * 1000;
@@ -355,7 +341,7 @@ export async function GET(request: NextRequest) {
       agents,
       timestamp: new Date().toISOString(),
       sources: {
-        kv: kvEntries.length,
+        kv: kvForSources.length,
         substrate: substrateEntries.length,
       },
       merged_from_archive: substrateEntries.length > 0,
@@ -393,6 +379,21 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  const redis = getJournalRedisClient();
+  if (redis) {
+    const writeResult = await appendJournalLaneEntry(redis, {
+      ...entry,
+      id: entry.id,
+      timestamp: entry.timestamp,
+    });
+
+    if (!writeResult.written) {
+      return NextResponse.json({ ok: true, duplicate: true, token: writeResult.token, substrate: 'writing' });
+    }
+    entry.id = writeResult.entry.id;
+    entry.timestamp = writeResult.entry.timestamp;
+  }
+
   void writeToSubstrate({
     agent: entry.agent,
     agentOrigin: entry.agentOrigin,
@@ -409,34 +410,38 @@ export async function POST(request: NextRequest) {
     console.error('[ledger] journal attest error', error);
   });
 
-  void writeJournalToSubstrate(toSubstrateGithubJournalEntry(entry)).catch((err) => {
+  const giAt =
+    input && typeof input.gi_snapshot === 'number' && Number.isFinite(input.gi_snapshot)
+      ? input.gi_snapshot
+      : undefined;
+
+  const substratePayload: SubstrateJournalWriteInput = {
+    id: entry.id,
+    agent: entry.agent,
+    agentOrigin: entry.agentOrigin,
+    cycle: entry.cycle,
+    scope: entry.scope,
+    category: entry.category,
+    severity: entry.severity,
+    observation: entry.observation,
+    inference: entry.inference,
+    recommendation: entry.recommendation,
+    confidence: entry.confidence,
+    derivedFrom: entry.derivedFrom,
+    source: entry.source,
+    tags: entry.tags ?? [],
+    ...(giAt !== undefined ? { gi_at_time: giAt } : {}),
+    status: entry.status,
+  };
+
+  void writeJournalToSubstrate(substratePayload).catch((err) => {
     console.error('[journal] substrate write failed:', err);
   });
 
-  const redis = getJournalRedisClient();
-  if (!redis) {
-    return NextResponse.json({
-      ok: true,
-      entryId: entry.id,
-      timestamp: entry.timestamp,
-      substrate: 'writing',
-    });
-  }
-
-  const writeResult = await appendJournalLaneEntry(redis, {
-    ...entry,
-    id: entry.id,
-    timestamp: entry.timestamp,
-  });
-
-  if (!writeResult.written) {
-    return NextResponse.json({ ok: true, duplicate: true, token: writeResult.token, substrate: 'writing' });
-  }
-
   return NextResponse.json({
     ok: true,
-    entryId: writeResult.entry.id,
-    timestamp: writeResult.entry.timestamp,
+    entryId: entry.id,
+    timestamp: entry.timestamp,
     substrate: 'writing',
   });
 }

--- a/app/api/terminal/snapshot/route.ts
+++ b/app/api/terminal/snapshot/route.ts
@@ -16,8 +16,8 @@ import {
   type SnapshotLaneState,
   type SnapshotLeaf,
 } from '@/lib/terminal/snapshotLanes';
-import type { JournalStoredRecord } from '@/lib/substrate/github-journal';
-import { readAllAgentJournals } from '@/lib/substrate/github-reader';
+import type { SubstrateJournalEntry } from '@/lib/substrate/github-journal';
+import { readAllSubstrateJournals } from '@/lib/substrate/github-reader';
 
 export const dynamic = 'force-dynamic';
 
@@ -68,34 +68,49 @@ export async function GET(request: NextRequest) {
     callHandler(makeRequest(baseUrl, '/api/eve/cycle-advance'), getEve),
   ]);
 
-  type SubstrateLatestRow = { agent: string; lastEntry: JournalStoredRecord };
+  type SubstrateAgentRow = {
+    agent: string;
+    lastEntry: SubstrateJournalEntry | null;
+    entryCount: number;
+  };
+
+  const SUBSTRATE_JOURNALS_TREE =
+    'https://github.com/kaizencycle/Mobius-Substrate/tree/main/journals';
 
   let substrate: {
     ok: boolean;
-    agents: string[];
     totalEntries: number;
-    latest: SubstrateLatestRow[];
+    agents: SubstrateAgentRow[];
+    repoUrl: string;
+    /** @deprecated Prefer `agents` (same rows as before C-274 shape refresh). */
+    latest: { agent: string; lastEntry: SubstrateJournalEntry }[];
   };
   try {
-    const substrateJournals = await readAllAgentJournals(3);
+    const substrateJournals = await readAllSubstrateJournals(3);
     const totalEntries = Object.values(substrateJournals).reduce((sum, arr) => sum + arr.length, 0);
+    const agentRows: SubstrateAgentRow[] = Object.entries(substrateJournals).map(([agent, entries]) => ({
+      agent,
+      lastEntry: entries[0] ?? null,
+      entryCount: entries.length,
+    }));
+    const withEntries = agentRows.filter((x) => x.lastEntry !== null);
     substrate = {
       ok: true,
-      agents: Object.keys(substrateJournals),
       totalEntries,
-      latest: Object.entries(substrateJournals)
-        .map(([agent, entries]) => ({
-          agent,
-          lastEntry: entries[0] ?? null,
-        }))
-        .filter((x): x is SubstrateLatestRow => x.lastEntry !== null),
+      agents: withEntries,
+      repoUrl: SUBSTRATE_JOURNALS_TREE,
+      latest: withEntries.map(({ agent, lastEntry }) => ({
+        agent,
+        lastEntry: lastEntry as SubstrateJournalEntry,
+      })),
     };
   } catch (error) {
     console.error('[terminal/snapshot] substrate journals read failed', error);
     substrate = {
       ok: false,
-      agents: [],
       totalEntries: 0,
+      agents: [],
+      repoUrl: SUBSTRATE_JOURNALS_TREE,
       latest: [],
     };
   }

--- a/docs/automations/DAEDALUS-SWEEP.md
+++ b/docs/automations/DAEDALUS-SWEEP.md
@@ -26,10 +26,10 @@ report.
 Repo: kaizencycle/mobius-civic-ai-terminal
 Live URL: https://mobius-civic-ai-terminal.vercel.app
 
-STEP 0 — Read shared context from terminal (C-274):
+STEP 0 — Read shared world state (C-274):
   GET https://mobius-civic-ai-terminal.vercel.app/api/terminal/snapshot
-  Extract: gi, cycle, signals.composite, anomalies, echo/epicon (latest entries),
-  sentiment.domains, substrate.latest (what other agents wrote).
+  Extract: cycle, gi, anomalies, echo/epicon (latest entries), sentiment,
+  substrate (substrate.agents / substrate.latest — what other agents wrote).
   Use as base context. Do NOT re-fetch USGS / CoinGecko / EONET separately.
 
 SWEEP CHECKLIST — run each check in order:

--- a/docs/automations/DAEDALUS-TRIAGE.md
+++ b/docs/automations/DAEDALUS-TRIAGE.md
@@ -26,10 +26,10 @@ fix it autonomously or produce a precise human-action card.
 Repo: kaizencycle/mobius-civic-ai-terminal
 Live URL: https://mobius-civic-ai-terminal.vercel.app
 
-STEP 0 — Read shared context from terminal (C-274):
+STEP 0 — Read shared world state (C-274):
   GET https://mobius-civic-ai-terminal.vercel.app/api/terminal/snapshot
-  Extract: gi, cycle, signals.composite, anomalies, echo/epicon (latest entries),
-  sentiment.domains, substrate.latest (what other agents wrote).
+  Extract: cycle, gi, anomalies, echo/epicon (latest entries), sentiment,
+  substrate (substrate.agents / substrate.latest — what other agents wrote).
   Use as base context. Do NOT re-fetch USGS / CoinGecko / EONET separately.
 
 STEP 1 — READ CURRENT SYSTEM STATE

--- a/docs/automations/README.md
+++ b/docs/automations/README.md
@@ -5,13 +5,13 @@ All automations follow the Mobius two-class taxonomy (Class A: code+git, Class B
 
 ---
 
-## STEP 0 — Read shared context from terminal (C-274)
+## STEP 0 — Read shared world state (C-274)
 
 Before other checks, every automation should start from the normalized terminal snapshot:
 
 **GET** `https://mobius-civic-ai-terminal.vercel.app/api/terminal/snapshot`
 
-Extract at minimum: **GI**, **cycle**, **signals** (composite), **anomalies** (where present), **echo** / **epicon** (latest entries), **sentiment** (domains), **`substrate.latest`** (recent agent journal rows from Mobius-Substrate).
+Extract and use: **cycle**, **gi**, **anomalies** (where present), **echo** / **epicon** (latest entries this cycle), **sentiment** (domain scores), **substrate** (other agents’ recent journal rows in Mobius-Substrate — **`substrate.agents`** and legacy **`substrate.latest`**).
 
 Use this as base context for all reasoning. **Do not** re-fetch USGS, CoinGecko, EONET, or similar separately when the snapshot already carries the normalized view.
 

--- a/docs/automations/THOUGHT_BROKER_SCHEDULER.md
+++ b/docs/automations/THOUGHT_BROKER_SCHEDULER.md
@@ -2,13 +2,13 @@
 
 This runbook migrates scheduler duties from Vercel cron to the Render thought-broker service.
 
-## STEP 0 — Terminal snapshot (C-274)
+## STEP 0 — Read shared world state (C-274)
 
 Before scheduling or interpreting failures, workers may use:
 
 **GET** `https://mobius-civic-ai-terminal.vercel.app/api/terminal/snapshot`
 
-Extract **gi**, **cycle**, **signals.composite**, **anomalies**, **echo** / **epicon** (latest), **sentiment.domains**, **`substrate.latest`**. Use as shared context; avoid duplicate fetches of USGS / CoinGecko / EONET when the snapshot already normalizes them.
+Extract **cycle**, **gi**, **anomalies**, **echo** / **epicon**, **sentiment**, **substrate** (**`substrate.agents`** / **`substrate.latest`**). Use as shared context; avoid duplicate fetches of USGS / CoinGecko / EONET when the snapshot already normalizes them.
 
 ## 1) Install runtime dependency on thought-broker
 

--- a/docs/ops/automation_policy.md
+++ b/docs/ops/automation_policy.md
@@ -17,13 +17,22 @@ This policy separates **code change workflows** from **runtime signal workflows*
 Git is for reviewable source changes.  
 KV is for live agent emissions, heartbeats, verification events, and ledger-feed runtime data.
 
-### STEP 0 — Terminal snapshot (C-274)
+### STEP 0 — Read shared world state (C-274)
 
 Automations that reason about live terminal state should begin from:
 
 **GET** `https://mobius-civic-ai-terminal.vercel.app/api/terminal/snapshot`
 
-Use **gi**, **cycle**, **signals**, **echo** / **epicon**, **sentiment**, and **`substrate.latest`** as shared context. Prefer this over re-fetching raw public APIs (USGS, CoinGecko, EONET, etc.) when the snapshot already carries normalized values.
+Extract and use:
+
+- **cycle** — current cycle ID
+- **gi** — current global integrity score (from the integrity lane / composite as applicable)
+- **anomalies** — active signal anomalies (where present in snapshot lanes)
+- **echo** / **epicon** — latest entries this cycle (including **echo.epicon**-shaped data when exposed)
+- **sentiment** — domain scores (financial, environmental, etc.)
+- **substrate** — what other agents last wrote to Mobius-Substrate (`substrate.agents` with `lastEntry` / `entryCount`, plus `substrate.latest` for the same rows)
+
+Use this as the base context for all reasoning. **Do not** separately fetch USGS, CoinGecko, EONET, or similar when the snapshot already carries a normalized view.
 
 ---
 

--- a/lib/substrate/github-journal.ts
+++ b/lib/substrate/github-journal.ts
@@ -1,8 +1,11 @@
 const SUBSTRATE_REPO = 'kaizencycle/Mobius-Substrate';
-const SUBSTRATE_API = 'https://api.github.com';
+const GITHUB_API = 'https://api.github.com';
+
 const GITHUB_TOKEN = process.env.SUBSTRATE_GITHUB_TOKEN;
 
-export interface JournalEntry {
+/** Persisted journal JSON under Mobius-Substrate `journals/{agent}/`. */
+export interface SubstrateJournalEntry {
+  id: string;
   agent: string;
   agentOrigin: string;
   cycle: string;
@@ -17,42 +20,41 @@ export interface JournalEntry {
   source: string;
   tags: string[];
   gi_at_time?: number;
-  /** When set (e.g. from terminal KV), reused so GET merge can dedupe on `id`. */
-  id?: string;
-  /** Persisted for round-trip with terminal `AgentJournalEntry`. */
+  timestamp: string;
+  /** Terminal journal lane status when bridged from the app. */
   status?: string;
 }
 
-/** Shape of a journal JSON file in Mobius-Substrate `docs/catalog/{agent}/`. */
-export type JournalStoredRecord = JournalEntry & {
-  id: string;
-  timestamp: string;
+/** Input for GitHub write: server assigns `id` and ISO `timestamp` when omitted. */
+export type SubstrateJournalWriteInput = Omit<SubstrateJournalEntry, 'id' | 'timestamp'> & {
+  id?: string;
 };
 
 export async function writeJournalToSubstrate(
-  entry: JournalEntry,
-): Promise<{ ok: boolean; path?: string; sha?: string; error?: string }> {
+  entry: SubstrateJournalWriteInput,
+): Promise<{ ok: boolean; path?: string; error?: string }> {
   if (!GITHUB_TOKEN) {
     console.error('[substrate] SUBSTRATE_GITHUB_TOKEN not set');
     return { ok: false, error: 'token_missing' };
   }
 
-  const timestamp = new Date().toISOString().replace(/:/g, '-').replace(/\./g, '-');
+  const timestampIso = new Date().toISOString();
+  const fileStamp = timestampIso.replace(/:/g, '-').replace(/\./g, '-');
   const agent = entry.agent.toLowerCase();
-  const path = `docs/catalog/${agent}/${timestamp}-journal.json`;
+  const path = `journals/${agent}/${fileStamp}-journal.json`;
 
-  const payload: Record<string, unknown> = {
+  const id = entry.id ?? `journal-${agent}-${Date.now()}`;
+
+  const payload: SubstrateJournalEntry = {
     ...entry,
-    timestamp,
-    id: entry.id ?? `journal-${agent}-${Date.now()}`,
-    status: entry.status ?? 'committed',
-    source: entry.source || 'agent-journal',
+    id,
+    timestamp: timestampIso,
   };
 
   const content = Buffer.from(JSON.stringify(payload, null, 2)).toString('base64');
 
   try {
-    const res = await fetch(`${SUBSTRATE_API}/repos/${SUBSTRATE_REPO}/contents/${path}`, {
+    const res = await fetch(`${GITHUB_API}/repos/${SUBSTRATE_REPO}/contents/${path}`, {
       method: 'PUT',
       headers: {
         Authorization: `Bearer ${GITHUB_TOKEN}`,
@@ -61,7 +63,7 @@ export async function writeJournalToSubstrate(
         'X-GitHub-Api-Version': '2022-11-28',
       },
       body: JSON.stringify({
-        message: `${agent}: journal entry · ${entry.cycle} [skip ci]`,
+        message: `${agent}: journal · ${entry.cycle} [skip ci]`,
         content,
         committer: {
           name: entry.agent,
@@ -73,18 +75,13 @@ export async function writeJournalToSubstrate(
 
     if (!res.ok) {
       const err = await res.text();
-      console.error(`[substrate] github write failed ${res.status}: ${err}`);
+      console.error(`[substrate] write failed ${res.status}: ${err}`);
       return { ok: false, error: `github_${res.status}` };
     }
 
-    const data = (await res.json()) as { content?: { sha?: string } };
-    return {
-      ok: true,
-      path,
-      sha: data.content?.sha,
-    };
+    return { ok: true, path };
   } catch (err) {
-    console.error('[substrate] github write error:', err);
+    console.error('[substrate] write error:', err);
     return { ok: false, error: String(err) };
   }
 }

--- a/lib/substrate/github-reader.ts
+++ b/lib/substrate/github-reader.ts
@@ -1,4 +1,4 @@
-import type { JournalStoredRecord } from '@/lib/substrate/github-journal';
+import type { SubstrateJournalEntry } from '@/lib/substrate/github-journal';
 
 const SUBSTRATE_REPO = 'kaizencycle/Mobius-Substrate';
 
@@ -14,7 +14,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function isJournalStoredRecord(value: unknown): value is JournalStoredRecord {
+function isSubstrateJournalEntry(value: unknown): value is SubstrateJournalEntry {
   if (!isRecord(value)) return false;
   const id = value.id;
   const agent = value.agent;
@@ -31,9 +31,11 @@ function isJournalStoredRecord(value: unknown): value is JournalStoredRecord {
   const source = value.source;
   const tags = value.tags;
   const agentOrigin = value.agentOrigin;
+  const giAt = value.gi_at_time;
 
   const tagsOk =
     tags === undefined || (Array.isArray(tags) && tags.every((x): x is string => typeof x === 'string'));
+  const giOk = giAt === undefined || (typeof giAt === 'number' && Number.isFinite(giAt));
 
   return (
     typeof id === 'string' &&
@@ -52,15 +54,16 @@ function isJournalStoredRecord(value: unknown): value is JournalStoredRecord {
     derivedFrom.every((x): x is string => typeof x === 'string') &&
     typeof source === 'string' &&
     tagsOk &&
-    typeof agentOrigin === 'string'
+    typeof agentOrigin === 'string' &&
+    giOk
   );
 }
 
-export async function readAgentJournal(agent: string, limit = 10): Promise<JournalStoredRecord[]> {
+export async function readAgentJournals(agent: string, limit = 10): Promise<SubstrateJournalEntry[]> {
   const agentLower = agent.toLowerCase();
 
   const listRes = await fetch(
-    `https://api.github.com/repos/${SUBSTRATE_REPO}/contents/docs/catalog/${agentLower}`,
+    `https://api.github.com/repos/${SUBSTRATE_REPO}/contents/journals/${agentLower}`,
     {
       headers: {
         Accept: 'application/vnd.github+json',
@@ -92,25 +95,27 @@ export async function readAgentJournal(agent: string, limit = 10): Promise<Journ
       const res = await fetch(url, { signal: AbortSignal.timeout(3000) });
       if (!res.ok) return null;
       const json: unknown = await res.json();
-      return isJournalStoredRecord(json) ? json : null;
+      return isSubstrateJournalEntry(json) ? json : null;
     }),
   );
 
   return entries
-    .filter((r): r is PromiseFulfilledResult<JournalStoredRecord | null> => r.status === 'fulfilled')
+    .filter((r): r is PromiseFulfilledResult<SubstrateJournalEntry | null> => r.status === 'fulfilled')
     .map((r) => r.value)
-    .filter((v): v is JournalStoredRecord => v !== null);
+    .filter((v): v is SubstrateJournalEntry => v !== null);
 }
 
-export async function readAllAgentJournals(limit = 5): Promise<Record<string, JournalStoredRecord[]>> {
+export async function readAllSubstrateJournals(
+  limitPerAgent = 3,
+): Promise<Record<string, SubstrateJournalEntry[]>> {
   const results = await Promise.allSettled(
     AGENT_SLUGS.map(async (a) => ({
       agent: a,
-      entries: await readAgentJournal(a, limit),
+      entries: await readAgentJournals(a, limitPerAgent),
     })),
   );
 
-  const pairs: [string, JournalStoredRecord[]][] = [];
+  const pairs: [string, SubstrateJournalEntry[]][] = [];
   for (const r of results) {
     if (r.status === 'fulfilled') {
       pairs.push([r.value.agent, r.value.entries]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "lucide-react": "^0.525.0",
         "motion": "^12.23.12",
         "next": "^15.1.0",
+        "next-auth": "^5.0.0-beta.30",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "recharts": "^2.15.4",
@@ -40,6 +41,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.0.tgz",
+      "integrity": "sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/runtime": {
@@ -736,6 +766,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@swc/helpers": {
@@ -1546,6 +1585,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1746,6 +1794,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
+      "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.0"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -1789,6 +1864,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
+      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {
@@ -2018,6 +2102,25 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
+      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/scripts/scaffold-substrate-journal-dirs.mjs
+++ b/scripts/scaffold-substrate-journal-dirs.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Create empty journals/{agent}/.gitkeep in kaizencycle/Mobius-Substrate via GitHub Contents API.
+ * Requires: SUBSTRATE_GITHUB_TOKEN (fine-grained PAT, Contents read+write on that repo only).
+ *
+ * Usage: node scripts/scaffold-substrate-journal-dirs.mjs
+ */
+const SUBSTRATE_REPO = 'kaizencycle/Mobius-Substrate';
+const API = 'https://api.github.com';
+const AGENTS = ['atlas', 'zeus', 'eve', 'hermes', 'aurea', 'jade', 'daedalus', 'echo'];
+
+const token = process.env.SUBSTRATE_GITHUB_TOKEN;
+if (!token) {
+  console.error('SUBSTRATE_GITHUB_TOKEN is not set');
+  process.exit(1);
+}
+
+const emptyB64 = Buffer.from('').toString('base64');
+
+async function putGitkeep(agent) {
+  const path = `journals/${agent}/.gitkeep`;
+  const url = `${API}/repos/${SUBSTRATE_REPO}/contents/${path}`;
+  const head = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  if (head.ok) {
+    console.log(`skip ${path} (exists)`);
+    return;
+  }
+  if (head.status !== 404) {
+    const t = await head.text();
+    throw new Error(`HEAD ${path} ${head.status}: ${t}`);
+  }
+
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({
+      message: `chore: scaffold ${agent} journal dir [skip ci]`,
+      content: emptyB64,
+      committer: { name: 'Mobius Terminal', email: 'terminal@mobius.systems' },
+    }),
+  });
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`PUT ${path} ${res.status}: ${err}`);
+  }
+  console.log(`created ${path}`);
+}
+
+async function main() {
+  for (const agent of AGENTS) {
+    await putGitkeep(agent);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change moves the GitHub journal bridge from `docs/catalog/{agent}/` to **`journals/{agent}/`** in [Mobius-Substrate](https://github.com/kaizencycle/Mobius-Substrate), matching the repo’s native layout. Agent journal POST still uses KV as the fast path; Substrate writes remain **fire-and-forget** behind `SUBSTRATE_GITHUB_TOKEN`. Terminal snapshot now exposes **`substrate.agents`** (per-agent `lastEntry`, `entryCount`) plus **`repoUrl`**, while keeping **`substrate.latest`** for backward compatibility.

## Details

- **`lib/substrate/github-journal.ts`**: `SubstrateJournalEntry` / `SubstrateJournalWriteInput`; write path `journals/{agent}/{iso-stamp}-journal.json`; commit message `${agent}: journal · ${cycle} [skip ci]`.
- **`lib/substrate/github-reader.ts`**: `readAgentJournals`, `readAllSubstrateJournals` against `journals/{agent}/` (public Contents API + raw downloads).
- **`POST /api/agents/journal`**: **`appendJournalLaneEntry` (KV) runs first** so returned `entryId` matches what we archive; then non-blocking `writeToSubstrate` (ledger) and `writeJournalToSubstrate` (GitHub). Optional `gi_snapshot` maps to `gi_at_time` on the archived JSON.
- **`GET /api/agents/journal`**: Merges KV + Substrate **when `?agent=` is set** (5s wall-clock budget on the Substrate list/fetch path); `sources.kv` counts KV rows for that agent when filtered.
- **`GET /api/terminal/snapshot`**: `substrate` block updated per C-274 shape; **`latest`** retained as deprecated alias of agents-with-entries.
- **`scripts/scaffold-substrate-journal-dirs.mjs`**: optional one-shot scaffold for `journals/{agent}/.gitkeep` via Contents API (run with token locally or in CI).
- **Automation canon**: STEP 0 text expanded (`substrate.agents` / `substrate.latest`); same reminder added as comments on **all six** workflows under `.github/workflows/`.
- **`package-lock.json`**: synced with `package.json` (e.g. next-auth) so `npm ci` works.

## Prerequisites (ops)

- **Vercel**: `SUBSTRATE_GITHUB_TOKEN` — fine-grained PAT, repo **kaizencycle/Mobius-Substrate** only, **Contents: Read and write**.
- **Substrate dirs**: run `node scripts/scaffold-substrate-journal-dirs.mjs` once (or create `journals/{agent}/` manually) so PUT targets exist.

## Tests

- `npx tsc --noEmit` — pass.
- `npm run lint` — prompts for interactive ESLint migration in this environment; not run non-interactively.

## Integrity & safety

- Writes to Substrate are **never awaited** on the hot path; reads use timeouts and empty/fallback behavior.
- No new npm runtime dependencies; ledger/KV behavior unchanged aside from POST ordering (KV before GitHub).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-577d3f0c-d363-488b-8456-2bbb2e289025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-577d3f0c-d363-488b-8456-2bbb2e289025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

