### PR TITLE
C-279: add closeout optimization and breathing test runbooks

### DIFF
--- a/docs/runbooks/c279-breathing-test.md
+++ b/docs/runbooks/c279-breathing-test.md
@@ -1,0 +1,180 @@
+# C-279 Breathing Test
+
+## Purpose
+
+This runbook defines the minimum proof that Mobius is not only observing, but **circulating**.
+
+A breathing test proves that a signal can move through the system and become:
+- visible
+- interpretable
+- actionable
+
+This is the fastest operator check for whether the stack is truly alive.
+
+---
+
+## Definition
+
+A breathing test passes when a single event can complete the following loop:
+
+```text
+signal lands
+→ KV stores it
+→ terminal surfaces it
+→ agent writes synthesis
+→ operator sees next action
+```
+
+A stronger version also includes:
+
+```text
+→ ledger candidate appears
+→ verification or promotion state updates
+```
+
+---
+
+## Why this matters
+
+Mobius can look alive while still being partially disconnected.
+
+Examples:
+- agents writing to the wrong KV keys
+- journal rows existing in storage but not surfacing in UI
+- terminal rendering fallback shell instead of lane truth
+- Pulse showing feed rows without explanation
+
+The breathing test is the shortest path to catching this.
+
+---
+
+## Test inputs
+
+A breathing test may use:
+- one real low-risk signal
+- one synthetic internal test signal
+- one manually triggered ingest event
+
+Prefer a test that is:
+- non-destructive
+- clearly typed
+- easy to identify in logs and UI
+
+Example labels:
+- `mobius-breathing-test`
+- `c279-test-event`
+- `journal-loop-test`
+
+---
+
+## Required checkpoints
+
+### 1. Signal landing
+Confirm the event exists in the originating lane.
+
+Examples:
+- ingest route response
+- internal state object
+- source-specific API row
+
+### 2. KV storage
+Confirm the event lands in the **shared readable key**, not only in agent-local state.
+
+Examples:
+- `epicon:feed`
+- current journal key schema documented in `CURRENT_CYCLE.md`
+
+### 3. Terminal visibility
+Confirm the event appears in at least one of:
+- `/api/terminal/snapshot`
+- `/api/epicon/feed`
+- `/api/agents/journal`
+- visible terminal chamber UI
+
+### 4. Agent synthesis
+Confirm one agent writes a journal entry with:
+- observation
+- inference
+- recommendation
+- source
+- agent origin
+
+### 5. Operator clarity
+Confirm the visible result makes the next action clearer.
+If the system surfaces the event but leaves the operator confused, the test is incomplete.
+
+---
+
+## Pass criteria
+
+A breathing test is a **pass** if all of the following are true:
+
+- event is stored in a shared readable lane
+- terminal or API surface shows it
+- journal entry exists for it
+- journal entry is not empty prose
+- operator can describe the next recommended action
+
+---
+
+## Failure modes
+
+### Failure mode A — local-only write
+The signal exists in agent-specific state but never reaches the shared feed.
+
+### Failure mode B — read path break
+The signal exists in KV or substrate, but the reader route returns zero.
+
+### Failure mode C — reflection gap
+The signal appears, but no journal synthesis is written.
+
+### Failure mode D — visibility gap
+The APIs are correct, but chamber UI still looks dead or fallback-heavy.
+
+### Failure mode E — action gap
+The system reports the issue, but does not help the operator know what to do next.
+
+---
+
+## Operator checklist
+
+Use this checklist once per cycle close.
+
+- [ ] Trigger or identify one breathing-test event
+- [ ] Confirm shared KV or journal write path
+- [ ] Check `/api/epicon/feed`
+- [ ] Check `/api/agents/journal`
+- [ ] Check `/api/terminal/snapshot`
+- [ ] Confirm one chamber shows the event
+- [ ] Confirm one journal explains it
+- [ ] Confirm next action is legible
+
+---
+
+## Reporting template
+
+```md
+### Breathing Test
+- Event: ...
+- Signal landed: yes/no
+- Shared KV visible: yes/no
+- Journal visible: yes/no
+- Terminal visible: yes/no
+- Operator next action clear: yes/no
+- Result: pass/fail
+- Notes: ...
+```
+
+---
+
+## Doctrine
+
+The breathing test is not a vanity demo.
+It is the minimum proof that Mobius can:
+- perceive
+- reflect
+- communicate
+
+One-line summary:
+
+> If Mobius cannot circulate one event end-to-end, it is not breathing yet.

--- a/docs/runbooks/c279-closeout-optimization-runbook.md
+++ b/docs/runbooks/c279-closeout-optimization-runbook.md
@@ -1,0 +1,155 @@
+# C-279 Closeout Optimization Runbook
+
+## Purpose
+
+This runbook captures the highest-value closeout work for C-279 **without** overriding the locked behaviors documented in `CURRENT_CYCLE.md`.
+
+It is designed for operators and agents who need a single place to understand:
+- what changed in C-279
+- what is considered healthy vs expected-empty
+- what to optimize next without breaking active circulation work
+
+This document is intentionally operational, not aspirational.
+
+---
+
+## C-279 system read
+
+Mobius now has three visible layers:
+
+1. **Perception**
+   - signals, heartbeats, watches, domain lanes
+2. **Reflection**
+   - agent journals are landing and surfacing reasoning
+3. **Constitution**
+   - repo law, build law, and cycle state now live in-repo
+
+The remaining bottleneck is not raw capability.
+It is **circulation**.
+
+Mobius feels strongest when all of these happen in sequence:
+
+```text
+signal lands
+→ KV stores it
+→ Terminal shows it
+→ agent synthesizes it
+→ operator sees next action
+```
+
+---
+
+## Closeout goals
+
+A good C-279 closeout improves at least one of these:
+- live state circulation
+- journal visibility
+- operator truth
+- mobile chamber clarity
+- event typing
+- end-to-end confidence in the loop
+
+A bad closeout:
+- reopens locked key schemas
+- rewrites expected-empty states as bugs
+- adds surface area without proving circulation
+- hides degraded state behind visual polish
+
+---
+
+## Ten closeout optimizations
+
+### 1. Prefer shared-feed truth over agent-local state
+Every completed EPICON write should be visible in the shared feed path the terminal reads.
+
+Guardrail:
+- do not bypass the locked `epicon:feed` bridge
+- do not introduce parallel shadow keys for the same committed EPICON rows
+
+### 2. Keep journal synthesis canonical
+Every agent journal entry should preserve the same required fields and source semantics.
+
+Required idea:
+- observation
+- inference
+- recommendation
+- confidence
+- severity
+- source
+- agent origin
+
+### 3. Surface newest synthesis in Pulse
+Pulse should show the freshest journal summary, not just raw feed rows.
+This turns Pulse into a decision surface instead of a scrolling log.
+
+### 4. Preserve lane-specific degradation
+Do not collapse the whole shell when only one lane is stale or empty.
+Each lane should declare its own state explicitly.
+
+### 5. Replace generic event labels aggressively
+Avoid `UNKNOWN` when a better event type can be inferred.
+Preferred types:
+- HEARTBEAT
+- WATCH
+- CATALOG
+- EPICON
+- JOURNAL
+- VERIFY
+- PROMOTION
+- SIGNAL
+
+### 6. Keep mobile map / desktop globe split stable
+World State should remain:
+- **Map** on mobile for clarity
+- **Globe** on desktop for presence
+
+Do not let one renderer silently replace the other.
+
+### 7. Keep console secondary on mobile
+The command console should support the chamber, not dominate it.
+Collapsed-by-default remains the correct mobile posture.
+
+### 8. Make source counts legible in UI
+Operators should be able to see how much state is arriving from:
+- GitHub
+- KV
+- ledger API
+- journals
+- memory fallbacks
+
+### 9. Prefer freshness over fake immediacy
+If a lane is cached or stale, say so.
+Do not create artificial timestamps or pretend a stale lane is live.
+
+### 10. Run one end-to-end breathing test per cycle close
+At least once per cycle, prove that a single synthetic or real test event can move through the full loop.
+
+---
+
+## What not to fix in this runbook
+
+This runbook defers to `CURRENT_CYCLE.md` for anything marked:
+- LOCKED
+- EXPECTED EMPTY
+
+If a task appears here and conflicts with those sections, `CURRENT_CYCLE.md` wins.
+
+---
+
+## Good operator questions at closeout
+
+- Did a new signal land in a shared readable lane?
+- Did at least one agent explain what it meant?
+- Did the terminal make the next action clearer?
+- Did we improve truth circulation without breaking architecture?
+
+---
+
+## Closeout doctrine
+
+**C-279 is not about adding more intelligence.**
+It is about making existing intelligence circulate more reliably.
+
+One-line summary:
+
+> Preserve the chamber. Preserve the truth. Close the circulation gap.


### PR DESCRIPTION
## What this does
- adds a **C-279 closeout optimization runbook** under `docs/runbooks/`
- adds a **C-279 breathing test runbook** under `docs/runbooks/`
- packages the end-of-day operational priorities into merge-safe documentation that agents and operators can follow without touching locked circulation behaviors

## Why
C-279 exposed a clear pattern:
- the repo and agent architecture are ahead of the public terminal surface
- the biggest remaining problem is **circulation**, not raw capability
- the system now needs a repeatable way to reason about:
  - what to optimize at closeout
  - how to prove Mobius is actually breathing end-to-end

This PR captures that operational doctrine in-repo so Cursor, Codex, Claude Code, and human operators have a shared reference.

## Scope
Docs only.

This PR does **not** modify:
- locked journal key behavior
- locked ECHO → `epicon:feed` bridge behavior
- substrate auth logic
- chamber rendering code
- runtime feed wiring

## Files added
- `docs/runbooks/c279-closeout-optimization-runbook.md`
- `docs/runbooks/c279-breathing-test.md`

## Why this is safe
This PR is intentionally low risk and does not alter any active or locked circulation paths described in `CURRENT_CYCLE.md`.

## Validation
- docs-only change
- no runtime behavior changed
- no key schemas changed
- no API routes changed

## Notes
This PR is meant to close the day cleanly by giving the repo a durable operational memory for:
- closeout optimization priorities
- breathing-test doctrine
- circulation-first thinking
