### PR TITLE
fix(journal): include agent mirror KV keys in journal reads and bump cycle to C-278

### DIFF
--- a/CURRENT_CYCLE.md
+++ b/CURRENT_CYCLE.md
@@ -1,7 +1,7 @@
 # CURRENT_CYCLE.md
 
 ## Cycle
-C-276
+C-278
 
 ## Active focus
 

--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -218,17 +218,26 @@ function buildEntry(input: AgentJournalCreateInput): AgentJournalEntry | null {
   return entry;
 }
 
-async function loadEntries(redis: ReturnType<typeof getJournalRedisClient>): Promise<AgentJournalEntry[]> {
+async function loadEntries(
+  redis: ReturnType<typeof getJournalRedisClient>,
+  agentFilter?: string,
+): Promise<AgentJournalEntry[]> {
   if (!redis) return [];
 
   try {
-    const rows = await redis.lrange<string[]>(KEY_ALL, 0, MAX_READ - 1);
+    const keys = agentFilter ? [KEY_ALL, `journal:${agentFilter.toLowerCase()}`] : [KEY_ALL];
+    const keyRows = await Promise.all(keys.map((key) => redis.lrange<string[]>(key, 0, MAX_READ - 1)));
+    const rows = keyRows.flat();
+    const seen = new Set<string>();
     const out: AgentJournalEntry[] = [];
     for (const row of rows ?? []) {
       if (typeof row !== 'string') continue;
       try {
         const parsed = parseEntry(JSON.parse(row));
-        if (parsed) out.push(parsed);
+        if (parsed && !seen.has(parsed.id)) {
+          seen.add(parsed.id);
+          out.push(parsed);
+        }
       } catch {
         continue;
       }
@@ -278,10 +287,10 @@ export async function GET(request: NextRequest) {
   const limitRaw = Number(searchParams.get('limit') ?? '20');
   const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(Math.floor(limitRaw), 100) : 20;
 
-  let kvEntries = await loadEntries(redis);
+  let kvEntries = await loadEntries(redis, agentFilter || undefined);
   if (kvEntries.length === 0 && redis) {
-    await seedGenesisEntries(redis, cycleFilter || 'C-272');
-    kvEntries = await loadEntries(redis);
+    await seedGenesisEntries(redis, cycleFilter || 'C-278');
+    kvEntries = await loadEntries(redis, agentFilter || undefined);
   }
 
   let substrateError: string | null = null;


### PR DESCRIPTION
### Motivation
- Terminal journal lists were often empty when agents wrote to per-agent mirror lists instead of the global feed, preventing the Terminal from surfacing agent syntheses and degrading operator truth. 

### Description
- Updated `app/api/agents/journal/route.ts` so `loadEntries` accepts an `agentFilter` and reads both `journal:all` and `journal:{agent}` when an agent filter is present, then deduplicates entries by `id` before returning results. 
- Adjusted the journal GET flow to pass the `agentFilter` into `loadEntries` and updated the genesis fallback cycle from `C-272` to `C-278`. 
- Bumped the repo cycle marker in `CURRENT_CYCLE.md` from `C-276` to `C-278`.

### Testing
- Ran `pnpm exec tsc --noEmit` which passed successfully. 
- Ran `pnpm build` which failed due to environment network limitations while Next.js attempted to download SWC binaries (`ENETUNREACH`). 
- Ran `pnpm lint` which also failed for the same SWC download/network issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad5ea9c0c832d83711167ba8ccb27)