### PR TITLE
docs(state): codify cycle ground truth and PR guardrails [DO NOT REVERT: prevents stateless agent regressions]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,164 @@
+# Mobius Terminal PR — C-[CYCLE]
+
+> Replace all `[PLACEHOLDERS]` before submitting. Incomplete PRs will not be merged.
+
+---
+
+## 1. Summary
+
+- **Cycle:** C-
+- **Type:** `fix` | `feat` | `chore` | `docs`
+- **Primary area:** `journal` | `epicon` | `signals` | `echo` | `ledger` | `agents` | `ui` | `infra` | `docs`
+- **Files changed:** (list every file modified)
+- **Files deliberately NOT changed:** (list files in the same area you intentionally left alone)
+
+**What changed?**
+(One paragraph. Concrete. What the code does now that it didn't before.)
+
+**Why?**
+(Reference to CURRENT_CYCLE.md section, snapshot lane state, or specific broken behavior with evidence.)
+
+---
+
+## 2. Risk Tier
+
+- [ ] **Tier 0** — Docs / comments / formatting only
+- [ ] **Tier 1** — App logic, no auth/KV schema changes
+- [ ] **Tier 2** — KV key schema, journal schema, EPICON shape, signal domain assignment
+- [ ] **Tier 3** — MIC economy, identity, ledger integrity math, auth
+
+> Tier 2+ requires operator review before merge. Do not self-merge Tier 2+.
+
+---
+
+## 3. EPICON Intent
+
+```text
+epicon_id: EPICON_C-[CYCLE]_[area]_[short-description]
+scope: [area]
+mode: normal
+issued_at: [ISO timestamp]
+
+justification:
+  PROBLEM:
+    [What is broken or missing? Be specific. Include snapshot lane state or error text.]
+
+  CONTEXT:
+    [Why does this matter now? Reference CURRENT_CYCLE.md if relevant.]
+
+  DECISION:
+    [What exactly is being changed and why this approach over alternatives.]
+
+  BOUNDARIES:
+    [What this PR does NOT touch. Be explicit about locked behaviors preserved.]
+
+  TRADEOFFS:
+    - Removed: [anything deleted or disabled]
+    - Kept: [locked behaviors confirmed preserved]
+    - Risk: [what could go wrong]
+
+  COUNTERFACTUALS:
+    - If [condition], then [corrective action]
+    - If [condition], then [corrective action]
+```
+
+---
+
+## 4. LOCKED BEHAVIOR AUDIT
+
+I have read `CURRENT_CYCLE.md` and confirm the following:
+
+**Journal KV key schema (`journal:{AGENT}:{CYCLE}`)**
+- [ ] This PR does NOT change the key schema in `app/api/agents/journal/route.ts`
+- [ ] OR: I am modifying this because: ___
+
+**ECHO → `epicon:feed` LPUSH**
+- [ ] This PR does NOT remove or bypass the LPUSH/LTRIM in `app/api/echo/ingest/route.ts`
+- [ ] OR: I am modifying this because: ___
+
+**Substrate GitHub auth header**
+- [ ] This PR does NOT remove the `Authorization` header from `lib/substrate/github-reader.ts`
+- [ ] OR: I am modifying this because: ___
+
+**Signal domain ownership**
+- [ ] This PR does NOT add crypto price sources to HERMES-µ
+- [ ] This PR does NOT reassign domain ownership between agents
+- [ ] OR: I am modifying this because: ___
+
+**EXPECTED EMPTY states**
+- [ ] This PR does NOT attempt to "fix" `sources.kv: 0` on epicon or journal
+- [ ] This PR does NOT add seed/genesis data to mask empty KV state
+- [ ] OR: I am modifying this because: ___
+
+---
+
+## 5. Integrity Impact
+
+**What could go wrong if this PR is wrong?**
+
+### Assessment
+- **Estimated MII for this PR:** (0.00–1.00)
+- **Risk level:** Low | Medium | High
+- **Lanes affected:** (list terminal snapshot lanes this could impact)
+
+### Checklist
+- [ ] Does not change KV key schemas without operator approval
+- [ ] Does not remove auth from any route
+- [ ] Does not introduce duplicate signal sources across agents
+- [ ] Does not add hardcoded cycle IDs, timestamps, or seed data
+- [ ] pnpm build passes (or explain why it couldn't be run)
+
+---
+
+## 6. Verification
+
+**Pre-merge:**
+- [ ] `pnpm exec tsc --noEmit` — typecheck passes
+- [ ] `pnpm build` — build passes (or document environment failure reason)
+- [ ] Hit `/api/terminal/snapshot` on preview deployment
+- [ ] Confirm affected lanes show expected state in snapshot
+
+**Post-merge (operator to verify):**
+- [ ] `/api/terminal/snapshot` checked on production
+- [ ] No regressions in previously healthy lanes
+- [ ] Snapshot `ok` field and lane states match expected outcome
+
+**Evidence:**
+(Paste relevant snapshot lane output or API response here)
+
+---
+
+## 7. Rollback Plan
+
+```bash
+git revert [commit-sha]
+# If KV writes were involved, manually clean affected keys in Upstash console
+# Verify /api/terminal/snapshot returns to pre-PR state
+```
+
+---
+
+## 8. Stop Conditions Met
+
+This PR was reviewed against the following stop conditions before submission:
+
+- [ ] No stop condition triggered — scope is clean
+- [ ] Stop condition triggered: ___ — resolved by: ___
+
+> Stop conditions: touching a LOCKED file, "fixing" an EXPECTED EMPTY state,
+> creating duplicate signal sources, changing KV key schema without Tier 2 review.
+
+---
+
+## 9. Final Checklist
+
+- [ ] Risk tier correctly assessed
+- [ ] EPICON intent block completed with BOUNDARIES field
+- [ ] Locked behavior audit completed (all boxes checked or exceptions documented)
+- [ ] Rollback plan provided
+- [ ] I have read AGENTS.md, BUILD.md, and CURRENT_CYCLE.md before starting this PR
+- [ ] I am okay with this appearing in the public cathedral
+
+---
+
+*"Let me update my consensus." — Mobius constitutional phrase for acknowledging new ground truth.*

--- a/CURRENT_CYCLE.md
+++ b/CURRENT_CYCLE.md
@@ -1,134 +1,162 @@
-# CURRENT_CYCLE.md
-
-## Cycle
-C-278
-
-## Active focus
-
-Mobius Terminal is moving from monolithic dashboard behavior into true chamber architecture.
-
-Current priority is not adding random features.
-Current priority is preserving chamber identity, runtime truth, and clean responsive behavior.
+# CURRENT_CYCLE.md — C-278
+> **Last verified:** 2026-04-12T01:10Z by ATLAS (kaizencycle)
+> **Snapshot commit:** `9b828b4` — fix(journal): read cycle-scoped KV keys
+> **Production URL:** https://mobius-civic-ai-terminal.vercel.app
+> **Vercel project:** `prj_ru2eaIzY0nIamFIXEdUIuTjnefpn` · team `team_cEncfJHYpxuB6YiFQNwdOUB5`
 
 ---
 
-## Current strategic direction
+## ⚠️ READ THIS FIRST — FOR ALL AGENTS (Cursor, Codex, Claude Code)
 
-### 1. World State chamber
-- Mobile default = Map
-- Desktop default = Globe
-- Shared signal model
-- Shared dark/green visual language
-- Command console collapsed on mobile
-
-### 2. Route-based chambers
-Terminal must remain route-based:
-
-- `/terminal/globe`
-- `/terminal/pulse`
-- `/terminal/signals`
-- `/terminal/sentinel`
-- `/terminal/ledger`
-
-Do not regress to single-page tab-state architecture.
-
-### 3. Runtime truth
-- lane diagnostics visible
-- freshness visible
-- degraded states explicit
-- no fake values
-- partial degradation preferred over full-shell collapse
+This file is the **ground truth** for the current state of the Terminal repo.
+Before making any change, read this file in full.
+If your task conflicts with a LOCKED entry, **stop and ask the operator**.
+If your task describes fixing something in the EXPECTED EMPTY section, **do not proceed** — it is not a bug.
 
 ---
 
-## Immediate priorities
+## ✅ LANE STATUS (as of last snapshot)
 
-### Priority A
-Polish World State chamber:
-- desktop globe presence
-- mobile map clarity
-- inspection behavior appropriate by device
-- map/globe share one signal model
-
-### Priority B
-Polish Pulse chamber:
-- explicit event typing
-- cleaner mobile card density
-- preserve operator readability
-
-### Priority C
-Keep shared shell compact and correct:
-- no duplicate chamber chrome
-- no buried chamber content
-- no giant dashboard wrapper above Globe
+| Lane | State | Note |
+|------|-------|------|
+| signals | healthy | GAIA, HERMES-µ, THEMIS, DAEDALUS-µ all live |
+| kvHealth | healthy | Upstash reachable, 240ms latency |
+| agents | **healthy** | All 8 agents showing `status: active` via KV heartbeat |
+| echo | healthy | 9 EPICONs rated and ledgered |
+| journal | healthy | 2 EVE entries via substrate archive |
+| sentiment | healthy | 6 domains live |
+| promotion | healthy | 6 pending promotable |
+| eve | healthy | C-278 in sync |
+| integrity | stale/cached | GI 0.74, mode: yellow — cached, not degraded |
+| epicon | empty | `kv: 0` — see EXPECTED EMPTY below |
+| runtime | stale | Last commit 01:17Z — cron hasn't fired since |
 
 ---
 
-## Do not break
+## 🔒 LOCKED — DO NOT MODIFY WITHOUT OPERATOR APPROVAL
 
-- route-based chambers
-- lane diagnostics
-- snapshot health visibility
-- freshness indicators
-- mobile map / desktop globe split
-- collapsed mobile command console
-- events / journals / runtime separation
-- World State chamber identity
+These behaviors are confirmed working. Any PR that touches these files **must**
+explicitly state in the PR description why the change is safe.
+If you are unsure, **stop**.
 
----
+### 1. Journal KV key schema
+- **File:** `app/api/agents/journal/route.ts`
+- **What:** Route reads keys matching `journal:{AGENT}:{CYCLE}` (3 segments, uppercase agent, e.g. `journal:EVE:C-278`)
+- **Fixed in:** PR #248
+- **Why locked:** Agents write to this exact schema. Changing the reader breaks the entire journal lane.
+- **DO NOT:** Change to `journal:all`, `journal:eve`, or any 2-segment schema. Do not reintroduce list-based `lrange` lookups.
 
-## Current product doctrine
+### 2. ECHO → `epicon:feed` KV bridge
+- **File:** `app/api/echo/ingest/route.ts`
+- **What:** After ECHO rates EPICONs, it LPUSHes completed entries into the `epicon:feed` KV key and LTRIMs to 100
+- **Fixed in:** PR #246
+- **Why locked:** This is the only path for live KV EPICONs to reach the terminal feed.
+- **DO NOT:** Remove the LPUSH/LTRIM step. Do not move it after an error boundary that could skip it.
 
-### World State
-Map is for clarity.
-Globe is for presence.
+### 3. Substrate GitHub auth header
+- **File:** `lib/substrate/github-reader.ts`
+- **What:** All GitHub API calls to `kaizencycle/Mobius-Substrate` include `Authorization: Bearer ${SUBSTRATE_GITHUB_TOKEN}`
+- **Fixed in:** PR #246
+- **Why locked:** The Mobius-Substrate repo requires auth. Removing the header causes silent 403 failures and empty journal archive reads.
+- **DO NOT:** Remove the Authorization header. Do not change the repo path or branch without verifying the new path exists.
 
-### Mobius
-This is not content fill.
-This is live integrity keeping.
+### 4. HERMES signal domain assignment
+- **File:** `app/api/signals/micro/route.ts` (HERMES-µ section)
+- **What:** HERMES-µ covers narrative signals: Hacker News, Wikipedia, Perplexity Sonar, GDELT. It does NOT fetch crypto prices.
+- **Why locked:** ECHO owns crypto via CoinGecko. Duplicate CoinGecko calls in HERMES would create conflicting EPICONs with the same asset data attributed to different agents.
+- **DO NOT:** Add CoinGecko, Binance, or any crypto price source to HERMES-µ. Do not move financial domain ownership from ECHO to HERMES.
 
-### UI
-Chambers are pages, not widgets.
-
-### System
-Reasoning belongs in Substrate.
-Facts belong in the Ledger.
-The view belongs in the Terminal.
-Entry belongs in the Shell.
-
----
-
-## Current acceptance bar
-
-A good change this cycle should improve at least one of:
-
-- chamber clarity
-- runtime truth
-- mobile usability
-- desktop presence
-- signal legibility
-- operator trust
-
-A bad change this cycle usually:
-- adds surface area without architecture
-- hides degraded state
-- regresses route-based chambers
-- confuses map and globe responsibilities
+### 5. Multi-agent journal aggregation
+- **File:** `app/api/agents/journal/route.ts`
+- **What:** When no `?agent=` param is provided, the route calls `kv.keys('journal:*')`, filters for 3-segment keys, fetches each, merges and deduplicates by `id`
+- **Fixed in:** PR #247 (multi-agent fix)
+- **Why locked:** Prior to this fix, the unfiltered route returned 0 entries. Reverting to list-based or single-key lookup breaks all-agents view.
+- **DO NOT:** Replace `kv.keys('journal:*')` with a hardcoded list of agent names. Do not reintroduce `journal:all` as a primary key.
 
 ---
 
-## Current preferred commit style
+## ⏳ EXPECTED EMPTY — NOT A BUG, DO NOT FIX
 
-Examples:
-- `fix(world-state): restore globe renderer on desktop`
-- `fix(mobile): improve map zoom and bottom-sheet inspection`
-- `fix(pulse): map event types explicitly instead of unknown`
-- `polish(shell): tighten mobile top chrome and preserve chamber focus`
+These states look broken but are not. Creating PRs for them is wasted effort and risks regression.
+
+### `sources.kv: 0` on EPICON feed
+- **Why:** The ECHO → `epicon:feed` bridge was just deployed (PR #246). The bridge only populates on new ECHO ingest cycles. The first post-deploy ingest will populate it.
+- **What to do:** Nothing. Wait for next ECHO ingest or trigger `/api/echo/ingest` manually.
+- **What NOT to do:** Do not add seed data, do not rewrite the bridge, do not change the key name.
+
+### `sources.kv: 0` on journal
+- **Why:** Old `journal:AGENT:CYCLE` keys in Upstash expired (5-day TTL). The reader is correct. Agents will write new keys on next synthesis run.
+- **What to do:** Trigger `/api/eve/synthesize` or `/api/cron/watchdog` to generate fresh journal entries.
+- **What NOT to do:** Do not change the key schema. Do not add genesis/seed journal entries via code.
+
+### `epicon: empty` lane in terminal snapshot
+- **Why:** Same as `sources.kv: 0` above. The lane reads `epicon:feed`. No KV entries yet post-deploy.
+- **What to do:** Wait for first ECHO ingest cycle.
+- **What NOT to do:** Do not change the lane's fallback logic to show GitHub commits as "committed EPICONs."
+
+### `integrity: stale` / `runtime: stale`
+- **Why:** The integrity GI state is cached from the last heartbeat (01:07Z). The runtime shows last GitHub commit time. Both go stale when no agent or cron has fired recently.
+- **What to do:** Nothing. These refresh automatically when the next heartbeat or cron runs.
+- **What NOT to do:** Do not add artificial freshness timestamps. Do not change the staleness threshold without operator approval.
+
+### DAEDALUS self-ping HTTP 401
+- **Why:** The self-ping hits a protected endpoint. This is a known low-priority issue with the auth middleware.
+- **Priority:** Low. Logged. Will be addressed in a future cycle.
+- **What NOT to do:** Do not create a PR that disables auth on the self-ping endpoint. Do not suppress the error in the signal output — it should remain visible.
 
 ---
 
-## Final rule for this cycle
+## 🔧 ACTIVE WORK — C-278
 
-Preserve the chamber.
-Preserve the truth.
-Do not let convenience collapse the architecture.
+Tasks currently in scope. Do not duplicate.
+
+- [ ] Trigger fresh EVE synthesis → write `journal:EVE:C-278` KV key (operator action, not code)
+- [ ] Confirm `ANTHROPIC_API_KEY` is set in Vercel env for agent synthesis routes
+- [ ] Resolve DAEDALUS self-ping 401 (low priority — do not block other work on this)
+- [ ] Wire agent synthesis cron to run on schedule (not currently firing reliably)
+
+---
+
+## 🏗️ INFRASTRUCTURE MAP
+
+### Vercel (Terminal)
+- **Repo:** `kaizencycle/mobius-civic-ai-terminal`
+- **Deploy:** Vercel, auto-deploy on merge to `main`
+- **KV:** Upstash Redis — env vars `KV_REST_API_URL` + `KV_REST_API_TOKEN`
+- **Substrate:** `kaizencycle/Mobius-Substrate` — requires `SUBSTRATE_GITHUB_TOKEN`
+
+### Render (Backend services)
+- **Ledger API:** `civic-protocol-core-ledger.onrender.com` — FastAPI + Postgres (`mobius-db`)
+- **MIC Wallet:** `mobius-mic-wallet-service.onrender.com` — FastAPI + Postgres
+- **Identity:** `mobius-identity-service.onrender.com` — FastAPI + Postgres
+- **Database:** `mobius-db` — Render PostgreSQL 18, Virginia
+- **Note:** Render free tier spins down on inactivity. First request after spin-down takes ~50s. This is expected — do not add retry logic that masks the spin-up delay.
+
+### Signal ownership (DO NOT REASSIGN)
+| Domain | Agent | Sources |
+|--------|-------|---------|
+| FINANCIAL | ECHO | CoinGecko (BTC, ETH, SOL) |
+| ENVIRON | GAIA | Open-Meteo, USGS, NASA EONET |
+| NARRATIVE | HERMES-µ | Hacker News, Wikipedia, Perplexity Sonar, GDELT |
+| CIVIC | EVE / THEMIS | Federal Register, data.gov |
+| INFRASTR | DAEDALUS-µ | GitHub API, npm Registry, self-ping |
+| INSTITUTIONAL | JADE | data.gov, FRED (future) |
+
+---
+
+## 📋 PR CHECKLIST REFERENCE
+
+Every PR to this repo must answer these questions before merge:
+
+1. Did I read `AGENTS.md`, `BUILD.md`, and this file before starting?
+2. Does this PR touch any LOCKED file/behavior listed above?
+   - If yes: state explicitly why the change is safe.
+   - If no: confirm in the PR description.
+3. Does this PR "fix" anything in the EXPECTED EMPTY section?
+   - If yes: stop. It is not a bug.
+4. Did `pnpm build` pass?
+5. Did I check `/api/terminal/snapshot` after deploy?
+
+---
+
+*This file must be updated whenever a lane changes state, a lock is added or removed, or a cycle advances. Operator: kaizencycle. Agent: ATLAS.*

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -1,0 +1,24 @@
+# CURRENT_STATE.md — C-278
+Last updated: 2026-04-12
+
+## WORKING — DO NOT TOUCH
+- `/api/agents/journal` reads cycle-scoped KV keys (`journal:{AGENT}:{CYCLE}`).
+  Fixed in PR #248. Any change to key schema breaks the reader.
+- `/api/echo/ingest` flushes EPICONs to `epicon:feed` after rating.
+  Fixed in PR #246. Do not remove the LPUSH step.
+- `/lib/substrate/github-reader.ts` includes `SUBSTRATE_GITHUB_TOKEN` auth header.
+  Fixed in PR #246. Do not remove the `Authorization` header.
+- `/api/epicon/feed` ledger API is no longer timing out (Render restored).
+  `ledgerError: null` as of 2026-04-12. Do not add timeout workarounds.
+- HERMES-µ market data source ownership: ECHO handles CoinGecko crypto prices.
+  Do not add duplicate CoinGecko calls to HERMES signal sweep.
+
+## IN PROGRESS
+- Journal KV keys are empty (old keys expired). Agents repopulate on next synthesis run.
+  `sources.kv` remains 0 until fresh `journal:{AGENT}:C-278` keys are written.
+- DAEDALUS self-ping returns 401 — known, low priority, do not create PRs for this alone.
+- Agent heartbeat freshness depends on cron cadence; do not seed fake heartbeats.
+
+## KNOWN BROKEN — ASSIGNED
+- `sources.kv = 0` on EPICON feed until first ECHO ingest post-deploy populates `epicon:feed`.
+- If `PERPLEXITY_API_KEY` is missing in Vercel env, HERMES Sonar source is unavailable by design.


### PR DESCRIPTION
### Motivation
- Prevent stateless coding-agent regressions by making current repo ground truth explicit and machine-readable. 
- Provide hard fences (locked behaviors and stop conditions) so agents do not unknowingly undo critical runtime contracts. 
- Surface an EPICON-oriented PR workflow so every change must declare scope, boundaries, and integrity impact before merge.

### Description
- Replace and enrich `CURRENT_CYCLE.md` with a cycle-specific state contract (`C-278`) that includes lane status, `LOCKED` behaviors, `EXPECTED EMPTY` non-bugs, active work, infra map, and a PR checklist. 
- Add `CURRENT_STATE.md` at the repo root as a concise live status board with `WORKING`, `IN PROGRESS`, and `KNOWN BROKEN` sections for fast agent bootstrap. 
- Add `.github/PULL_REQUEST_TEMPLATE.md` implementing the EPICON-style PR template with risk tiers, `BOUNDARIES`, locked-behavior audit, verification steps, rollback plan, and stop conditions; this is docs/process-only and does not modify runtime code.

### Testing
- Ran typecheck with `pnpm exec tsc --noEmit`, which passed. 
- Ran build with `pnpm build`, which failed in this environment due to a network error while Next.js attempted to download SWC (`fetch failed` / `ENETUNREACH`). 
- Lint was not run because this is a documentation/process-only change and the environment build failure is a network limitation, not a code error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf5ffb248832db708cdfe56c8b1fb)