### PR TITLE
chore: remove unused globe.gl dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "recharts": "^2.15.4",
-    "tailwind-merge": "^3.3.1",
-    "globe.gl": "^2.41.4"
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
### Motivation
- Remove the unused `globe.gl` runtime dependency to reduce install time and avoid keeping an unused package in `package.json`.

### Description
- Deleted `globe.gl` from the `dependencies` section of `package.json` and committed the change with message `chore: remove unused globe.gl dependency`.

### Testing
- Ran `pnpm build` and `pnpm lint`, but both failed in this environment due to Next.js SWC binary download error (`ENETUNREACH`), so no further automated tests could be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92ad5df5c832d8c259e5561198ef7)