### PR TITLE
C-280: fix mobile world map data path

### DIFF
--- a/components/terminal/chambers/GlobeChamber.tsx
+++ b/components/terminal/chambers/GlobeChamber.tsx
@@ -54,5 +54,5 @@ function useIsMobile(breakpoint = 768): boolean {
 
 export default function GlobeChamber(props: GlobeChamberProps) {
   const isMobile = useIsMobile(768);
-  return isMobile ? <WorldMapView /> : <GlobeView {...props} />;
+  return isMobile ? <WorldMapView {...props} /> : <GlobeView {...props} />;
 }


### PR DESCRIPTION
## What this does
- fixes the mobile World State renderer so it receives the same live props as the desktop Globe
- restores live `micro`, `echoEpicon`, `cycleId`, and `giScore` into the mobile map path
- removes the immediate cause of the blank mobile map / `GI 0.00` regression

## Root cause
`GlobeChamber` was rendering the mobile path as:

```tsx
return isMobile ? <WorldMapView /> : <GlobeView {...props} />;
```

That meant the mobile map always received default fallback values:
- `micro = null`
- `echoEpicon = []`
- `cycleId = '—'`
- `giScore = 0`

So mobile showed a blank grid-like surface and `GI 0.00` even when desktop Globe was live.

## Fix
Pass the live chamber props into `WorldMapView` the same way desktop already receives them:

```tsx
return isMobile ? <WorldMapView {...props} /> : <GlobeView {...props} />;
```

## Why this is safe
- one-line behavioral fix in `GlobeChamber`
- does not change key schemas
- does not touch locked KV bridge logic
- does not touch journal routes
- does not alter desktop Globe behavior
- keeps the mobile map / desktop globe split intact

## Files changed
- `components/terminal/chambers/GlobeChamber.tsx`

## Expected result
On mobile:
- World State map receives live signal data
- GI no longer falls back to `0.00`
- cycle label and pin set reflect real terminal state

## Follow-up
This PR fixes the missing data path.
A separate follow-up can improve the mobile renderer itself by adding richer landmass/world geometry if needed.
