### PR TITLE
Fix journal fetch logic and add Journal to chamber switcher

### DIFF
--- a/app/terminal/journal/JournalPageClient.tsx
+++ b/app/terminal/journal/JournalPageClient.tsx
@@ -64,21 +64,38 @@ export default function JournalPageClient() {
   useEffect(() => {
     let mounted = true;
     void (async () => {
-      const [journalRes, epiconRes] = await Promise.allSettled([
-        fetch('/api/agents/journal?agent=ALL&limit=200', { cache: 'no-store' }).then((r) => r.json() as Promise<JournalResponse>),
-        fetch('/api/epicon/feed?limit=100', { cache: 'no-store' }).then((r) => r.json() as Promise<{ items?: EpiconItem[] }>),
-      ]);
+      // Fetch journal independently — passing agent=ALL treats "ALL" as a literal agent name
+      // and returns zero results. Omitting the agent param returns entries for all agents.
+      let journalEntries: JournalEntry[] = [];
+      try {
+        const res = await fetch('/api/agents/journal?limit=100', { cache: 'no-store' });
+        const data = (await res.json()) as JournalResponse;
+        journalEntries = data.entries ?? [];
+      } catch {
+        // network failure — fall through to epicon fallback
+      }
 
       if (!mounted) return;
 
-      const journalEntries = journalRes.status === 'fulfilled' ? (journalRes.value.entries ?? []) : [];
       if (journalEntries.length > 0) {
         setDerivedMode(false);
         setEntries(journalEntries);
         return;
       }
 
-      const epiconItems = epiconRes.status === 'fulfilled' ? epiconRes.value.items ?? [] : [];
+      // Only fetch epicon when journal has no entries so a slow/hung epicon endpoint
+      // cannot block the journal UI indefinitely.
+      let epiconItems: EpiconItem[] = [];
+      try {
+        const res = await fetch('/api/epicon/feed?limit=100', { cache: 'no-store' });
+        const data = (await res.json()) as { items?: EpiconItem[] };
+        epiconItems = data.items ?? [];
+      } catch {
+        // ignore
+      }
+
+      if (!mounted) return;
+
       const derived = epiconItems
         .filter((item) => item.type === 'zeus-verify' || item.author === 'cursor-agent' || item.author === 'mobius-bot' || item.type === 'heartbeat')
         .map(toDerivedEntry);
@@ -114,7 +131,7 @@ export default function JournalPageClient() {
       {entries.length === 0 ? (
         <div className="space-y-4">
           <ChamberEmptyState
-            title="Journal archive initializing"
+            title="No journal entries yet for this cycle"
             reason="Agent journals initialize when automations run."
             action="To activate: set SUBSTRATE_GITHUB_TOKEN in Vercel"
             actionDetail="Use a fine-grained PAT for kaizencycle/Mobius-Substrate with Contents read + write permissions."

--- a/components/terminal/ChamberSwitcher.tsx
+++ b/components/terminal/ChamberSwitcher.tsx
@@ -11,6 +11,7 @@ const CHAMBERS = [
   { label: 'Signals', mobileLabel: 'Sig', href: '/terminal/signals', icon: '⊕', shortcut: 'Alt+3' },
   { label: 'Sentinel', mobileLabel: 'Snt', href: '/terminal/sentinel', icon: '◉', shortcut: 'Alt+4' },
   { label: 'Ledger', mobileLabel: 'Ldg', href: '/terminal/ledger', icon: '⛓', shortcut: 'Alt+5' },
+  { label: 'Journal', mobileLabel: 'Jrl', href: '/terminal/journal', icon: '✦', shortcut: 'Alt+6' },
 ] as const;
 
 const KEY_TO_ROUTE: Record<string, string> = {
@@ -19,6 +20,7 @@ const KEY_TO_ROUTE: Record<string, string> = {
   '3': '/terminal/signals',
   '4': '/terminal/sentinel',
   '5': '/terminal/ledger',
+  '6': '/terminal/journal',
 };
 
 export default function ChamberSwitcher() {


### PR DESCRIPTION
# Mobius Terminal PR — C-[CYCLE]

## 1. Summary

- **Cycle:** C-[CYCLE]
- **Type:** `fix`
- **Primary area:** `journal` | `ui`
- **Files changed:** `app/terminal/journal/JournalPageClient.tsx`, `components/terminal/ChamberSwitcher.tsx`
- **Files deliberately NOT changed:** `app/api/agents/journal/route.ts`, `app/api/epicon/feed/route.ts`, `lib/substrate/github-reader.ts`

**What changed?**
The journal fetch logic now omits the `agent=ALL` query parameter (which was treated as a literal agent name and returned zero results), fetches journal independently with proper error handling, and only falls back to EPICON when journal has no entries. The Journal chamber was also added to the ChamberSwitcher navigation with keyboard shortcut Alt+6. The empty state message was updated to reflect "No journal entries yet for this cycle" instead of "Journal archive initializing".

**Why?**
The `agent=ALL` parameter was causing the journal API to return zero results because it was being treated as a literal agent name rather than a wildcard. Omitting the parameter returns entries for all agents as intended. Sequential fetching with conditional fallback prevents a slow/hung EPICON endpoint from blocking the journal UI. Adding Journal to the chamber switcher completes the terminal navigation UI.

---

## 2. Risk Tier

- [ ] **Tier 0** — Docs / comments / formatting only
- [x] **Tier 1** — App logic, no auth/KV schema changes
- [ ] **Tier 2** — KV key schema, journal schema, EPICON shape, signal domain assignment
- [ ] **Tier 3** — MIC economy, identity, ledger integrity math, auth

---

## 3. EPICON Intent

```text
epicon_id: EPICON_C-[CYCLE]_journal_fix-fetch-logic
scope: journal
mode: normal
issued_at: [ISO timestamp]

justification:
  PROBLEM:
    Journal fetch was passing agent=ALL which is treated as a literal agent name,
    returning zero results. Additionally, Promise.allSettled() fetched both journal
    and EPICON in parallel, allowing a slow EPICON endpoint to block journal display.

  CONTEXT:
    Journal UI should display agent entries when available, with EPICON as fallback
    only when journal is empty. Current behavior prevents journal from ever showing
    because agent=ALL returns no results.

  DECISION:
    - Omit agent parameter to fetch all agents (API default behavior)
    - Fetch journal independently with try/catch error handling
    - Only fetch EPICON if journal returns empty, preventing slow endpoints from
      blocking the primary UI
    - Add mounted check before EPICON processing to avoid state updates on unmounted
      components
    - Update empty state message to reflect current cycle context

  BOUNDARIES:
    - Does NOT change /api/agents/journal route or KV key schema
    - Does NOT modify /api/epicon/feed endpoint
    - Does NOT change journal or EPICON data shapes
    - Preserves fallback to EPICON when journal is empty
    - Preserves all filtering and transformation logic for derived entries

  TRADEOFFS:
    - Removed: agent=ALL parameter (was causing zero results)
    - Removed: Promise.allSettled() parallel fetch (now sequential)
    - Kept: EPICON fallback behavior when journal empty
    - Kept: All entry filtering and transformation logic
    - Risk: If journal endpoint is slow, EPICON fetch is delayed (acceptable
      because EPICON is fallback-only)

  COUNTERFACTUALS:
    - If journal fetch fails, EPICON fallback still works
    - If journal returns empty, EPICON is fetched as intended
    - If component unmounts during EPICON fetch, state update is skipped
```

---

## 4. LOCKED BEHAVIOR AUDIT

I have read `CURRENT_CYCLE.md` and confirm the following:

**Journal KV key schema (`journal:{AGENT}:{CYCLE}`)**
- [x] This PR

https://claude.ai/code/session_013wRpEJE1qhHa9wFTzZADo6