### PR TITLE
refactor(terminal): chambers as dedicated pages with shared shell layout [C-274]

### DIFF
--- a/app/terminal/journal/[agent]/page.tsx
+++ b/app/terminal/journal/[agent]/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+
+type Entry = { id: string; agent: string; category?: string; timestamp: string; observation?: string };
+
+export default function AgentJournalPage() {
+  const params = useParams<{ agent: string }>();
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const agent = useMemo(() => decodeURIComponent(params.agent ?? ''), [params.agent]);
+
+  useEffect(() => {
+    if (!agent) return;
+    fetch(`/api/agents/journal?agent=${encodeURIComponent(agent)}&limit=200`, { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((json) => setEntries((json.entries ?? []) as Entry[]))
+      .catch(() => undefined);
+  }, [agent]);
+
+  return (
+    <div className="h-full overflow-y-auto p-4">
+      <div className="mb-3 text-sm font-semibold">{agent} journal</div>
+      <div className="space-y-2">
+        {entries.map((entry) => (
+          <div key={entry.id} className="rounded border border-slate-800 bg-slate-900/60 p-3">
+            <div className="text-xs font-mono text-slate-500">{entry.category ?? 'journal'}</div>
+            <div className="text-xs text-slate-300">{entry.observation ?? '—'}</div>
+            <div className="text-xs text-slate-500">{entry.timestamp}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/terminal/journal/page.tsx
+++ b/app/terminal/journal/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+type Entry = { id: string; agent: string; category?: string; timestamp: string; observation?: string };
+
+export default function JournalArchivePage() {
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [agent, setAgent] = useState('ALL');
+
+  useEffect(() => {
+    fetch('/api/agents/journal?limit=200', { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((json) => setEntries((json.entries ?? []) as Entry[]))
+      .catch(() => undefined);
+  }, []);
+
+  const agents = useMemo(() => ['ALL', ...Array.from(new Set(entries.map((e) => e.agent))).sort()], [entries]);
+  const filtered = useMemo(() => (agent === 'ALL' ? entries : entries.filter((e) => e.agent === agent)), [entries, agent]);
+
+  return (
+    <div className="h-full overflow-y-auto p-4">
+      <div className="mb-3">
+        <select value={agent} onChange={(e) => setAgent(e.target.value)} className="rounded border border-slate-700 bg-slate-900 px-2 py-1 text-xs">
+          {agents.map((name) => <option key={name} value={name}>{name}</option>)}
+        </select>
+      </div>
+      <div className="space-y-2">
+        {filtered.map((entry) => (
+          <div key={entry.id} className="rounded border border-slate-800 bg-slate-900/60 p-3">
+            <div className="text-xs font-mono text-slate-500">{entry.agent} · {entry.category ?? 'journal'}</div>
+            <div className="text-xs text-slate-300">{entry.observation ?? '—'}</div>
+            <div className="text-xs text-slate-500">{entry.timestamp}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/terminal/layout.tsx
+++ b/app/terminal/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+import TerminalShell from '@/components/terminal/TerminalShell';
+
+export default function TerminalLayout({ children }: { children: ReactNode }) {
+  return <TerminalShell>{children}</TerminalShell>;
+}

--- a/app/terminal/ledger/page.tsx
+++ b/app/terminal/ledger/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type LedgerEvent = { id: string; title?: string; summary?: string; timestamp?: string; hash?: string; mii_score?: number };
+
+export default function LedgerPage() {
+  const [entries, setEntries] = useState<LedgerEvent[]>([]);
+
+  useEffect(() => {
+    let alive = true;
+    fetch('/ledger/events?limit=50', { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((json) => {
+        if (!alive) return;
+        setEntries((json.entries ?? json.items ?? []) as LedgerEvent[]);
+      })
+      .catch(() => undefined);
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <div className="h-full overflow-y-auto p-4">
+      <div className="space-y-2">
+        {entries.map((entry) => (
+          <div key={entry.id} className="rounded border border-slate-800 bg-slate-900/60 p-3">
+            <div className="text-xs font-mono text-slate-500">{entry.id}</div>
+            <div className="text-sm text-slate-200">{entry.title ?? entry.summary ?? 'Ledger event'}</div>
+            <div className="mt-1 text-xs text-slate-400">hash: {entry.hash ?? '—'} · MII: {entry.mii_score ?? '—'}</div>
+            <div className="text-xs text-slate-500">{entry.timestamp ?? '—'}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/terminal/mic/page.tsx
+++ b/app/terminal/mic/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import MICWalletPanel from '@/components/terminal/MICWalletPanel';
+import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
+
+export default function MicPage() {
+  const { snapshot } = useTerminalSnapshot();
+  const integrity = (snapshot?.integrity?.data ?? {}) as { global_integrity?: number };
+  return (
+    <div className="h-full overflow-y-auto p-4">
+      <MICWalletPanel
+        gi={{
+          score: Number(integrity.global_integrity ?? 0),
+          delta: 0,
+          institutionalTrust: 0,
+          infoReliability: 0,
+          consensusStability: 0,
+          weekly: [],
+        }}
+        integrity={null}
+      />
+    </div>
+  );
+}

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -1,9 +1,37 @@
-import TerminalPageClient from './TerminalPageClient';
-import { getTerminalBootstrapSnapshot } from '@/lib/terminal/bootstrap';
+'use client';
 
-export const dynamic = 'force-dynamic';
+import GlobeChamber from '@/components/terminal/chambers/GlobeChamber';
+import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
+import type { MicroAgentSweepResult } from '@/lib/agents/micro';
+import type { EpiconItem } from '@/lib/terminal/types';
 
-export default async function TerminalPage() {
-  const bootstrap = await getTerminalBootstrapSnapshot();
-  return <TerminalPageClient bootstrap={bootstrap} />;
+export default function TerminalPage() {
+  const { snapshot } = useTerminalSnapshot();
+  const integrity = (snapshot?.integrity?.data ?? {}) as { cycle?: string; global_integrity?: number };
+  const micro = (snapshot?.signals?.data ?? null) as MicroAgentSweepResult | null;
+  const echo = (snapshot?.epicon?.data ?? {}) as { items?: EpiconItem[] };
+  const sentiment = (snapshot?.sentiment?.data ?? {}) as {
+    domains?: Array<{ key: 'civic' | 'environ' | 'financial' | 'narrative' | 'infrastructure' | 'institutional'; label: string; agent: string; score: number | null }>;
+  };
+
+  const domains = (sentiment.domains ?? []).map((d) => ({
+    ...d,
+    status: (d.score === null ? 'unknown' : d.score >= 0.8 ? 'nominal' : d.score >= 0.6 ? 'stressed' : 'critical') as
+      | 'nominal'
+      | 'stressed'
+      | 'critical'
+      | 'unknown',
+  }));
+
+  return (
+    <GlobeChamber
+      micro={micro}
+      echoEpicon={echo.items ?? []}
+      domains={domains}
+      cycleId={integrity.cycle ?? 'C-271'}
+      clockLabel={new Date().toISOString().slice(11, 16) + ' UTC'}
+      giScore={Number(integrity.global_integrity ?? 0)}
+      miiScore={null}
+    />
+  );
 }

--- a/app/terminal/pulse/page.tsx
+++ b/app/terminal/pulse/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import EventScreener, { type EpiconFeedItem } from '@/components/terminal/EventScreener';
+import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
+
+export default function PulsePage() {
+  const { snapshot } = useTerminalSnapshot();
+  const epicon = (snapshot?.epicon?.data ?? {}) as {
+    items?: EpiconFeedItem[];
+    summary?: Record<string, unknown>;
+    sources?: { github: number; kv: number };
+    total?: number;
+  };
+
+  return (
+    <div className="h-full overflow-y-auto p-4">
+      <EventScreener
+        items={epicon.items}
+        summary={epicon.summary ?? {}}
+        sources={epicon.sources ?? { github: 0, kv: 0 }}
+        total={epicon.total ?? 0}
+      />
+    </div>
+  );
+}

--- a/app/terminal/sentiment/page.tsx
+++ b/app/terminal/sentiment/page.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import SentimentMap from '@/components/terminal/SentimentMap';
+import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
+
+export default function SentimentPage() {
+  const { snapshot } = useTerminalSnapshot();
+  const sentiment = (snapshot?.sentiment?.data ?? {}) as {
+    cycle?: string;
+    timestamp?: string;
+    gi?: number;
+    overall_sentiment?: number | null;
+    domains?: Array<{ key: 'civic' | 'environ' | 'financial' | 'narrative' | 'infrastructure' | 'institutional'; label: string; agent: string; score: number | null; sourceLabel: string }>;
+  };
+
+  return (
+    <div className="h-full overflow-y-auto p-4">
+      <SentimentMap
+        cycleId={sentiment.cycle ?? 'C-271'}
+        timestamp={sentiment.timestamp ?? new Date().toISOString()}
+        sentimentTimestamp={sentiment.timestamp ?? null}
+        gi={sentiment.gi ?? 0}
+        overallSentiment={sentiment.overall_sentiment ?? null}
+        domains={(sentiment.domains ?? []).map((domain) => ({ ...domain, trend: 'flat', status: 'unknown' }))}
+        history={{}}
+        journalEntries={[]}
+        onAskAgent={() => undefined}
+      />
+    </div>
+  );
+}

--- a/app/terminal/sentinel/page.tsx
+++ b/app/terminal/sentinel/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import Link from 'next/link';
+import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
+
+export default function SentinelPage() {
+  const { snapshot } = useTerminalSnapshot();
+  const agents = (snapshot?.agents?.data ?? {}) as { agents?: Array<{ id: string; name: string; role: string; status: string; lastAction?: string; tier?: string }> };
+
+  return (
+    <div className="h-full overflow-y-auto p-4">
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {(agents.agents ?? []).map((agent) => (
+          <div key={agent.id} className="rounded border border-slate-800 bg-slate-900/60 p-4">
+            <div className="text-sm font-semibold">{agent.name}</div>
+            <div className="text-xs text-slate-400">{agent.role}</div>
+            <div className="mt-2 text-xs font-mono">status: {agent.status}</div>
+            <div className="text-xs font-mono">tier: {agent.tier ?? '—'}</div>
+            <div className="mt-2 text-xs text-slate-400">{agent.lastAction ?? 'No action recorded.'}</div>
+            <Link href={`/terminal/journal/${encodeURIComponent(agent.name)}`} className="mt-3 inline-block text-xs text-cyan-300">View journal →</Link>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/terminal/signals/page.tsx
+++ b/app/terminal/signals/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
+
+export default function SignalsPage() {
+  const { snapshot } = useTerminalSnapshot();
+  const signals = (snapshot?.signals?.data ?? {}) as { agents?: Array<{ agentName: string; healthy: boolean; reason?: string }> };
+
+  return (
+    <div className="h-full overflow-y-auto p-4">
+      <div className="mb-4 text-sm font-semibold uppercase tracking-wide">Micro-agent signals</div>
+      <div className="grid gap-3 md:grid-cols-2">
+        {(signals.agents ?? []).map((agent) => (
+          <div key={agent.agentName} className="rounded border border-slate-800 bg-slate-900/60 p-4">
+            <div className="text-xs font-mono text-slate-400">{agent.agentName}</div>
+            <div className={agent.healthy ? 'text-emerald-300' : 'text-rose-300'}>{agent.healthy ? 'healthy' : 'anomaly'}</div>
+            {agent.reason ? <div className="mt-1 text-xs text-slate-400">{agent.reason}</div> : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/terminal/tripwire/page.tsx
+++ b/app/terminal/tripwire/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import TripwirePanel from '@/components/tripwire/TripwirePanel';
+
+export default function TripwirePage() {
+  return (
+    <div className="h-full overflow-y-auto p-4">
+      <TripwirePanel />
+    </div>
+  );
+}

--- a/components/terminal/CommandSurface.tsx
+++ b/components/terminal/CommandSurface.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { signIn, signOut, useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 import type { NavKey } from '@/lib/terminal/types';
+import { signIn, signOut, useSession } from 'next-auth/react';
 
 type CommandOutput = {
   timestamp: string;
@@ -12,19 +13,16 @@ type CommandOutput = {
 };
 
 const COMMANDS = [
-  '/help', '/status', '/agents', '/globe', '/pulse', '/signals', '/sentinel', '/ledger', '/wallet', '/journal', '/ask', '/login', '/logout', '/whoami', '/epicon', '/gi', '/render', '/clear',
+  '/help', '/status', '/agents', '/globe', '/pulse', '/signals', '/sentinel', '/ledger', '/tripwire', '/sentiment', '/mic', '/wallet', '/journal', '/ask', '/login', '/logout', '/whoami', '/epicon', '/gi', '/render', '/clear',
 ];
 
-export default function CommandSurface({
-  onSwitchChamber,
-}: {
-  onSwitchChamber: (nav: NavKey) => void;
-}) {
+export default function CommandSurface({ onSwitchChamber }: { onSwitchChamber?: (nav: NavKey) => void } = {}) {
   const [input, setInput] = useState('');
   const [history, setHistory] = useState<string[]>([]);
   const [output, setOutput] = useState<CommandOutput[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
   const { data: session } = useSession();
+  const router = useRouter();
 
   const matches = useMemo(() => COMMANDS.filter((c) => c.startsWith(input.trim().toLowerCase())), [input]);
 
@@ -76,23 +74,40 @@ ${greeting}`,
       return;
     }
     if (base === '/globe') {
-      onSwitchChamber('globe');
+      onSwitchChamber?.('globe');
+      router.push('/terminal');
       push(trimmed, '→ Globe chamber', 'success');
       return;
     }
     if (base === '/pulse') {
-      onSwitchChamber('pulse');
+      onSwitchChamber?.('pulse');
+      router.push('/terminal/pulse');
       push(trimmed, '→ Pulse chamber', 'success');
       return;
     }
     if (base === '/signals') {
-      onSwitchChamber('sentiment');
+      onSwitchChamber?.('sentiment');
+      router.push('/terminal/signals');
       push(trimmed, '→ Signals chamber', 'success');
       return;
     }
     if (base === '/sentinel') {
-      onSwitchChamber('agents');
+      onSwitchChamber?.('agents');
+      router.push('/terminal/sentinel');
       push(trimmed, '→ Sentinel chamber', 'success');
+      return;
+    }
+
+    if (base === '/tripwire') {
+      onSwitchChamber?.('infrastructure');
+      router.push('/terminal/tripwire');
+      push(trimmed, '→ Tripwire chamber', 'success');
+      return;
+    }
+    if (base === '/sentiment') {
+      onSwitchChamber?.('sentiment');
+      router.push('/terminal/sentiment');
+      push(trimmed, '→ Sentiment chamber', 'success');
       return;
     }
     if (base === '/render') {
@@ -185,16 +200,18 @@ ${greeting}`,
         push(trimmed, JSON.stringify(seed, null, 2), seed?.ok ? 'success' : 'error');
         return;
       }
-      onSwitchChamber('ledger');
+      onSwitchChamber?.('ledger');
+      router.push('/terminal/ledger');
       push(trimmed, '→ Ledger chamber', 'success');
       return;
     }
-    if (base === '/wallet') {
+    if (base === '/wallet' || base === '/mic') {
       if (!session?.user) {
         push(trimmed, 'Login required — /login', 'error');
         return;
       }
-      onSwitchChamber('wallet');
+      onSwitchChamber?.('wallet');
+      router.push('/terminal/mic');
       push(trimmed, '→ Wallet chamber', 'success');
       return;
     }
@@ -243,6 +260,11 @@ ${greeting}`,
     }
 
     if (base === '/journal') {
+      if (!rest[0]) {
+        router.push('/terminal/journal');
+        push(trimmed, '→ Journal chamber', 'success');
+        return;
+      }
       const agent = rest[0] ?? '';
       const url = agent ? `/api/agents/journal?agent=${encodeURIComponent(agent)}&limit=3` : '/api/agents/journal?limit=3';
       const journal = await fetch(url, { cache: 'no-store' }).then((r) => r.json());

--- a/components/terminal/TerminalShell.tsx
+++ b/components/terminal/TerminalShell.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { WalletProvider } from '@/contexts/WalletContext';
+import CommandSurface from '@/components/terminal/CommandSurface';
+import { cn } from '@/lib/utils';
+
+type IntegrityStatus = {
+  cycle?: string;
+  global_integrity?: number;
+};
+
+const NAV = [
+  { label: 'Globe', href: '/terminal' },
+  { label: 'Pulse', href: '/terminal/pulse' },
+  { label: 'Signals', href: '/terminal/signals' },
+  { label: 'Sentinel', href: '/terminal/sentinel' },
+  { label: 'Ledger', href: '/terminal/ledger' },
+  { label: 'Tripwire', href: '/terminal/tripwire' },
+  { label: 'Sentiment', href: '/terminal/sentiment' },
+  { label: 'MIC', href: '/terminal/mic' },
+  { label: 'Journal', href: '/terminal/journal' },
+] as const;
+
+export default function TerminalShell({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const [integrity, setIntegrity] = useState<IntegrityStatus | null>(null);
+  const [kvHealth, setKvHealth] = useState<'healthy' | 'degraded'>('degraded');
+  const [heartbeat, setHeartbeat] = useState<string>('—');
+
+  useEffect(() => {
+    let alive = true;
+    const load = async () => {
+      const [giRes, kvRes] = await Promise.allSettled([
+        fetch('/api/integrity-status', { cache: 'no-store' }).then((r) => r.json() as Promise<IntegrityStatus>),
+        fetch('/api/kv/health', { cache: 'no-store' }).then((r) => r.json() as Promise<{ ok?: boolean }>),
+      ]);
+      if (!alive) return;
+      if (giRes.status === 'fulfilled') {
+        setIntegrity(giRes.value);
+        setHeartbeat(new Date().toISOString());
+      }
+      if (kvRes.status === 'fulfilled') setKvHealth(kvRes.value.ok ? 'healthy' : 'degraded');
+    };
+    void load();
+    const id = window.setInterval(load, 60_000);
+    return () => {
+      alive = false;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  const gi = Number(integrity?.global_integrity ?? 0);
+  const giTone = gi >= 0.85 ? 'text-emerald-300 border-emerald-500/40' : gi >= 0.7 ? 'text-amber-300 border-amber-500/40' : 'text-rose-300 border-rose-500/40';
+
+  const runtimeLabel = useMemo(() => (gi >= 0.85 ? 'nominal' : gi >= 0.7 ? 'guarded' : 'critical'), [gi]);
+
+  return (
+    <WalletProvider>
+      <div className="flex min-h-screen flex-col bg-[#020617] text-slate-100">
+        <header className="sticky top-0 z-40 border-b border-slate-800 bg-slate-950/95 px-4 py-3 backdrop-blur">
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <div className="rounded border border-cyan-400/60 bg-cyan-400/10 px-2 py-0.5 font-mono text-xs">⌘</div>
+              <div className="text-sm font-semibold tracking-wide">MOBIUS CIVIC TERMINAL</div>
+            </div>
+            <div className="flex items-center gap-2 text-xs font-mono">
+              <span className={cn('rounded border px-2 py-1', giTone)}>GI {gi.toFixed(2)}</span>
+              <span className="rounded border border-slate-700 px-2 py-1">{integrity?.cycle ?? 'C-—'}</span>
+            </div>
+          </div>
+          <nav className="flex gap-2 overflow-x-auto pb-1">
+            {NAV.map((tab) => {
+              const active = pathname === tab.href;
+              return (
+                <Link
+                  key={tab.href}
+                  href={tab.href}
+                  className={cn(
+                    'whitespace-nowrap rounded border px-2 py-1 text-[11px] font-mono uppercase tracking-wide',
+                    active ? 'border-cyan-400/60 bg-cyan-400/15 text-cyan-100' : 'border-slate-700 text-slate-400 hover:text-slate-200',
+                  )}
+                >
+                  {tab.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </header>
+
+        <main className="flex-1 overflow-hidden pb-28">{children}</main>
+
+        <div className="fixed bottom-14 left-0 right-0 z-30 border-t border-slate-800 bg-slate-950/95 px-4 py-1 text-[10px] font-mono uppercase tracking-wide text-slate-400">
+          Runtime {runtimeLabel} · KV {kvHealth} · Last heartbeat {heartbeat === '—' ? '—' : new Date(heartbeat).toISOString()}
+        </div>
+
+        <CommandSurface />
+      </div>
+    </WalletProvider>
+  );
+}

--- a/hooks/useTerminalSnapshot.ts
+++ b/hooks/useTerminalSnapshot.ts
@@ -1,0 +1,83 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type SnapshotLeaf = {
+  ok: boolean;
+  status: number;
+  data: unknown;
+  error: string | null;
+};
+
+export type TerminalSnapshot = {
+  ok: boolean;
+  timestamp?: string;
+  integrity?: SnapshotLeaf;
+  signals?: SnapshotLeaf;
+  kvHealth?: SnapshotLeaf;
+  agents?: SnapshotLeaf;
+  epicon?: SnapshotLeaf;
+  journal?: SnapshotLeaf;
+  sentiment?: SnapshotLeaf;
+  runtime?: SnapshotLeaf;
+  promotion?: SnapshotLeaf;
+  eve?: SnapshotLeaf;
+  substrate?: unknown;
+};
+
+let cachedSnapshot: TerminalSnapshot | null = null;
+let cachedAt = 0;
+let inflight: Promise<TerminalSnapshot> | null = null;
+
+const TTL_MS = 60_000;
+
+async function fetchSnapshot(): Promise<TerminalSnapshot> {
+  const now = Date.now();
+  if (cachedSnapshot && now - cachedAt < TTL_MS) return cachedSnapshot;
+  if (inflight) return inflight;
+
+  inflight = fetch('/api/terminal/snapshot', { cache: 'no-store' })
+    .then(async (res) => {
+      if (!res.ok) throw new Error(`snapshot failed (${res.status})`);
+      const json = (await res.json()) as TerminalSnapshot;
+      cachedSnapshot = json;
+      cachedAt = Date.now();
+      return json;
+    })
+    .finally(() => {
+      inflight = null;
+    });
+
+  return inflight;
+}
+
+export function useTerminalSnapshot() {
+  const [snapshot, setSnapshot] = useState<TerminalSnapshot | null>(cachedSnapshot);
+  const [loading, setLoading] = useState(!cachedSnapshot);
+
+  useEffect(() => {
+    let alive = true;
+
+    const load = async () => {
+      try {
+        const next = await fetchSnapshot();
+        if (!alive) return;
+        setSnapshot(next);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    };
+
+    void load();
+    const interval = window.setInterval(() => {
+      void load();
+    }, TTL_MS);
+
+    return () => {
+      alive = false;
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  return { snapshot, loading };
+}


### PR DESCRIPTION
### Motivation

- The terminal UI currently attempts to show globe, ledger, signals, agents, tripwires and command surface on one page, producing visual clutter and unclear focus. 
- The goal is to convert the terminal into a shell + focused chambers so each chamber can occupy the full viewport and be linkable/bookmarkable. 
- Use Next.js App Router pages to make each chamber independently loadable and share persistent chrome (header, command surface, footer).

### Description

- Introduced a shared shell layout `app/terminal/layout.tsx` and `components/terminal/TerminalShell.tsx` that provide a persistent header with nav tabs, GI chip + cycle polling, runtime footer, and the `CommandSurface` rendered globally. 
- Split the monolithic terminal into dedicated chamber pages under `app/terminal/*` (globe `/terminal`, `/terminal/pulse`, `/terminal/signals`, `/terminal/sentinel`, `/terminal/ledger`, `/terminal/tripwire`, `/terminal/sentiment`, `/terminal/mic`, `/terminal/journal` and per-agent `/terminal/journal/[agent]`) and simplified `app/terminal/page.tsx` to render `GlobeChamber` only. 
- Added `hooks/useTerminalSnapshot.ts` which polls `/api/terminal/snapshot` every 60s and uses a module-level cache to avoid redundant fetches when navigating between chambers. 
- Updated `components/terminal/CommandSurface.tsx` to use Next.js `router.push()` for chamber navigation (and to retain an optional `onSwitchChamber` callback for backward compatibility), and extended the command set to map to the new pages. 

### Testing

- Ran `pnpm build`, which completed successfully and passed TypeScript checks and page generation. 
- The build output shows static/dynamic pages generated for all new `/terminal/*` routes without type errors. 
- No automated UI/browser screenshots were produced in this environment (build-only validation performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5a4b32210832db245d34e57544129)