### PR TITLE
polish(mobile): refine chamber UX across Globe and Pulse

### DIFF
--- a/app/terminal/pulse/PulsePageClient.tsx
+++ b/app/terminal/pulse/PulsePageClient.tsx
@@ -12,10 +12,32 @@ type PulseItem = {
   title?: string;
   timestamp?: string;
   severity?: string;
+  type?: string;
+  category?: string;
+  tags?: string[];
   mii_score?: number;
   source?: string;
   status?: string;
 };
+
+const EVENT_TYPES = ['HEARTBEAT', 'WATCH', 'CATALOG', 'EPICON', 'JOURNAL', 'VERIFY', 'ROUTING', 'PROMOTION', 'SIGNAL'] as const;
+
+function mapEventType(item: PulseItem): (typeof EVENT_TYPES)[number] | 'OTHER' {
+  const raw = [item.type, item.category, item.title, ...(item.tags ?? [])]
+    .filter((v): v is string => Boolean(v))
+    .join(' ')
+    .toLowerCase();
+  if (raw.includes('heartbeat')) return 'HEARTBEAT';
+  if (raw.includes('watch') || raw.includes('tripwire')) return 'WATCH';
+  if (raw.includes('catalog')) return 'CATALOG';
+  if (raw.includes('journal')) return 'JOURNAL';
+  if (raw.includes('verify') || raw.includes('verification') || raw.includes('zeus')) return 'VERIFY';
+  if (raw.includes('routing') || raw.includes('route')) return 'ROUTING';
+  if (raw.includes('promotion') || raw.includes('promoted') || raw.includes('promoter')) return 'PROMOTION';
+  if (raw.includes('signal') || raw.includes('integrity')) return 'SIGNAL';
+  if (raw.includes('epicon') || item.id.startsWith('epi_') || item.id.startsWith('epicon')) return 'EPICON';
+  return 'OTHER';
+}
 
 export default function PulsePageClient() {
   const { snapshot, loading } = useTerminalSnapshot();
@@ -44,15 +66,28 @@ export default function PulsePageClient() {
       </div>
       <div className="space-y-2">
         {filtered.map((item) => (
-          <article key={item.id} className="rounded border border-slate-800 bg-slate-900/60 p-3">
-            <div className="flex flex-wrap items-center gap-2 text-xs">
-              <span className="rounded border border-slate-700 px-1.5 py-0.5 font-mono">{item.agent ?? 'UNKNOWN'}</span>
-              <span className="text-slate-300">{item.title ?? 'Untitled EPICON event'}</span>
+          <article key={item.id} className="rounded border border-slate-800 bg-slate-900/60 p-2.5 md:p-3">
+            <div className="mb-1 flex flex-wrap items-center gap-1.5 text-[10px] md:text-xs">
+              <span className="rounded border border-cyan-600/40 bg-cyan-500/10 px-1.5 py-0.5 font-mono text-cyan-100">
+                {mapEventType(item)}
+              </span>
+              <span className="rounded border border-slate-700 px-1.5 py-0.5 font-mono text-slate-400">{item.agent ?? 'SYSTEM'}</span>
+              <span className="text-slate-500">{item.status ?? 'active'}</span>
             </div>
-            <div className="mt-1 text-xs text-slate-400">
-              {item.timestamp ?? '—'} · severity {item.severity ?? 'unknown'} · MII {item.mii_score ?? '—'} · source {item.source ?? '—'}
+            <div className="text-sm font-semibold leading-snug text-slate-100">
+              {item.title ?? 'Untitled EPICON event'}
             </div>
-            <div className="mt-1 text-xs text-cyan-200">{item.status ?? 'active'}</div>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-slate-400">
+              <span>{item.timestamp ?? '—'}</span>
+              <span>sev {item.severity ?? 'unknown'}</span>
+              <span>MII {item.mii_score ?? '—'}</span>
+            </div>
+            <details className="mt-1.5 text-[10px] text-slate-500">
+              <summary className="cursor-pointer list-none text-slate-500 underline decoration-dotted underline-offset-2">
+                More details
+              </summary>
+              <div className="mt-1">source {item.source ?? '—'} · id {item.id}</div>
+            </details>
           </article>
         ))}
       </div>

--- a/components/terminal/ChamberSwitcher.tsx
+++ b/components/terminal/ChamberSwitcher.tsx
@@ -6,11 +6,11 @@ import { useEffect } from 'react';
 import { cn } from '@/lib/utils';
 
 const CHAMBERS = [
-  { label: 'Globe', href: '/terminal/globe', icon: '◎', shortcut: 'Alt+1' },
-  { label: 'Pulse', href: '/terminal/pulse', icon: '∿', shortcut: 'Alt+2' },
-  { label: 'Signals', href: '/terminal/signals', icon: '⊕', shortcut: 'Alt+3' },
-  { label: 'Sentinel', href: '/terminal/sentinel', icon: '◉', shortcut: 'Alt+4' },
-  { label: 'Ledger', href: '/terminal/ledger', icon: '⛓', shortcut: 'Alt+5' },
+  { label: 'Globe', mobileLabel: 'Glb', href: '/terminal/globe', icon: '◎', shortcut: 'Alt+1' },
+  { label: 'Pulse', mobileLabel: 'Pls', href: '/terminal/pulse', icon: '∿', shortcut: 'Alt+2' },
+  { label: 'Signals', mobileLabel: 'Sig', href: '/terminal/signals', icon: '⊕', shortcut: 'Alt+3' },
+  { label: 'Sentinel', mobileLabel: 'Snt', href: '/terminal/sentinel', icon: '◉', shortcut: 'Alt+4' },
+  { label: 'Ledger', mobileLabel: 'Ldg', href: '/terminal/ledger', icon: '⛓', shortcut: 'Alt+5' },
 ] as const;
 
 const KEY_TO_ROUTE: Record<string, string> = {
@@ -43,7 +43,7 @@ export default function ChamberSwitcher() {
   }, [router]);
 
   return (
-    <nav className="flex gap-2 overflow-x-auto pb-1" aria-label="Terminal chambers">
+    <nav className="-mx-1 flex gap-1 overflow-x-auto px-1 pb-0.5 md:mx-0 md:gap-2 md:px-0 md:pb-1" aria-label="Terminal chambers">
       {CHAMBERS.map((tab) => {
         const active = pathname === tab.href || pathname.startsWith(`${tab.href}/`);
         return (
@@ -52,12 +52,13 @@ export default function ChamberSwitcher() {
             href={tab.href}
             title={tab.shortcut}
             className={cn(
-              'whitespace-nowrap rounded border px-2 py-1 text-[11px] font-mono uppercase tracking-wide',
+              'whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-mono uppercase tracking-[0.12em] md:rounded md:px-2 md:py-1 md:text-[11px] md:tracking-wide',
               active ? 'border-cyan-300/60 bg-cyan-400/10 text-cyan-100' : 'border-slate-700/80 bg-slate-900/50 text-slate-400',
             )}
           >
             <span className="mr-1">{tab.icon}</span>
-            {tab.label}
+            <span className="md:hidden">{tab.mobileLabel}</span>
+            <span className="hidden md:inline">{tab.label}</span>
           </Link>
         );
       })}

--- a/components/terminal/CommandSurface.tsx
+++ b/components/terminal/CommandSurface.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { signIn, signOut, useSession } from 'next-auth/react';
 
@@ -20,6 +20,11 @@ export default function CommandSurface() {
   const [history, setHistory] = useState<string[]>([]);
   const [output, setOutput] = useState<CommandOutput[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.matchMedia('(max-width: 767px)').matches : false,
+  );
+  const [expanded, setExpanded] = useState(false);
+  const touchStartY = useRef<number | null>(null);
   const { data: session } = useSession();
   const router = useRouter();
 
@@ -51,6 +56,19 @@ ${greeting}`,
       active = false;
     };
   }, [session?.user?.githubUsername]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mql = window.matchMedia('(max-width: 767px)');
+    const sync = () => {
+      const nextMobile = mql.matches;
+      setIsMobile(nextMobile);
+      setExpanded((prev) => (nextMobile ? prev : true));
+    };
+    sync();
+    mql.addEventListener('change', sync);
+    return () => mql.removeEventListener('change', sync);
+  }, []);
 
   function push(command: string, response: string, type: CommandOutput['type'] = 'info') {
     setOutput((prev) => [{ timestamp: new Date().toISOString(), command, response, type }, ...prev].slice(0, 25));
@@ -285,48 +303,78 @@ ${greeting}`,
     push(trimmed, `Unknown command: ${base}`, 'error');
   }
 
+  const isOpen = isMobile ? expanded : true;
+
   return (
-    <div className="fixed bottom-7 left-0 right-0 z-40 border-t border-slate-800 bg-slate-950 px-3 py-2 font-mono text-[11px] tracking-wide">
-      <div className="mb-2 max-h-40 overflow-y-auto">
-        {output.map((row) => (
-          <div key={`${row.timestamp}-${row.command}`} className="mb-2 border-b border-slate-900 pb-2">
-            <div className="text-slate-500">{row.timestamp}</div>
-            <div className="text-slate-500">&gt; {row.command}</div>
-            <pre className={row.type === 'error' ? 'whitespace-pre-wrap text-red-400' : row.type === 'success' ? 'whitespace-pre-wrap text-emerald-400' : 'whitespace-pre-wrap text-slate-300'}>{row.response}</pre>
-          </div>
-        ))}
-      </div>
-      <div className="flex items-center gap-2">
-        <span className="text-slate-500">&gt;</span>
-        <input
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              void runCommand(input);
-              setInput('');
-            }
-            if (event.key === 'Escape') setInput('');
-            if (event.key === 'ArrowUp' && history.length > 0) {
-              event.preventDefault();
-              const next = Math.min(historyIndex + 1, history.length - 1);
-              setHistoryIndex(next);
-              setInput(history[next] ?? '');
-            }
-            if (event.key === 'ArrowDown' && history.length > 0) {
-              event.preventDefault();
-              const next = Math.max(historyIndex - 1, -1);
-              setHistoryIndex(next);
-              setInput(next === -1 ? '' : history[next] ?? '');
-            }
-            if (event.key === 'Tab') {
-              event.preventDefault();
-              if (matches[0]) setInput(matches[0]);
-            }
-          }}
-          className="w-full bg-transparent text-sky-300 outline-none"
-          placeholder="Type /help"
-        />
+    <div className="fixed bottom-7 left-0 right-0 z-40 border-t border-slate-800 bg-slate-950 font-mono text-[11px] tracking-wide">
+      <button
+        type="button"
+        onClick={() => setExpanded((current) => !current)}
+        onTouchStart={(event) => {
+          touchStartY.current = event.touches[0]?.clientY ?? null;
+        }}
+        onTouchEnd={(event) => {
+          const startY = touchStartY.current;
+          const endY = event.changedTouches[0]?.clientY;
+          touchStartY.current = null;
+          if (!isMobile || startY == null || endY == null) return;
+          if (endY - startY > 36) setExpanded(false);
+        }}
+        className="flex w-full items-center justify-between px-3 py-1.5 text-[10px] uppercase tracking-[0.14em] text-slate-400 md:hidden"
+        aria-expanded={isOpen}
+        aria-controls="mobius-command-console"
+      >
+        <span>Command console</span>
+        <span className="rounded border border-slate-700 px-2 py-0.5 text-[9px]">
+          {isOpen ? 'Collapse' : 'Open'}
+        </span>
+      </button>
+
+      <div
+        id="mobius-command-console"
+        className={`${isOpen ? 'max-h-[56vh] px-3 py-2' : 'max-h-0 px-3 py-0'} overflow-hidden transition-all duration-300`}
+      >
+        <div className="mb-2 max-h-40 overflow-y-auto">
+          {output.map((row) => (
+            <div key={`${row.timestamp}-${row.command}`} className="mb-2 border-b border-slate-900 pb-2">
+              <div className="text-slate-500">{row.timestamp}</div>
+              <div className="text-slate-500">&gt; {row.command}</div>
+              <pre className={row.type === 'error' ? 'whitespace-pre-wrap text-red-400' : row.type === 'success' ? 'whitespace-pre-wrap text-emerald-400' : 'whitespace-pre-wrap text-slate-300'}>{row.response}</pre>
+            </div>
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-slate-500">&gt;</span>
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                void runCommand(input);
+                setInput('');
+              }
+              if (event.key === 'Escape') setInput('');
+              if (event.key === 'ArrowUp' && history.length > 0) {
+                event.preventDefault();
+                const next = Math.min(historyIndex + 1, history.length - 1);
+                setHistoryIndex(next);
+                setInput(history[next] ?? '');
+              }
+              if (event.key === 'ArrowDown' && history.length > 0) {
+                event.preventDefault();
+                const next = Math.max(historyIndex - 1, -1);
+                setHistoryIndex(next);
+                setInput(next === -1 ? '' : history[next] ?? '');
+              }
+              if (event.key === 'Tab') {
+                event.preventDefault();
+                if (matches[0]) setInput(matches[0]);
+              }
+            }}
+            className="w-full bg-transparent text-sky-300 outline-none"
+            placeholder="Type /help"
+          />
+        </div>
       </div>
     </div>
   );

--- a/components/terminal/TerminalShell.tsx
+++ b/components/terminal/TerminalShell.tsx
@@ -70,27 +70,27 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
 
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-[#020617] text-slate-100">
-      <header className="sticky top-0 z-50 border-b border-slate-800 bg-slate-950/95 px-4 py-3 backdrop-blur">
-        <div className="mb-2 flex items-center justify-between gap-3">
-          <div className="flex items-center gap-3">
-            <div className="rounded border border-cyan-400/60 bg-cyan-400/10 px-2 py-0.5 font-mono text-xs">⌘</div>
-            <div className="text-sm font-semibold tracking-wide">MOBIUS CIVIC TERMINAL</div>
+      <header className="sticky top-0 z-50 border-b border-slate-800 bg-slate-950/95 px-3 py-2 backdrop-blur md:px-4 md:py-3">
+        <div className="mb-1.5 flex items-center justify-between gap-2 md:mb-2 md:gap-3">
+          <div className="flex items-center gap-2 md:gap-3">
+            <div className="rounded border border-cyan-400/60 bg-cyan-400/10 px-1.5 py-0.5 font-mono text-[10px] md:px-2 md:text-xs">⌘</div>
+            <div className="text-[13px] font-semibold tracking-[0.04em] md:text-sm md:tracking-wide">MOBIUS CIVIC TERMINAL</div>
           </div>
-          <div className="flex items-center gap-2 text-[11px] font-mono">
-            <span className={cn('rounded border px-2 py-1', giTone)}>GI {gi.toFixed(2)}</span>
-            <span className={cn('rounded border px-2 py-1 uppercase', runtimeBadgeClass(runtime))}>{runtime}</span>
+          <div className="flex items-center gap-1.5 text-[10px] font-mono md:gap-2 md:text-[11px]">
+            <span className={cn('rounded border px-1.5 py-0.5 md:px-2 md:py-1', giTone)}>GI {gi.toFixed(2)}</span>
+            <span className={cn('rounded border px-1.5 py-0.5 uppercase md:px-2 md:py-1', runtimeBadgeClass(runtime))}>{runtime}</span>
             <span className="hidden rounded border border-slate-700 px-2 py-1 md:inline">{clock}</span>
-            <span className="rounded border border-slate-700 px-2 py-1">{integrity?.cycle ?? 'C-—'}</span>
+            <span className="rounded border border-slate-700 px-1.5 py-0.5 md:px-2 md:py-1">{integrity?.cycle ?? 'C-—'}</span>
           </div>
         </div>
 
-        <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center justify-between gap-1.5 md:gap-2">
           <ChamberSwitcher />
           <button
             type="button"
             onClick={() => setShowLaneDiagnostics((current) => !current)}
             className={cn(
-              'shrink-0 rounded border px-2 py-1 text-[10px] font-mono uppercase tracking-wide',
+              'shrink-0 rounded border px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-[0.12em] md:px-2 md:py-1 md:text-[10px] md:tracking-wide',
               showLaneDiagnostics ? 'border-cyan-500/60 text-cyan-200' : 'border-slate-700 text-slate-400',
             )}
           >
@@ -99,7 +99,7 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
         </div>
       </header>
 
-      <main className="min-h-0 flex-1 overflow-hidden pb-28">{children}</main>
+      <main className="min-h-0 flex-1 overflow-hidden pb-16 md:pb-28">{children}</main>
     </div>
   );
 }

--- a/components/terminal/chambers/GlobeChamber.tsx
+++ b/components/terminal/chambers/GlobeChamber.tsx
@@ -318,6 +318,9 @@ export default function GlobeChamber({
     | { status: 'unavailable'; message: string }
   >({ status: 'idle' });
   const [heroBusy, setHeroBusy] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+  const [sheetOffset, setSheetOffset] = useState(0);
+  const sheetTouchStartY = useRef<number | null>(null);
   const prevPinsRef = useRef<GlobePin[]>([]);
   const [deltaLines, setDeltaLines] = useState<string[]>([]);
 
@@ -330,6 +333,19 @@ export default function GlobeChamber({
     setDeltaLines(computeGlobeDeltaLines(prevPinsRef.current, pins, giScore));
     prevPinsRef.current = pins;
   }, [pins, giScore]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mql = window.matchMedia('(max-width: 767px)');
+    const sync = () => setIsMobile(mql.matches);
+    sync();
+    mql.addEventListener('change', sync);
+    return () => mql.removeEventListener('change', sync);
+  }, []);
+
+  useEffect(() => {
+    if (!selected) setSheetOffset(0);
+  }, [selected]);
 
   const domainByKey = useMemo(
     () => Object.fromEntries(domains.map((d) => [d.key, d])) as Record<string, SentimentDomain>,
@@ -892,10 +908,50 @@ export default function GlobeChamber({
       ) : null}
 
       {selected ? (
-        <div
-          className="fixed inset-x-2 bottom-2 z-50 max-h-[68vh] overflow-y-auto rounded-md border border-white/10 bg-[#020408]/95 p-4 shadow-xl backdrop-blur-md md:inset-x-auto md:bottom-auto md:right-4 md:top-1/2 md:max-h-[min(88vh,640px)] md:w-[min(92vw,280px)] md:p-5"
-          style={{ animation: 'globeInsp 0.2s ease' }}
-        >
+        <>
+          {isMobile ? (
+            <button
+              type="button"
+              aria-label="Dismiss inspection"
+              className="fixed inset-0 z-40 bg-black/35"
+              onClick={() => {
+                setSelected(null);
+                setSelectedDomain(null);
+              }}
+            />
+          ) : null}
+          <div
+            className="fixed inset-x-0 bottom-0 z-50 max-h-[74vh] overflow-y-auto rounded-t-xl border border-white/10 bg-[#020408]/95 p-4 shadow-xl backdrop-blur-md md:inset-x-auto md:bottom-auto md:right-4 md:top-1/2 md:max-h-[min(88vh,640px)] md:w-[min(92vw,280px)] md:rounded-md md:p-5"
+            style={{
+              animation: 'globeInsp 0.2s ease',
+              transform: isMobile ? `translateY(${sheetOffset}px)` : undefined,
+              transition: isMobile ? 'transform 120ms ease' : undefined,
+            }}
+            onTouchStart={(event) => {
+              if (!isMobile) return;
+              sheetTouchStartY.current = event.touches[0]?.clientY ?? null;
+            }}
+            onTouchMove={(event) => {
+              if (!isMobile) return;
+              const startY = sheetTouchStartY.current;
+              const currentY = event.touches[0]?.clientY;
+              if (startY == null || currentY == null) return;
+              const delta = Math.max(0, currentY - startY);
+              setSheetOffset(Math.min(220, delta));
+            }}
+            onTouchEnd={() => {
+              if (!isMobile) return;
+              if (sheetOffset > 120) {
+                setSelected(null);
+                setSelectedDomain(null);
+                setSheetOffset(0);
+              } else {
+                setSheetOffset(0);
+              }
+              sheetTouchStartY.current = null;
+            }}
+          >
+            {isMobile ? <div className="mx-auto mb-2 h-1.5 w-10 rounded-full bg-slate-700/90" /> : null}
           <button
             type="button"
             className="absolute right-3 top-3 text-slate-500 hover:text-slate-300"
@@ -935,7 +991,7 @@ export default function GlobeChamber({
 
           <div className="mb-1 text-[9px] uppercase tracking-[0.12em] text-slate-500">{selected.source}</div>
           <div className="mb-2 text-[13px] leading-snug text-slate-200">{selected.title}</div>
-          <p className="mb-3 text-[10px] leading-relaxed text-slate-500">{selected.narrativeWhy}</p>
+          <p className="mb-3 rounded border border-cyan-500/20 bg-cyan-500/5 px-2 py-1.5 text-[10px] leading-relaxed text-cyan-100/90">{selected.narrativeWhy}</p>
 
           <div className="mb-2 flex flex-wrap gap-1 text-[8px] uppercase tracking-[0.08em]">
             <span className="rounded border border-slate-600/60 px-1.5 py-0.5 text-slate-500">Feed</span>
@@ -1020,7 +1076,8 @@ export default function GlobeChamber({
           <div className="mt-3 inline-block rounded border border-sky-500/20 bg-sky-500/10 px-2 py-0.5 text-[9px] uppercase tracking-[0.1em] text-sky-300">
             {selected.agent}
           </div>
-        </div>
+          </div>
+        </>
       ) : null}
 
       {loadError ? (


### PR DESCRIPTION
### Motivation
- Mobile view needed vertical reprioritization so chambers (Globe / Pulse) have more visible space and feel native on phones.
- Bottom console and top shell were consuming too much viewport; chamber nav and Globe inspect UX were still desktop-centric.
- Pulse rows showed weak "UNKNOWN" badges and were too dense for quick scanning on small screens.

### Description
- Collapse command console into a mobile-first drawer with a slim handle, tap-to-expand, and swipe-down collapse while keeping full desktop behavior in `components/terminal/CommandSurface.tsx`.
- Make chamber switcher mobile-friendly by adding compact pill styling, short `mobileLabel`s, tighter spacing and improved horizontal scroll ergonomics in `components/terminal/ChamberSwitcher.tsx`.
- Reduce top shell height and tighten header spacing/padding so chamber content gains vertical room in `components/terminal/TerminalShell.tsx`.
- Convert Globe inspection to a mobile bottom sheet with backdrop, drag handle and swipe-to-dismiss while preserving desktop side-panel behavior; keep image/provenance/score/metadata and emphasize the "why this matters" narrative in `components/terminal/chambers/GlobeChamber.tsx`.
- Improve Pulse ledger cards by adding best-effort event type mapping (`HEARTBEAT`, `WATCH`, `CATALOG`, `EPICON`, `JOURNAL`, `VERIFY`, `ROUTING`, `PROMOTION`, `SIGNAL`) and reduce card density by promoting title and moving secondary data into a collapsible `details` area in `app/terminal/pulse/PulsePageClient.tsx`.

### Testing
- Type-check: `pnpm exec tsc --noEmit` ran and passed successfully.
- Lint: `pnpm lint` could not be run non-interactively in this environment because Next.js prompted for ESLint setup, so automated linting was not completed here.
- No runtime tests were added; manual UI validation expected during QA for touch gestures, sheet dismissal thresholds, and mobile layout polish.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7da3b2464832d97ea79420e5e1379)