### PR TITLE
fix: bridge ECHO EPICON feed writes and substrate journal archive reads

### DIFF
--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -295,9 +295,11 @@ export async function GET(request: NextRequest) {
 
   let substrateError: string | null = null;
   let substrateEntries: AgentJournalEntry[] = [];
-  if (agentFilter) {
+  const substrateAgents = agentFilter ? [agentFilter] : [...GENESIS_AGENTS];
+  const substrateLimit = agentFilter ? 10 : Math.max(3, Math.ceil(limit / substrateAgents.length));
+  for (const agent of substrateAgents) {
     try {
-      const substrateRead = readAgentJournals(agentFilter.toLowerCase(), 10);
+      const substrateRead = readAgentJournals(agent.toLowerCase(), substrateLimit);
       const rows = await Promise.race([
         substrateRead,
         new Promise<SubstrateJournalEntry[]>((_, reject) =>
@@ -309,8 +311,8 @@ export async function GET(request: NextRequest) {
         if (mapped) substrateEntries.push(mapped);
       }
     } catch (error) {
-      console.error('[journal] substrate read error', error);
-      substrateError = error instanceof Error ? error.message : 'substrate read failed';
+      console.error('[journal] substrate fetch failed:', error instanceof Error ? error.message : error);
+      if (!substrateError) substrateError = error instanceof Error ? error.message : 'substrate read failed';
     }
   }
 

--- a/app/api/echo/ingest/route.ts
+++ b/app/api/echo/ingest/route.ts
@@ -12,6 +12,7 @@
  */
 
 import { NextResponse } from 'next/server';
+import { Redis } from '@upstash/redis';
 import { fetchAllSources } from '@/lib/echo/sources';
 import { transformBatch } from '@/lib/echo/transform';
 import { pushIngestResult, getEchoStatus, getEchoEpicon, getEchoLedger, getEchoAlerts } from '@/lib/echo/store';
@@ -19,6 +20,56 @@ import { writeSnapshot } from '@/lib/echo/snapshot-writer';
 import { saveEchoState } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
+
+type KvEpiconEntry = {
+  id: string;
+  timestamp: string;
+  author: string;
+  title: string;
+  type: 'epicon';
+  severity: 'nominal' | 'elevated' | 'critical' | 'degraded' | 'info';
+  source: 'kv-ledger';
+  tags: string[];
+  verified: boolean;
+};
+
+function getRedisClient(): Redis | null {
+  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  try {
+    return new Redis({ url, token });
+  } catch {
+    return null;
+  }
+}
+
+function toFeedSeverity(confidenceTier: number): KvEpiconEntry['severity'] {
+  if (confidenceTier >= 3) return 'critical';
+  if (confidenceTier >= 2) return 'elevated';
+  if (confidenceTier >= 1) return 'nominal';
+  return 'info';
+}
+
+function toFeedTimestamp(rawTimestamp: string): string {
+  const ts = new Date(rawTimestamp);
+  if (Number.isNaN(ts.getTime())) return new Date().toISOString();
+  return ts.toISOString();
+}
+
+async function flushEpiconFeed(entries: KvEpiconEntry[]): Promise<void> {
+  const redis = getRedisClient();
+  if (!redis || entries.length === 0) return;
+
+  try {
+    const payload = entries.map((entry) => JSON.stringify(entry));
+    await redis.lpush('epicon:feed', ...payload);
+    await redis.ltrim('epicon:feed', 0, 99);
+  } catch (error) {
+    console.error('[echo] epicon feed flush failed:', error);
+  }
+}
 
 export async function GET() {
   const status = getEchoStatus();
@@ -64,6 +115,19 @@ export async function POST() {
       timestamp: new Date().toISOString(),
       dedupRate,
     }).catch(() => {});
+
+    const kvFeedEntries: KvEpiconEntry[] = result.epicon.map((entry) => ({
+      id: entry.id,
+      timestamp: toFeedTimestamp(entry.timestamp),
+      author: entry.ownerAgent,
+      title: entry.title,
+      type: 'epicon',
+      severity: entry.status === 'contradicted' ? 'degraded' : toFeedSeverity(entry.confidenceTier),
+      source: 'kv-ledger',
+      tags: entry.sources,
+      verified: entry.status === 'verified',
+    }));
+    await flushEpiconFeed(kvFeedEntries);
 
     // 4. Generate docs/echo/ snapshot (fire-and-forget, non-blocking)
     let snapshotWritten = false;

--- a/lib/substrate/github-reader.ts
+++ b/lib/substrate/github-reader.ts
@@ -10,6 +10,17 @@ type GitHubContentItem = {
   download_url: string | null;
 };
 
+function githubHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  const token = process.env.SUBSTRATE_GITHUB_TOKEN?.trim();
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -62,18 +73,19 @@ function isSubstrateJournalEntry(value: unknown): value is SubstrateJournalEntry
 export async function readAgentJournals(agent: string, limit = 10): Promise<SubstrateJournalEntry[]> {
   const agentLower = agent.toLowerCase();
 
-  const listRes = await fetch(
-    `https://api.github.com/repos/${SUBSTRATE_REPO}/contents/journals/${agentLower}`,
-    {
-      headers: {
-        Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-      signal: AbortSignal.timeout(5000),
-    },
-  ).catch(() => null);
+  const listRes = await fetch(`https://api.github.com/repos/${SUBSTRATE_REPO}/contents/journals/${agentLower}`, {
+    headers: githubHeaders(),
+    signal: AbortSignal.timeout(5000),
+  }).catch((error) => {
+    throw new Error(
+      `[substrate] fetch failed for ${agentLower}: ${error instanceof Error ? error.message : 'unknown_error'}`,
+    );
+  });
 
-  if (!listRes?.ok) return [];
+  if (!listRes.ok) {
+    const errorBody = await listRes.text().catch(() => '');
+    throw new Error(`[substrate] journals/${agentLower} -> ${listRes.status} ${errorBody.slice(0, 180)}`);
+  }
 
   const rawList: unknown = await listRes.json();
   if (!Array.isArray(rawList)) return [];
@@ -92,7 +104,7 @@ export async function readAgentJournals(agent: string, limit = 10): Promise<Subs
     journalFiles.map(async (f) => {
       const url = f.download_url;
       if (!url) return null;
-      const res = await fetch(url, { signal: AbortSignal.timeout(3000) });
+      const res = await fetch(url, { headers: githubHeaders(), signal: AbortSignal.timeout(3000) });
       if (!res.ok) return null;
       const json: unknown = await res.json();
       return isSubstrateJournalEntry(json) ? json : null;


### PR DESCRIPTION
### Motivation
- Ensure ECHO ingest flushes finalized EPICONs into the shared KV list so the EPICON feed route returns populated `sources.kv` and the terminal shows epicon lane health. 
- Restore reliable Substrate journal archive reads by adding proper GitHub auth and surfacing failures so `/api/agents/journal` no longer silently returns zero archive entries.

### Description
- Added a lightweight Upstash `Redis` client and a KV bridge in `POST /api/echo/ingest` that normalizes finalized EPICONs and `LPUSH`es JSON rows into `epicon:feed` then `LTRIM` to 100 entries, preserving existing rating/ledger/state logic (`app/api/echo/ingest/route.ts`).
- Normalized the KV EPICON payload to include `id`, ISO `timestamp`, `author`, `title`, `type: "epicon"`, mapped `severity`, `source: "kv-ledger"`, `tags`, and `verified` to match feed expectations. 
- Updated the Substrate GitHub reader to include `SUBSTRATE_GITHUB_TOKEN` bearer auth headers for both listing and file downloads and to throw/log explicit errors on non-OK responses to avoid silent failures (`lib/substrate/github-reader.ts`).
- Changed the journal GET handler to attempt archive reads across the relevant agent set (or the filtered agent) with per-agent timeouts and exposed any fetch errors in `archive_error`/`archive_fetched_count` so archive fetch failures are visible (`app/api/agents/journal/route.ts`).

### Testing
- Ran typecheck with `pnpm exec tsc --noEmit` and it passed. 
- Attempted build with `pnpm build` but it failed in this environment due to Next.js SWC binary download/network error (`ENETUNREACH`) unrelated to code changes. 
- Attempted lint with `pnpm lint` which also failed for the same environmental SWC/network issue. 
- Commit recorded the changes (three files modified: `app/api/echo/ingest/route.ts`, `app/api/agents/journal/route.ts`, `lib/substrate/github-reader.ts`) and the patch was prepared for PR; follow-up deploy should verify `/api/epicon/feed` shows `sources.kv > 0` and `/api/agents/journal` reports `archive_fetched_count > 0` (ensure `SUBSTRATE_GITHUB_TOKEN` is set if the repo is private).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dadae4c74c832da9dbb594c10df29c)