### PR TITLE
C-280: surface live reasoning and source counts in Pulse

### DIFF
--- a/app/terminal/pulse/PulsePageClient.tsx
+++ b/app/terminal/pulse/PulsePageClient.tsx
@@ -18,9 +18,27 @@ type PulseItem = {
   mii_score?: number;
   source?: string;
   status?: string;
+  cycle?: string;
+  gi?: number | null;
 };
 
 const EVENT_TYPES = ['HEARTBEAT', 'WATCH', 'CATALOG', 'EPICON', 'JOURNAL', 'VERIFY', 'ROUTING', 'PROMOTION', 'SIGNAL'] as const;
+type JournalEntry = {
+  id: string;
+  agent: string;
+  timestamp: string;
+  observation: string;
+  inference: string;
+  recommendation: string;
+  severity?: string;
+  confidence?: number;
+  cycle?: string;
+};
+
+type LaneState = {
+  key: string;
+  state: 'healthy' | 'degraded' | 'offline' | 'stale' | 'empty';
+};
 
 function mapEventType(item: PulseItem): (typeof EVENT_TYPES)[number] | 'OTHER' {
   const raw = [item.type, item.category, item.title, ...(item.tags ?? [])]
@@ -39,6 +57,30 @@ function mapEventType(item: PulseItem): (typeof EVENT_TYPES)[number] | 'OTHER' {
   return 'OTHER';
 }
 
+function parseCycleNumber(cycle: string | null): number | null {
+  if (!cycle) return null;
+  const match = /^C-(\d+)$/i.exec(cycle.trim());
+  if (!match) return null;
+  return Number.parseInt(match[1], 10);
+}
+
+function fmtCycle(num: number | null): string | null {
+  if (num == null || Number.isNaN(num) || num <= 0) return null;
+  return `C-${String(num).padStart(3, '0')}`;
+}
+
+function relTime(ts?: string): string {
+  if (!ts) return 'unknown freshness';
+  const ms = new Date(ts).getTime();
+  if (!Number.isFinite(ms)) return 'unknown freshness';
+  const deltaMin = Math.max(0, Math.floor((Date.now() - ms) / 60000));
+  if (deltaMin < 1) return 'just now';
+  if (deltaMin < 60) return `${deltaMin}m ago`;
+  const h = Math.floor(deltaMin / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
 export default function PulsePageClient() {
   const { snapshot, loading } = useTerminalSnapshot();
   const [selected, setSelected] = useState<(typeof AGENT_FILTERS)[number]>('ALL');
@@ -51,6 +93,45 @@ export default function PulsePageClient() {
     () => (selected === 'ALL' ? items : items.filter((item) => (item.agent ?? '').toUpperCase() === selected)),
     [items, selected],
   );
+  const journalEntries = useMemo(
+    () => ((snapshot?.journal?.data ?? {}) as { entries?: JournalEntry[] }).entries ?? [],
+    [snapshot],
+  );
+  const latestSynthesis = journalEntries[0] ?? null;
+  const eveCycle = useMemo(() => {
+    const eve = (snapshot?.eve?.data ?? {}) as { currentCycle?: string; cycleId?: string };
+    return eve.currentCycle ?? eve.cycleId ?? null;
+  }, [snapshot]);
+  const prevCycle = useMemo(() => {
+    const n = parseCycleNumber(eveCycle);
+    return fmtCycle(n != null ? n - 1 : null);
+  }, [eveCycle]);
+  const currentGi = ((snapshot?.epicon?.data ?? {}) as { summary?: { latestGI?: number | null } }).summary?.latestGI ?? null;
+  const prevGi = useMemo(
+    () =>
+      items
+        .filter((item) => item.cycle && item.cycle === prevCycle && typeof item.gi === 'number')
+        .map((item) => item.gi as number)[0] ?? null,
+    [items, prevCycle],
+  );
+  const giDelta = currentGi != null && prevGi != null ? currentGi - prevGi : null;
+  const newEpiconCount = useMemo(
+    () => (prevCycle ? items.filter((item) => item.cycle === eveCycle).length : items.length),
+    [items, eveCycle, prevCycle],
+  );
+  const newJournalCount = useMemo(
+    () => (prevCycle ? journalEntries.filter((entry) => entry.cycle === eveCycle).length : journalEntries.length),
+    [journalEntries, eveCycle, prevCycle],
+  );
+  const degradedLaneCount = useMemo(() => {
+    const lanes = ((snapshot as { lanes?: LaneState[] } | null)?.lanes ?? []) as LaneState[];
+    return lanes.filter((lane) => lane.state === 'degraded' || lane.state === 'offline').length;
+  }, [snapshot]);
+  const promotionCounters = ((snapshot?.promotion?.data ?? {}) as { counters?: { pending_promotable_count?: number; promoted_this_cycle_count?: number } }).counters;
+  const epiconSources = ((snapshot?.epicon?.data ?? {}) as {
+    sources?: { github?: number; kv?: number; ledgerApi?: number; memory?: number; memoryLedger?: number };
+  }).sources;
+  const journalSources = ((snapshot?.journal?.data ?? {}) as { sources?: { kv?: number; substrate?: number } }).sources;
 
   if (loading && !snapshot) return <ChamberSkeleton blocks={8} />;
 
@@ -67,6 +148,56 @@ export default function PulsePageClient() {
           </button>
         ))}
       </div>
+      <section className="mb-3 rounded border border-slate-800 bg-slate-900/60 p-2.5">
+        <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-400">DELTA</div>
+        <div className="flex flex-wrap gap-1.5 text-[11px]">
+          <span className="rounded border border-slate-700 px-1.5 py-0.5 text-slate-200">EPICON +{newEpiconCount}</span>
+          <span className="rounded border border-slate-700 px-1.5 py-0.5 text-slate-200">JOURNAL +{newJournalCount}</span>
+          <span className="rounded border border-amber-700/70 px-1.5 py-0.5 text-amber-200">degraded lanes {degradedLaneCount}</span>
+          <span className="rounded border border-slate-700 px-1.5 py-0.5 text-slate-200">
+            GI Δ {giDelta == null ? '—' : `${giDelta >= 0 ? '+' : ''}${giDelta.toFixed(2)}`}
+          </span>
+          {promotionCounters && (
+            <span className="rounded border border-slate-700 px-1.5 py-0.5 text-slate-200">
+              promotions {promotionCounters.pending_promotable_count ?? 0} pending · {promotionCounters.promoted_this_cycle_count ?? 0} promoted
+            </span>
+          )}
+        </div>
+      </section>
+      <section className="mb-3 rounded border border-cyan-700/40 bg-cyan-950/20 p-2.5">
+        <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-cyan-300">LATEST SYNTHESIS</div>
+        {latestSynthesis ? (
+          <div>
+            <div className="mb-1 flex flex-wrap items-center gap-1.5 text-[10px]">
+              <span className="rounded border border-cyan-600/50 bg-cyan-500/10 px-1.5 py-0.5 font-mono text-cyan-100">{latestSynthesis.agent}</span>
+              <span className="text-slate-400">{latestSynthesis.timestamp}</span>
+              <span className="text-slate-500">{relTime(latestSynthesis.timestamp)}</span>
+              <span className="rounded border border-slate-700 px-1.5 py-0.5 text-slate-300">sev {latestSynthesis.severity ?? 'nominal'}</span>
+              {typeof latestSynthesis.confidence === 'number' && (
+                <span className="rounded border border-slate-700 px-1.5 py-0.5 text-slate-300">
+                  conf {(latestSynthesis.confidence * 100).toFixed(0)}%
+                </span>
+              )}
+            </div>
+            <p className="text-[11px] leading-snug text-slate-200"><span className="text-slate-400">Obs:</span> {latestSynthesis.observation}</p>
+            <p className="mt-1 text-[11px] leading-snug text-slate-200"><span className="text-slate-400">Inf:</span> {latestSynthesis.inference}</p>
+            <p className="mt-1 text-[11px] leading-snug text-slate-200"><span className="text-slate-400">Rec:</span> {latestSynthesis.recommendation}</p>
+          </div>
+        ) : (
+          <div className="text-xs text-slate-400">No journal synthesis available yet in this cycle.</div>
+        )}
+      </section>
+      <section className="mb-4 rounded border border-slate-800 bg-slate-900/60 p-2.5">
+        <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-400">SOURCES</div>
+        <div className="flex flex-wrap gap-1.5 text-[11px] text-slate-200">
+          <span className="rounded border border-slate-700 px-1.5 py-0.5">GitHub {epiconSources?.github ?? 0}</span>
+          <span className="rounded border border-slate-700 px-1.5 py-0.5">KV {epiconSources?.kv ?? 0}</span>
+          <span className="rounded border border-slate-700 px-1.5 py-0.5">Journal {journalEntries.length}</span>
+          <span className="rounded border border-slate-700 px-1.5 py-0.5">Ledger API {epiconSources?.ledgerApi ?? 0}</span>
+          <span className="rounded border border-slate-700 px-1.5 py-0.5">Memory {((epiconSources?.memory ?? 0) + (epiconSources?.memoryLedger ?? 0))}</span>
+          <span className="rounded border border-slate-700 px-1.5 py-0.5">Journal KV {journalSources?.kv ?? 0}</span>
+        </div>
+      </section>
       <div className="space-y-2">
         {filtered.map((item) => (
           <article key={item.id} className="rounded border border-slate-800 bg-slate-900/60 p-2.5 md:p-3">


### PR DESCRIPTION
### Motivation
- Improve Pulse operator visibility by surfacing the freshest agent synthesis, a compact delta of what changed since the last cycle, and concise source counts for provenance without changing locked schemas or bridge logic.
- Keep the Pulse feed mobile-friendly and preserve the existing typed event rows and lane health semantics.

### Description
- Added compact `LATEST SYNTHESIS` card that reads the freshest journal entry from the `journal` lane and displays `agent`, `timestamp` (and relative freshness), `observation`, `inference`, `recommendation`, `severity`, and optional `confidence` with an explicit empty-state when absent.
- Added a compact `DELTA` strip that computes and shows new EPICON and journal counts, degraded/offline lane count, GI delta (when derivable), and promotion counters when available using the terminal snapshot lanes and epicon/promotion summaries.
- Added a compact `SOURCES` diagnostics row exposing GitHub/KV/journal/ledger/memory source counts pulled from the epicon and journal snapshot payloads.
- Implemented small helper types and utilities (`JournalEntry`, cycle parsing, `relTime`) and kept existing event typing and rendering logic intact; change is scoped to `app/terminal/pulse/PulsePageClient.tsx` only.

### Testing
- Commands run: `pnpm exec tsc --noEmit`, `pnpm build`, `pnpm lint`.
- `pnpm exec tsc --noEmit` passed successfully and typecheck is green for the modified files.
- `pnpm build` failed in this environment due to network/SWC binary download error (`ENETUNREACH`) and not due to code type errors.
- `pnpm lint` could not complete in this environment for the same SWC/network issue (reported as environment failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd526fa50832d9cbbc908325c405b)