### PR TITLE
feat(globe): Globe chamber as terminal landing view [C-274]

### DIFF
--- a/app/api/globe/render-asset/route.ts
+++ b/app/api/globe/render-asset/route.ts
@@ -1,0 +1,132 @@
+import { NextResponse } from 'next/server';
+import { buildGlobeAssetCacheKey, getCachedGlobeAsset, setCachedGlobeAsset } from '@/lib/globe/assetCache';
+import { nanoBananaGenerate, stableAssetId } from '@/lib/globe/renderProviders/nanoBanana';
+import { promptForKind } from '@/lib/globe/renderPrompts';
+import type { GlobeRenderAssetRequest, GlobeRenderAssetResponse } from '@/lib/globe/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  let body: GlobeRenderAssetRequest;
+  try {
+    body = (await request.json()) as GlobeRenderAssetRequest;
+  } catch {
+    return NextResponse.json(
+      {
+        ok: false,
+        status: 'failed',
+        assetId: '',
+        provider: 'nano-banana',
+        cached: false,
+        error: 'Invalid JSON body',
+      } satisfies GlobeRenderAssetResponse,
+      { status: 400 },
+    );
+  }
+
+  if (!body?.kind || !body?.title) {
+    return NextResponse.json(
+      {
+        ok: false,
+        status: 'failed',
+        assetId: '',
+        provider: 'nano-banana',
+        cached: false,
+        error: 'kind and title are required',
+      } satisfies GlobeRenderAssetResponse,
+      { status: 400 },
+    );
+  }
+
+  const prompt = promptForKind(body.kind, {
+    title: body.title,
+    domain: body.domain,
+    cycle: body.cycle,
+    severity: body.severity,
+    metadata: body.metadata,
+    customPrompt: body.prompt,
+  });
+
+  const cacheKey = buildGlobeAssetCacheKey({
+    kind: body.kind,
+    cycle: body.cycle,
+    signalId: body.signalId,
+    title: body.title,
+    severity: body.severity,
+    prompt,
+  });
+
+  const cached = await getCachedGlobeAsset(cacheKey);
+  if (cached?.imageUrl) {
+    const res: GlobeRenderAssetResponse = {
+      ok: true,
+      status: 'completed',
+      assetId: cached.assetId,
+      imageUrl: cached.imageUrl,
+      provider: 'nano-banana',
+      cached: true,
+      diagnostics: {
+        provider: 'nano-banana',
+        cached: true,
+        createdAt: cached.createdAt,
+        sourceSignalId: body.signalId,
+        cycle: body.cycle,
+      },
+    };
+    return NextResponse.json(res);
+  }
+
+  const assetId = stableAssetId([cacheKey, body.kind]);
+
+  const gen = await nanoBananaGenerate({
+    prompt,
+    referenceImageUrls: body.referenceImageUrls,
+    asyncMode: false,
+  });
+
+  if (!gen.ok) {
+    const res: GlobeRenderAssetResponse = {
+      ok: false,
+      status: 'failed',
+      assetId,
+      provider: 'nano-banana',
+      cached: false,
+      error: gen.error,
+      diagnostics: {
+        provider: 'nano-banana',
+        cached: false,
+        createdAt: new Date().toISOString(),
+        sourceSignalId: body.signalId,
+        cycle: body.cycle,
+        failureReason: gen.error,
+      },
+    };
+    return NextResponse.json(res, { status: 502 });
+  }
+
+  const createdAt = new Date().toISOString();
+  await setCachedGlobeAsset(cacheKey, {
+    assetId,
+    imageUrl: gen.imageUrl,
+    kind: body.kind,
+    createdAt,
+    cacheKey,
+  });
+
+  const res: GlobeRenderAssetResponse = {
+    ok: true,
+    status: 'completed',
+    assetId,
+    imageUrl: gen.imageUrl,
+    provider: 'nano-banana',
+    cached: false,
+    diagnostics: {
+      provider: 'nano-banana',
+      cached: false,
+      createdAt,
+      sourceSignalId: body.signalId,
+      cycle: body.cycle,
+    },
+  };
+  return NextResponse.json(res);
+}

--- a/app/terminal/TerminalPageClient.tsx
+++ b/app/terminal/TerminalPageClient.tsx
@@ -9,7 +9,9 @@ import { evaluateCircuitBreaker } from '@/lib/integrity-check';
 import { integrityStatusToGISnapshot } from '@/lib/terminal/api';
 import { isEveSynthesisFeedSource } from '@/lib/epicon/eveLedgerSource';
 import { cn } from '@/lib/utils';
-import type { LedgerEntry, NavKey } from '@/lib/terminal/types';
+import type { MicroAgentSweepResult } from '@/lib/agents/micro';
+import type { EpiconItem, LedgerEntry, NavKey } from '@/lib/terminal/types';
+import GlobeChamber from '@/components/terminal/chambers/GlobeChamber';
 import type { AgentJournalEntry } from '@/lib/terminal/types';
 import { AGENT_MANIFESTS, AGENT_ORDER } from '@/lib/agents/manifests';
 import AgentGrid from '@/components/agents/AgentGrid';
@@ -37,15 +39,12 @@ type AgentStatusApi = {
 
 type AgentStatusResponse = { ok: boolean; agents: AgentStatusApi[] };
 
-type MicroSignal = { agentName: string; value: number };
 type MicroAgent = { agentName: string; healthy: boolean };
-type MicroSweepResponse = {
-  ok: boolean;
-  timestamp: string;
-  composite: number;
-  healthy: boolean;
-  agents: MicroAgent[];
-  allSignals: MicroSignal[];
+type MicroSweepResponse = MicroAgentSweepResult & {
+  ok?: boolean;
+  cached?: boolean;
+  kv?: boolean;
+  source?: string;
 };
 
 type KvHealthResponse = { ok: boolean; latencyMs: number | null };
@@ -113,11 +112,12 @@ type TerminalSnapshotResponse = {
 };
 
 const TABS: Array<{ key: NavKey; label: string }> = [
+  { key: 'globe', label: 'Globe' },
   { key: 'pulse', label: 'Pulse' },
-  { key: 'ledger', label: 'Epicon' },
-  { key: 'agents', label: 'Agents' },
+  { key: 'sentiment', label: 'Signals' },
+  { key: 'agents', label: 'Sentinel' },
+  { key: 'ledger', label: 'Ledger' },
   { key: 'infrastructure', label: 'Tripwire' },
-  { key: 'sentiment', label: 'Sentiment' },
   { key: 'wallet', label: 'MIC' },
 ];
 
@@ -171,7 +171,7 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
   type SortField = 'time' | 'agent' | 'type' | 'severity' | 'gi' | 'status' | 'source';
   type SortDirection = 'asc' | 'desc';
 
-  const [selectedNav, setSelectedNav] = useState<NavKey>('pulse');
+  const [selectedNav, setSelectedNav] = useState<NavKey>('globe');
   const [selectedLedgerId, setSelectedLedgerId] = useState<string | null>(null);
   const [expandedLedgerId, setExpandedLedgerId] = useState<string | null>(null);
   const [agentFilter, setAgentFilter] = useState<string>('ALL');
@@ -191,6 +191,7 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
   const [sentimentHistory, setSentimentHistory] = useState<
     Partial<Record<SentimentDomainKey, Array<{ timestamp: string; value: number | null; sourceLabel: string }>>>
   >({});
+  const [echoEpicon, setEchoEpicon] = useState<EpiconItem[]>([]);
   const [ledgerView, setLedgerView] = useState<'events' | 'journal' | 'runtime'>('events');
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<SortField>('time');
@@ -424,6 +425,11 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
         } else if (sentimentLane?.fallbackMode === 'cached' && sentimentRef.current) {
           applySentiment(sentimentRef.current);
         }
+
+        const echoPayload = json.echo.data as { epicon?: EpiconItem[] } | null;
+        if (json.echo.ok && echoPayload && Array.isArray(echoPayload.epicon)) {
+          setEchoEpicon(echoPayload.epicon);
+        }
       } catch (err) {
         if (mounted) {
           setRuntimeBadge('offline');
@@ -439,6 +445,38 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
       window.clearInterval(poll);
     };
   }, [applySentiment, cycleId, includeCatalog]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function pullGlobeFeeds() {
+      try {
+        const [microRes, echoRes] = await Promise.all([
+          fetch('/api/signals/micro', { cache: 'no-store' }),
+          fetch('/api/echo/feed', { cache: 'no-store' }),
+        ]);
+        const microJson = (await microRes.json()) as MicroSweepResponse;
+        const echoJson = (await echoRes.json()) as { epicon?: EpiconItem[] };
+        if (!mounted) return;
+        if (microJson?.ok) {
+          microRef.current = microJson;
+          setMicro(microJson);
+        }
+        if (Array.isArray(echoJson?.epicon)) {
+          setEchoEpicon(echoJson.epicon);
+        }
+      } catch {
+        // no-op — snapshot lane still supplies cached micro
+      }
+    }
+
+    pullGlobeFeeds();
+    const id = window.setInterval(pullGlobeFeeds, 60_000);
+    return () => {
+      mounted = false;
+      window.clearInterval(id);
+    };
+  }, []);
 
   const breaker = evaluateCircuitBreaker({
     giScore: effectiveGi.score,
@@ -513,8 +551,34 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
     rosterLoaded,
     tripwireFreshAt,
   ]);
-  const chamberLabel = selectedNav === 'pulse' ? 'PULSE CHAMBER' : selectedNav === 'agents' ? 'AGENT CHAMBER' : selectedNav === 'ledger' ? 'CIVIC LEDGER CHAMBER' : selectedNav === 'infrastructure' ? 'TRIPWIRE CHAMBER' : selectedNav === 'sentiment' ? 'SENTIMENT CHAMBER' : 'MIC CHAMBER';
-  const commandSurfaceTitle = selectedNav === 'wallet' ? 'Wallet Chamber' : selectedNav === 'agents' ? 'Agent Chamber' : selectedNav === 'ledger' ? 'Civic Ledger Chamber' : selectedNav === 'infrastructure' ? 'Tripwire Chamber' : selectedNav === 'sentiment' ? 'Sentiment Chamber' : 'Pulse Chamber';
+  const chamberLabel =
+    selectedNav === 'globe'
+      ? 'GLOBE CHAMBER'
+      : selectedNav === 'pulse'
+        ? 'PULSE CHAMBER'
+        : selectedNav === 'agents'
+          ? 'SENTINEL CHAMBER'
+          : selectedNav === 'ledger'
+            ? 'CIVIC LEDGER CHAMBER'
+            : selectedNav === 'infrastructure'
+              ? 'TRIPWIRE CHAMBER'
+              : selectedNav === 'sentiment'
+                ? 'SIGNALS CHAMBER'
+                : 'MIC CHAMBER';
+  const commandSurfaceTitle =
+    selectedNav === 'globe'
+      ? 'Globe Chamber'
+      : selectedNav === 'wallet'
+        ? 'Wallet Chamber'
+        : selectedNav === 'agents'
+          ? 'Sentinel Chamber'
+          : selectedNav === 'ledger'
+            ? 'Civic Ledger Chamber'
+            : selectedNav === 'infrastructure'
+              ? 'Tripwire Chamber'
+              : selectedNav === 'sentiment'
+                ? 'Signals Chamber'
+                : 'Pulse Chamber';
 
   const snapshotSummaryLine = useMemo(() => {
     const parts: string[] = [];
@@ -526,13 +590,15 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
 
   const integrityDisplayTs = integrityStatus?.timestamp ?? giFreshAt;
   const commandSurfaceButtons: Array<{ label: string; nav: NavKey }> =
-    selectedNav === 'wallet'
-      ? [{ label: 'Inspect', nav: 'wallet' }, { label: 'Open Chamber', nav: 'wallet' }, { label: 'Review Signals', nav: 'pulse' }]
-      : selectedNav === 'agents'
-        ? [{ label: 'Inspect', nav: 'agents' }, { label: 'Open Chamber', nav: 'agents' }, { label: 'Review Signals', nav: 'ledger' }]
-        : selectedNav === 'sentiment'
-          ? [{ label: 'Inspect', nav: 'sentiment' }, { label: 'Open Chamber', nav: 'sentiment' }, { label: 'Review Signals', nav: 'pulse' }]
-        : [{ label: 'Inspect', nav: 'infrastructure' }, { label: 'Open Chamber', nav: selectedNav }, { label: 'Review Signals', nav: 'ledger' }];
+    selectedNav === 'globe'
+      ? [{ label: 'Inspect', nav: 'globe' }, { label: 'Open Chamber', nav: 'globe' }, { label: 'Pulse feed', nav: 'pulse' }]
+      : selectedNav === 'wallet'
+        ? [{ label: 'Inspect', nav: 'wallet' }, { label: 'Open Chamber', nav: 'wallet' }, { label: 'Review Signals', nav: 'pulse' }]
+        : selectedNav === 'agents'
+          ? [{ label: 'Inspect', nav: 'agents' }, { label: 'Open Chamber', nav: 'agents' }, { label: 'Review Signals', nav: 'ledger' }]
+          : selectedNav === 'sentiment'
+            ? [{ label: 'Inspect', nav: 'sentiment' }, { label: 'Open Chamber', nav: 'sentiment' }, { label: 'Review Signals', nav: 'pulse' }]
+            : [{ label: 'Inspect', nav: 'infrastructure' }, { label: 'Open Chamber', nav: selectedNav }, { label: 'Review Signals', nav: 'ledger' }];
   const statusChips: Array<{ label: string; tone: string; nav: NavKey }> = [
     { label: 'ZEUS ACTIVE', tone: 'border-sky-500/40 bg-sky-500/10 text-sky-200', nav: 'agents' },
     { label: 'ECHO LIVE', tone: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200', nav: 'pulse' },
@@ -684,6 +750,19 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
   }, []);
 
   const renderCenterContent = () => {
+    if (selectedNav === 'globe') {
+      return (
+        <GlobeChamber
+          micro={micro}
+          echoEpicon={echoEpicon}
+          domains={sentimentDomains}
+          cycleId={cycleId}
+          clockLabel={clock ? `${clock.slice(11, 16)} UTC` : ''}
+          giScore={giScore}
+          miiScore={sentiment?.overall_sentiment ?? null}
+        />
+      );
+    }
     if (selectedNav === 'agents') {
       return (
         <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-3">
@@ -867,7 +946,7 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
         </div>
         <div className="mb-3 flex flex-wrap items-center gap-2 text-[10px] font-mono uppercase tracking-[0.12em] text-slate-500">
           {/* Optimization 9: inline shortcut hints for faster operator discovery. */}
-          <span className="rounded border border-slate-700 bg-slate-950 px-2 py-1">Alt+1..6 switch chambers</span>
+          <span className="rounded border border-slate-700 bg-slate-950 px-2 py-1">Alt+1..7 switch chambers</span>
           <span className="rounded border border-slate-700 bg-slate-950 px-2 py-1">/ focus agent search</span>
           <span className="rounded border border-slate-700 bg-slate-950 px-2 py-1">L toggle ledger</span>
         </div>

--- a/components/terminal/CommandSurface.tsx
+++ b/components/terminal/CommandSurface.tsx
@@ -12,7 +12,7 @@ type CommandOutput = {
 };
 
 const COMMANDS = [
-  '/help', '/status', '/agents', '/globe', '/pulse', '/signals', '/sentinel', '/ledger', '/wallet', '/journal', '/ask', '/login', '/logout', '/whoami', '/epicon', '/gi', '/clear',
+  '/help', '/status', '/agents', '/globe', '/pulse', '/signals', '/sentinel', '/ledger', '/wallet', '/journal', '/ask', '/login', '/logout', '/whoami', '/epicon', '/gi', '/render', '/clear',
 ];
 
 export default function CommandSurface({
@@ -93,6 +93,77 @@ ${greeting}`,
     if (base === '/sentinel') {
       onSwitchChamber('agents');
       push(trimmed, '→ Sentinel chamber', 'success');
+      return;
+    }
+    if (base === '/render') {
+      const sub = (rest[0] ?? '').toLowerCase();
+      const arg = rest.slice(1).join(' ').trim();
+      if (sub === 'cycle') {
+        const integrity = await fetch('/api/integrity-status', { cache: 'no-store' }).then((r) => r.json());
+        const cycle = String(integrity.cycle ?? 'C-current');
+        const gi = Number(integrity.global_integrity ?? 0);
+        const res = await fetch('/api/globe/render-asset', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            kind: 'cycle_hero',
+            title: `${cycle} world state`,
+            cycle,
+            severity: gi > 0.85 ? 'nominal' : gi > 0.7 ? 'elevated' : 'critical',
+            metadata: {
+              giBand: gi > 0.85 ? 'nominal' : gi > 0.7 ? 'watch' : 'stressed',
+              highlights: [`GI ${gi.toFixed(2)}`],
+            },
+          }),
+        }).then((r) => r.json());
+        if (res?.ok && res.imageUrl) {
+          push(trimmed, `Cycle hero ready: ${res.imageUrl}${res.cached ? ' (cached)' : ''}`, 'success');
+        } else {
+          push(trimmed, res?.error ?? 'Render failed', 'error');
+        }
+        return;
+      }
+      if (sub === 'incident') {
+        if (!arg) {
+          push(trimmed, 'Usage: /render incident <title text>', 'error');
+          return;
+        }
+        const res = await fetch('/api/globe/render-asset', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ kind: 'incident_card', title: arg }),
+        }).then((r) => r.json());
+        if (res?.ok && res.imageUrl) {
+          push(trimmed, `Incident art: ${res.imageUrl}`, 'success');
+        } else {
+          push(trimmed, res?.error ?? 'Render failed', 'error');
+        }
+        return;
+      }
+      if (sub === 'domain') {
+        const dom = (rest[1] ?? '').toLowerCase();
+        const allowed = ['civic', 'environ', 'financial', 'narrative', 'infrastructure', 'institutional'];
+        if (!allowed.includes(dom)) {
+          push(trimmed, `Usage: /render domain (${allowed.join('|')})`, 'error');
+          return;
+        }
+        const res = await fetch('/api/globe/render-asset', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            kind: 'domain_icon',
+            title: `${dom} domain sigil`,
+            domain: dom,
+          }),
+        }).then((r) => r.json());
+        if (res?.ok && res.imageUrl) {
+          push(trimmed, `Domain icon: ${res.imageUrl}`, 'success');
+        } else {
+          push(trimmed, res?.error ?? 'Render failed', 'error');
+        }
+        return;
+      }
+      push(trimmed, 'Usage: /render cycle | /render incident <title> | /render domain <civic|environ|…>', 'error');
       return;
     }
     if (base === '/ledger') {

--- a/components/terminal/CommandSurface.tsx
+++ b/components/terminal/CommandSurface.tsx
@@ -12,7 +12,7 @@ type CommandOutput = {
 };
 
 const COMMANDS = [
-  '/help', '/status', '/agents', '/pulse', '/signals', '/ledger', '/wallet', '/journal', '/ask', '/login', '/logout', '/whoami', '/epicon', '/gi', '/clear',
+  '/help', '/status', '/agents', '/globe', '/pulse', '/signals', '/sentinel', '/ledger', '/wallet', '/journal', '/ask', '/login', '/logout', '/whoami', '/epicon', '/gi', '/clear',
 ];
 
 export default function CommandSurface({
@@ -75,6 +75,11 @@ ${greeting}`,
       push(trimmed, COMMANDS.join('\n'));
       return;
     }
+    if (base === '/globe') {
+      onSwitchChamber('globe');
+      push(trimmed, '→ Globe chamber', 'success');
+      return;
+    }
     if (base === '/pulse') {
       onSwitchChamber('pulse');
       push(trimmed, '→ Pulse chamber', 'success');
@@ -83,6 +88,11 @@ ${greeting}`,
     if (base === '/signals') {
       onSwitchChamber('sentiment');
       push(trimmed, '→ Signals chamber', 'success');
+      return;
+    }
+    if (base === '/sentinel') {
+      onSwitchChamber('agents');
+      push(trimmed, '→ Sentinel chamber', 'success');
       return;
     }
     if (base === '/ledger') {

--- a/components/terminal/SidebarNav.tsx
+++ b/components/terminal/SidebarNav.tsx
@@ -5,6 +5,7 @@ import type { NavKey } from '@/lib/terminal/types';
 import { cn } from '@/lib/terminal/utils';
 
 const NAV_ICONS: Partial<Record<NavKey, string>> = {
+  globe: '◉',
   pulse: 'P',
   agents: 'A',
   ledger: 'L',

--- a/components/terminal/chambers/GlobeChamber.tsx
+++ b/components/terminal/chambers/GlobeChamber.tsx
@@ -1,0 +1,589 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { MicroAgentSweepResult } from '@/lib/agents/micro';
+import type { EpiconItem } from '@/lib/terminal/types';
+import {
+  buildGlobePinsFromMicro,
+  GLOBE_DOMAIN_ORDER,
+  type GlobePin,
+  type SentimentDomainKey,
+} from '@/lib/terminal/globePins';
+import { cn } from '@/lib/utils';
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- Three.js loaded from CDN at runtime */
+
+type MicroSweepResponse = MicroAgentSweepResult & { ok?: boolean };
+
+type SentimentDomain = {
+  key: SentimentDomainKey;
+  label: string;
+  agent: string;
+  score: number | null;
+  status: 'nominal' | 'stressed' | 'critical' | 'unknown';
+};
+
+const THREE_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js';
+
+function loadThreeScript(): Promise<void> {
+  if (typeof window === 'undefined') return Promise.resolve();
+  const w = window as unknown as { THREE?: any };
+  if (w.THREE) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[src="${THREE_CDN}"]`);
+    if (existing) {
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener('error', () => reject(new Error('Three.js load failed')), { once: true });
+      return;
+    }
+    const s = document.createElement('script');
+    s.src = THREE_CDN;
+    s.async = true;
+    s.onload = () => resolve();
+    s.onerror = () => reject(new Error('Three.js load failed'));
+    document.head.appendChild(s);
+  });
+}
+
+function latLngToXYZ(THREE: any, lat: number, lng: number, r = 1.015) {
+  const phi = (90 - lat) * (Math.PI / 180);
+  const theta = (lng + 180) * (Math.PI / 180);
+  return new THREE.Vector3(
+    -r * Math.sin(phi) * Math.cos(theta),
+    r * Math.cos(phi),
+    r * Math.sin(phi) * Math.sin(theta),
+  );
+}
+
+function severityColor(sev: GlobePin['severity']): number {
+  if (sev === 'critical') return 0xef4444;
+  if (sev === 'elevated') return 0xf59e0b;
+  return 0x10b981;
+}
+
+function giChipClass(score: number): string {
+  if (score > 0.85) return 'border-emerald-500 text-emerald-400 bg-emerald-500/10';
+  if (score > 0.7) return 'border-amber-500 text-amber-400 bg-amber-500/10';
+  return 'border-rose-500 text-rose-400 bg-rose-500/10';
+}
+
+function giChipLabel(score: number): string {
+  if (score > 0.85) return 'GREEN';
+  if (score > 0.7) return 'YELLOW';
+  return 'RED';
+}
+
+type GlobeSceneState = {
+  THREE: any;
+  scene: any;
+  camera: any;
+  renderer: any;
+  globe: any;
+  pinMeshes: any[];
+  pulseMeshes: any[];
+  pins: GlobePin[];
+  animationId: number;
+  raycaster: any;
+  mouse: any;
+  isDragging: boolean;
+  prevMouse: { x: number; y: number };
+  autoRotate: boolean;
+  autoRotateTimer: number | null;
+  onMove: (e: MouseEvent) => void;
+  onDown: (e: MouseEvent) => void;
+  onUp: (e: MouseEvent) => void;
+  resize: () => void;
+  t: number;
+};
+
+export default function GlobeChamber({
+  micro,
+  echoEpicon,
+  domains,
+  cycleId,
+  clockLabel,
+  giScore,
+  miiScore,
+}: {
+  micro: MicroSweepResponse | null;
+  echoEpicon: EpiconItem[];
+  domains: SentimentDomain[];
+  cycleId: string;
+  clockLabel: string;
+  giScore: number;
+  miiScore: number | null;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [selected, setSelected] = useState<GlobePin | null>(null);
+  const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [webglReady, setWebglReady] = useState(false);
+
+  const pins = useMemo(
+    () => buildGlobePinsFromMicro(micro, echoEpicon),
+    [micro, echoEpicon],
+  );
+
+  const domainByKey = useMemo(() => Object.fromEntries(domains.map((d) => [d.key, d])) as Record<string, SentimentDomain>, [domains]);
+
+  const sceneRef = useRef<GlobeSceneState | null>(null);
+
+  const pinsKey = useMemo(() => pins.map((p) => `${p.id}:${p.lat.toFixed(2)}:${p.lng.toFixed(2)}:${p.severity}`).join('|'), [pins]);
+
+  useEffect(() => {
+    const host = containerRef.current;
+    if (!host) return;
+
+    let disposed = false;
+
+    async function boot() {
+      try {
+        await loadThreeScript();
+      } catch {
+        if (!disposed) setLoadError('Globe requires WebGL and Three.js');
+        return;
+      }
+      if (disposed) return;
+
+      const el = containerRef.current;
+      if (!el) return;
+
+      const w = window as unknown as { THREE: any };
+      const THREE = w.THREE;
+      if (!THREE) {
+        setLoadError('Three.js unavailable');
+        return;
+      }
+
+      const width = el.clientWidth || 800;
+      const height = el.clientHeight || 520;
+
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+      camera.position.z = 2.8;
+
+      const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+      renderer.setSize(width, height);
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+      renderer.setClearColor(0x020408, 1);
+      el.appendChild(renderer.domElement);
+
+      const globeGeo = new THREE.SphereGeometry(1, 64, 64);
+      const globeMat = new THREE.MeshPhongMaterial({
+        color: 0x0a1628,
+        emissive: 0x040d1a,
+        specular: 0x1e3a5f,
+        shininess: 8,
+        transparent: true,
+        opacity: 0.95,
+      });
+      const globe = new THREE.Mesh(globeGeo, globeMat);
+      scene.add(globe);
+
+      const wireGeo = new THREE.SphereGeometry(1.001, 24, 24);
+      const wireMat = new THREE.MeshBasicMaterial({
+        color: 0x0f2744,
+        wireframe: true,
+        transparent: true,
+        opacity: 0.15,
+      });
+      scene.add(new THREE.Mesh(wireGeo, wireMat));
+
+      const atmGeo = new THREE.SphereGeometry(1.08, 64, 64);
+      const atmMat = new THREE.MeshPhongMaterial({
+        color: 0x0a3060,
+        transparent: true,
+        opacity: 0.08,
+        side: THREE.BackSide,
+      });
+      scene.add(new THREE.Mesh(atmGeo, atmMat));
+
+      scene.add(new THREE.AmbientLight(0x112244, 0.6));
+      const sun = new THREE.DirectionalLight(0x4488cc, 0.8);
+      sun.position.set(5, 3, 5);
+      scene.add(sun);
+      const rim = new THREE.DirectionalLight(0x001133, 0.4);
+      rim.position.set(-5, -3, -5);
+      scene.add(rim);
+
+      const raycaster = new THREE.Raycaster();
+      const mouse = new THREE.Vector2();
+      let isDragging = false;
+      let prevMouse = { x: 0, y: 0 };
+      let autoRotate = true;
+      let autoRotateTimer: number | null = null;
+      let t = 0;
+
+      const state: GlobeSceneState = {
+        THREE,
+        scene,
+        camera,
+        renderer,
+        globe,
+        pinMeshes: [],
+        pulseMeshes: [],
+        pins: [],
+        animationId: 0,
+        raycaster,
+        mouse,
+        isDragging,
+        prevMouse,
+        autoRotate,
+        autoRotateTimer,
+        onMove: (_e: MouseEvent) => {},
+        onDown: (_e: MouseEvent) => {},
+        onUp: (_e: MouseEvent) => {},
+        resize: () => {},
+        t,
+      };
+      sceneRef.current = state;
+
+      const rotateAttached = (dy: number, dx: number) => {
+        globe.rotation.y += dy;
+        globe.rotation.x += dx;
+        scene.children.forEach((c: any) => {
+          if (c !== globe && c.type === 'Mesh') {
+            c.rotation.y += dy;
+            c.rotation.x += dx;
+          }
+        });
+      };
+
+      state.onDown = (e: MouseEvent) => {
+        state.isDragging = true;
+        state.autoRotate = false;
+        if (state.autoRotateTimer != null) window.clearTimeout(state.autoRotateTimer);
+        state.prevMouse = { x: e.clientX, y: e.clientY };
+      };
+
+      state.onMove = (e: MouseEvent) => {
+        if (state.isDragging) {
+          const dx = e.clientX - state.prevMouse.x;
+          const dy = e.clientY - state.prevMouse.y;
+          const rotY = dx * 0.005;
+          const rotX = dy * 0.005;
+          rotateAttached(rotY, rotX);
+          state.prevMouse = { x: e.clientX, y: e.clientY };
+        }
+
+        const rect = renderer.domElement.getBoundingClientRect();
+        state.mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+        state.mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+        state.raycaster.setFromCamera(state.mouse, state.camera);
+        const heads = state.pinMeshes.filter((m) => m.userData.kind === 'head');
+        const hits = state.raycaster.intersectObjects(heads);
+        if (hits.length > 0) {
+          const sig = hits[0].object.userData.pin as GlobePin;
+          setTooltip({
+            x: e.clientX + 14,
+            y: e.clientY - 10,
+            text: `${sig.source} · ${(sig.value * 100).toFixed(0)}%`,
+          });
+          renderer.domElement.style.cursor = 'pointer';
+        } else {
+          setTooltip(null);
+          renderer.domElement.style.cursor = 'grab';
+        }
+      };
+
+      state.onUp = (e: MouseEvent) => {
+        if (!state.isDragging) return;
+        state.isDragging = false;
+
+        const rect = renderer.domElement.getBoundingClientRect();
+        state.mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+        state.mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+        state.raycaster.setFromCamera(state.mouse, state.camera);
+        const heads = state.pinMeshes.filter((m) => m.userData.kind === 'head');
+        const hits = state.raycaster.intersectObjects(heads);
+        if (hits.length > 0) {
+          setSelected(hits[0].object.userData.pin as GlobePin);
+        }
+
+        const tid = window.setTimeout(() => {
+          state.autoRotate = true;
+          state.autoRotateTimer = null;
+        }, 4000);
+        state.autoRotateTimer = tid;
+      };
+
+      state.resize = () => {
+        if (!containerRef.current) return;
+        const cw = containerRef.current.clientWidth;
+        const ch = containerRef.current.clientHeight;
+        if (cw < 2 || ch < 2) return;
+        state.camera.aspect = cw / ch;
+        state.camera.updateProjectionMatrix();
+        state.renderer.setSize(cw, ch);
+      };
+
+      renderer.domElement.addEventListener('mousedown', state.onDown);
+      renderer.domElement.addEventListener('mousemove', state.onMove);
+      renderer.domElement.addEventListener('mouseup', state.onUp);
+      window.addEventListener('resize', state.resize);
+
+      function animate() {
+        state.animationId = requestAnimationFrame(animate);
+        state.t += 0.016;
+
+        if (state.autoRotate) {
+          const dy = 0.0008;
+          globe.rotation.y += dy;
+          scene.children.forEach((c: any) => {
+            if (c !== globe && c.type === 'Mesh') c.rotation.y += dy;
+          });
+        }
+
+        for (const ring of state.pulseMeshes) {
+          const ud = ring.userData as { phase: number; speed: number };
+          const s = 1 + Math.sin(state.t * ud.speed * 40 + ud.phase) * 0.4;
+          ring.scale.setScalar(s);
+          const mat = ring.material as { opacity?: number };
+          if (typeof mat.opacity === 'number') {
+            mat.opacity = 0.5 - Math.sin(state.t * ud.speed * 40 + ud.phase) * 0.3;
+          }
+        }
+
+        renderer.render(scene, camera);
+      }
+      animate();
+      setWebglReady(true);
+    }
+
+    void boot();
+
+    return () => {
+      disposed = true;
+      setWebglReady(false);
+      const st = sceneRef.current;
+      if (st) {
+        cancelAnimationFrame(st.animationId);
+        if (st.autoRotateTimer != null) window.clearTimeout(st.autoRotateTimer);
+        st.renderer.domElement.removeEventListener('mousedown', st.onDown);
+        st.renderer.domElement.removeEventListener('mousemove', st.onMove);
+        st.renderer.domElement.removeEventListener('mouseup', st.onUp);
+        window.removeEventListener('resize', st.resize);
+        st.renderer.dispose();
+        if (st.renderer.domElement.parentElement) {
+          st.renderer.domElement.parentElement.removeChild(st.renderer.domElement);
+        }
+      }
+      sceneRef.current = null;
+    };
+  }, []);
+
+  const rebuildPins = useCallback(() => {
+    const st = sceneRef.current;
+    if (!st) return;
+
+    for (const m of st.pinMeshes) {
+      st.scene.remove(m);
+      if (m.geometry) m.geometry.dispose();
+      const mat = m.material as { dispose?: () => void };
+      mat?.dispose?.();
+    }
+    for (const m of st.pulseMeshes) {
+      st.scene.remove(m);
+      if (m.geometry) m.geometry.dispose();
+      const mat = m.material as { dispose?: () => void };
+      mat?.dispose?.();
+    }
+    st.pinMeshes = [];
+    st.pulseMeshes = [];
+    st.pins = pins;
+
+    const THREE = st.THREE;
+
+    for (const sig of pins) {
+      const pos = latLngToXYZ(THREE, sig.lat, sig.lng);
+      const color = severityColor(sig.severity);
+
+      const stemGeo = new THREE.CylinderGeometry(0.003, 0.003, 0.06, 6);
+      const stemMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.7 });
+      const stem = new THREE.Mesh(stemGeo, stemMat);
+      stem.position.copy(pos.clone().multiplyScalar(0.97));
+      stem.lookAt(0, 0, 0);
+      stem.rotateX(Math.PI / 2);
+      st.scene.add(stem);
+      st.pinMeshes.push(stem);
+
+      const headGeo = new THREE.SphereGeometry(0.018, 8, 8);
+      const headMat = new THREE.MeshBasicMaterial({ color });
+      const head = new THREE.Mesh(headGeo, headMat);
+      head.position.copy(pos.clone().multiplyScalar(1.04));
+      head.userData = { pin: sig, kind: 'head' };
+      st.scene.add(head);
+      st.pinMeshes.push(head);
+
+      if (sig.pulse) {
+        const ringGeo = new THREE.RingGeometry(0.02, 0.028, 16);
+        const ringMat = new THREE.MeshBasicMaterial({
+          color,
+          transparent: true,
+          opacity: 0.6,
+          side: THREE.DoubleSide,
+        });
+        const ring = new THREE.Mesh(ringGeo, ringMat);
+        ring.position.copy(pos.clone().multiplyScalar(1.04));
+        ring.lookAt(pos.clone().multiplyScalar(2));
+        ring.userData = { phase: Math.random() * Math.PI * 2, speed: 0.02 + Math.random() * 0.01 };
+        st.scene.add(ring);
+        st.pulseMeshes.push(ring);
+      }
+    }
+
+    requestAnimationFrame(() => sceneRef.current?.resize());
+  }, [pins]);
+
+  useEffect(() => {
+    if (!webglReady || !sceneRef.current) return;
+    const id = requestAnimationFrame(rebuildPins);
+    return () => cancelAnimationFrame(id);
+  }, [webglReady, pinsKey, rebuildPins]);
+
+  const focusDomain = useCallback(
+    (key: SentimentDomainKey) => {
+      const match = pins.find((p) => p.domainKey === key);
+      if (match) setSelected(match);
+    },
+    [pins],
+  );
+
+  return (
+    <div className="relative overflow-hidden rounded-lg border border-slate-800 bg-[#020408] font-mono text-slate-200">
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `@keyframes globeInsp { from { opacity: 0; transform: translateY(-50%) translateX(8px); } to { opacity: 1; transform: translateY(-50%) translateX(0); } }`,
+        }}
+      />
+      <div ref={containerRef} className="relative h-[min(72vh,640px)] w-full" />
+
+      <div className="pointer-events-none absolute inset-x-0 top-0 flex items-center justify-between bg-gradient-to-b from-[#020408]/95 to-transparent px-4 py-3">
+        <div className="text-[11px] uppercase tracking-[0.18em] text-slate-500">Mobius Civic Terminal</div>
+        <div
+          className={cn(
+            'pointer-events-none rounded border px-3 py-1 text-[11px] uppercase tracking-[0.12em]',
+            giChipClass(giScore),
+          )}
+        >
+          GI {giScore.toFixed(2)} · {giChipLabel(giScore)}
+        </div>
+        <div className="text-[10px] tracking-[0.1em] text-slate-600">
+          {cycleId} · {clockLabel}
+        </div>
+      </div>
+
+      <div className="pointer-events-none absolute bottom-14 left-1/2 -translate-x-1/2 text-[9px] uppercase tracking-[0.12em] text-slate-600">
+        Drag to rotate · Click pins to inspect
+      </div>
+
+      <div className="flex border-t border-white/[0.06] bg-[#020408]/90">
+        {GLOBE_DOMAIN_ORDER.map((key) => {
+          const d = domainByKey[key];
+          const score = d?.score;
+          const label = d?.label ?? key.toUpperCase();
+          const agent = d?.agent ?? '—';
+          const scoreClass =
+            score == null ? 'text-slate-500'
+            : score >= 0.8 ? 'text-emerald-400'
+            : score >= 0.6 ? 'text-amber-400'
+            : 'text-rose-400';
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => focusDomain(key)}
+              className="flex flex-1 flex-col items-center border-r border-white/[0.04] px-1 py-2 transition hover:bg-white/[0.04] sm:px-2"
+            >
+              <div className="text-[9px] uppercase tracking-[0.1em] text-slate-600">{label}</div>
+              <div className={cn('text-[13px] font-bold', scoreClass)}>{score != null ? score.toFixed(2) : '—'}</div>
+              <div className="text-[8px] text-slate-700">{agent}</div>
+            </button>
+          );
+        })}
+      </div>
+
+      {tooltip ? (
+        <div
+          className="pointer-events-none fixed z-[60] rounded border border-white/10 bg-[#020408]/90 px-3 py-2 text-[10px] text-slate-400"
+          style={{ left: tooltip.x, top: tooltip.y }}
+        >
+          {tooltip.text}
+        </div>
+      ) : null}
+
+      {selected ? (
+        <div
+          className="fixed right-4 top-1/2 z-50 w-[min(92vw,280px)] rounded-md border border-white/10 bg-[#020408]/95 p-5 shadow-xl backdrop-blur-md"
+          style={{ top: '50%', animation: 'globeInsp 0.2s ease' }}
+        >
+          <button
+            type="button"
+            className="absolute right-3 top-3 text-slate-500 hover:text-slate-300"
+            aria-label="Close inspection"
+            onClick={() => setSelected(null)}
+          >
+            ✕
+          </button>
+          <div className="mb-1 text-[9px] uppercase tracking-[0.12em] text-slate-500">{selected.source}</div>
+          <div className="mb-3 text-[13px] leading-snug text-slate-200">{selected.title}</div>
+          <div className="mb-2 flex items-center gap-2">
+            <span
+              className={cn(
+                'text-[28px] font-bold',
+                selected.value >= 0.75 ? 'text-emerald-400' : selected.value >= 0.5 ? 'text-amber-400' : 'text-rose-400',
+              )}
+            >
+              {selected.value.toFixed(2)}
+            </span>
+            <span
+              className={cn(
+                'rounded border px-2 py-0.5 text-[9px] uppercase tracking-[0.1em]',
+                selected.severity === 'nominal'
+                  ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'
+                  : selected.severity === 'critical'
+                    ? 'border-rose-500/30 bg-rose-500/10 text-rose-300'
+                    : 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+              )}
+            >
+              {selected.severity}
+            </span>
+          </div>
+          <div className="mb-3 h-1 overflow-hidden rounded bg-white/10">
+            <div
+              className="h-full rounded transition-all duration-500"
+              style={{
+                width: `${selected.value * 100}%`,
+                background:
+                  selected.value >= 0.75 ? '#10b981' : selected.value >= 0.5 ? '#f59e0b' : '#ef4444',
+              }}
+            />
+          </div>
+          {miiScore != null ? (
+            <div className="mb-3 text-[10px] text-slate-500">
+              MII <span className="text-slate-300">{miiScore.toFixed(2)}</span>
+            </div>
+          ) : null}
+          <hr className="mb-3 border-white/[0.06]" />
+          <div className="max-h-40 space-y-1 overflow-y-auto text-[9px] leading-relaxed text-slate-500">
+            {Object.entries(selected.meta).map(([k, v]) => (
+              <div key={k}>
+                <span className="text-slate-600">{k}: </span>
+                {String(v)}
+              </div>
+            ))}
+          </div>
+          <div className="mt-3 inline-block rounded border border-sky-500/20 bg-sky-500/10 px-2 py-0.5 text-[9px] uppercase tracking-[0.1em] text-sky-300">
+            {selected.agent}
+          </div>
+        </div>
+      ) : null}
+
+      {loadError ? (
+        <div className="absolute inset-0 flex items-center justify-center bg-[#020408]/90 p-4 text-center text-sm text-slate-400">
+          {loadError}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/terminal/chambers/GlobeChamber.tsx
+++ b/components/terminal/chambers/GlobeChamber.tsx
@@ -9,6 +9,7 @@ import {
   type GlobePin,
   type SentimentDomainKey,
 } from '@/lib/terminal/globePins';
+import { computeGlobeDeltaLines } from '@/lib/globe/globeDelta';
 import { cn } from '@/lib/utils';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- Three.js loaded from CDN at runtime */
@@ -24,6 +25,10 @@ type SentimentDomain = {
 };
 
 const THREE_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js';
+const DRAG_CLICK_THRESHOLD = 8;
+const FRESH_SEC = 120;
+const AGING_SEC = 900;
+const STALE_SEC = 3600;
 
 function loadThreeScript(): Promise<void> {
   if (typeof window === 'undefined') return Promise.resolve();
@@ -61,6 +66,17 @@ function severityColor(sev: GlobePin['severity']): number {
   return 0x10b981;
 }
 
+function freshnessHeadOpacity(ageSec: number): number {
+  if (ageSec < FRESH_SEC) return 1;
+  if (ageSec < AGING_SEC) return 1 - ((ageSec - FRESH_SEC) / (AGING_SEC - FRESH_SEC)) * 0.45;
+  if (ageSec < STALE_SEC) return 0.55 - ((ageSec - AGING_SEC) / (STALE_SEC - AGING_SEC)) * 0.2;
+  return 0.32;
+}
+
+function stemOpacity(ageSec: number): number {
+  return Math.max(0.25, freshnessHeadOpacity(ageSec) * 0.72);
+}
+
 function giChipClass(score: number): string {
   if (score > 0.85) return 'border-emerald-500 text-emerald-400 bg-emerald-500/10';
   if (score > 0.7) return 'border-amber-500 text-amber-400 bg-amber-500/10';
@@ -78,7 +94,7 @@ type GlobeSceneState = {
   scene: any;
   camera: any;
   renderer: any;
-  globe: any;
+  globeGroup: any;
   pinMeshes: any[];
   pulseMeshes: any[];
   pins: GlobePin[];
@@ -86,15 +102,25 @@ type GlobeSceneState = {
   raycaster: any;
   mouse: any;
   isDragging: boolean;
+  dragDistance: number;
   prevMouse: { x: number; y: number };
   autoRotate: boolean;
   autoRotateTimer: number | null;
+  targetRotX: number;
+  targetRotY: number;
   onMove: (e: MouseEvent) => void;
   onDown: (e: MouseEvent) => void;
   onUp: (e: MouseEvent) => void;
   resize: () => void;
   t: number;
 };
+
+function rotateGlobeTargetToLatLng(THREE: any, lat: number, lng: number) {
+  return {
+    y: THREE.MathUtils.degToRad(-(lng + 90)),
+    x: THREE.MathUtils.degToRad(lat * 0.65),
+  };
+}
 
 export default function GlobeChamber({
   micro,
@@ -115,20 +141,135 @@ export default function GlobeChamber({
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [selected, setSelected] = useState<GlobePin | null>(null);
+  const [selectedDomain, setSelectedDomain] = useState<SentimentDomainKey | null>(null);
   const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [webglReady, setWebglReady] = useState(false);
+  const [incidentAsset, setIncidentAsset] = useState<
+    | { status: 'idle' }
+    | { status: 'loading' }
+    | { status: 'ready'; url: string; cached: boolean }
+    | { status: 'unavailable'; message: string }
+  >({ status: 'idle' });
+  const [heroBusy, setHeroBusy] = useState(false);
+  const prevPinsRef = useRef<GlobePin[]>([]);
+  const [deltaLines, setDeltaLines] = useState<string[]>([]);
 
   const pins = useMemo(
     () => buildGlobePinsFromMicro(micro, echoEpicon),
     [micro, echoEpicon],
   );
 
-  const domainByKey = useMemo(() => Object.fromEntries(domains.map((d) => [d.key, d])) as Record<string, SentimentDomain>, [domains]);
+  useEffect(() => {
+    setDeltaLines(computeGlobeDeltaLines(prevPinsRef.current, pins, giScore));
+    prevPinsRef.current = pins;
+  }, [pins, giScore]);
+
+  const domainByKey = useMemo(
+    () => Object.fromEntries(domains.map((d) => [d.key, d])) as Record<string, SentimentDomain>,
+    [domains],
+  );
 
   const sceneRef = useRef<GlobeSceneState | null>(null);
 
-  const pinsKey = useMemo(() => pins.map((p) => `${p.id}:${p.lat.toFixed(2)}:${p.lng.toFixed(2)}:${p.severity}`).join('|'), [pins]);
+  const pinsKey = useMemo(
+    () =>
+      pins
+        .map(
+          (p) =>
+            `${p.id}:${p.lat.toFixed(2)}:${p.lng.toFixed(2)}:${p.severity}:${p.confidence.toFixed(2)}:${p.provisional}:${p.updatedAt}`,
+        )
+        .join('|'),
+    [pins],
+  );
+
+  useEffect(() => {
+    if (!selected) {
+      setIncidentAsset({ status: 'idle' });
+      return;
+    }
+    if (selected.severity === 'nominal') {
+      setIncidentAsset({ status: 'idle' });
+      return;
+    }
+    let cancelled = false;
+    setIncidentAsset({ status: 'loading' });
+    void (async () => {
+      try {
+        const res = await fetch('/api/globe/render-asset', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            kind: 'incident_card',
+            title: selected.title,
+            domain: selected.domainKey,
+            signalId: selected.id,
+            cycle: cycleId,
+            severity: selected.severity,
+            metadata: {
+              region: selected.meta.region ?? selected.meta.place,
+              cluster: selected.clusterLabel,
+            },
+          }),
+        });
+        const j = (await res.json()) as {
+          ok?: boolean;
+          imageUrl?: string;
+          cached?: boolean;
+          error?: string;
+        };
+        if (cancelled) return;
+        if (j.ok && j.imageUrl) {
+          setIncidentAsset({ status: 'ready', url: j.imageUrl, cached: Boolean(j.cached) });
+        } else {
+          setIncidentAsset({
+            status: 'unavailable',
+            message: j.error ?? 'Visual asset unavailable',
+          });
+        }
+      } catch {
+        if (!cancelled) {
+          setIncidentAsset({ status: 'unavailable', message: 'Provider offline' });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [selected?.id, selected?.severity, cycleId, selected?.title, selected?.domainKey]);
+
+  const requestCycleHero = useCallback(async () => {
+    setHeroBusy(true);
+    try {
+      const elevated = pins.filter((p) => p.severity !== 'nominal').length;
+      const res = await fetch('/api/globe/render-asset', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          kind: 'cycle_hero',
+          title: `${cycleId} world state`,
+          cycle: cycleId,
+          severity: giScore > 0.85 ? 'nominal' : giScore > 0.7 ? 'elevated' : 'critical',
+          metadata: {
+            giBand: giScore > 0.85 ? 'nominal' : giScore > 0.7 ? 'watch' : 'stressed',
+            highlights: [
+              `${pins.length} globe pins`,
+              elevated ? `${elevated} non-nominal` : 'all nominal pins',
+              `GI ${giScore.toFixed(2)}`,
+            ],
+          },
+        }),
+      });
+      const j = (await res.json()) as { ok?: boolean; imageUrl?: string; error?: string };
+      if (j.ok && j.imageUrl) {
+        window.open(j.imageUrl, '_blank', 'noopener,noreferrer');
+      } else {
+        window.alert(j.error ?? 'Cycle hero render failed');
+      }
+    } finally {
+      setHeroBusy(false);
+    }
+  }, [pins, cycleId, giScore]);
 
   useEffect(() => {
     const host = containerRef.current;
@@ -168,6 +309,9 @@ export default function GlobeChamber({
       renderer.setClearColor(0x020408, 1);
       el.appendChild(renderer.domElement);
 
+      const globeGroup = new THREE.Group();
+      scene.add(globeGroup);
+
       const globeGeo = new THREE.SphereGeometry(1, 64, 64);
       const globeMat = new THREE.MeshPhongMaterial({
         color: 0x0a1628,
@@ -178,7 +322,7 @@ export default function GlobeChamber({
         opacity: 0.95,
       });
       const globe = new THREE.Mesh(globeGeo, globeMat);
-      scene.add(globe);
+      globeGroup.add(globe);
 
       const wireGeo = new THREE.SphereGeometry(1.001, 24, 24);
       const wireMat = new THREE.MeshBasicMaterial({
@@ -187,7 +331,7 @@ export default function GlobeChamber({
         transparent: true,
         opacity: 0.15,
       });
-      scene.add(new THREE.Mesh(wireGeo, wireMat));
+      globeGroup.add(new THREE.Mesh(wireGeo, wireMat));
 
       const atmGeo = new THREE.SphereGeometry(1.08, 64, 64);
       const atmMat = new THREE.MeshPhongMaterial({
@@ -196,7 +340,7 @@ export default function GlobeChamber({
         opacity: 0.08,
         side: THREE.BackSide,
       });
-      scene.add(new THREE.Mesh(atmGeo, atmMat));
+      globeGroup.add(new THREE.Mesh(atmGeo, atmMat));
 
       scene.add(new THREE.AmbientLight(0x112244, 0.6));
       const sun = new THREE.DirectionalLight(0x4488cc, 0.8);
@@ -209,9 +353,12 @@ export default function GlobeChamber({
       const raycaster = new THREE.Raycaster();
       const mouse = new THREE.Vector2();
       let isDragging = false;
+      let dragDistance = 0;
       let prevMouse = { x: 0, y: 0 };
       let autoRotate = true;
       let autoRotateTimer: number | null = null;
+      let targetRotX = 0;
+      let targetRotY = 0;
       let t = 0;
 
       const state: GlobeSceneState = {
@@ -219,7 +366,7 @@ export default function GlobeChamber({
         scene,
         camera,
         renderer,
-        globe,
+        globeGroup,
         pinMeshes: [],
         pulseMeshes: [],
         pins: [],
@@ -227,9 +374,12 @@ export default function GlobeChamber({
         raycaster,
         mouse,
         isDragging,
+        dragDistance,
         prevMouse,
         autoRotate,
         autoRotateTimer,
+        targetRotX,
+        targetRotY,
         onMove: (_e: MouseEvent) => {},
         onDown: (_e: MouseEvent) => {},
         onUp: (_e: MouseEvent) => {},
@@ -238,35 +388,27 @@ export default function GlobeChamber({
       };
       sceneRef.current = state;
 
-      const rotateAttached = (dy: number, dx: number) => {
-        globe.rotation.y += dy;
-        globe.rotation.x += dx;
-        scene.children.forEach((c: any) => {
-          if (c !== globe && c.type === 'Mesh') {
-            c.rotation.y += dy;
-            c.rotation.x += dx;
-          }
-        });
-      };
-
       state.onDown = (e: MouseEvent) => {
         state.isDragging = true;
+        state.dragDistance = 0;
         state.autoRotate = false;
         if (state.autoRotateTimer != null) window.clearTimeout(state.autoRotateTimer);
         state.prevMouse = { x: e.clientX, y: e.clientY };
       };
 
       state.onMove = (e: MouseEvent) => {
+        const rect = renderer.domElement.getBoundingClientRect();
         if (state.isDragging) {
           const dx = e.clientX - state.prevMouse.x;
           const dy = e.clientY - state.prevMouse.y;
-          const rotY = dx * 0.005;
-          const rotX = dy * 0.005;
-          rotateAttached(rotY, rotX);
+          state.dragDistance += Math.abs(dx) + Math.abs(dy);
+          globeGroup.rotation.y += dx * 0.005;
+          globeGroup.rotation.x += dy * 0.005;
+          state.targetRotY = globeGroup.rotation.y;
+          state.targetRotX = globeGroup.rotation.x;
           state.prevMouse = { x: e.clientX, y: e.clientY };
         }
 
-        const rect = renderer.domElement.getBoundingClientRect();
         state.mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
         state.mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
         state.raycaster.setFromCamera(state.mouse, state.camera);
@@ -277,7 +419,7 @@ export default function GlobeChamber({
           setTooltip({
             x: e.clientX + 14,
             y: e.clientY - 10,
-            text: `${sig.source} · ${(sig.value * 100).toFixed(0)}%`,
+            text: `${sig.source} · conf ${(sig.confidence * 100).toFixed(0)}% · ${sig.ageSec < 60 ? `${sig.ageSec}s` : `${Math.floor(sig.ageSec / 60)}m`} fresh`,
           });
           renderer.domElement.style.cursor = 'pointer';
         } else {
@@ -291,13 +433,15 @@ export default function GlobeChamber({
         state.isDragging = false;
 
         const rect = renderer.domElement.getBoundingClientRect();
-        state.mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
-        state.mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
-        state.raycaster.setFromCamera(state.mouse, state.camera);
-        const heads = state.pinMeshes.filter((m) => m.userData.kind === 'head');
-        const hits = state.raycaster.intersectObjects(heads);
-        if (hits.length > 0) {
-          setSelected(hits[0].object.userData.pin as GlobePin);
+        if (state.dragDistance < DRAG_CLICK_THRESHOLD) {
+          state.mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+          state.mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+          state.raycaster.setFromCamera(state.mouse, state.camera);
+          const heads = state.pinMeshes.filter((m) => m.userData.kind === 'head');
+          const hits = state.raycaster.intersectObjects(heads);
+          if (hits.length > 0) {
+            setSelected(hits[0].object.userData.pin as GlobePin);
+          }
         }
 
         const tid = window.setTimeout(() => {
@@ -327,20 +471,20 @@ export default function GlobeChamber({
         state.t += 0.016;
 
         if (state.autoRotate) {
-          const dy = 0.0008;
-          globe.rotation.y += dy;
-          scene.children.forEach((c: any) => {
-            if (c !== globe && c.type === 'Mesh') c.rotation.y += dy;
-          });
+          state.targetRotY += 0.0008;
         }
+        const lerp = 0.08;
+        globeGroup.rotation.y += (state.targetRotY - globeGroup.rotation.y) * lerp;
+        globeGroup.rotation.x += (state.targetRotX - globeGroup.rotation.x) * lerp;
 
         for (const ring of state.pulseMeshes) {
-          const ud = ring.userData as { phase: number; speed: number };
+          const ud = ring.userData as { phase: number; speed: number; baseOpacity: number };
           const s = 1 + Math.sin(state.t * ud.speed * 40 + ud.phase) * 0.4;
           ring.scale.setScalar(s);
           const mat = ring.material as { opacity?: number };
           if (typeof mat.opacity === 'number') {
-            mat.opacity = 0.5 - Math.sin(state.t * ud.speed * 40 + ud.phase) * 0.3;
+            const swing = Math.sin(state.t * ud.speed * 40 + ud.phase) * 0.22;
+            mat.opacity = Math.max(0.12, Math.min(0.92, ud.baseOpacity + swing));
           }
         }
 
@@ -372,18 +516,39 @@ export default function GlobeChamber({
     };
   }, []);
 
+  const focusDomain = useCallback(
+    (key: SentimentDomainKey) => {
+      const match = pins.find((p) => p.domainKey === key);
+      if (!match) return;
+      setSelectedDomain(key);
+      setSelected(match);
+      const st = sceneRef.current;
+      if (!st) return;
+      st.autoRotate = false;
+      if (st.autoRotateTimer != null) window.clearTimeout(st.autoRotateTimer);
+      const t = rotateGlobeTargetToLatLng(st.THREE, match.lat, match.lng);
+      st.targetRotY = t.y;
+      st.targetRotX = t.x;
+      window.setTimeout(() => {
+        if (!sceneRef.current) return;
+        sceneRef.current.autoRotate = true;
+      }, 5000);
+    },
+    [pins],
+  );
+
   const rebuildPins = useCallback(() => {
     const st = sceneRef.current;
     if (!st) return;
 
     for (const m of st.pinMeshes) {
-      st.scene.remove(m);
+      st.globeGroup.remove(m);
       if (m.geometry) m.geometry.dispose();
       const mat = m.material as { dispose?: () => void };
       mat?.dispose?.();
     }
     for (const m of st.pulseMeshes) {
-      st.scene.remove(m);
+      st.globeGroup.remove(m);
       if (m.geometry) m.geometry.dispose();
       const mat = m.material as { dispose?: () => void };
       mat?.dispose?.();
@@ -393,41 +558,68 @@ export default function GlobeChamber({
     st.pins = pins;
 
     const THREE = st.THREE;
+    const group = st.globeGroup;
 
     for (const sig of pins) {
       const pos = latLngToXYZ(THREE, sig.lat, sig.lng);
       const color = severityColor(sig.severity);
+      const headOp = freshnessHeadOpacity(sig.ageSec);
+      const stemOp = stemOpacity(sig.ageSec);
 
       const stemGeo = new THREE.CylinderGeometry(0.003, 0.003, 0.06, 6);
-      const stemMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.7 });
+      const stemMat = new THREE.MeshBasicMaterial({
+        color,
+        transparent: true,
+        opacity: stemOp,
+      });
       const stem = new THREE.Mesh(stemGeo, stemMat);
       stem.position.copy(pos.clone().multiplyScalar(0.97));
       stem.lookAt(0, 0, 0);
       stem.rotateX(Math.PI / 2);
-      st.scene.add(stem);
+      group.add(stem);
       st.pinMeshes.push(stem);
 
       const headGeo = new THREE.SphereGeometry(0.018, 8, 8);
-      const headMat = new THREE.MeshBasicMaterial({ color });
+      const headMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: headOp });
       const head = new THREE.Mesh(headGeo, headMat);
       head.position.copy(pos.clone().multiplyScalar(1.04));
       head.userData = { pin: sig, kind: 'head' };
-      st.scene.add(head);
+      group.add(head);
       st.pinMeshes.push(head);
+
+      if (sig.provisional) {
+        const dashGeo = new THREE.RingGeometry(0.032, 0.036, 32);
+        const dashMat = new THREE.MeshBasicMaterial({
+          color: 0x64748b,
+          transparent: true,
+          opacity: 0.35,
+          side: THREE.DoubleSide,
+        });
+        const dash = new THREE.Mesh(dashGeo, dashMat);
+        dash.position.copy(pos.clone().multiplyScalar(1.04));
+        dash.lookAt(pos.clone().multiplyScalar(2));
+        group.add(dash);
+        st.pinMeshes.push(dash);
+      }
 
       if (sig.pulse) {
         const ringGeo = new THREE.RingGeometry(0.02, 0.028, 16);
+        const baseOp = 0.35 + sig.confidence * 0.45;
         const ringMat = new THREE.MeshBasicMaterial({
           color,
           transparent: true,
-          opacity: 0.6,
+          opacity: baseOp,
           side: THREE.DoubleSide,
         });
         const ring = new THREE.Mesh(ringGeo, ringMat);
         ring.position.copy(pos.clone().multiplyScalar(1.04));
         ring.lookAt(pos.clone().multiplyScalar(2));
-        ring.userData = { phase: Math.random() * Math.PI * 2, speed: 0.02 + Math.random() * 0.01 };
-        st.scene.add(ring);
+        ring.userData = {
+          phase: Math.random() * Math.PI * 2,
+          speed: 0.02 + Math.random() * 0.01,
+          baseOpacity: baseOp,
+        };
+        group.add(ring);
         st.pulseMeshes.push(ring);
       }
     }
@@ -441,13 +633,11 @@ export default function GlobeChamber({
     return () => cancelAnimationFrame(id);
   }, [webglReady, pinsKey, rebuildPins]);
 
-  const focusDomain = useCallback(
-    (key: SentimentDomainKey) => {
-      const match = pins.find((p) => p.domainKey === key);
-      if (match) setSelected(match);
-    },
-    [pins],
-  );
+  const formatAge = (sec: number) => {
+    if (sec < 60) return `${sec}s ago`;
+    if (sec < 3600) return `${Math.floor(sec / 60)}m ago`;
+    return `${Math.floor(sec / 3600)}h ago`;
+  };
 
   return (
     <div className="relative overflow-hidden rounded-lg border border-slate-800 bg-[#020408] font-mono text-slate-200">
@@ -458,15 +648,39 @@ export default function GlobeChamber({
       />
       <div ref={containerRef} className="relative h-[min(72vh,640px)] w-full" />
 
-      <div className="pointer-events-none absolute inset-x-0 top-0 flex items-center justify-between bg-gradient-to-b from-[#020408]/95 to-transparent px-4 py-3">
-        <div className="text-[11px] uppercase tracking-[0.18em] text-slate-500">Mobius Civic Terminal</div>
-        <div
-          className={cn(
-            'pointer-events-none rounded border px-3 py-1 text-[11px] uppercase tracking-[0.12em]',
-            giChipClass(giScore),
-          )}
-        >
-          GI {giScore.toFixed(2)} · {giChipLabel(giScore)}
+      <div className="pointer-events-none absolute left-3 top-12 z-10 max-w-[14rem] rounded border border-white/[0.06] bg-[#020408]/85 px-2.5 py-2 backdrop-blur-sm">
+        <div className="text-[8px] uppercase tracking-[0.16em] text-slate-500">World state delta</div>
+        {deltaLines.map((line) => (
+          <div key={line} className="text-[9px] leading-snug text-slate-400">
+            {line}
+          </div>
+        ))}
+      </div>
+
+      <div className="pointer-events-none absolute inset-x-0 top-0 flex items-start justify-between bg-gradient-to-b from-[#020408]/95 to-transparent px-4 py-3">
+        <div>
+          <div className="text-[11px] uppercase tracking-[0.18em] text-slate-500">Mobius Civic Terminal</div>
+          <div className="mt-1 text-[9px] uppercase tracking-[0.12em] text-slate-600">
+            Globe chamber · live world state
+          </div>
+        </div>
+        <div className="flex flex-col items-end gap-1">
+          <div
+            className={cn(
+              'pointer-events-none rounded border px-3 py-1 text-[11px] uppercase tracking-[0.12em]',
+              giChipClass(giScore),
+            )}
+          >
+            GI {giScore.toFixed(2)} · {giChipLabel(giScore)}
+          </div>
+          <button
+            type="button"
+            onClick={() => void requestCycleHero()}
+            disabled={heroBusy}
+            className="pointer-events-auto rounded border border-slate-600/80 bg-slate-900/90 px-2 py-0.5 text-[8px] uppercase tracking-[0.14em] text-slate-400 hover:border-cyan-500/40 hover:text-cyan-200 disabled:opacity-40"
+          >
+            {heroBusy ? 'Rendering…' : 'Render cycle hero'}
+          </button>
         </div>
         <div className="text-[10px] tracking-[0.1em] text-slate-600">
           {cycleId} · {clockLabel}
@@ -477,7 +691,7 @@ export default function GlobeChamber({
         Drag to rotate · Click pins to inspect
       </div>
 
-      <div className="flex border-t border-white/[0.06] bg-[#020408]/90">
+      <div className="flex overflow-x-auto border-t border-white/[0.06] bg-[#020408]/90 [-webkit-overflow-scrolling:touch]">
         {GLOBE_DOMAIN_ORDER.map((key) => {
           const d = domainByKey[key];
           const score = d?.score;
@@ -488,12 +702,16 @@ export default function GlobeChamber({
             : score >= 0.8 ? 'text-emerald-400'
             : score >= 0.6 ? 'text-amber-400'
             : 'text-rose-400';
+          const active = selectedDomain === key;
           return (
             <button
               key={key}
               type="button"
               onClick={() => focusDomain(key)}
-              className="flex flex-1 flex-col items-center border-r border-white/[0.04] px-1 py-2 transition hover:bg-white/[0.04] sm:px-2"
+              className={cn(
+                'flex min-w-[4.5rem] shrink-0 flex-col items-center border-r border-white/[0.04] px-2 py-2 transition sm:min-w-0 sm:flex-1',
+                active ? 'bg-cyan-500/10 ring-1 ring-inset ring-cyan-500/25' : 'hover:bg-white/[0.04]',
+              )}
             >
               <div className="text-[9px] uppercase tracking-[0.1em] text-slate-600">{label}</div>
               <div className={cn('text-[13px] font-bold', scoreClass)}>{score != null ? score.toFixed(2) : '—'}</div>
@@ -514,28 +732,75 @@ export default function GlobeChamber({
 
       {selected ? (
         <div
-          className="fixed right-4 top-1/2 z-50 w-[min(92vw,280px)] rounded-md border border-white/10 bg-[#020408]/95 p-5 shadow-xl backdrop-blur-md"
+          className="fixed right-4 top-1/2 z-50 max-h-[min(88vh,640px)] w-[min(92vw,280px)] overflow-y-auto rounded-md border border-white/10 bg-[#020408]/95 p-5 shadow-xl backdrop-blur-md"
           style={{ top: '50%', animation: 'globeInsp 0.2s ease' }}
         >
           <button
             type="button"
             className="absolute right-3 top-3 text-slate-500 hover:text-slate-300"
             aria-label="Close inspection"
-            onClick={() => setSelected(null)}
+            onClick={() => {
+              setSelected(null);
+              setSelectedDomain(null);
+            }}
           >
             ✕
           </button>
+
+          {incidentAsset.status === 'loading' ? (
+            <div className="mb-3 rounded border border-amber-500/20 bg-amber-500/5 px-2 py-2 text-[9px] text-amber-200/90">
+              Rendering visual asset…
+            </div>
+          ) : null}
+          {incidentAsset.status === 'ready' ? (
+            <div className="mb-3">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={incidentAsset.url}
+                alt=""
+                className="w-full rounded border border-white/10 object-cover"
+                loading="lazy"
+              />
+              {incidentAsset.cached ? (
+                <div className="mt-1 text-[8px] text-slate-600">Cached asset</div>
+              ) : null}
+            </div>
+          ) : null}
+          {incidentAsset.status === 'unavailable' ? (
+            <div className="mb-3 rounded border border-slate-700/80 bg-slate-900/50 px-2 py-2 text-[9px] text-slate-500">
+              Visual asset unavailable — {incidentAsset.message}
+            </div>
+          ) : null}
+
           <div className="mb-1 text-[9px] uppercase tracking-[0.12em] text-slate-500">{selected.source}</div>
-          <div className="mb-3 text-[13px] leading-snug text-slate-200">{selected.title}</div>
+          <div className="mb-2 text-[13px] leading-snug text-slate-200">{selected.title}</div>
+          <p className="mb-3 text-[10px] leading-relaxed text-slate-500">{selected.narrativeWhy}</p>
+
+          <div className="mb-2 flex flex-wrap gap-1 text-[8px] uppercase tracking-[0.08em]">
+            <span className="rounded border border-slate-600/60 px-1.5 py-0.5 text-slate-500">Feed</span>
+            <span className="text-slate-600">{selected.source.split('·')[1]?.trim() ?? 'micro'}</span>
+            {selected.meta.epiconId ? (
+              <span className="rounded border border-sky-500/25 px-1.5 py-0.5 text-sky-400/90">
+                EPICON {String(selected.meta.epiconId).slice(0, 12)}…
+              </span>
+            ) : (
+              <span className="rounded border border-slate-700 px-1.5 py-0.5 text-slate-500">Ledger pending path</span>
+            )}
+          </div>
+
           <div className="mb-2 flex items-center gap-2">
+            <span className="text-[10px] text-slate-500">Integrity</span>
             <span
               className={cn(
-                'text-[28px] font-bold',
+                'text-[22px] font-bold',
                 selected.value >= 0.75 ? 'text-emerald-400' : selected.value >= 0.5 ? 'text-amber-400' : 'text-rose-400',
               )}
             >
               {selected.value.toFixed(2)}
             </span>
+            <span className="text-[10px] text-slate-500">Conf {(selected.confidence * 100).toFixed(0)}%</span>
+          </div>
+          <div className="mb-2 flex flex-wrap items-center gap-2">
             <span
               className={cn(
                 'rounded border px-2 py-0.5 text-[9px] uppercase tracking-[0.1em]',
@@ -548,6 +813,11 @@ export default function GlobeChamber({
             >
               {selected.severity}
             </span>
+            {selected.provisional ? (
+              <span className="rounded border border-dashed border-slate-500/50 px-2 py-0.5 text-[8px] uppercase tracking-[0.12em] text-slate-500">
+                Provisional
+              </span>
+            ) : null}
           </div>
           <div className="mb-3 h-1 overflow-hidden rounded bg-white/10">
             <div
@@ -559,13 +829,26 @@ export default function GlobeChamber({
               }}
             />
           </div>
+          <div className="mb-2 text-[9px] text-slate-500">
+            Updated <span className="text-slate-400">{formatAge(selected.ageSec)}</span>
+            {selected.clusterLabel ? (
+              <>
+                {' '}
+                · <span className="text-slate-400">{selected.clusterLabel}</span>
+              </>
+            ) : null}
+          </div>
           {miiScore != null ? (
             <div className="mb-3 text-[10px] text-slate-500">
               MII <span className="text-slate-300">{miiScore.toFixed(2)}</span>
             </div>
           ) : null}
+          <div className="mb-2 text-[9px] text-slate-600">
+            <span className="text-slate-500">Provenance: </span>
+            {selected.provenance}
+          </div>
           <hr className="mb-3 border-white/[0.06]" />
-          <div className="max-h-40 space-y-1 overflow-y-auto text-[9px] leading-relaxed text-slate-500">
+          <div className="max-h-32 space-y-1 overflow-y-auto text-[9px] leading-relaxed text-slate-500">
             {Object.entries(selected.meta).map(([k, v]) => (
               <div key={k}>
                 <span className="text-slate-600">{k}: </span>

--- a/hooks/useTerminalCommands.ts
+++ b/hooks/useTerminalCommands.ts
@@ -17,7 +17,9 @@ import type {
 } from '@/lib/terminal/types';
 
 const NAV_COMMANDS: Record<string, { nav: NavKey; label: string }> = {
+  '/globe': { nav: 'globe', label: 'Globe' },
   '/pulse': { nav: 'pulse', label: 'Pulse' },
+  '/sentinel': { nav: 'agents', label: 'Sentinel' },
   '/markets': { nav: 'markets', label: 'Markets' },
   '/market': { nav: 'markets', label: 'Markets' },
   '/ledger': { nav: 'ledger', label: 'Ledger' },

--- a/hooks/useTerminalData.ts
+++ b/hooks/useTerminalData.ts
@@ -295,7 +295,10 @@ export function useTerminalData(selectedNav: NavKey, initialData?: TerminalBoots
   );
 
   const filteredAgents = useMemo(
-    () => (selectedNav === 'pulse' || selectedNav === 'agents' ? agents : agents.filter((agent) => agent.status !== 'idle')),
+    () =>
+      selectedNav === 'pulse' || selectedNav === 'agents' || selectedNav === 'globe'
+        ? agents
+        : agents.filter((agent) => agent.status !== 'idle'),
     [agents, selectedNav],
   );
 

--- a/lib/agents/micro/gaia.ts
+++ b/lib/agents/micro/gaia.ts
@@ -15,7 +15,7 @@ import {
   normalizeDirect,
   safeFetch,
 } from './core';
-import { fetchEonetEvents, scoreEonetEvents } from '@/lib/signals/eonet';
+import { fetchEonetEvents, scoreEonetEvents, type EonetEvent } from '@/lib/signals/eonet';
 
 export const GAIA_CONFIG: MicroAgentConfig = {
   name: 'GAIA',
@@ -74,6 +74,7 @@ async function pollWeather(): Promise<MicroSignal | null> {
 // ── USGS Earthquake API: significant earthquakes in last day ──────────────
 type USGSFeature = {
   properties: { mag: number; place: string; time: number };
+  geometry?: { type?: string; coordinates?: number[] | number[][] | number[][][] };
 };
 type USGSResponse = {
   features?: USGSFeature[];
@@ -99,6 +100,29 @@ async function pollEarthquakes(): Promise<MicroSignal | null> {
 
   const strongest = quakes[0]?.properties;
 
+  const byMag = [...quakes].sort((a, b) => b.properties.mag - a.properties.mag);
+  const samples = byMag.slice(0, 10).map((f) => {
+    const coords = f.geometry?.coordinates;
+    let lng: number | null = null;
+    let lat: number | null = null;
+    if (Array.isArray(coords) && typeof coords[0] === 'number' && typeof coords[1] === 'number') {
+      lng = coords[0];
+      lat = coords[1];
+    } else if (Array.isArray(coords) && Array.isArray(coords[0]) && typeof coords[0][0] === 'number') {
+      const ring = coords[0] as number[][];
+      if (ring[0] && typeof ring[0][0] === 'number' && typeof ring[0][1] === 'number') {
+        lng = ring[0][0];
+        lat = ring[0][1];
+      }
+    }
+    return {
+      mag: f.properties.mag,
+      place: f.properties.place,
+      lat,
+      lng,
+    };
+  });
+
   return {
     agentName: 'GAIA',
     source: 'USGS Earthquake',
@@ -106,8 +130,24 @@ async function pollEarthquakes(): Promise<MicroSignal | null> {
     value,
     label: `Seismic: ${count} quakes M2.5+ today, max M${maxMag.toFixed(1)}${strongest ? ` near ${strongest.place}` : ''}`,
     severity: classifySeverity(value, { watch: 0.5, elevated: 0.3, critical: 0.1 }),
-    raw: { count, maxMag },
+    raw: { count, maxMag, samples },
   };
+}
+
+function eonetFirstLatLng(event: EonetEvent): { lat: number; lng: number } | null {
+  for (const g of event.geometry) {
+    const c = g.coordinates;
+    if (g.type === 'Point' && Array.isArray(c) && typeof c[0] === 'number' && typeof c[1] === 'number') {
+      return { lng: c[0], lat: c[1] };
+    }
+    if (Array.isArray(c) && Array.isArray(c[0])) {
+      const first = c[0] as unknown;
+      if (Array.isArray(first) && typeof first[0] === 'number' && typeof first[1] === 'number') {
+        return { lng: first[0], lat: first[1] };
+      }
+    }
+  }
+  return null;
 }
 
 async function pollEonet(): Promise<MicroSignal | null> {
@@ -115,6 +155,16 @@ async function pollEonet(): Promise<MicroSignal | null> {
     .then((events) => {
       const storms = events.filter((event) => event.categories.some((category) => category.id === 'severeStorms')).length;
       const fires = events.filter((event) => event.categories.some((category) => category.id === 'wildfires')).length;
+
+      const eonetSamples = events
+        .map((ev) => {
+          const ll = eonetFirstLatLng(ev);
+          if (!ll) return null;
+          const cat = ev.categories[0]?.id ?? 'event';
+          return { id: ev.id, title: ev.title, lat: ll.lat, lng: ll.lng, category: cat };
+        })
+        .filter((row): row is NonNullable<typeof row> => row !== null)
+        .slice(0, 14);
 
       return {
         agentName: 'GAIA',
@@ -128,6 +178,7 @@ async function pollEonet(): Promise<MicroSignal | null> {
           topEvent: events[0]?.title ?? null,
           severeStorms: storms,
           wildfires: fires,
+          samples: eonetSamples,
         },
       } satisfies MicroSignal;
     })

--- a/lib/echo/sources.ts
+++ b/lib/echo/sources.ts
@@ -84,12 +84,21 @@ export async function fetchUSGS(): Promise<RawEvent[]> {
         tsunami?: number;
       };
       id: string;
+      geometry?: { type?: string; coordinates?: number[] | number[][] | number[][][] };
     }> = data?.features ?? [];
 
     return features.slice(0, 6).map((f) => {
       const mag = f.properties.mag ?? 0;
       const severity: RawEvent['severity'] =
         mag >= 6 ? 'high' : mag >= 4 ? 'medium' : 'low';
+
+      const coords = f.geometry?.coordinates;
+      let lat: number | undefined;
+      let lng: number | undefined;
+      if (Array.isArray(coords) && typeof coords[0] === 'number' && typeof coords[1] === 'number') {
+        lng = coords[0];
+        lat = coords[1];
+      }
 
       return {
         sourceId: `usgs-${f.id}`,
@@ -106,6 +115,8 @@ export async function fetchUSGS(): Promise<RawEvent[]> {
           magnitude: mag,
           alert: f.properties.alert,
           tsunami: f.properties.tsunami,
+          lat,
+          lng,
         },
       };
     });

--- a/lib/echo/transform.ts
+++ b/lib/echo/transform.ts
@@ -92,6 +92,11 @@ export function toEpiconItem(raw: RawEvent): EpiconItem {
     timestamp: formatTimestamp(raw.timestamp),
     sources: [raw.source, ...(raw.url ? [new URL(raw.url).hostname] : [])],
     summary: raw.summary,
+    echoIngest: {
+      source: raw.source,
+      severity: raw.severity,
+      metadata: raw.metadata,
+    },
     trace: [
       `ECHO captured signal from ${raw.source}`,
       `${agent} classified as ${raw.category}`,

--- a/lib/globe/assetCache.ts
+++ b/lib/globe/assetCache.ts
@@ -1,0 +1,51 @@
+import { createHash } from 'crypto';
+import { kvGet, kvSet, isRedisAvailable } from '@/lib/kv/store';
+import type { CachedGlobeAssetRecord, GlobeRenderKind } from './types';
+
+const CACHE_PREFIX = 'globe:asset:';
+const TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
+export function buildGlobeAssetCacheKey(params: {
+  kind: GlobeRenderKind;
+  cycle?: string;
+  signalId?: string;
+  title: string;
+  severity?: string;
+  prompt: string;
+}): string {
+  const normalized = [
+    params.kind,
+    params.cycle ?? '',
+    params.signalId ?? '',
+    params.title.trim().toLowerCase().slice(0, 200),
+    params.severity ?? '',
+    params.prompt.trim().slice(0, 500),
+  ].join('|');
+  return createHash('sha256').update(normalized).digest('hex');
+}
+
+const memoryCache = new Map<string, CachedGlobeAssetRecord>();
+const MEMORY_MAX = 200;
+
+export async function getCachedGlobeAsset(cacheKey: string): Promise<CachedGlobeAssetRecord | null> {
+  if (isRedisAvailable()) {
+    const v = await kvGet<CachedGlobeAssetRecord>(`${CACHE_PREFIX}${cacheKey}`);
+    if (v) return v;
+  }
+  return memoryCache.get(cacheKey) ?? null;
+}
+
+export async function setCachedGlobeAsset(
+  cacheKey: string,
+  record: CachedGlobeAssetRecord,
+): Promise<boolean> {
+  memoryCache.set(cacheKey, record);
+  if (memoryCache.size > MEMORY_MAX) {
+    const first = memoryCache.keys().next().value as string | undefined;
+    if (first) memoryCache.delete(first);
+  }
+  if (isRedisAvailable()) {
+    return kvSet(`${CACHE_PREFIX}${cacheKey}`, record, TTL_SECONDS);
+  }
+  return true;
+}

--- a/lib/globe/globeDelta.ts
+++ b/lib/globe/globeDelta.ts
@@ -1,0 +1,33 @@
+import type { GlobePin } from '@/lib/terminal/globePins';
+
+function countElevated(pins: GlobePin[]) {
+  return pins.filter((p) => p.severity === 'elevated' || p.severity === 'critical').length;
+}
+
+function countByDomain(pins: GlobePin[], key: GlobePin['domainKey']) {
+  return pins.filter((p) => p.domainKey === key).length;
+}
+
+export function computeGlobeDeltaLines(prev: GlobePin[], next: GlobePin[], giScore: number): string[] {
+  const lines: string[] = [];
+  const prevEl = countElevated(prev);
+  const nextEl = countElevated(next);
+  const d = nextEl - prevEl;
+  if (d > 0) lines.push(`+${d} elevated signal${d === 1 ? '' : 's'}`);
+  else if (d < 0) lines.push(`${d} elevated signal${d === -1 ? '' : 's'} (cleared)`);
+
+  const prevPins = new Set(prev.map((p) => p.id));
+  const newcomers = next.filter((p) => !prevPins.has(p.id));
+  const seismicNew = newcomers.filter((p) => p.source.includes('USGS')).length;
+  if (seismicNew > 0) lines.push(`+${seismicNew} new seismic pin${seismicNew === 1 ? '' : 's'}`);
+
+  const fin = countByDomain(next, 'financial');
+  if (fin > 0) lines.push(`Financial lane: ${fin} live pin${fin === 1 ? '' : 's'}`);
+
+  if (giScore >= 0.85) lines.push('GI band: nominal');
+  else if (giScore >= 0.7) lines.push('GI band: watch');
+  else lines.push('GI band: stressed');
+
+  if (lines.length === 0) lines.push('World state steady — no pin churn');
+  return lines.slice(0, 4);
+}

--- a/lib/globe/renderPrompts.ts
+++ b/lib/globe/renderPrompts.ts
@@ -1,0 +1,97 @@
+import type { GlobeRenderDomain, GlobeRenderKind } from './types';
+
+function domainTone(domain?: GlobeRenderDomain): string {
+  switch (domain) {
+    case 'civic':
+      return 'regulatory transparency, federal civic layer';
+    case 'environ':
+      return 'natural systems, hazards, ecological integrity';
+    case 'financial':
+      return 'market pulse, stability-oriented civic finance view';
+    case 'narrative':
+      return 'information velocity, discourse integrity';
+    case 'infrastructure':
+      return 'systems resilience, deployment substrate';
+    case 'institutional':
+      return 'open data, institutional trust signals';
+    default:
+      return 'civic integrity systems';
+  }
+}
+
+export function buildIncidentCardPrompt(params: {
+  title: string;
+  domain?: GlobeRenderDomain;
+  severity?: string;
+  regionHint?: string;
+}): string {
+  const { title, domain, severity, regionHint } = params;
+  const tone = domainTone(domain);
+  const sev = severity ?? 'elevated';
+  const place = regionHint ? `Focus: ${regionHint}. ` : '';
+  return [
+    'Dark civic command interface artwork, glowing globe, Mobius Terminal aesthetic.',
+    `${place}Subject: ${title.slice(0, 120)}.`,
+    `${tone}. Severity mood: ${sev} — amber pulse accents if elevated, restrained red if critical.`,
+    'Midnight palette, cyan and amber signal lines, minimal text, high contrast, precise not generic sci-fi.',
+  ].join(' ');
+}
+
+export function buildCycleHeroPrompt(params: {
+  cycle: string;
+  giBand: string;
+  highlights: string[];
+}): string {
+  const lines = params.highlights.slice(0, 4).join(' · ');
+  return [
+    `Mobius Civic Terminal cycle recap: ${params.cycle}.`,
+    `Global integrity band: ${params.giBand}.`,
+    lines ? `Signal highlights: ${lines}.` : 'Live world-state synthesis.',
+    'Deep midnight background, globe with elevated pulse regions, cyan and amber accents, constitutional systems feeling, elegant technical composition, no logos.',
+  ].join(' ');
+}
+
+export function promptForKind(
+  kind: GlobeRenderKind,
+  body: {
+    title: string;
+    domain?: GlobeRenderDomain;
+    cycle?: string;
+    severity?: string;
+    metadata?: Record<string, unknown>;
+    customPrompt?: string;
+  },
+): string {
+  if (body.customPrompt?.trim()) return body.customPrompt.trim();
+
+  if (kind === 'cycle_hero') {
+    const meta = body.metadata as { highlights?: string[]; giBand?: string } | undefined;
+    return buildCycleHeroPrompt({
+      cycle: body.cycle ?? 'C-current',
+      giBand: meta?.giBand ?? 'nominal',
+      highlights: Array.isArray(meta?.highlights) ? meta.highlights : [body.title],
+    });
+  }
+
+  if (kind === 'domain_icon') {
+    return `Minimal sigil icon for Mobius domain ${body.domain ?? 'civic'}, ${domainTone(body.domain)}, flat vector-like, midnight and cyan, square asset.`;
+  }
+
+  if (kind === 'overlay_texture') {
+    return `Subtle transparent overlay texture for globe, ${domainTone(body.domain)}, soft signal bloom, tileable, dark base.`;
+  }
+
+  const regionHint =
+    typeof body.metadata?.region === 'string'
+      ? body.metadata.region
+      : typeof body.metadata?.place === 'string'
+        ? body.metadata.place
+        : undefined;
+
+  return buildIncidentCardPrompt({
+    title: body.title,
+    domain: body.domain,
+    severity: body.severity,
+    regionHint,
+  });
+}

--- a/lib/globe/renderProviders/nanoBanana.ts
+++ b/lib/globe/renderProviders/nanoBanana.ts
@@ -1,0 +1,107 @@
+/**
+ * Nano Banana–style image API wrapper (server-only).
+ * Endpoint shape is configurable; ecosystem varies by vendor.
+ */
+
+import { createHash } from 'crypto';
+
+export type NanoBananaGenerateInput = {
+  prompt: string;
+  referenceImageUrls?: string[];
+  asyncMode?: boolean;
+};
+
+export type NanoBananaGenerateResult =
+  | { ok: true; imageUrl: string; raw?: unknown }
+  | { ok: false; error: string; queuedJobId?: string };
+
+function getConfig() {
+  const apiKey = process.env.NANO_BANANA_API_KEY?.trim();
+  const baseUrl = (process.env.NANO_BANANA_BASE_URL ?? '').replace(/\/$/, '');
+  const model = process.env.NANO_BANANA_MODEL?.trim() || 'default';
+  const timeoutMs = Math.min(120_000, Math.max(5_000, Number(process.env.NANO_BANANA_TIMEOUT_MS) || 45_000));
+  return { apiKey, baseUrl, model, timeoutMs };
+}
+
+/**
+ * Attempt sync generation. If API returns async job id, caller may poll separately (v1 returns failed with hint).
+ */
+export async function nanoBananaGenerate(input: NanoBananaGenerateInput): Promise<NanoBananaGenerateResult> {
+  const { apiKey, baseUrl, model, timeoutMs } = getConfig();
+
+  if (!apiKey || !baseUrl) {
+    return { ok: false, error: 'Provider not configured (NANO_BANANA_API_KEY / NANO_BANANA_BASE_URL)' };
+  }
+
+  const url = `${baseUrl}/api/v1/generate`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const body: Record<string, unknown> = {
+      prompt: input.prompt,
+      model,
+      mode: input.asyncMode ? 'async' : 'sync',
+    };
+    if (input.referenceImageUrls?.length) {
+      body.referenceImageUrls = input.referenceImageUrls;
+    }
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+
+    if (!res.ok) {
+      const msg = json && typeof json.error === 'string' ? json.error : `HTTP ${res.status}`;
+      return { ok: false, error: msg };
+    }
+
+    if (!json) {
+      return { ok: false, error: 'Empty provider response' };
+    }
+
+    const dataUrl =
+      json.data && typeof json.data === 'object' && json.data !== null && 'url' in json.data
+        ? (json.data as { url?: unknown }).url
+        : undefined;
+
+    const imageUrl =
+      (typeof json.imageUrl === 'string' && json.imageUrl) ||
+      (typeof json.url === 'string' && json.url) ||
+      (typeof json.output_url === 'string' && json.output_url) ||
+      (typeof dataUrl === 'string' && dataUrl) ||
+      '';
+
+    if (imageUrl) {
+      return { ok: true, imageUrl, raw: json };
+    }
+
+    const jobId =
+      (typeof json.jobId === 'string' && json.jobId) ||
+      (typeof json.id === 'string' && json.id) ||
+      undefined;
+    if (jobId) {
+      return { ok: false, error: 'Async job created; polling not implemented in v1', queuedJobId: jobId };
+    }
+
+    return { ok: false, error: 'Provider response missing image URL' };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Request failed';
+    return { ok: false, error: controller.signal.aborted ? `Timeout after ${timeoutMs}ms` : msg };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function stableAssetId(parts: string[]): string {
+  const h = createHash('sha256').update(parts.join('|')).digest('hex');
+  return `gba-${h.slice(0, 24)}`;
+}

--- a/lib/globe/types.ts
+++ b/lib/globe/types.ts
@@ -1,0 +1,55 @@
+export type GlobeRenderKind = 'incident_card' | 'cycle_hero' | 'domain_icon' | 'overlay_texture';
+
+export type GlobeRenderDomain =
+  | 'civic'
+  | 'environ'
+  | 'financial'
+  | 'narrative'
+  | 'infrastructure'
+  | 'institutional';
+
+export type GlobeRenderAssetRequest = {
+  kind: GlobeRenderKind;
+  title: string;
+  domain?: GlobeRenderDomain;
+  prompt?: string;
+  signalId?: string;
+  cycle?: string;
+  severity?: 'nominal' | 'elevated' | 'critical';
+  metadata?: Record<string, unknown>;
+  referenceImageUrls?: string[];
+};
+
+export type GlobeRenderAssetResponse = {
+  ok: boolean;
+  status: 'queued' | 'completed' | 'failed';
+  assetId: string;
+  imageUrl?: string;
+  provider: 'nano-banana';
+  cached: boolean;
+  error?: string;
+  diagnostics?: {
+    provider: string;
+    cached: boolean;
+    createdAt: string;
+    sourceSignalId?: string;
+    cycle?: string;
+    failureReason?: string;
+  };
+};
+
+export type GlobeVisualAsset = {
+  assetId: string;
+  imageUrl: string;
+  kind: GlobeRenderKind;
+  status: 'queued' | 'completed' | 'failed';
+  provider: 'nano-banana';
+};
+
+export type CachedGlobeAssetRecord = {
+  assetId: string;
+  imageUrl: string;
+  kind: GlobeRenderKind;
+  createdAt: string;
+  cacheKey: string;
+};

--- a/lib/terminal/globePins.ts
+++ b/lib/terminal/globePins.ts
@@ -1,5 +1,6 @@
 import type { MicroSignal } from '@/lib/agents/micro/core';
 import type { EpiconItem } from '@/lib/terminal/types';
+import type { GlobeVisualAsset } from '@/lib/globe/types';
 
 export type GlobePinSeverity = 'nominal' | 'elevated' | 'critical';
 
@@ -9,12 +10,23 @@ export type GlobePin = {
   lng: number;
   source: string;
   title: string;
+  /** 0–1 confidence / signal strength (distinct from severity) */
   value: number;
+  confidence: number;
   severity: GlobePinSeverity;
   agent: string;
   meta: Record<string, string | number | boolean | null>;
   pulse: boolean;
   domainKey: SentimentDomainKey;
+  updatedAt: string;
+  ageSec: number;
+  provisional: boolean;
+  /** Regional / investigative grouping (e.g. Pacific Rim seismic) */
+  clusterKey: string | null;
+  clusterLabel: string | null;
+  provenance: string;
+  narrativeWhy: string;
+  visualAsset?: GlobeVisualAsset | null;
 };
 
 export type SentimentDomainKey =
@@ -79,16 +91,76 @@ type MicroSweepLike = {
   allSignals?: MicroSignal[];
 };
 
-function pushPin(
-  pins: GlobePin[],
-  seen: Set<string>,
-  pin: Omit<GlobePin, 'pulse'> & { pulse?: boolean },
-) {
+type GlobePinInput = Pick<
+  GlobePin,
+  'id' | 'lat' | 'lng' | 'source' | 'title' | 'value' | 'severity' | 'agent' | 'meta' | 'domainKey'
+> & {
+  pulse?: boolean;
+  confidence?: number;
+  signalTimestamp?: string;
+  clusterKey?: string | null;
+  clusterLabel?: string | null;
+  provenance?: string;
+  narrativeWhy?: string;
+  provisional?: boolean;
+  visualAsset?: GlobeVisualAsset | null;
+};
+
+function seismicCluster(lat: number, lng: number): { key: string; label: string } | null {
+  const pacificRim =
+    (lng <= -70 && lng >= -180 && lat >= -55 && lat <= 72)
+    || (lng >= 95 && lat >= -50 && lat <= 55)
+    || (lng >= -180 && lng <= -90 && lat >= -60 && lat <= 35);
+  if (pacificRim) return { key: 'pacific_rim_seismic', label: 'Pacific Rim seismic activity' };
+  if (lat >= 25 && lat <= 50 && lng >= -15 && lng <= 40) return { key: 'europe_mena', label: 'Europe / MENA corridor' };
+  return null;
+}
+
+function pushPin(pins: GlobePin[], seen: Set<string>, pin: GlobePinInput) {
   if (seen.has(pin.id)) return;
   seen.add(pin.id);
   const pulse =
     pin.pulse ?? (pin.severity === 'elevated' || pin.severity === 'critical');
-  pins.push({ ...pin, pulse });
+  const confidence = typeof pin.confidence === 'number' ? pin.confidence : pin.value;
+  const updatedAt = pin.signalTimestamp ?? new Date().toISOString();
+  const ageSec = Math.max(0, Math.floor((Date.now() - new Date(updatedAt).getTime()) / 1000));
+  let clusterKey = pin.clusterKey ?? null;
+  let clusterLabel = pin.clusterLabel ?? null;
+  if (clusterKey == null && pin.source.includes('USGS')) {
+    const c = seismicCluster(pin.lat, pin.lng);
+    if (c) {
+      clusterKey = c.key;
+      clusterLabel = c.label;
+    }
+  }
+  const provisional =
+    pin.provisional
+    ?? (pin.source.includes('Wikipedia') || pin.source.includes('npm Registry') || confidence < 0.45);
+  const out: GlobePin = {
+    id: pin.id,
+    lat: pin.lat,
+    lng: pin.lng,
+    source: pin.source,
+    title: pin.title,
+    value: pin.value,
+    severity: pin.severity,
+    agent: pin.agent,
+    meta: pin.meta,
+    domainKey: pin.domainKey,
+    pulse,
+    confidence,
+    ageSec,
+    updatedAt,
+    clusterKey,
+    clusterLabel,
+    provisional,
+    provenance: pin.provenance ?? `${pin.agent} synthesis · ${pin.source}`,
+    narrativeWhy:
+      pin.narrativeWhy
+      ?? `Elevated attention for ${pin.domainKey} lane — operators should verify against ledger and journal context.`,
+  };
+  if (pin.visualAsset !== undefined) out.visualAsset = pin.visualAsset;
+  pins.push(out);
 }
 
 /**
@@ -121,6 +193,7 @@ export function buildGlobePinsFromMicro(
           const q = samples[i];
           const id = `usgs-${i}-${q.lat!.toFixed(2)}-${q.lng!.toFixed(2)}`;
           const magNorm = Math.max(0, Math.min(1, 1 - (q.mag - 2.5) / 5.5));
+          const pinSev = q.mag >= 5.5 ? 'critical' : q.mag >= 4 ? 'elevated' : sev;
           pushPin(pins, seen, {
             id,
             lat: q.lat!,
@@ -128,9 +201,16 @@ export function buildGlobePinsFromMicro(
             source: `${agent} · USGS Earthquake`,
             title: `M ${q.mag.toFixed(1)} — ${q.place}`,
             value: magNorm,
-            severity: q.mag >= 5.5 ? 'critical' : q.mag >= 4 ? 'elevated' : sev,
+            confidence: Math.min(1, 0.55 + (q.mag / 8) * 0.45),
+            severity: pinSev,
             agent,
             domainKey,
+            signalTimestamp: sig.timestamp,
+            provenance: 'USGS public feed · GAIA micro-agent sweep',
+            narrativeWhy:
+              pinSev !== 'nominal'
+                ? 'Seismic stress on globe — verify cascading civic and infrastructure risk if activity clusters persist.'
+                : 'Background seismicity within sweep tolerance.',
             meta: {
               mag: q.mag,
               place: q.place,
@@ -148,9 +228,14 @@ export function buildGlobePinsFromMicro(
         source: `${agent} · USGS Earthquake`,
         title: sig.label,
         value: sig.value,
+        confidence: sig.value,
         severity: sev,
         agent,
         domainKey,
+        signalTimestamp: sig.timestamp,
+        provenance: 'USGS aggregate · GAIA sweep (no per-event coordinates)',
+        narrativeWhy: 'Aggregate seismic lane — open inspection for sweep context.',
+        provisional: true,
         meta: { note: 'aggregate (no per-event coordinates)' },
       });
       continue;
@@ -173,9 +258,15 @@ export function buildGlobePinsFromMicro(
             source: `${agent} · NASA EONET`,
             title: ev.title,
             value: sig.value,
+            confidence: Math.min(1, 0.5 + sig.value * 0.5),
             severity: sev,
             agent,
             domainKey,
+            signalTimestamp: sig.timestamp,
+            clusterKey: 'eonet_natural',
+            clusterLabel: 'Global natural events (EONET)',
+            provenance: 'NASA EONET · GAIA',
+            narrativeWhy: 'Environmental hazard layer — cross-check with civic readiness and supply routes.',
             meta: { category: ev.category, openEvents: raw?.count ?? samples.length },
           });
         }
@@ -204,6 +295,12 @@ export function buildGlobePinsFromMicro(
     }
 
     const id = `micro-${sig.source.replace(/\s+/g, '-').toLowerCase()}-${sig.timestamp.slice(0, 13)}`;
+    const prov =
+      sig.source === 'Federal Register' || sig.source.startsWith('data.gov')
+        ? 'Federal Register / data.gov · THEMIS sweep'
+        : sig.source === 'Hacker News'
+          ? 'Hacker News API · HERMES-µ'
+          : `${agent} · ${sig.source}`;
     pushPin(pins, seen, {
       id,
       lat,
@@ -211,10 +308,22 @@ export function buildGlobePinsFromMicro(
       source: `${agent} · ${sig.source}`,
       title: sig.label,
       value: sig.value,
+      confidence: sig.value,
       severity: sev,
       agent,
       domainKey,
-      meta: flattenRaw(sig.raw),
+      signalTimestamp: sig.timestamp,
+      provenance: prov,
+      narrativeWhy:
+        sig.source === 'Federal Register'
+          ? 'Regulatory volume shapes civic risk surface — JADE / THEMIS attestation path applies.'
+          : sig.source.includes('data.gov')
+            ? 'Institutional data freshness signals transparency health.'
+            : `Information or systems signal for ${domainKey} — HERMES / DAEDALUS verification lanes.`,
+      meta: {
+        ...flattenRaw(sig.raw),
+        freshnessSec: Math.max(0, Math.floor((Date.now() - new Date(sig.timestamp).getTime()) / 1000)),
+      },
     });
   }
 
@@ -245,6 +354,8 @@ export function buildGlobePinsFromMicro(
 
     const agent = item.ownerAgent ?? 'ECHO';
 
+    const echoTs = parseEpiconTimestamp(item.timestamp);
+
     pushPin(pins, seen, {
       id,
       lat,
@@ -252,14 +363,30 @@ export function buildGlobePinsFromMicro(
       source: `${agent} · ${src}`,
       title,
       value,
+      confidence: Math.min(1, 0.4 + Math.abs(change) / 15),
       severity: echoSev,
       agent,
       domainKey: sourceDomain(src),
-      meta: flattenRaw(meta),
+      signalTimestamp: echoTs,
+      provenance: 'CoinGecko · ECHO ingest · EPICON pipeline',
+      narrativeWhy: 'Market pulse on financial lane — ECHO routes to HERMES narrative coupling.',
+      meta: {
+        ...flattenRaw(meta),
+        epiconId: item.id,
+        ledger: 'ECHO EPICON row (see Events chamber)',
+        freshnessSec: Math.max(0, Math.floor((Date.now() - new Date(echoTs).getTime()) / 1000)),
+      },
     });
   }
 
   return pins;
+}
+
+function parseEpiconTimestamp(ts: string): string {
+  const m = ts.match(/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}) UTC$/);
+  if (m) return `${m[1]}T${m[2]}:00.000Z`;
+  const d = new Date(ts);
+  return Number.isFinite(d.getTime()) ? d.toISOString() : new Date().toISOString();
 }
 
 function flattenRaw(raw: unknown): Record<string, string | number | boolean | null> {

--- a/lib/terminal/globePins.ts
+++ b/lib/terminal/globePins.ts
@@ -1,0 +1,292 @@
+import type { MicroSignal } from '@/lib/agents/micro/core';
+import type { EpiconItem } from '@/lib/terminal/types';
+
+export type GlobePinSeverity = 'nominal' | 'elevated' | 'critical';
+
+export type GlobePin = {
+  id: string;
+  lat: number;
+  lng: number;
+  source: string;
+  title: string;
+  value: number;
+  severity: GlobePinSeverity;
+  agent: string;
+  meta: Record<string, string | number | boolean | null>;
+  pulse: boolean;
+  domainKey: SentimentDomainKey;
+};
+
+export type SentimentDomainKey =
+  | 'civic'
+  | 'environ'
+  | 'financial'
+  | 'narrative'
+  | 'infrastructure'
+  | 'institutional';
+
+const DC: [number, number] = [38.9, -77.0];
+const DC_DATAGOV: [number, number] = [38.9, -77.05];
+const SF: [number, number] = [37.4, -122.1];
+const SF_GH: [number, number] = [37.4, -122.4];
+const NYC: [number, number] = [40.7, -74.0];
+const LONDON: [number, number] = [51.5, -0.12];
+const WIKI: [number, number] = [0, 20];
+const NPM_GLOBAL: [number, number] = [0, -30];
+
+function microSeverityToGlobe(s: MicroSignal['severity']): GlobePinSeverity {
+  if (s === 'critical') return 'critical';
+  if (s === 'elevated' || s === 'watch') return 'elevated';
+  return 'nominal';
+}
+
+function echoSeverityToGlobe(s: string): GlobePinSeverity {
+  const x = s.toLowerCase();
+  if (x === 'high' || x === 'critical') return 'critical';
+  if (x === 'medium' || x === 'elevated') return 'elevated';
+  return 'nominal';
+}
+
+function agentLabel(agentName: string): string {
+  if (agentName === 'HERMES-µ') return 'HERMES';
+  if (agentName === 'DAEDALUS-µ') return 'DAEDALUS';
+  return agentName;
+}
+
+function sourceDomain(source: string): SentimentDomainKey {
+  const s = source.toLowerCase();
+  if (s.includes('federal register') || s.includes('fr ')) return 'civic';
+  if (
+    s.includes('usgs')
+    || s.includes('open-meteo')
+    || s.includes('eonet')
+    || s.includes('nasa')
+  ) {
+    return 'environ';
+  }
+  if (s.includes('coingecko') || s.includes('bitcoin') || s.includes('ethereum') || s.includes('solana')) {
+    return 'financial';
+  }
+  if (s.includes('hacker') || s.includes('wikipedia') || s.includes('gdelt') || s.includes('sonar')) {
+    return 'narrative';
+  }
+  if (s.includes('github') || s.includes('npm') || s.includes('self-ping')) return 'infrastructure';
+  if (s.includes('data.gov')) return 'institutional';
+  return 'infrastructure';
+}
+
+type MicroSweepLike = {
+  allSignals?: MicroSignal[];
+};
+
+function pushPin(
+  pins: GlobePin[],
+  seen: Set<string>,
+  pin: Omit<GlobePin, 'pulse'> & { pulse?: boolean },
+) {
+  if (seen.has(pin.id)) return;
+  seen.add(pin.id);
+  const pulse =
+    pin.pulse ?? (pin.severity === 'elevated' || pin.severity === 'critical');
+  pins.push({ ...pin, pulse });
+}
+
+/**
+ * Derive globe pins from `/api/signals/micro` and optional ECHO EPICON items
+ * (`epicon` array from `/api/echo/feed`, with `echoIngest` from the transform layer).
+ */
+export function buildGlobePinsFromMicro(
+  micro: MicroSweepLike | null,
+  echoEpicon: EpiconItem[] | null,
+): GlobePin[] {
+  const pins: GlobePin[] = [];
+  const seen = new Set<string>();
+
+  for (const sig of micro?.allSignals ?? []) {
+    const agent = agentLabel(sig.agentName);
+    const domainKey = sourceDomain(sig.source);
+    const sev = microSeverityToGlobe(sig.severity);
+
+    if (sig.source === 'USGS Earthquake') {
+      const raw = sig.raw as
+        | {
+            samples?: Array<{ mag: number; place: string; lat: number | null; lng: number | null }>;
+            count?: number;
+            maxMag?: number;
+          }
+        | undefined;
+      const samples = raw?.samples?.filter((q) => q.lat != null && q.lng != null) ?? [];
+      if (samples.length > 0) {
+        for (let i = 0; i < samples.length; i++) {
+          const q = samples[i];
+          const id = `usgs-${i}-${q.lat!.toFixed(2)}-${q.lng!.toFixed(2)}`;
+          const magNorm = Math.max(0, Math.min(1, 1 - (q.mag - 2.5) / 5.5));
+          pushPin(pins, seen, {
+            id,
+            lat: q.lat!,
+            lng: q.lng!,
+            source: `${agent} · USGS Earthquake`,
+            title: `M ${q.mag.toFixed(1)} — ${q.place}`,
+            value: magNorm,
+            severity: q.mag >= 5.5 ? 'critical' : q.mag >= 4 ? 'elevated' : sev,
+            agent,
+            domainKey,
+            meta: {
+              mag: q.mag,
+              place: q.place,
+              region: q.place,
+              sweepCount: raw?.count ?? samples.length,
+            },
+          });
+        }
+        continue;
+      }
+      pushPin(pins, seen, {
+        id: 'usgs-aggregate',
+        lat: 20,
+        lng: -100,
+        source: `${agent} · USGS Earthquake`,
+        title: sig.label,
+        value: sig.value,
+        severity: sev,
+        agent,
+        domainKey,
+        meta: { note: 'aggregate (no per-event coordinates)' },
+      });
+      continue;
+    }
+
+    if (sig.source === 'NASA EONET') {
+      const raw = sig.raw as
+        | {
+            samples?: Array<{ id: string; title: string; lat: number; lng: number; category: string }>;
+            count?: number;
+          }
+        | undefined;
+      const samples = raw?.samples ?? [];
+      if (samples.length > 0) {
+        for (const ev of samples) {
+          pushPin(pins, seen, {
+            id: `eonet-${ev.id}`,
+            lat: ev.lat,
+            lng: ev.lng,
+            source: `${agent} · NASA EONET`,
+            title: ev.title,
+            value: sig.value,
+            severity: sev,
+            agent,
+            domainKey,
+            meta: { category: ev.category, openEvents: raw?.count ?? samples.length },
+          });
+        }
+        continue;
+      }
+    }
+
+    let lat: number;
+    let lng: number;
+    if (sig.source === 'Federal Register') {
+      [lat, lng] = DC;
+    } else if (sig.source.startsWith('data.gov') || sig.source === 'data.gov') {
+      [lat, lng] = DC_DATAGOV;
+    } else if (sig.source === 'Hacker News') {
+      [lat, lng] = SF;
+    } else if (sig.source === 'Wikipedia Recent Changes') {
+      [lat, lng] = WIKI;
+    } else if (sig.source === 'Open-Meteo') {
+      [lat, lng] = NYC;
+    } else if (sig.source === 'GitHub API') {
+      [lat, lng] = SF_GH;
+    } else if (sig.source === 'npm Registry') {
+      [lat, lng] = NPM_GLOBAL;
+    } else {
+      [lat, lng] = [15, 0];
+    }
+
+    const id = `micro-${sig.source.replace(/\s+/g, '-').toLowerCase()}-${sig.timestamp.slice(0, 13)}`;
+    pushPin(pins, seen, {
+      id,
+      lat,
+      lng,
+      source: `${agent} · ${sig.source}`,
+      title: sig.label,
+      value: sig.value,
+      severity: sev,
+      agent,
+      domainKey,
+      meta: flattenRaw(sig.raw),
+    });
+  }
+
+  for (const item of echoEpicon ?? []) {
+    const ingest = item.echoIngest;
+    if (!ingest) continue;
+    const src = ingest.source;
+    // USGS quakes already come from micro with coordinates; CoinGecko only exists on ECHO ingest.
+    if (src !== 'CoinGecko') continue;
+
+    const meta = ingest.metadata ?? {};
+    const coin = typeof meta.coin === 'string' ? meta.coin.toLowerCase() : '';
+    let lat: number;
+    let lng: number;
+    if (coin === 'ethereum') {
+      [lat, lng] = LONDON;
+    } else if (coin === 'solana') {
+      [lat, lng] = SF;
+    } else {
+      [lat, lng] = NYC;
+    }
+
+    const title = item.title ?? item.summary ?? src;
+    const id = `echo-${item.id}`;
+    const echoSev = echoSeverityToGlobe(ingest.severity);
+    const change = typeof meta.change24h === 'number' ? meta.change24h : 0;
+    const value = Math.max(0, Math.min(1, 1 - Math.min(1, Math.abs(change) / 12)));
+
+    const agent = item.ownerAgent ?? 'ECHO';
+
+    pushPin(pins, seen, {
+      id,
+      lat,
+      lng,
+      source: `${agent} · ${src}`,
+      title,
+      value,
+      severity: echoSev,
+      agent,
+      domainKey: sourceDomain(src),
+      meta: flattenRaw(meta),
+    });
+  }
+
+  return pins;
+}
+
+function flattenRaw(raw: unknown): Record<string, string | number | boolean | null> {
+  if (raw === null || raw === undefined) return {};
+  if (typeof raw !== 'object') {
+    return { value: String(raw) };
+  }
+  const out: Record<string, string | number | boolean | null> = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (v === null || v === undefined) {
+      out[k] = null;
+    } else if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+      out[k] = v;
+    } else if (Array.isArray(v)) {
+      out[k] = JSON.stringify(v).slice(0, 200);
+    } else {
+      out[k] = JSON.stringify(v).slice(0, 200);
+    }
+  }
+  return out;
+}
+
+export const GLOBE_DOMAIN_ORDER: SentimentDomainKey[] = [
+  'civic',
+  'environ',
+  'financial',
+  'narrative',
+  'infrastructure',
+  'institutional',
+];

--- a/lib/terminal/types.ts
+++ b/lib/terminal/types.ts
@@ -43,6 +43,12 @@ export type EpiconItem = {
   promotionState?: 'pending' | 'selected' | 'promoted' | 'failed';
   assignedAgents?: string[];
   committedEntries?: string[];
+  /** ECHO pipeline: original external source + metadata for globe / inspectors */
+  echoIngest?: {
+    source: string;
+    severity: 'low' | 'medium' | 'high';
+    metadata?: Record<string, unknown>;
+  };
 };
 
 export type TripwireLayer =
@@ -108,6 +114,7 @@ export type GISnapshot = {
 };
 
 export type NavKey =
+  | 'globe'
   | 'pulse'
   | 'agents'
   | 'ledger'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Globe Chamber v2: **single `globeGroup` rotation**, **click vs drag threshold**, **domain strip rotates globe** toward the focused pin (smooth target lerp + auto-rotate resume), **freshness-based pin opacity**, **severity (pin color) vs confidence (pulse ring base opacity)** + **dashed outer ring for provisional** signals, **world state delta** card, **chamber subline**, **provenance / “why this matters”** in inspection, horizontal-scroll domain strip with **selected highlight**.

Adds **Nano Banana–style** optional asset path: `POST /api/globe/render-asset` (server-only), provider wrapper, **KV + in-memory** cache, prompts helper. Inspection panel requests **incident art** for non-nominal pins; **Render cycle hero** button + `/render cycle|incident|domain` in Command Surface. Globe stays functional if provider is offline.

## Env (optional)

- `NANO_BANANA_API_KEY`
- `NANO_BANANA_BASE_URL` (e.g. vendor root; wrapper POSTs `{base}/api/v1/generate`)
- Optional: `NANO_BANANA_MODEL`, `NANO_BANANA_TIMEOUT_MS`

## Commits (this iteration)

- `feat(globe): add render-asset API, Nano Banana provider wrapper, and KV cache [C-274]`
- `feat(globe): pin freshness, clusters, confidence vs severity on normalized signals [C-274]`
- `feat(globe): globeGroup rotation, click threshold, focus navigation, inspection art slot [C-274]`
- `feat(globe): /render commands for cycle hero, incident, and domain assets [C-274]`

## Tests

- `pnpm build` — passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e02403ad-5444-44eb-a962-5f30edab58c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e02403ad-5444-44eb-a962-5f30edab58c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

