### PR TITLE
refactor(chambers): route Globe as landing page and simplify mobile chamber shell

### DIFF
--- a/app/terminal/globe/page.tsx
+++ b/app/terminal/globe/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import GlobePageClient from '../GlobePageClient';
+
+export const metadata: Metadata = {
+  title: 'Globe · Mobius Terminal',
+};
+
+export default function GlobePage() {
+  return <GlobePageClient />;
+}

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -1,12 +1,5 @@
-import type { Metadata } from 'next';
-import TerminalPageClient from './TerminalPageClient';
-import { getTerminalBootstrapSnapshot } from '@/lib/terminal/bootstrap';
+import { redirect } from 'next/navigation';
 
-export const metadata: Metadata = {
-  title: 'Terminal · Mobius Terminal',
-};
-
-export default async function TerminalPage() {
-  const bootstrap = await getTerminalBootstrapSnapshot();
-  return <TerminalPageClient bootstrap={bootstrap} />;
+export default function TerminalIndexPage() {
+  redirect('/terminal/globe');
 }

--- a/components/terminal/TerminalHeader.tsx
+++ b/components/terminal/TerminalHeader.tsx
@@ -6,15 +6,11 @@ import { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
 
 const CHAMBERS = [
-  { label: 'Globe', href: '/terminal', icon: '◎' },
+  { label: 'Globe', href: '/terminal/globe', icon: '◎' },
   { label: 'Pulse', href: '/terminal/pulse', icon: '∿' },
   { label: 'Signals', href: '/terminal/signals', icon: '⊕' },
   { label: 'Sentinel', href: '/terminal/sentinel', icon: '◉' },
   { label: 'Ledger', href: '/terminal/ledger', icon: '⛓' },
-  { label: 'Tripwire', href: '/terminal/tripwire', icon: '⚠' },
-  { label: 'Sentiment', href: '/terminal/sentiment', icon: '◈' },
-  { label: 'MIC', href: '/terminal/mic', icon: '◇' },
-  { label: 'Journal', href: '/terminal/journal', icon: '◻' },
 ] as const;
 
 type IntegrityStatus = { cycle?: string; global_integrity?: number };
@@ -41,6 +37,30 @@ export default function TerminalHeader() {
 
   const gi = Number(integrity?.global_integrity ?? 0);
 
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!event.altKey) return;
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName?.toLowerCase();
+      if (tag === 'input' || tag === 'textarea' || target?.isContentEditable) return;
+
+      const routeMap: Record<string, string> = {
+        '1': '/terminal/globe',
+        '2': '/terminal/pulse',
+        '3': '/terminal/signals',
+        '4': '/terminal/sentinel',
+        '5': '/terminal/ledger',
+      };
+      const route = routeMap[event.key];
+      if (!route) return;
+      event.preventDefault();
+      window.location.assign(route);
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
   return (
     <header className="sticky top-0 z-50 border-b border-slate-800 bg-slate-950/95 px-4 py-3 backdrop-blur">
       <div className="mb-2 flex items-center justify-between gap-3">
@@ -55,7 +75,7 @@ export default function TerminalHeader() {
       </div>
       <nav className="flex gap-2 overflow-x-auto pb-1">
         {CHAMBERS.map((tab) => {
-          const active = tab.href === '/terminal' ? pathname === '/terminal' : pathname.startsWith(tab.href);
+          const active = pathname === tab.href || pathname.startsWith(`${tab.href}/`);
           return (
             <Link
               key={tab.href}

--- a/components/terminal/chambers/GlobeChamber.tsx
+++ b/components/terminal/chambers/GlobeChamber.tsx
@@ -807,7 +807,7 @@ export default function GlobeChamber({
   };
 
   return (
-    <div className="relative overflow-hidden rounded-lg border border-slate-800 bg-[#020408] font-mono text-slate-200">
+    <div className="relative -mx-0.5 overflow-hidden border-y border-slate-800 bg-[#020408] font-mono text-slate-200 sm:mx-0 sm:rounded-lg sm:border">
       <style
         dangerouslySetInnerHTML={{
           __html: `@keyframes globeInsp { from { opacity: 0; transform: translateY(-50%) translateX(8px); } to { opacity: 1; transform: translateY(-50%) translateX(0); } }`,
@@ -824,17 +824,11 @@ export default function GlobeChamber({
         ))}
       </div>
 
-      <div className="pointer-events-none absolute inset-x-0 top-0 flex items-start justify-between bg-gradient-to-b from-[#020408]/95 to-transparent px-4 py-3">
-        <div>
-          <div className="text-[11px] uppercase tracking-[0.18em] text-slate-500">Mobius Civic Terminal</div>
-          <div className="mt-1 text-[9px] uppercase tracking-[0.12em] text-slate-600">
-            Globe chamber · live world state
-          </div>
-        </div>
-        <div className="flex flex-col items-end gap-1">
+      <div className="pointer-events-none absolute inset-x-0 top-0 flex items-start justify-end bg-gradient-to-b from-[#020408]/95 to-transparent px-3 py-2 sm:px-4 sm:py-3">
+        <div className="flex items-center gap-2 sm:gap-3">
           <div
             className={cn(
-              'pointer-events-none rounded border px-3 py-1 text-[11px] uppercase tracking-[0.12em]',
+              'pointer-events-none rounded border px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] sm:px-3 sm:py-1 sm:text-[11px]',
               giChipClass(giScore),
             )}
           >
@@ -848,9 +842,9 @@ export default function GlobeChamber({
           >
             {heroBusy ? 'Rendering…' : 'Render cycle hero'}
           </button>
-        </div>
-        <div className="text-[10px] tracking-[0.1em] text-slate-600">
-          {cycleId} · {clockLabel}
+          <div className="text-[9px] tracking-[0.1em] text-slate-600 sm:text-[10px]">
+            {cycleId} · {clockLabel}
+          </div>
         </div>
       </div>
 
@@ -899,8 +893,8 @@ export default function GlobeChamber({
 
       {selected ? (
         <div
-          className="fixed right-4 top-1/2 z-50 max-h-[min(88vh,640px)] w-[min(92vw,280px)] overflow-y-auto rounded-md border border-white/10 bg-[#020408]/95 p-5 shadow-xl backdrop-blur-md"
-          style={{ top: '50%', animation: 'globeInsp 0.2s ease' }}
+          className="fixed inset-x-2 bottom-2 z-50 max-h-[68vh] overflow-y-auto rounded-md border border-white/10 bg-[#020408]/95 p-4 shadow-xl backdrop-blur-md md:inset-x-auto md:bottom-auto md:right-4 md:top-1/2 md:max-h-[min(88vh,640px)] md:w-[min(92vw,280px)] md:p-5"
+          style={{ animation: 'globeInsp 0.2s ease' }}
         >
           <button
             type="button"


### PR DESCRIPTION
### Motivation
- The Globe chamber was being rendered as a nested panel inside the legacy Pulse dashboard, which buried Globe on mobile and produced duplicate header chrome. 
- Chambers should behave as distinct pages (routes) so each chamber can own its own layout and mobile experience. 
- Make Globe the default mobile-first landing view so the world-state visualization is the first thing users see. 

### Description
- Redirect `/terminal` to `/terminal/globe` via `app/terminal/page.tsx` so Globe is the default landing chamber. 
- Add an explicit Globe route at `app/terminal/globe/page.tsx` that renders the existing `GlobePageClient`. 
- Update the chamber switcher in `components/terminal/TerminalHeader.tsx` to use route links for the primary chambers, simplify the set of visible chamber links, fix the active-path detection, and add `Alt+1..Alt+5` keyboard shortcuts that navigate to the corresponding chamber routes. 
- Simplify Globe chrome and improve mobile behavior in `components/terminal/chambers/GlobeChamber.tsx` by tightening the top status strip, removing duplicate in-card title chrome, and changing the pin inspection panel to a mobile-first bottom-sheet (while preserving desktop side-panel placement via responsive classes). 

### Testing
- Ran `npx tsc --noEmit`, which completed without type errors. 
- Attempted `npm run lint`, but `next lint` in this repo launches the interactive ESLint setup prompt so it could not complete non-interactively in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d67d708d04832dab4898590badc8c2)