### PR TITLE
feat(mii): implement MII Truth Pipe — scores-only integrity time series

### DIFF
--- a/app/api/echo/ingest/route.ts
+++ b/app/api/echo/ingest/route.ts
@@ -17,7 +17,8 @@ import { fetchAllSources } from '@/lib/echo/sources';
 import { transformBatch } from '@/lib/echo/transform';
 import { pushIngestResult, getEchoStatus, getEchoEpicon, getEchoLedger, getEchoAlerts } from '@/lib/echo/store';
 import { writeSnapshot } from '@/lib/echo/snapshot-writer';
-import { saveEchoState } from '@/lib/kv/store';
+import { saveEchoState, loadGIState } from '@/lib/kv/store';
+import { writeMiiState } from '@/lib/kv/mii';
 
 export const dynamic = 'force-dynamic';
 
@@ -140,6 +141,34 @@ export async function POST() {
       verified: entry.status === 'verified',
     }));
     await flushEpiconFeed(kvFeedEntries);
+
+    // 5. Write MII state for each rated agent (fire-and-forget)
+    void (async () => {
+      try {
+        const giState = await loadGIState();
+        const currentGi = Number((giState?.global_integrity ?? 0.74).toFixed(4));
+        const miiTimestamp = new Date().toISOString();
+        const agentAverages = result.integrity.agentAverages;
+        const agents = ['ATLAS', 'ZEUS', 'JADE', 'EVE'] as const;
+
+        await Promise.all(
+          agents
+            .filter((agent) => typeof agentAverages[agent] === 'number')
+            .map((agent) =>
+              writeMiiState({
+                agent,
+                mii: Number(agentAverages[agent].toFixed(4)),
+                gi: currentGi,
+                cycle: result.cycleId,
+                timestamp: miiTimestamp,
+                source: 'live',
+              }),
+            ),
+        );
+      } catch (err) {
+        console.error('[echo] mii write failed:', err instanceof Error ? err.message : err);
+      }
+    })();
 
     // 4. Generate docs/echo/ snapshot (fire-and-forget, non-blocking)
     let snapshotWritten = false;

--- a/app/api/eve/cycle-synthesize/route.ts
+++ b/app/api/eve/cycle-synthesize/route.ts
@@ -21,6 +21,8 @@ import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { getEveSynthesisAuthError, isVercelCronInvocation } from '@/lib/security/serviceAuth';
 import { runSignalEngine } from '@/lib/signals/engine';
 import { appendAgentJournalEntry } from '@/lib/agents/journal';
+import { loadGIState } from '@/lib/kv/store';
+import { writeMiiState } from '@/lib/kv/mii';
 
 export const dynamic = 'force-dynamic';
 
@@ -121,6 +123,8 @@ export async function POST(request: NextRequest) {
         ? await processEveEscalationSynthesis(cycleId, force, reason)
         : await processEveCycleWindowSynthesis(cycleId, force);
 
+    const eveMii = inferEveConfidence(payload);
+
     void appendAgentJournalEntry({
       agent: 'EVE',
       cycle: cycleId,
@@ -133,13 +137,29 @@ export async function POST(request: NextRequest) {
         mode === 'escalation'
           ? 'Prioritize ZEUS verification and ATLAS oversight checks.'
           : 'Continue normal verification cadence across ZEUS and ATLAS.',
-      confidence: inferEveConfidence(payload),
+      confidence: eveMii,
       derivedFrom: ['signal-engine:run', `eve-synthesis:${cycleId}`],
       relatedAgents: ['ZEUS', 'ATLAS'],
       status: 'committed',
       category: mode === 'escalation' ? 'alert' : 'inference',
       severity: inferEveSeverity(payload),
     }).catch(() => {});
+
+    void (async () => {
+      try {
+        const giState = await loadGIState();
+        await writeMiiState({
+          agent: 'EVE',
+          mii: Number(eveMii.toFixed(4)),
+          gi: Number((giState?.global_integrity ?? 0.74).toFixed(4)),
+          cycle: cycleId,
+          timestamp: new Date().toISOString(),
+          source: 'live',
+        });
+      } catch (err) {
+        console.error('[eve] mii write failed:', err instanceof Error ? err.message : err);
+      }
+    })();
 
     return NextResponse.json(payload);
   } catch (err) {

--- a/app/api/mii/feed/route.ts
+++ b/app/api/mii/feed/route.ts
@@ -1,0 +1,40 @@
+/**
+ * MII Feed — GET /api/mii/feed
+ *
+ * Returns the last 100 MII state entries from the rolling mii:feed KV list.
+ * Each entry is one agent's integrity score at a point in time.
+ *
+ * Query params:
+ *   ?agent=ZEUS  — filter to a single agent (case-insensitive)
+ *
+ * Response: { ok, count, entries, agents, timestamp }
+ *
+ * This endpoint reads scores only. No reasoning, no events, no observations.
+ * Those belong in the Journal.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { readMiiFeed } from '@/lib/kv/mii';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const agentFilter = request.nextUrl.searchParams.get('agent');
+
+  const entries = await readMiiFeed(agentFilter);
+  const agents = Array.from(new Set(entries.map((e) => e.agent)));
+
+  return NextResponse.json(
+    {
+      ok: true,
+      count: entries.length,
+      entries,
+      agents,
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: { 'Cache-Control': 'no-store' },
+    },
+  );
+}

--- a/lib/kv/mii.ts
+++ b/lib/kv/mii.ts
@@ -1,0 +1,105 @@
+/**
+ * MII Truth Pipe — Mobius Integrity Index state recorder
+ *
+ * Each agent records its MII score after a synthesis or verification action.
+ * This is the integrity score of each agent, recorded over time — not events,
+ * not reasoning, not observations. Scores only.
+ *
+ * Schema:
+ *   Key:   mii:{AGENT_UPPERCASE}:{CYCLE_ID}  → latest score for agent in cycle
+ *   Feed:  mii:feed                          → LPUSH rolling list (max 200)
+ *
+ * Reads:
+ *   GET /api/mii/feed  → last 100 entries, optional ?agent= filter
+ */
+
+import { Redis } from '@upstash/redis';
+
+export type MiiEntry = {
+  agent: string;    // e.g. "ZEUS"
+  mii: number;      // 0.00–1.00
+  gi: number;       // global integrity at time of write
+  cycle: string;    // e.g. "C-279"
+  timestamp: string; // ISO 8601
+  source: 'live';   // always "live", never "mock"
+};
+
+const FEED_KEY = 'mii:feed';
+const FEED_MAX = 200;
+
+function getMiiRedisClient(): Redis | null {
+  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  try {
+    return new Redis({ url, token });
+  } catch {
+    return null;
+  }
+}
+
+function isMiiEntry(value: unknown): value is MiiEntry {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.agent === 'string' &&
+    typeof v.mii === 'number' &&
+    typeof v.gi === 'number' &&
+    typeof v.cycle === 'string' &&
+    typeof v.timestamp === 'string' &&
+    v.source === 'live'
+  );
+}
+
+/**
+ * Write one agent's MII state to KV.
+ * - Sets mii:{AGENT}:{CYCLE} to the entry (latest score for that agent/cycle pair)
+ * - LPUSHes to mii:feed and LTRIMs to FEED_MAX
+ */
+export async function writeMiiState(entry: MiiEntry): Promise<void> {
+  const redis = getMiiRedisClient();
+  if (!redis) return;
+
+  const key = `mii:${entry.agent.toUpperCase()}:${entry.cycle}`;
+  const packed = JSON.stringify(entry);
+
+  try {
+    await redis.set(key, packed);
+    await redis.lpush(FEED_KEY, packed);
+    await redis.ltrim(FEED_KEY, 0, FEED_MAX - 1);
+  } catch (error) {
+    console.error('[mii] write failed:', error instanceof Error ? error.message : error);
+  }
+}
+
+/**
+ * Read the rolling mii:feed. Returns up to 100 entries.
+ * Optionally filtered by agent name (case-insensitive).
+ */
+export async function readMiiFeed(agentFilter?: string | null): Promise<MiiEntry[]> {
+  const redis = getMiiRedisClient();
+  if (!redis) return [];
+
+  const normalizedFilter = agentFilter ? agentFilter.trim().toUpperCase() : null;
+
+  try {
+    const raw = await redis.lrange<string>(FEED_KEY, 0, 99);
+    const entries: MiiEntry[] = [];
+
+    for (const item of raw) {
+      try {
+        const parsed: unknown = typeof item === 'string' ? JSON.parse(item) : item;
+        if (!isMiiEntry(parsed)) continue;
+        if (normalizedFilter && parsed.agent.toUpperCase() !== normalizedFilter) continue;
+        entries.push(parsed);
+      } catch {
+        // skip malformed entries
+      }
+    }
+
+    return entries;
+  } catch (error) {
+    console.error('[mii] read failed:', error instanceof Error ? error.message : error);
+    return [];
+  }
+}


### PR DESCRIPTION
Add a minimal MII state recording system. After each agent synthesis or
verification action, write exactly four fields to KV: agent, mii, gi,
cycle, timestamp. Nothing else — no reasoning, no events, no observations.

## What was added

- lib/kv/mii.ts — MiiEntry type, writeMiiState (SET + LPUSH/LTRIM),
  readMiiFeed (lrange with optional agent filter)

- app/api/echo/ingest/route.ts — after ECHO rates a batch, write MII
  for ATLAS, ZEUS, JADE, EVE from result.integrity.agentAverages.
  Fire-and-forget; does not block ingest response.

- app/api/eve/cycle-synthesize/route.ts — after EVE synthesis, write
  MII for EVE using inferEveConfidence(payload). Fire-and-forget.

- app/api/mii/feed/route.ts — GET /api/mii/feed returns last 100 entries
  from mii:feed. Supports ?agent=ZEUS filter. Returns { ok, count,
  entries, agents, timestamp }.

## KV schema

  mii:{AGENT}:{CYCLE}  →  latest score for that agent/cycle pair
  mii:feed             →  LPUSH rolling list (LTRIM to 200)

## Verification path

Trigger /api/echo/ingest → then GET /api/mii/feed.
Each entry will have exactly: agent, mii, gi, cycle, timestamp, source.

https://claude.ai/code/session_01X6vfFfA4yYu281ckHftVMT