### PR TITLE
C-275: restore terminal first-paint parity and snapshot truth

### DIFF
--- a/app/terminal/TerminalPageClient.tsx
+++ b/app/terminal/TerminalPageClient.tsx
@@ -2,7 +2,6 @@
 
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import HardHalt from '@/components/modals/HardHalt';
-import { WalletProvider } from '@/contexts/WalletContext';
 import { useTerminalData, type TerminalBootstrapSeed } from '@/hooks/useTerminalData';
 import { integrityStatus as mockIntegrityStatus } from '@/lib/mock/integrityStatus';
 import { evaluateCircuitBreaker } from '@/lib/integrity-check';
@@ -160,11 +159,7 @@ function PanelLaneNotice({ lane, label }: { lane: SnapshotLaneState | undefined;
 }
 
 export default function TerminalPageWrapper({ bootstrap }: TerminalPageWrapperProps) {
-  return (
-    <WalletProvider>
-      <TerminalPage bootstrap={bootstrap} />
-    </WalletProvider>
-  );
+  return <TerminalPage bootstrap={bootstrap} />;
 }
 
 function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from 'next';
-import GlobePageClient from './GlobePageClient';
+import TerminalPageClient from './TerminalPageClient';
+import { getTerminalBootstrapSnapshot } from '@/lib/terminal/bootstrap';
 
 export const metadata: Metadata = {
-  title: 'Globe · Mobius Terminal',
+  title: 'Terminal · Mobius Terminal',
 };
 
-export default function TerminalPage() {
-  return <GlobePageClient />;
+export default async function TerminalPage() {
+  const bootstrap = await getTerminalBootstrapSnapshot();
+  return <TerminalPageClient bootstrap={bootstrap} />;
 }


### PR DESCRIPTION
### Motivation

- Ensure the `/terminal` route renders the full terminal shell on first paint so the UI reflects production runtime truth (integrity, lane state, deployment) immediately.
- Prevent the slim Globe-only fallback from masking real operational state and keep degraded behavior lane-specific instead of collapsing the whole shell.

### Description

- Replaced the Globe-only client entry with a server-bootstrapped terminal entry by updating `app/terminal/page.tsx` to call `getTerminalBootstrapSnapshot()` and render `TerminalPageClient` with the bootstrap data on first paint.
- Hydrated the client terminal from server bootstrap data so `integrity`/GI and lane context are available immediately (`getTerminalBootstrapSnapshot` import and usage).
- Removed the redundant nested `WalletProvider` wrapper from `app/terminal/TerminalPageClient.tsx` since the terminal layout already provides the provider, simplifying client boot sequence.
- Kept existing lane-level degradation and snapshot handling logic unchanged so partial outages remain lane-specific and snapshot parity is still served by `/api/terminal/snapshot`.

### Testing

- Ran type checks with `npx tsc --noEmit`, which completed successfully.
- Attempted `npm run lint` but the environment triggered an interactive Next.js ESLint prompt, so linting was not completed non-interactively (interactive prompt observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d644a16ad0832db641ae3133b0d2d9)