### PR TITLE
C-276: GI cold-start seed, heartbeat KV, EPICON bridge, SSE journal, and Globe EONET

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -16,6 +16,9 @@ from app.schemas import (
     TripwireResponse,
     SystemHealthResponse,
 )
+from api.routes.heartbeat import router as heartbeat_router
+from api.routes.epicon import router as epicon_router
+from api.routes.stream import router as stream_router, start_journal_watcher
 
 app = FastAPI(
     title=settings.app_name,
@@ -33,6 +36,15 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(heartbeat_router, prefix="/api/v1/system")
+app.include_router(epicon_router, prefix="/api/v1")
+app.include_router(stream_router, prefix="/api/v1")
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    asyncio.create_task(start_journal_watcher())
 
 
 def now_utc() -> datetime:
@@ -268,30 +280,6 @@ def get_agents_status():
         "cycle": settings.default_cycle,
         "timestamp": now_utc(),
         "agents": build_mock_agents(),
-    }
-
-
-@app.get(
-    "/api/v1/epicon/feed",
-    response_model=EpiconFeedResponse,
-    tags=["epicon"],
-)
-def get_epicon_feed(
-    limit: int = Query(default=20, ge=1, le=100),
-    category: Optional[str] = Query(default=None),
-    status: Optional[str] = Query(default=None),
-):
-    items = build_mock_epicon()
-
-    if category:
-        items = [item for item in items if item["category"] == category]
-    if status:
-        items = [item for item in items if item["status"] == status]
-
-    return {
-        "cycle": settings.default_cycle,
-        "timestamp": now_utc(),
-        "items": items[:limit],
     }
 
 

--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""API route modules for Mobius FastAPI service."""

--- a/api/routes/epicon.py
+++ b/api/routes/epicon.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Query, HTTPException, status
+from pydantic import BaseModel, Field
+
+router = APIRouter()
+
+LEDGER_URL = os.getenv("CIVIC_LEDGER_API_URL", "")
+LEDGER_KEY = os.getenv("CIVIC_LEDGER_API_KEY", "")
+
+
+def _ledger_headers() -> dict[str, str]:
+    h = {"Accept": "application/json"}
+    if LEDGER_KEY:
+        h["Authorization"] = f"Bearer {LEDGER_KEY}"
+    return h
+
+
+async def _ledger_get(path: str, params: dict | None = None) -> Any:
+    if not LEDGER_URL:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="CIVIC_LEDGER_API_URL is not configured",
+        )
+    url = f"{LEDGER_URL.rstrip('/')}{path}"
+    async with httpx.AsyncClient(timeout=8.0) as client:
+        r = await client.get(url, headers=_ledger_headers(), params=params or {})
+        if r.status_code == 404:
+            raise HTTPException(status_code=404, detail="Entry not found in ledger")
+        r.raise_for_status()
+        return r.json()
+
+
+class EPICONEntry(BaseModel):
+    id: str
+    cycle: str
+    timestamp: str
+    agent: str | None = None
+    intent: str | None = None
+    action: str | None = None
+    outcome: str | None = None
+    confidence: float | None = None
+    integrity_delta: float | None = None
+    status: str = "verified"
+    source_refs: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    raw: dict | None = None
+
+
+class EPICONFeedResponse(BaseModel):
+    entries: list[EPICONEntry]
+    total: int
+    page: int
+    per_page: int
+    has_more: bool
+
+
+class EPICONStats(BaseModel):
+    total_entries: int
+    verified: int
+    pending: int
+    contradicted: int
+    agents_active: int
+    latest_cycle: str
+
+
+def _normalise(raw: dict) -> EPICONEntry:
+    return EPICONEntry(
+        id=str(raw.get("id") or raw.get("entry_id") or ""),
+        cycle=str(raw.get("cycle") or raw.get("epicon_cycle") or "—"),
+        timestamp=str(raw.get("created_at") or raw.get("timestamp") or ""),
+        agent=raw.get("agent") or raw.get("sentinel_id"),
+        intent=raw.get("intent") or raw.get("intent_statement"),
+        action=raw.get("action") or raw.get("action_taken"),
+        outcome=raw.get("outcome"),
+        confidence=raw.get("confidence") or raw.get("confidence_score"),
+        integrity_delta=raw.get("integrity_delta") or raw.get("gi_delta"),
+        status=raw.get("status") or raw.get("verification_status") or "verified",
+        source_refs=raw.get("source_refs") or raw.get("sources") or [],
+        tags=raw.get("tags") or [],
+        raw=raw,
+    )
+
+
+@router.get("/epicon/feed", response_model=EPICONFeedResponse)
+async def get_epicon_feed(
+    page: int = Query(1, ge=1),
+    per_page: int = Query(25, ge=1, le=100),
+    agent: str | None = Query(None),
+    status_filter: str | None = Query(None, alias="status"),
+    cycle: str | None = Query(None),
+) -> EPICONFeedResponse:
+    params: dict[str, Any] = {"page": page, "per_page": per_page}
+    if agent:
+        params["agent"] = agent
+    if status_filter:
+        params["status"] = status_filter
+    if cycle:
+        params["cycle"] = cycle
+
+    try:
+        data = await _ledger_get("/api/v1/entries", params=params)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Ledger upstream error: {exc}") from exc
+
+    if isinstance(data, list):
+        entries_raw = data
+        total = len(data)
+    else:
+        entries_raw = data.get("entries") or data.get("results") or data.get("data") or []
+        total = data.get("total") or data.get("count") or len(entries_raw)
+
+    entries = [_normalise(e) for e in entries_raw]
+
+    return EPICONFeedResponse(
+        entries=entries,
+        total=total,
+        page=page,
+        per_page=per_page,
+        has_more=(page * per_page) < total,
+    )
+
+
+@router.get("/epicon/entry/{entry_id}", response_model=EPICONEntry)
+async def get_epicon_entry(entry_id: str) -> EPICONEntry:
+    data = await _ledger_get(f"/api/v1/entries/{entry_id}")
+    return _normalise(data)
+
+
+@router.get("/epicon/stats", response_model=EPICONStats)
+async def get_epicon_stats() -> EPICONStats:
+    try:
+        data = await _ledger_get("/api/v1/entries/stats")
+    except Exception:
+        feed = await _ledger_get("/api/v1/entries", params={"per_page": 1})
+        total = feed.get("total") or feed.get("count") or 0
+        return EPICONStats(
+            total_entries=total,
+            verified=0,
+            pending=0,
+            contradicted=0,
+            agents_active=0,
+            latest_cycle="—",
+        )
+
+    return EPICONStats(
+        total_entries=data.get("total") or 0,
+        verified=data.get("verified") or 0,
+        pending=data.get("pending") or 0,
+        contradicted=data.get("contradicted") or 0,
+        agents_active=data.get("agents_active") or 0,
+        latest_cycle=data.get("latest_cycle") or "—",
+    )

--- a/api/routes/heartbeat.py
+++ b/api/routes/heartbeat.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+import httpx
+from fastapi import APIRouter, Header, HTTPException, status
+from pydantic import BaseModel
+
+router = APIRouter()
+
+KV_URL = os.getenv("UPSTASH_REDIS_REST_URL", "")
+KV_TOKEN = os.getenv("UPSTASH_REDIS_REST_TOKEN", "")
+HB_SECRET = os.getenv("MOBIUS_HEARTBEAT_SECRET", "")
+
+HB_KEY = "mobius:heartbeat_at"
+HB_CYCLE_KEY = "mobius:heartbeat_cycle"
+HB_TTL_S = 3600
+
+
+async def kv_set(key: str, value: str, ex: int | None = None) -> None:
+    if not KV_URL or not KV_TOKEN:
+        return
+    cmd = ["SET", key, value]
+    if ex:
+        cmd += ["EX", str(ex)]
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            KV_URL,
+            headers={"Authorization": f"Bearer {KV_TOKEN}"},
+            json=cmd,
+            timeout=4.0,
+        )
+        r.raise_for_status()
+
+
+async def kv_get(key: str) -> str | None:
+    if not KV_URL or not KV_TOKEN:
+        return None
+    async with httpx.AsyncClient() as client:
+        r = await client.get(
+            f"{KV_URL}/get/{key}",
+            headers={"Authorization": f"Bearer {KV_TOKEN}"},
+            timeout=4.0,
+        )
+        if r.status_code == 200:
+            data = r.json()
+            return data.get("result")
+    return None
+
+
+class HeartbeatPayload(BaseModel):
+    cycle: str | None = None
+    source: str | None = "render-broker"
+
+
+class HeartbeatResponse(BaseModel):
+    heartbeat_at: str
+    cycle: str | None
+    kv_written: bool
+
+
+@router.post("/heartbeat", response_model=HeartbeatResponse, status_code=status.HTTP_200_OK)
+async def post_heartbeat(
+    payload: HeartbeatPayload,
+    x_heartbeat_secret: str | None = Header(default=None),
+) -> HeartbeatResponse:
+    if HB_SECRET and x_heartbeat_secret != HB_SECRET:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid heartbeat secret")
+
+    now = datetime.now(timezone.utc).isoformat()
+    kv_written = True
+
+    try:
+        await kv_set(HB_KEY, now, ex=HB_TTL_S)
+        if payload.cycle:
+            await kv_set(HB_CYCLE_KEY, payload.cycle, ex=HB_TTL_S)
+    except Exception:
+        kv_written = False
+
+    return HeartbeatResponse(heartbeat_at=now, cycle=payload.cycle, kv_written=kv_written)
+
+
+@router.get("/heartbeat", response_model=HeartbeatResponse)
+async def get_heartbeat() -> HeartbeatResponse:
+    hb_at = await kv_get(HB_KEY)
+    hb_cycle = await kv_get(HB_CYCLE_KEY)
+    return HeartbeatResponse(
+        heartbeat_at=hb_at or "",
+        cycle=hb_cycle,
+        kv_written=hb_at is not None,
+    )

--- a/api/routes/stream.py
+++ b/api/routes/stream.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from datetime import datetime, timezone
+from typing import AsyncGenerator
+
+import httpx
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+
+router = APIRouter()
+
+KV_URL = os.getenv("UPSTASH_REDIS_REST_URL", "")
+KV_TOKEN = os.getenv("UPSTASH_REDIS_REST_TOKEN", "")
+JOURNAL_KEY = "mobius:agent_journal"
+POLL_S = 5
+MAX_QUEUE_SIZE = 256
+
+_subscribers: list[asyncio.Queue[dict]] = []
+_last_seen_id: str | None = None
+
+
+def _register() -> asyncio.Queue[dict]:
+    q: asyncio.Queue[dict] = asyncio.Queue(maxsize=MAX_QUEUE_SIZE)
+    _subscribers.append(q)
+    return q
+
+
+def _unregister(q: asyncio.Queue[dict]) -> None:
+    try:
+        _subscribers.remove(q)
+    except ValueError:
+        pass
+
+
+def _broadcast(event: dict) -> None:
+    for q in list(_subscribers):
+        try:
+            q.put_nowait(event)
+        except asyncio.QueueFull:
+            pass
+
+
+async def _kv_lrange(key: str, start: int, stop: int) -> list[str]:
+    if not KV_URL or not KV_TOKEN:
+        return []
+    url = f"{KV_URL}/lrange/{key}/{start}/{stop}"
+    async with httpx.AsyncClient(timeout=4.0) as client:
+        r = await client.get(url, headers={"Authorization": f"Bearer {KV_TOKEN}"})
+        if r.status_code == 200:
+            return r.json().get("result") or []
+    return []
+
+
+async def start_journal_watcher() -> None:
+    global _last_seen_id
+    while True:
+        try:
+            raw_entries = await _kv_lrange(JOURNAL_KEY, 0, 19)
+            for raw in reversed(raw_entries):
+                try:
+                    entry: dict = json.loads(raw) if isinstance(raw, str) else raw
+                except json.JSONDecodeError:
+                    continue
+
+                entry_id = str(entry.get("id") or entry.get("ts") or "")
+                if entry_id and entry_id == _last_seen_id:
+                    break
+
+                _broadcast(entry)
+
+            if raw_entries:
+                try:
+                    first = json.loads(raw_entries[0]) if isinstance(raw_entries[0], str) else raw_entries[0]
+                    _last_seen_id = str(first.get("id") or first.get("ts") or "")
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+        await asyncio.sleep(POLL_S)
+
+
+async def _event_generator(q: asyncio.Queue[dict]) -> AsyncGenerator[str, None]:
+    yield ": keepalive\n\n"
+    try:
+        while True:
+            try:
+                event = await asyncio.wait_for(q.get(), timeout=25.0)
+                payload = json.dumps(event, default=str)
+                yield f"data: {payload}\n\n"
+            except asyncio.TimeoutError:
+                yield f": ping {datetime.now(timezone.utc).isoformat()}\n\n"
+    except asyncio.CancelledError:
+        pass
+    finally:
+        _unregister(q)
+
+
+@router.get("/stream/journal-events")
+async def stream_journal_events() -> StreamingResponse:
+    q = _register()
+    return StreamingResponse(
+        _event_generator(q),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )

--- a/app/terminal/globe/page.tsx
+++ b/app/terminal/globe/page.tsx
@@ -1,10 +1,250 @@
-import type { Metadata } from 'next';
-import GlobePageClient from '../GlobePageClient';
+"use client";
 
-export const metadata: Metadata = {
-  title: 'Globe · Mobius Terminal',
+import { useEffect, useState, useCallback } from "react";
+import {
+  ComposableMap,
+  Geographies,
+  Geography,
+  Marker,
+  ZoomableGroup,
+} from "react-simple-maps";
+
+type EONETCategory =
+  | "wildfires"
+  | "severeStorms"
+  | "volcanoes"
+  | "floods"
+  | "earthquakes"
+  | "drought"
+  | "other";
+
+interface EONETEvent {
+  id: string;
+  title: string;
+  category: EONETCategory;
+  coordinates: [number, number];
+  date: string;
+  link?: string;
+}
+
+interface EONETApiEvent {
+  id: string;
+  title: string;
+  categories: { id: string; title: string }[];
+  geometry: { date: string; coordinates: [number, number] }[];
+  sources?: { url: string }[];
+}
+
+const CATEGORY_COLORS: Record<EONETCategory, string> = {
+  wildfires: "#f97316",
+  severeStorms: "#60a5fa",
+  volcanoes: "#f43f5e",
+  floods: "#38bdf8",
+  earthquakes: "#a78bfa",
+  drought: "#fbbf24",
+  other: "#94a3b8",
 };
 
-export default function GlobePage() {
-  return <GlobePageClient />;
+const CATEGORY_LABELS: Record<EONETCategory, string> = {
+  wildfires: "Wildfire",
+  severeStorms: "Storm",
+  volcanoes: "Volcano",
+  floods: "Flood",
+  earthquakes: "Quake",
+  drought: "Drought",
+  other: "Event",
+};
+
+function resolveCategory(cats: { id: string }[]): EONETCategory {
+  const ids = cats.map((c) => c.id.toLowerCase());
+  if (ids.some((i) => i.includes("wildfire"))) return "wildfires";
+  if (ids.some((i) => i.includes("storm") || i.includes("cyclone"))) return "severeStorms";
+  if (ids.some((i) => i.includes("volcan"))) return "volcanoes";
+  if (ids.some((i) => i.includes("flood"))) return "floods";
+  if (ids.some((i) => i.includes("quake") || i.includes("seismic"))) return "earthquakes";
+  if (ids.some((i) => i.includes("drought"))) return "drought";
+  return "other";
+}
+
+const EONET_URL = "https://eonet.gsfc.nasa.gov/api/v3/events?status=open&limit=80&days=30";
+
+async function fetchEONET(): Promise<EONETEvent[]> {
+  const res = await fetch(EONET_URL, { next: { revalidate: 3600 } });
+  if (!res.ok) throw new Error(`EONET ${res.status}`);
+  const data = await res.json();
+
+  return (data.events as EONETApiEvent[]).flatMap((ev) => {
+    const geo = ev.geometry?.[0];
+    if (!geo?.coordinates) return [];
+    const [lng, lat] = geo.coordinates;
+    if (typeof lng !== "number" || typeof lat !== "number") return [];
+    return [
+      {
+        id: ev.id,
+        title: ev.title,
+        category: resolveCategory(ev.categories),
+        coordinates: [lng, lat],
+        date: geo.date,
+        link: ev.sources?.[0]?.url,
+      },
+    ];
+  });
+}
+
+const GEO_URL = "https://cdn.jsdelivr.net/npm/world-atlas@2/countries-110m.json";
+
+export default function GlobeChamber() {
+  const [events, setEvents] = useState<EONETEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tooltip, setTooltip] = useState<EONETEvent | null>(null);
+  const [activeCategories, setActiveCategories] = useState<Set<EONETCategory>>(
+    new Set(Object.keys(CATEGORY_COLORS) as EONETCategory[]),
+  );
+
+  const load = useCallback(async () => {
+    try {
+      setError(null);
+      const evts = await fetchEONET();
+      setEvents(evts);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "EONET fetch failed");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const counts = events.reduce<Record<string, number>>((acc, ev) => {
+    acc[ev.category] = (acc[ev.category] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const toggleCat = (cat: EONETCategory) => {
+    setActiveCategories((prev) => {
+      const next = new Set(prev);
+      next.has(cat) ? next.delete(cat) : next.add(cat);
+      return next;
+    });
+  };
+
+  const visible = events.filter((e) => activeCategories.has(e.category));
+
+  return (
+    <div className="flex h-full select-none flex-col bg-black font-mono text-green-400">
+      <div className="flex items-center gap-4 border-b border-green-900 px-4 py-2 text-xs">
+        <span className="uppercase tracking-widest text-green-500">◎ Globe</span>
+        <span className="text-green-700">NASA EONET · Open Events · Last 30 days</span>
+        <span className="ml-auto text-green-700">
+          {loading ? "Loading…" : error ? `⚠ ${error}` : `${visible.length} events`}
+        </span>
+        <button
+          onClick={load}
+          className="text-green-600 transition-colors hover:text-green-400"
+          aria-label="Refresh EONET data"
+        >
+          ↻
+        </button>
+      </div>
+
+      <div className="relative flex-1 overflow-hidden">
+        <ComposableMap
+          projection="geoEqualEarth"
+          style={{ width: "100%", height: "100%", background: "transparent" }}
+        >
+          <ZoomableGroup zoom={1} minZoom={0.8} maxZoom={6}>
+            <Geographies geography={GEO_URL}>
+              {({ geographies }: { geographies: any[] }) =>
+                geographies.map((geo: any) => (
+                  <Geography
+                    key={geo.rsmKey}
+                    geography={geo}
+                    fill="#0d1a0d"
+                    stroke="#1a3a1a"
+                    strokeWidth={0.3}
+                    style={{
+                      default: { outline: "none" },
+                      hover: { fill: "#112211", outline: "none" },
+                      pressed: { outline: "none" },
+                    }}
+                  />
+                ))
+              }
+            </Geographies>
+
+            {visible.map((ev) => (
+              <Marker
+                key={ev.id}
+                coordinates={ev.coordinates}
+                onMouseEnter={() => setTooltip(ev)}
+                onMouseLeave={() => setTooltip(null)}
+              >
+                <circle
+                  r={4}
+                  fill={CATEGORY_COLORS[ev.category]}
+                  fillOpacity={0.85}
+                  stroke="#000"
+                  strokeWidth={0.5}
+                  className="cursor-pointer"
+                  style={{ transition: "r 0.15s" }}
+                  onMouseEnter={(e) => {
+                    (e.target as SVGCircleElement).setAttribute("r", "7");
+                  }}
+                  onMouseLeave={(e) => {
+                    (e.target as SVGCircleElement).setAttribute("r", "4");
+                  }}
+                />
+              </Marker>
+            ))}
+          </ZoomableGroup>
+        </ComposableMap>
+
+        {tooltip && (
+          <div className="pointer-events-none absolute bottom-4 left-4 z-10 max-w-xs border border-green-800 bg-black/90 px-3 py-2 text-xs">
+            <div className="truncate font-medium text-green-300">{tooltip.title}</div>
+            <div className="mt-0.5 text-green-600">
+              {CATEGORY_LABELS[tooltip.category]} · {new Date(tooltip.date).toLocaleDateString()}
+            </div>
+            <div className="mt-0.5 text-[10px] text-green-700">
+              {tooltip.coordinates[1].toFixed(2)}°N {tooltip.coordinates[0].toFixed(2)}°E
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-2 border-t border-green-900 px-4 py-2 text-[10px]">
+        {(Object.keys(CATEGORY_COLORS) as EONETCategory[]).map((cat) => {
+          const active = activeCategories.has(cat);
+          return (
+            <button
+              key={cat}
+              onClick={() => toggleCat(cat)}
+              className="flex items-center gap-1.5 border px-2 py-0.5 transition-opacity"
+              style={{
+                borderColor: CATEGORY_COLORS[cat],
+                opacity: active ? 1 : 0.3,
+                color: CATEGORY_COLORS[cat],
+              }}
+            >
+              <span
+                style={{
+                  width: 6,
+                  height: 6,
+                  borderRadius: "50%",
+                  background: active ? CATEGORY_COLORS[cat] : "transparent",
+                  display: "inline-block",
+                  border: `1px solid ${CATEGORY_COLORS[cat]}`,
+                }}
+              />
+              {CATEGORY_LABELS[cat]}
+              {counts[cat] ? ` (${counts[cat]})` : ""}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
 }

--- a/lib/terminal/useAgentJournal.ts
+++ b/lib/terminal/useAgentJournal.ts
@@ -1,0 +1,175 @@
+"use client";
+
+import { useEffect, useReducer, useRef, useCallback } from "react";
+
+export type JournalAgent =
+  | "ATLAS"
+  | "ZEUS"
+  | "HERMES"
+  | "ECHO"
+  | "AUREA"
+  | "JADE"
+  | "EVE"
+  | "DAEDALUS";
+
+export interface JournalEntry {
+  id: string;
+  ts: string;
+  agent: JournalAgent | string;
+  action: string;
+  detail?: string;
+  cycle?: string;
+  integrity_delta?: number;
+  tags?: string[];
+}
+
+export type SSEStatus = "connecting" | "live" | "fallback" | "error";
+
+interface JournalState {
+  entries: JournalEntry[];
+  status: SSEStatus;
+  lastEventAt: Date | null;
+}
+
+type JournalAction =
+  | { type: "push"; entry: JournalEntry }
+  | { type: "set_status"; status: SSEStatus }
+  | { type: "seed"; entries: JournalEntry[] };
+
+const MAX_ENTRIES = 200;
+
+function journalReducer(state: JournalState, action: JournalAction): JournalState {
+  switch (action.type) {
+    case "seed":
+      return { ...state, entries: action.entries.slice(0, MAX_ENTRIES) };
+    case "push": {
+      if (state.entries.some((e) => e.id === action.entry.id)) return state;
+      const next = [action.entry, ...state.entries].slice(0, MAX_ENTRIES);
+      return { ...state, entries: next, lastEventAt: new Date() };
+    }
+    case "set_status":
+      return { ...state, status: action.status };
+    default:
+      return state;
+  }
+}
+
+interface UseAgentJournalOptions {
+  apiBase?: string;
+  agents?: JournalAgent[];
+  maxEntries?: number;
+}
+
+export function useAgentJournal(opts: UseAgentJournalOptions = {}) {
+  const { apiBase = process.env.NEXT_PUBLIC_MOBIUS_API_BASE ?? "", agents } = opts;
+
+  const [state, dispatch] = useReducer(journalReducer, {
+    entries: [],
+    status: "connecting",
+    lastEventAt: null,
+  });
+
+  const esRef = useRef<EventSource | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const seed = useCallback(async () => {
+    try {
+      const res = await fetch(`${apiBase}/api/v1/agents/journal?per_page=50`, {
+        next: { revalidate: 0 },
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+      const entries: JournalEntry[] = (data.entries ?? data ?? []).map(normalise);
+      dispatch({ type: "seed", entries });
+    } catch {
+      // no-op
+    }
+  }, [apiBase]);
+
+  const startFallbackPoll = useCallback(() => {
+    if (pollRef.current) return;
+    pollRef.current = setInterval(async () => {
+      try {
+        const res = await fetch(`${apiBase}/api/v1/agents/journal?per_page=10`, {
+          next: { revalidate: 0 },
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        (data.entries ?? data ?? []).forEach((raw: Record<string, unknown>) => {
+          const entry = normalise(raw);
+          if (!agents || agents.includes(entry.agent as JournalAgent)) {
+            dispatch({ type: "push", entry });
+          }
+        });
+        connectSSE();
+      } catch {
+        dispatch({ type: "set_status", status: "error" });
+      }
+    }, 30_000);
+  }, [apiBase, agents]);
+
+  const connectSSE = useCallback(() => {
+    if (esRef.current) {
+      esRef.current.close();
+      esRef.current = null;
+    }
+
+    const es = new EventSource(`${apiBase}/api/v1/stream/journal-events`);
+    esRef.current = es;
+
+    es.onopen = () => {
+      dispatch({ type: "set_status", status: "live" });
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+
+    es.onmessage = (evt) => {
+      try {
+        const raw = JSON.parse(evt.data);
+        const entry = normalise(raw);
+        if (!agents || agents.includes(entry.agent as JournalAgent)) {
+          dispatch({ type: "push", entry });
+        }
+      } catch {
+        // malformed payload
+      }
+    };
+
+    es.onerror = () => {
+      dispatch({ type: "set_status", status: "fallback" });
+      es.close();
+      esRef.current = null;
+      startFallbackPoll();
+    };
+  }, [apiBase, agents, startFallbackPoll]);
+
+  useEffect(() => {
+    seed();
+    connectSSE();
+    return () => {
+      esRef.current?.close();
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [seed, connectSSE]);
+
+  return {
+    entries: state.entries,
+    status: state.status,
+    lastEventAt: state.lastEventAt,
+  };
+}
+
+function normalise(raw: Record<string, unknown>): JournalEntry {
+  return {
+    id: String(raw.id ?? raw.ts ?? crypto.randomUUID()),
+    ts: String(raw.ts ?? raw.timestamp ?? raw.created_at ?? new Date().toISOString()),
+    agent: String(raw.agent ?? raw.sentinel_id ?? "ATLAS") as JournalAgent,
+    action: String(raw.action ?? raw.event ?? raw.message ?? ""),
+    detail: raw.detail != null ? String(raw.detail) : undefined,
+    cycle: raw.cycle != null ? String(raw.cycle) : undefined,
+    integrity_delta: typeof raw.integrity_delta === "number" ? raw.integrity_delta : undefined,
+    tags: Array.isArray(raw.tags) ? raw.tags.map(String) : undefined,
+  };
+}

--- a/lib/terminal/useGlobalIntegrity.ts
+++ b/lib/terminal/useGlobalIntegrity.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+
+export type GIStatus = "live" | "stale" | "offline";
+
+export interface GISnapshot {
+  score: number;
+  delta: number;
+  cycle: string;
+  timestamp: string;
+  status: GIStatus;
+  components?: {
+    institutional_trust: number;
+    info_reliability: number;
+    consensus_stability: number;
+  };
+}
+
+interface UseGlobalIntegrityOptions {
+  pollMs?: number;
+  apiBase?: string;
+}
+
+function resolveSeed(): GISnapshot {
+  const raw = process.env.NEXT_PUBLIC_GI_SEED;
+  const score = raw ? parseFloat(raw) : 0.72;
+  return {
+    score: Number.isFinite(score) ? Math.min(1, Math.max(0, score)) : 0.72,
+    delta: 0,
+    cycle: process.env.NEXT_PUBLIC_GI_SEED_CYCLE ?? "—",
+    timestamp: new Date(0).toISOString(),
+    status: "offline",
+  };
+}
+
+export function useGlobalIntegrity(opts: UseGlobalIntegrityOptions = {}) {
+  const {
+    pollMs = 30_000,
+    apiBase = process.env.NEXT_PUBLIC_MOBIUS_API_BASE ?? "",
+  } = opts;
+
+  const [gi, setGi] = useState<GISnapshot>(resolveSeed);
+  const [loading, setLoading] = useState(true);
+  const prevScoreRef = useRef<number>(gi.score);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchGI = useCallback(async () => {
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    try {
+      const res = await fetch(`${apiBase}/api/v1/integrity/current`, {
+        signal: ac.signal,
+        next: { revalidate: 0 },
+      });
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      const data = await res.json();
+      const score = typeof data.score === "number" ? data.score : parseFloat(data.score ?? "0");
+      const prev = prevScoreRef.current;
+      prevScoreRef.current = score;
+
+      setGi({
+        score,
+        delta: score - prev,
+        cycle: data.cycle ?? data.epicon_cycle ?? "—",
+        timestamp: data.timestamp ?? new Date().toISOString(),
+        status: "live",
+        components: data.components,
+      });
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === "AbortError") return;
+      setGi((prev) => ({
+        ...prev,
+        status: prev.status === "live" ? "stale" : "offline",
+      }));
+    } finally {
+      setLoading(false);
+    }
+  }, [apiBase]);
+
+  useEffect(() => {
+    fetchGI();
+    const id = setInterval(fetchGI, pollMs);
+    return () => {
+      clearInterval(id);
+      abortRef.current?.abort();
+    };
+  }, [fetchGI, pollMs]);
+
+  return { gi, loading, refresh: fetchGI };
+}

--- a/lib/terminal/useSystemStatus.ts
+++ b/lib/terminal/useSystemStatus.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export type KVStatus = "live" | "degraded" | "unknown";
+
+export interface SystemStatus {
+  heartbeatAt: Date | null;
+  heartbeatAgo: string;
+  cycle: string | null;
+  kvStatus: KVStatus;
+  runtimeGuarded: boolean;
+}
+
+const STALE_THRESHOLD_MS = 10 * 60 * 1000;
+const POLL_MS = 60_000;
+
+function formatAgo(date: Date | null): string {
+  if (!date) return "—";
+  const diffMs = Date.now() - date.getTime();
+  if (diffMs < 0) return "just now";
+  const mins = Math.floor(diffMs / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  return `${hrs}h ago`;
+}
+
+function inferKVStatus(date: Date | null): KVStatus {
+  if (!date) return "unknown";
+  return Date.now() - date.getTime() > STALE_THRESHOLD_MS ? "degraded" : "live";
+}
+
+export function useSystemStatus(apiBase?: string): SystemStatus {
+  const base = apiBase ?? process.env.NEXT_PUBLIC_MOBIUS_API_BASE ?? "";
+
+  const [hbAt, setHbAt] = useState<Date | null>(null);
+  const [cycle, setCycle] = useState<string | null>(null);
+  const [, tick] = useState(0);
+
+  const fetchHeartbeat = useCallback(async () => {
+    try {
+      const res = await fetch(`${base}/api/v1/system/heartbeat`, {
+        next: { revalidate: 0 },
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.heartbeat_at) {
+        setHbAt(new Date(data.heartbeat_at));
+      }
+      if (data.cycle) setCycle(data.cycle);
+    } catch {
+      // no-op
+    }
+  }, [base]);
+
+  useEffect(() => {
+    fetchHeartbeat();
+    const fetchId = setInterval(fetchHeartbeat, POLL_MS);
+    const tickId = setInterval(() => tick((n) => n + 1), 30_000);
+    return () => {
+      clearInterval(fetchId);
+      clearInterval(tickId);
+    };
+  }, [fetchHeartbeat]);
+
+  const kvStatus = inferKVStatus(hbAt);
+
+  return {
+    heartbeatAt: hbAt,
+    heartbeatAgo: formatAgo(hbAt),
+    cycle,
+    kvStatus,
+    runtimeGuarded: true,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "motion": "^12.23.12",
     "recharts": "^2.15.4",
     "tailwind-merge": "^3.3.1",
-    "next-auth": "^5.0.0-beta.30"
+    "next-auth": "^5.0.0-beta.30",
+    "react-simple-maps": "^3.0.0",
+    "topojson-client": "^3.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
@@ -28,6 +30,7 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.13",
-    "typescript": "^5.6.2"
+    "typescript": "^5.6.2",
+    "@types/topojson-client": "^3.0.0"
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent cold Vercel boots from showing `GI 0.00 · offline` by rendering a build-time GI seed and then hydrating from KV. 
- Persist heartbeat pings to Upstash KV so the terminal footer can show a real "Last heartbeat" delta. 
- Surface real EPICON entries from the Civic Ledger API instead of mock data. 
- Deliver agent journal events to clients in near real time via SSE and avoid 30s polling lag. 
- Provide a lightweight Globe chamber rendering NASA EONET events as pins with category filters.

### Description
- Added `lib/terminal/useGlobalIntegrity.ts` which seeds GI from `NEXT_PUBLIC_GI_SEED` on first paint, hydrates asynchronously from `/api/v1/integrity/current`, polls, and degrades status to `stale`/`offline` if KV misses. 
- Added `lib/terminal/useSystemStatus.ts` which reads `/api/v1/system/heartbeat`, computes a human-friendly `heartbeatAgo`, and infers KV health (`live` | `degraded` | `unknown`). 
- Added `lib/terminal/useAgentJournal.ts` which subscribes to `/api/v1/stream/journal-events` via SSE, deduplicates entries by id, seeds from a REST page, and falls back to a 30s REST poll on SSE disconnect. 
- Added FastAPI route modules under `api/routes`: `heartbeat.py` (POST/GET heartbeat with Upstash KV writes and optional shared-secret validation), `epicon.py` (proxy/paginate/normalize Civic Ledger entries: `/epicon/feed`, `/epicon/entry/{id}`, `/epicon/stats`), and `stream.py` (SSE endpoint `/stream/journal-events` plus a background journal watcher that polls KV and fans out events). 
- Registered the new routers and started the journal watcher on startup in `api/app/main.py`. 
- Replaced the Globe page implementation at `app/terminal/globe/page.tsx` with a client-side NASA EONET chamber using `react-simple-maps`, TopoJSON world data, ATLAS color grammar pins, hover tooltips, and a category filter legend. 
- Declared new dependencies in `package.json`: `react-simple-maps`, `topojson-client`, and `@types/topojson-client` for the Globe chamber.

### Testing
- `python -m compileall api/routes api/app/main.py` succeeded and compiled the new FastAPI modules. 
- `npm run lint` could not complete non-interactively in this environment because the Next.js ESLint setup prompted for interactive configuration. 
- `npx tsc --noEmit` failed due to missing `react-simple-maps` types in this environment because `npm install` was blocked by registry policy. 
- `npm install` attempted but failed with `403 Forbidden` for `@types/topojson-client` due to the environment's npm registry restrictions, so typechecking and linter runs that depend on installed packages could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7dc925b90832d9f6f43c72a327fd0)