### PR TITLE
C-280: ATLAS/ZEUS cron journals, echo KV bridge, GI refresh, terminal polish

### DIFF
--- a/CURRENT_CYCLE.md
+++ b/CURRENT_CYCLE.md
@@ -90,7 +90,7 @@ _Use only when the operator has confirmed the state is intentional._
 - [ ] **promotion** — require `AGENT_SERVICE_TOKEN` / `RENDER_API_KEY` before commit; explicit logs (Opt 3)
 - [ ] **ATLAS / ZEUS** overnight journals — `/api/agents/atlas/observe`, `/api/agents/zeus/verify` after EVE cron (Opt 1)
 - [ ] **MII all agents** — ATLAS/ZEUS MII on sentinel routes; echo batch unchanged (Opt 4)
-- [ ] **GI freshness** — `/api/cron/gi-refresh` every 30 minutes (Opt 6)
+- [ ] **GI freshness** — `/api/cron/gi-refresh` once daily 00:45 UTC (Hobby cron limit; Opt 6)
 
 ---
 

--- a/CURRENT_CYCLE.md
+++ b/CURRENT_CYCLE.md
@@ -1,6 +1,6 @@
-# CURRENT_CYCLE.md — C-279
-> **Last verified:** 2026-04-12T23:35Z by ATLAS (kaizencycle)
-> **Snapshot commit:** `7773db68` — terminal optimization scan
+# CURRENT_CYCLE.md — C-280
+> **Last verified:** 2026-04-13T12:25Z by ATLAS (kaizencycle)
+> **Snapshot commit:** `74fc1493` — C-280 in sync (agent work may advance this SHA after merge)
 > **Production URL:** https://mobius-civic-ai-terminal.vercel.app
 > **Vercel project:** `prj_ru2eaIzY0nIamFIXEdUIuTjnefpn` · team `team_cEncfJHYpxuB6YiFQNwdOUB5`
 
@@ -15,22 +15,23 @@ If your task describes fixing something in the EXPECTED EMPTY section, **do not 
 
 ---
 
-## ✅ LANE STATUS (as of last snapshot)
+## ✅ LANE STATUS (as of last snapshot @ 12:25Z)
 
 | Lane | State | Note |
 |------|-------|------|
-| signals | healthy | GAIA, HERMES-µ, THEMIS, DAEDALUS-µ all live |
-| kvHealth | healthy | Upstash reachable, 240ms latency |
-| agents | **healthy** | All 8 agents showing `status: active` via KV heartbeat |
-| echo | healthy | 9 EPICONs rated and ledgered |
-| journal | healthy | 2 EVE entries via substrate archive |
-| sentiment | healthy | 6 domains live |
-| promotion | healthy | 6 pending promotable |
-| eve | healthy | C-278 in sync |
-| integrity | healthy | source `kv LIVE`, GI 0.75 |
-| epicon | empty | `kv: 0` — see EXPECTED EMPTY below |
-| runtime | stale | Last commit aging; freshness remains explicit |
-| mii | healthy | `mii:feed` live (8 entries, EVE writing) |
+| snapshot | healthy | `ok: true`, `cycle: "C-280"` at root |
+| integrity | degraded/live | GI ~0.73, source **kv** ✅, mode yellow |
+| signals | healthy | All four micro-agents live |
+| kvHealth | healthy | ~354ms latency |
+| agents | healthy | All eight active; heartbeat fresh |
+| journal | healthy | `sources.kv: 1` ✅ — first KV journal write (EVE) |
+| mii | healthy | `mii:feed` — nine entries; EVE hourly; ATLAS/ZEUS MII after cron once deployed |
+| echo | healthy | Nine C-280 EPICONs; `duplicateSuppressedCount: 0` ✅ |
+| sentiment | healthy | Six domains; CIVIC / INSTITUTIONAL ~0.965 |
+| epicon | empty | `kv: 0` on feed list — bridge alignment + stale feed persistence in progress (C-280) |
+| runtime | healthy | Freshness nominal |
+| promotion | silent | Eligible items found; zero commits — token / commit path (C-280) |
+| eve | healthy | Cycle synthesis cron + POST |
 
 ---
 
@@ -42,79 +43,54 @@ If you are unsure, **stop**.
 
 ### 1. Journal KV key schema
 - **File:** `app/api/agents/journal/route.ts`
-- **What:** Route reads keys matching `journal:{AGENT}:{CYCLE}` (3 segments, uppercase agent, e.g. `journal:EVE:C-278`)
-- **Fixed in:** PR #248
+- **What:** Route reads keys matching `journal:{AGENT}:{CYCLE}` (three segments, uppercase agent, e.g. `journal:EVE:C-280`)
 - **Why locked:** Agents write to this exact schema. Changing the reader breaks the entire journal lane.
-- **DO NOT:** Change to `journal:all`, `journal:eve`, or any 2-segment schema. Do not reintroduce list-based `lrange` lookups.
+- **DO NOT:** Change to `journal:all`, `journal:eve`, or any two-segment schema.
 
 ### 2. ECHO → `epicon:feed` KV bridge
-- **File:** `app/api/echo/ingest/route.ts`
-- **What:** After ECHO rates EPICONs, it LPUSHes completed entries into the `epicon:feed` KV key and LTRIMs to 100
-- **Fixed in:** PR #246
-- **Why locked:** This is the only path for live KV EPICONs to reach the terminal feed.
+- **File:** `app/api/echo/ingest/route.ts` (shared helper `lib/echo/kv-persist-ingest.ts`)
+- **What:** After ECHO rates EPICONs, LPUSH completed entries into `epicon:feed` and LTRIM to 100
+- **Why locked:** Primary path for live KV EPICONs to reach the terminal feed.
 - **DO NOT:** Remove the LPUSH/LTRIM step. Do not move it after an error boundary that could skip it.
 
 ### 3. Substrate GitHub auth header
 - **File:** `lib/substrate/github-reader.ts`
-- **What:** All GitHub API calls to `kaizencycle/Mobius-Substrate` include `Authorization: Bearer ${SUBSTRATE_GITHUB_TOKEN}`
-- **Fixed in:** PR #246
-- **Why locked:** The Mobius-Substrate repo requires auth. Removing the header causes silent 403 failures and empty journal archive reads.
-- **DO NOT:** Remove the Authorization header. Do not change the repo path or branch without verifying the new path exists.
+- **What:** GitHub API calls to `kaizencycle/Mobius-Substrate` include `Authorization: Bearer ${SUBSTRATE_GITHUB_TOKEN}`
+- **DO NOT:** Remove the Authorization header.
 
 ### 4. HERMES signal domain assignment
 - **File:** `app/api/signals/micro/route.ts` (HERMES-µ section)
-- **What:** HERMES-µ covers narrative signals: Hacker News, Wikipedia, Perplexity Sonar, GDELT. It does NOT fetch crypto prices.
-- **Why locked:** ECHO owns crypto via CoinGecko. Duplicate CoinGecko calls in HERMES would create conflicting EPICONs with the same asset data attributed to different agents.
-- **DO NOT:** Add CoinGecko, Binance, or any crypto price source to HERMES-µ. Do not move financial domain ownership from ECHO to HERMES.
+- **DO NOT:** Add CoinGecko or other crypto price sources to HERMES-µ (ECHO owns financial).
 
 ### 5. Multi-agent journal aggregation
 - **File:** `app/api/agents/journal/route.ts`
-- **What:** When no `?agent=` param is provided, the route calls `kv.keys('journal:*')`, filters for 3-segment keys, fetches each, merges and deduplicates by `id`
-- **Fixed in:** PR #247 (multi-agent fix)
-- **Why locked:** Prior to this fix, the unfiltered route returned 0 entries. Reverting to list-based or single-key lookup breaks all-agents view.
-- **DO NOT:** Replace `kv.keys('journal:*')` with a hardcoded list of agent names. Do not reintroduce `journal:all` as a primary key.
+- **DO NOT:** Replace `kv.keys('journal:*')` with a hardcoded agent list.
+
+### 6. MII entry shape
+- **Shape:** `{ agent, mii, gi, cycle, timestamp, source: "live" }`
+- **DO NOT:** Change field names or `source` semantics without operator approval.
+
+### 7. GI formula and weighting
+- **File:** `lib/gi/compute.ts`
+- **DO NOT:** Change weights or inputs without operator approval.
 
 ---
 
 ## ⏳ EXPECTED EMPTY — NOT A BUG, DO NOT FIX
 
-These states look broken but are not. Creating PRs for them is wasted effort and risks regression.
-
-### `sources.kv: 0` on EPICON feed
-- **Why:** The ECHO → `epicon:feed` bridge was just deployed (PR #246). The bridge only populates on new ECHO ingest cycles. The first post-deploy ingest will populate it.
-- **What to do:** Nothing. Wait for next ECHO ingest or trigger `/api/echo/ingest` manually.
-- **What NOT to do:** Do not add seed data, do not rewrite the bridge, do not change the key name.
-
-### `sources.kv: 0` on journal
-- **Why:** Old `journal:AGENT:CYCLE` keys in Upstash expired (5-day TTL). The reader is correct. Agents will write new keys on next synthesis run.
-- **What to do:** Trigger `/api/eve/synthesize` or `/api/cron/watchdog` to generate fresh journal entries.
-- **What NOT to do:** Do not change the key schema. Do not add genesis/seed journal entries via code.
-
-### `epicon: empty` lane in terminal snapshot
-- **Why:** Same as `sources.kv: 0` above. The lane reads `epicon:feed`. No KV entries yet post-deploy.
-- **What to do:** Wait for first ECHO ingest cycle.
-- **What NOT to do:** Do not change the lane's fallback logic to show GitHub commits as "committed EPICONs."
-
-### `integrity: stale` / `runtime: stale`
-- **Why:** The integrity GI state is cached from the last heartbeat (01:07Z). The runtime shows last GitHub commit time. Both go stale when no agent or cron has fired recently.
-- **What to do:** Nothing. These refresh automatically when the next heartbeat or cron runs.
-- **What NOT to do:** Do not add artificial freshness timestamps. Do not change the staleness threshold without operator approval.
-
-### DAEDALUS self-ping HTTP 401
-- **Why:** The self-ping hits a protected endpoint. This is a known low-priority issue with the auth middleware.
-- **Priority:** Low. Logged. Will be addressed in a future cycle.
-- **What NOT to do:** Do not create a PR that disables auth on the self-ping endpoint. Do not suppress the error in the signal output — it should remain visible.
+_Use only when the operator has confirmed the state is intentional._
 
 ---
 
-## 🔧 ACTIVE WORK — C-279
+## 🔧 ACTIVE WORK — C-280
 
-Tasks currently in scope. Do not duplicate.
-
-- [ ] ECHO_STATE KV heartbeat write path active work (ingest-level unconditional write)
-- [ ] TRIPWIRE_STATE KV heartbeat write path active work (post-tripwire run write)
-- [ ] Snapshot root `ok:false` + `cycle:null` known issue being fixed
-- [ ] Promotion engine `eligible > 0` but `promoted_this_cycle = 0` active work
+- [ ] **ECHO_STATE** KV key-exists in `/api/kv/health` — `echo:kv:heartbeat` + legacy diagnostics (Opt 2)
+- [ ] **TRIPWIRE_STATE** — aligned KV heartbeat key for health (Opt 2)
+- [ ] **epicon:feed** `kv: 0` — persist on stale `/api/echo/feed` re-ingest + LPUSH logging (Opt 5)
+- [ ] **promotion** — require `AGENT_SERVICE_TOKEN` / `RENDER_API_KEY` before commit; explicit logs (Opt 3)
+- [ ] **ATLAS / ZEUS** overnight journals — `/api/agents/atlas/observe`, `/api/agents/zeus/verify` after EVE cron (Opt 1)
+- [ ] **MII all agents** — ATLAS/ZEUS MII on sentinel routes; echo batch unchanged (Opt 4)
+- [ ] **GI freshness** — `/api/cron/gi-refresh` every 30 minutes (Opt 6)
 
 ---
 
@@ -122,41 +98,21 @@ Tasks currently in scope. Do not duplicate.
 
 ### Vercel (Terminal)
 - **Repo:** `kaizencycle/mobius-civic-ai-terminal`
-- **Deploy:** Vercel, auto-deploy on merge to `main`
-- **KV:** Upstash Redis — env vars `KV_REST_API_URL` + `KV_REST_API_TOKEN`
-- **Substrate:** `kaizencycle/Mobius-Substrate` — requires `SUBSTRATE_GITHUB_TOKEN`
+- **KV:** Upstash — `KV_REST_API_URL` + `KV_REST_API_TOKEN`
+- **Substrate:** `kaizencycle/Mobius-Substrate` — `SUBSTRATE_GITHUB_TOKEN`
+- **Promotion / ledger attest:** `AGENT_SERVICE_TOKEN` (or legacy `RENDER_API_KEY`)
 
 ### Render (Backend services)
-- **Ledger API:** `civic-protocol-core-ledger.onrender.com` — FastAPI + Postgres (`mobius-db`)
-- **MIC Wallet:** `mobius-mic-wallet-service.onrender.com` — FastAPI + Postgres
-- **Identity:** `mobius-identity-service.onrender.com` — FastAPI + Postgres
-- **Database:** `mobius-db` — Render PostgreSQL 18, Virginia
-- **Note:** Render free tier spins down on inactivity. First request after spin-down takes ~50s. This is expected — do not add retry logic that masks the spin-up delay.
-
-### Signal ownership (DO NOT REASSIGN)
-| Domain | Agent | Sources |
-|--------|-------|---------|
-| FINANCIAL | ECHO | CoinGecko (BTC, ETH, SOL) |
-| ENVIRON | GAIA | Open-Meteo, USGS, NASA EONET |
-| NARRATIVE | HERMES-µ | Hacker News, Wikipedia, Perplexity Sonar, GDELT |
-| CIVIC | EVE / THEMIS | Federal Register, data.gov |
-| INFRASTR | DAEDALUS-µ | GitHub API, npm Registry, self-ping |
-| INSTITUTIONAL | JADE | data.gov, FRED (future) |
+- **Ledger API:** `civic-protocol-core-ledger.onrender.com`
 
 ---
 
 ## 📋 PR CHECKLIST REFERENCE
 
-Every PR to this repo must answer these questions before merge:
-
 1. Did I read `AGENTS.md`, `BUILD.md`, and this file before starting?
-2. Does this PR touch any LOCKED file/behavior listed above?
-   - If yes: state explicitly why the change is safe.
-   - If no: confirm in the PR description.
-3. Does this PR "fix" anything in the EXPECTED EMPTY section?
-   - If yes: stop. It is not a bug.
-4. Did `pnpm build` pass?
-5. Did I check `/api/terminal/snapshot` after deploy?
+2. Does this PR touch any LOCKED file/behavior? If yes, state why safe.
+3. Did `pnpm build` pass?
+4. Did I check `/api/terminal/snapshot` after deploy?
 
 ---
 

--- a/app/api/agents/atlas/observe/route.ts
+++ b/app/api/agents/atlas/observe/route.ts
@@ -1,0 +1,72 @@
+/**
+ * POST /api/agents/atlas/observe — ATLAS cycle observation journal (cron / post-EVE).
+ * Auth: same as EVE cycle synthesis (Vercel cron headers or service Bearer).
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getEveSynthesisAuthError } from '@/lib/security/serviceAuth';
+import { appendAtlasCronJournal, parseAtlasObserveBody } from '@/lib/agents/sentinel-cycle-journals';
+import { loadGIState } from '@/lib/kv/store';
+import { writeMiiState } from '@/lib/kv/mii';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    info: 'POST JSON { cycle, gi?, source?: "cron" } — ATLAS observation journal write',
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const authErr = getEveSynthesisAuthError(request);
+  if (authErr) return authErr;
+
+  let body: unknown = {};
+  try {
+    const text = await request.text();
+    if (text.trim()) body = JSON.parse(text) as unknown;
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const parsed = parseAtlasObserveBody(body);
+  if (!parsed) {
+    return NextResponse.json({ ok: false, error: 'cycle (string) is required' }, { status: 400 });
+  }
+
+  let gi = parsed.gi;
+  try {
+    const st = await loadGIState();
+    if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
+      gi = Math.max(0, Math.min(1, st.global_integrity));
+    }
+  } catch {
+    // use body gi
+  }
+
+  try {
+    const entry = await appendAtlasCronJournal({ ...parsed, gi });
+    const ts = new Date().toISOString();
+    await writeMiiState({
+      agent: 'ATLAS',
+      mii: Number(entry.confidence.toFixed(4)),
+      gi,
+      cycle: parsed.cycle,
+      timestamp: ts,
+      source: 'live',
+    });
+    return NextResponse.json({
+      ok: true,
+      agent: 'ATLAS',
+      journalId: entry.id,
+      cycle: parsed.cycle,
+      gi,
+      source: parsed.source,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'ATLAS observe failed';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/app/api/agents/zeus/verify/route.ts
+++ b/app/api/agents/zeus/verify/route.ts
@@ -1,0 +1,74 @@
+/**
+ * POST /api/agents/zeus/verify — ZEUS cycle verification journal (cron / post-EVE).
+ * Distinct from POST /api/zeus/verify (single EPICON candidate verification).
+ * Auth: same as EVE cycle synthesis.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getEveSynthesisAuthError } from '@/lib/security/serviceAuth';
+import { appendZeusCronJournal, parseZeusCronBody } from '@/lib/agents/sentinel-cycle-journals';
+import { loadGIState } from '@/lib/kv/store';
+import { writeMiiState } from '@/lib/kv/mii';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    info: 'POST JSON { cycle, gi?, atlasEntry?, source?: "cron" } — ZEUS verification journal write',
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const authErr = getEveSynthesisAuthError(request);
+  if (authErr) return authErr;
+
+  let body: unknown = {};
+  try {
+    const text = await request.text();
+    if (text.trim()) body = JSON.parse(text) as unknown;
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const parsed = parseZeusCronBody(body);
+  if (!parsed) {
+    return NextResponse.json({ ok: false, error: 'cycle (string) is required' }, { status: 400 });
+  }
+
+  let gi = parsed.gi;
+  try {
+    const st = await loadGIState();
+    if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
+      gi = Math.max(0, Math.min(1, st.global_integrity));
+    }
+  } catch {
+    // use body gi
+  }
+
+  try {
+    const entry = await appendZeusCronJournal({ ...parsed, gi });
+    const ts = new Date().toISOString();
+    await writeMiiState({
+      agent: 'ZEUS',
+      mii: Number(entry.confidence.toFixed(4)),
+      gi,
+      cycle: parsed.cycle,
+      timestamp: ts,
+      source: 'live',
+    });
+    return NextResponse.json({
+      ok: true,
+      agent: 'ZEUS',
+      journalId: entry.id,
+      cycle: parsed.cycle,
+      gi,
+      atlasEntry: parsed.atlasEntry ?? null,
+      source: parsed.source,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'ZEUS verify journal failed';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/app/api/cron/gi-refresh/route.ts
+++ b/app/api/cron/gi-refresh/route.ts
@@ -1,5 +1,6 @@
 /**
- * GET /api/cron/gi-refresh — refresh GI_STATE in KV every 30m (Vercel cron).
+ * GET /api/cron/gi-refresh — refresh GI_STATE in KV (Vercel cron).
+ * Schedule: once daily on Hobby (`45 0 * * *` UTC); Pro can use a sub-daily expression if desired.
  * Runs signal engine for fresh ECHO-backed scores, then recomputes GI.
  */
 

--- a/app/api/cron/gi-refresh/route.ts
+++ b/app/api/cron/gi-refresh/route.ts
@@ -1,0 +1,34 @@
+/**
+ * GET /api/cron/gi-refresh — refresh GI_STATE in KV every 30m (Vercel cron).
+ * Runs signal engine for fresh ECHO-backed scores, then recomputes GI.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getEveSynthesisAuthError } from '@/lib/security/serviceAuth';
+import { runSignalEngine } from '@/lib/signals/engine';
+import { recomputeAndSaveGIState } from '@/lib/integrity/buildStatus';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const authErr = getEveSynthesisAuthError(request);
+  if (authErr) return authErr;
+
+  try {
+    await runSignalEngine();
+    const giState = await recomputeAndSaveGIState();
+    return NextResponse.json({
+      ok: true,
+      refreshed: giState !== null,
+      global_integrity: giState?.global_integrity ?? null,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    console.error('[cron/gi-refresh] failed:', err);
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : 'gi refresh failed' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/echo/feed/route.ts
+++ b/app/api/echo/feed/route.ts
@@ -15,6 +15,7 @@ import { NextResponse } from 'next/server';
 import { getEchoEpicon, getEchoLedger, getEchoAlerts, getEchoIntegrity, getEchoStatus, pushIngestResult } from '@/lib/echo/store';
 import { fetchAllSources } from '@/lib/echo/sources';
 import { transformBatch } from '@/lib/echo/transform';
+import { persistEchoIngestSideEffects } from '@/lib/echo/kv-persist-ingest';
 
 export const dynamic = 'force-dynamic';
 
@@ -34,6 +35,7 @@ export async function GET() {
       if (rawEvents.length > 0) {
         const result = transformBatch(rawEvents);
         pushIngestResult(result);
+        await persistEchoIngestSideEffects(result);
       }
     } catch {
       // Proceed with whatever data we have

--- a/app/api/echo/ingest/route.ts
+++ b/app/api/echo/ingest/route.ts
@@ -12,102 +12,16 @@
  */
 
 import { NextResponse } from 'next/server';
-import { Redis } from '@upstash/redis';
 import { fetchAllSources } from '@/lib/echo/sources';
 import type { RawEvent } from '@/lib/echo/sources';
 import { transformBatch } from '@/lib/echo/transform';
 import { pushIngestResult, getEchoStatus, getEchoEpicon, getEchoLedger, getEchoAlerts } from '@/lib/echo/store';
 import { writeSnapshot } from '@/lib/echo/snapshot-writer';
-import { saveEchoState, loadGIState } from '@/lib/kv/store';
-import { readMiiFeed, type MiiEntry } from '@/lib/kv/mii';
+import { saveEchoState } from '@/lib/kv/store';
 import { querySonarForLane } from '@/lib/signals/perplexity-sonar';
-import { currentCycleId } from '@/lib/eve/cycle-engine';
+import { persistEchoIngestSideEffects, writeEchoKvHeartbeatToMobius } from '@/lib/echo/kv-persist-ingest';
 
 export const dynamic = 'force-dynamic';
-
-type KvEpiconEntry = {
-  id: string;
-  timestamp: string;
-  author: string;
-  title: string;
-  type: 'epicon';
-  severity: 'nominal' | 'elevated' | 'critical' | 'degraded' | 'info';
-  source: 'kv-ledger';
-  tags: string[];
-  verified: boolean;
-};
-
-function getRedisClient(): Redis | null {
-  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) return null;
-
-  try {
-    return new Redis({ url, token });
-  } catch {
-    return null;
-  }
-}
-
-function toFeedSeverity(confidenceTier: number): KvEpiconEntry['severity'] {
-  if (confidenceTier >= 3) return 'critical';
-  if (confidenceTier >= 2) return 'elevated';
-  if (confidenceTier >= 1) return 'nominal';
-  return 'info';
-}
-
-function toFeedTimestamp(rawTimestamp: string): string {
-  const ts = new Date(rawTimestamp);
-  if (Number.isNaN(ts.getTime())) return new Date().toISOString();
-  return ts.toISOString();
-}
-
-async function flushEpiconFeed(entries: KvEpiconEntry[]): Promise<void> {
-  const redis = getRedisClient();
-  if (!redis || entries.length === 0) return;
-
-  try {
-    const payload = entries.map((entry) => JSON.stringify(entry));
-    await redis.lpush('epicon:feed', ...payload);
-    await redis.ltrim('epicon:feed', 0, 99);
-  } catch (error) {
-    console.error('[echo] epicon feed flush failed:', error);
-  }
-}
-
-async function writeEchoKvHeartbeat(status: ReturnType<typeof getEchoStatus>): Promise<void> {
-  const redis = getRedisClient();
-  if (!redis) return;
-  const now = new Date().toISOString();
-  try {
-    await redis.set(
-      'ECHO_STATE',
-      JSON.stringify({
-        cycleId: currentCycleId(),
-        lastIngest: now,
-        totalIngested: status.totalIngested,
-        duplicateSuppressed: status.duplicateSuppressedCount,
-        healthy: true,
-        timestamp: now,
-      }),
-    );
-  } catch (error) {
-    console.error('[echo] ECHO_STATE write failed:', error);
-  }
-}
-
-async function writeMiiFeedBatch(entries: MiiEntry[]): Promise<void> {
-  const redis = getRedisClient();
-  if (!redis || entries.length === 0) return;
-  try {
-    const packed = entries.map((entry) => JSON.stringify(entry));
-    await Promise.all(entries.map((entry) => redis.set(`mii:${entry.agent.toUpperCase()}:${entry.cycle}`, JSON.stringify(entry))));
-    await redis.lpush('mii:feed', ...packed);
-    await redis.ltrim('mii:feed', 0, 199);
-  } catch (error) {
-    console.error('[echo] mii batch write failed:', error);
-  }
-}
 
 export async function GET() {
   const status = getEchoStatus();
@@ -168,6 +82,7 @@ export async function POST() {
 
     if (rawEvents.length === 0) {
       const emptyStatus = getEchoStatus();
+      await writeEchoKvHeartbeatToMobius(emptyStatus, false);
       await saveEchoState({
         lastIngest: emptyStatus.lastIngest,
         cycleId: emptyStatus.cycleId,
@@ -192,63 +107,7 @@ export async function POST() {
 
     // 3. Push to store
     pushIngestResult(result);
-    const status = getEchoStatus();
-    await writeEchoKvHeartbeat(status);
-    const dedupDenominator = Math.max(1, status.totalIngested + status.duplicateSuppressedCount);
-    const dedupRate = Number((status.duplicateSuppressedCount / dedupDenominator).toFixed(3));
-    await saveEchoState({
-      lastIngest: status.lastIngest,
-      cycleId: status.cycleId,
-      totalIngested: status.totalIngested,
-      healthy: true,
-      epiconCount: status.counts.epicon,
-      ledgerCount: status.counts.ledger,
-      alertCount: status.counts.alerts,
-      timestamp: new Date().toISOString(),
-      dedupRate,
-    }).catch(() => {});
-
-    const kvFeedEntries: KvEpiconEntry[] = result.epicon.map((entry) => ({
-      id: entry.id,
-      timestamp: toFeedTimestamp(entry.timestamp),
-      author: entry.ownerAgent,
-      title: entry.title,
-      type: 'epicon',
-      severity: entry.status === 'contradicted' ? 'degraded' : toFeedSeverity(entry.confidenceTier),
-      source: 'kv-ledger',
-      tags: entry.sources,
-      verified: entry.status === 'verified',
-    }));
-    await flushEpiconFeed(kvFeedEntries);
-
-    // 5. Write MII state for each rated agent (fire-and-forget)
-    void (async () => {
-      try {
-        const giState = await loadGIState();
-        const currentGi = Number((giState?.global_integrity ?? 0.74).toFixed(4));
-        const miiTimestamp = new Date().toISOString();
-        const agentAverages = result.integrity.agentAverages;
-        const agents = ['ATLAS', 'ZEUS', 'JADE', 'EVE'] as const;
-        const recentFeed = await readMiiFeed();
-        const lastKnown: Record<string, number> = {};
-        for (const entry of recentFeed) {
-          if (!(entry.agent in lastKnown)) {
-            lastKnown[entry.agent] = entry.mii;
-          }
-        }
-        const batch: MiiEntry[] = agents.map((agent) => ({
-          agent,
-          mii: Number((typeof agentAverages[agent] === 'number' ? agentAverages[agent] : (lastKnown[agent] ?? 0.90)).toFixed(4)),
-          gi: currentGi,
-          cycle: result.cycleId,
-          timestamp: miiTimestamp,
-          source: 'live',
-        }));
-        await writeMiiFeedBatch(batch);
-      } catch (err) {
-        console.error('[echo] mii write failed:', err instanceof Error ? err.message : err);
-      }
-    })();
+    await persistEchoIngestSideEffects(result);
 
     // 4. Generate docs/echo/ snapshot (fire-and-forget, non-blocking)
     let snapshotWritten = false;

--- a/app/api/epicon/promote/route.ts
+++ b/app/api/epicon/promote/route.ts
@@ -10,7 +10,7 @@ import type { EpiconItem } from '@/lib/terminal/types';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { defaultPromotionState, getPromotionState, savePromotionState } from '@/lib/epicon/promotion';
 import { appendJournalLaneEntry, getJournalRedisClient } from '@/lib/agents/journalLane';
-import { writeToSubstrate } from '@/lib/substrate/client';
+import { getAgentBearerToken, writeToSubstrate } from '@/lib/substrate/client';
 
 export const dynamic = 'force-dynamic';
 
@@ -302,6 +302,14 @@ async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: stri
   let seq = 1;
   const promotedIdsThisCycle: string[] = [];
 
+  const agentToken = getAgentBearerToken();
+  const ledgerReady = agentToken.length > 0;
+  if (!ledgerReady) {
+    console.error(
+      '[promoter] AGENT_SERVICE_TOKEN (or RENDER_API_KEY) missing — skipping ledger push and substrate attest; set token in Vercel to enable commits',
+    );
+  }
+
   for (const epicon of pending) {
     const existing = state[epicon.id] ?? defaultPromotionState(nowIso);
     const assignedAgents = AGENT_ROUTING[epicon.category] ?? ['ZEUS'];
@@ -321,6 +329,9 @@ async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: stri
 
         const commit = buildCommit(agent, epicon, cycleId, seq++);
         try {
+          if (!ledgerReady) {
+            throw new Error('AGENT_SERVICE_TOKEN not configured');
+          }
           await pushLedgerEntry(commit);
           await writeCommitJournalEntry(commit, epicon);
           void writeToSubstrate({

--- a/app/api/eve/cycle-synthesize/route.ts
+++ b/app/api/eve/cycle-synthesize/route.ts
@@ -18,13 +18,62 @@ import {
   processEveEscalationSynthesis,
 } from '@/lib/eve/governance-synthesis';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
-import { getEveSynthesisAuthError, isVercelCronInvocation } from '@/lib/security/serviceAuth';
+import {
+  getEveSynthesisAuthError,
+  isVercelCronInvocation,
+  serviceAuthorizationHeaderValue,
+} from '@/lib/security/serviceAuth';
 import { runSignalEngine } from '@/lib/signals/engine';
 import { appendAgentJournalEntry } from '@/lib/agents/journal';
 import { loadGIState } from '@/lib/kv/store';
 import { writeMiiState } from '@/lib/kv/mii';
 
 export const dynamic = 'force-dynamic';
+
+function extractGiFromSynthesisPayload(payload: Record<string, unknown>): number | null {
+  const trace = payload.trace;
+  if (trace && typeof trace === 'object' && typeof (trace as Record<string, unknown>).gi === 'number') {
+    const g = (trace as Record<string, unknown>).gi as number;
+    return Number.isFinite(g) ? g : null;
+  }
+  return null;
+}
+
+async function fanOutAtlasZeusAfterEve(
+  request: NextRequest,
+  cycleId: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const giFromSynth = extractGiFromSynthesisPayload(payload);
+  const giVal = giFromSynth !== null ? giFromSynth : 0.74;
+  const base = request.nextUrl.origin;
+  const authHeader = serviceAuthorizationHeaderValue();
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (authHeader) headers.Authorization = authHeader;
+
+  const atlasRes = await fetch(`${base}/api/agents/atlas/observe`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ cycle: cycleId, gi: giVal, source: 'cron' }),
+    cache: 'no-store',
+    signal: AbortSignal.timeout(20_000),
+  });
+  const atlasJson = (await atlasRes.json().catch(() => null)) as { journalId?: string } | null;
+  const atlasJournalId = typeof atlasJson?.journalId === 'string' ? atlasJson.journalId : null;
+
+  await fetch(`${base}/api/agents/zeus/verify`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      cycle: cycleId,
+      gi: giVal,
+      atlasEntry: atlasJournalId,
+      source: 'cron',
+    }),
+    cache: 'no-store',
+    signal: AbortSignal.timeout(20_000),
+  });
+}
 
 type CycleBody = {
   cycleId?: unknown;
@@ -85,6 +134,9 @@ export async function GET(request: NextRequest) {
   if (isVercelCronInvocation(request)) {
     await runSignalEngine();
     const payload = await processEveCycleWindowSynthesis(cycleId, false);
+    void fanOutAtlasZeusAfterEve(request, cycleId, payload as Record<string, unknown>).catch((err) => {
+      console.error('[eve/cycle-synthesize] ATLAS/ZEUS cron follow-up failed:', err);
+    });
     return NextResponse.json(payload);
   }
 
@@ -160,6 +212,10 @@ export async function POST(request: NextRequest) {
         console.error('[eve] mii write failed:', err instanceof Error ? err.message : err);
       }
     })();
+
+    void fanOutAtlasZeusAfterEve(request, cycleId, payload as Record<string, unknown>).catch((err) => {
+      console.error('[eve/cycle-synthesize] ATLAS/ZEUS follow-up failed:', err);
+    });
 
     return NextResponse.json(payload);
   } catch (err) {

--- a/app/api/tripwire/status/route.ts
+++ b/app/api/tripwire/status/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getTripwireState, setTripwireState, type RuntimeTripwireState } from '@/lib/tripwire/store';
 import { mockTripwire } from '@/lib/mock-data';
 import { liveEnvelope, mockEnvelope } from '@/lib/response-envelope';
-import { saveTripwireState } from '@/lib/kv/store';
+import { saveTripwireState, kvSet, KV_KEYS } from '@/lib/kv/store';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { Redis } from '@upstash/redis';
 
@@ -58,16 +58,15 @@ function getRedisClient(): Redis | null {
 async function writeTripwireKvState(activeTripwires: number): Promise<void> {
   const redis = getRedisClient();
   if (!redis) return;
+  const payload = {
+    cycleId: currentCycleId(),
+    tripwireCount: activeTripwires,
+    elevated: activeTripwires > 0,
+    timestamp: new Date().toISOString(),
+  };
   try {
-    await redis.set(
-      'TRIPWIRE_STATE',
-      JSON.stringify({
-        cycleId: currentCycleId(),
-        tripwireCount: activeTripwires,
-        elevated: activeTripwires > 0,
-        timestamp: new Date().toISOString(),
-      }),
-    );
+    await redis.set('TRIPWIRE_STATE', JSON.stringify(payload));
+    await kvSet(KV_KEYS.TRIPWIRE_STATE_KV, payload, 3600);
   } catch (error) {
     console.error('[tripwire] TRIPWIRE_STATE write failed', error);
   }

--- a/app/terminal/GlobePageClient.tsx
+++ b/app/terminal/GlobePageClient.tsx
@@ -12,7 +12,13 @@ export default function GlobePageClient() {
 
   const integrity = (snapshot?.integrity?.data ?? {}) as { cycle?: string; global_integrity?: number };
   const micro = (snapshot?.signals?.data ?? null) as MicroAgentSweepResult | null;
-  const echo = (snapshot?.epicon?.data ?? {}) as { items?: EpiconItem[] };
+  const epiconLane = (snapshot?.epicon?.data ?? {}) as { items?: EpiconItem[] };
+  const echoLane = (snapshot?.echo?.data ?? {}) as { epicon?: EpiconItem[] };
+  const byId = new Map<string, EpiconItem>();
+  for (const row of [...(echoLane.epicon ?? []), ...(epiconLane.items ?? [])]) {
+    if (row?.id) byId.set(row.id, row);
+  }
+  const echoEpicon = [...byId.values()];
   const sentiment = (snapshot?.sentiment?.data ?? {}) as {
     domains?: Array<{ key: 'civic' | 'environ' | 'financial' | 'narrative' | 'infrastructure' | 'institutional'; label: string; agent: string; score: number | null }>;
   };
@@ -29,7 +35,7 @@ export default function GlobePageClient() {
   return (
     <GlobeChamber
       micro={micro}
-      echoEpicon={echo.items ?? []}
+      echoEpicon={echoEpicon}
       domains={domains}
       cycleId={integrity.cycle ?? 'C-271'}
       clockLabel={`${new Date().toISOString().slice(11, 16)} UTC`}

--- a/app/terminal/journal/JournalPageClient.tsx
+++ b/app/terminal/journal/JournalPageClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import ChamberEmptyState from '@/components/terminal/ChamberEmptyState';
 import ChamberSkeleton from '@/components/terminal/ChamberSkeleton';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
 
 const AGENTS = ['ATLAS', 'ZEUS', 'EVE', 'AUREA', 'HERMES', 'JADE', 'DAEDALUS', 'ECHO'] as const;
 
@@ -59,6 +60,7 @@ function toDerivedEntry(item: EpiconItem): JournalEntry {
 export default function JournalPageClient() {
   const [entries, setEntries] = useState<JournalEntry[] | null>(null);
   const [agent, setAgent] = useState('ALL');
+  const [cycleTab, setCycleTab] = useState<string>(() => currentCycleId());
   const [derivedMode, setDerivedMode] = useState(false);
 
   useEffect(() => {
@@ -113,10 +115,44 @@ export default function JournalPageClient() {
     () => ['ALL', ...Array.from(new Set((entries ?? []).map((e) => e.agent))).sort()],
     [entries],
   );
-  const filtered = useMemo(
-    () => (agent === 'ALL' ? entries ?? [] : (entries ?? []).filter((e) => e.agent === agent)),
-    [entries, agent],
-  );
+
+  const cycleOptions = useMemo(() => {
+    const set = new Set<string>();
+    for (const e of entries ?? []) {
+      const c = e.cycle?.trim();
+      if (c) set.add(c);
+    }
+    const list = Array.from(set).sort((a, b) => {
+      const na = parseInt(a.replace(/\D/g, ''), 10);
+      const nb = parseInt(b.replace(/\D/g, ''), 10);
+      if (Number.isFinite(na) && Number.isFinite(nb) && na !== nb) return nb - na;
+      return b.localeCompare(a);
+    });
+    const current = currentCycleId();
+    if (!list.includes(current)) list.unshift(current);
+    return ['All', ...list];
+  }, [entries]);
+
+  const cycleCounts = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const e of entries ?? []) {
+      const c = e.cycle?.trim();
+      if (!c) continue;
+      m.set(c, (m.get(c) ?? 0) + 1);
+    }
+    return m;
+  }, [entries]);
+
+  const filtered = useMemo(() => {
+    let rows = entries ?? [];
+    if (cycleTab !== 'All') {
+      rows = rows.filter((e) => (e.cycle?.trim() ?? '') === cycleTab);
+    }
+    if (agent !== 'ALL') {
+      rows = rows.filter((e) => e.agent === agent);
+    }
+    return rows;
+  }, [entries, agent, cycleTab]);
 
   if (entries === null) return <ChamberSkeleton blocks={8} />;
 
@@ -148,6 +184,26 @@ export default function JournalPageClient() {
         </div>
       ) : (
         <>
+          <div className="mb-2 flex gap-2 overflow-x-auto pb-1">
+            {cycleOptions.map((c) => {
+              const count = c === 'All' ? (entries?.length ?? 0) : (cycleCounts.get(c) ?? 0);
+              const label = c === 'All' ? `All (${count})` : `${c} (${count})`;
+              return (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => setCycleTab(c)}
+                  className={`whitespace-nowrap rounded border px-2 py-1 text-xs ${
+                    cycleTab === c
+                      ? 'border-violet-400/60 bg-violet-500/10 text-violet-100'
+                      : 'border-slate-700 text-slate-400'
+                  }`}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
           <div className="mb-3 flex gap-2 overflow-x-auto pb-1">
             {agents.map((name) => (
               <button

--- a/app/terminal/sentinel/SentinelPageClient.tsx
+++ b/app/terminal/sentinel/SentinelPageClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import ChamberSkeleton from '@/components/terminal/ChamberSkeleton';
 import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
 
 type Agent = { id: string; name: string; role: string; status: string; lastAction?: string; tier?: string; mii_avg?: number };
 type JournalEntry = { id: string; observation?: string; cycle?: string };
@@ -55,7 +56,7 @@ const AGENT_COLORS: Record<string, string> = {
 export default function SentinelPageClient() {
   const { snapshot, loading } = useTerminalSnapshot();
   const [expanded, setExpanded] = useState<string | null>(null);
-  const [journal, setJournal] = useState<JournalEntry[]>([]);
+  const [journalByAgent, setJournalByAgent] = useState<Record<string, JournalEntry[]>>({});
   const [miiData, setMiiData] = useState<Record<string, MiiEntry[]>>({});
 
   useEffect(() => {
@@ -75,6 +76,29 @@ export default function SentinelPageClient() {
   if (loading && !snapshot) return <ChamberSkeleton blocks={8} />;
 
   const agents = (snapshot?.agents?.data ?? {}) as { agents?: Agent[] };
+  const eveData = (snapshot?.eve?.data ?? {}) as Record<string, unknown>;
+  const currentCycle =
+    typeof eveData.currentCycle === 'string'
+      ? eveData.currentCycle
+      : typeof eveData.cycleId === 'string'
+        ? eveData.cycleId
+        : currentCycleId();
+
+  useEffect(() => {
+    void fetch('/api/agents/journal?limit=100', { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((json: { entries?: JournalEntry[] }) => {
+        const grouped: Record<string, JournalEntry[]> = {};
+        for (const e of json.entries ?? []) {
+          const a = (e as { agent?: string }).agent;
+          if (!a) continue;
+          if (!grouped[a]) grouped[a] = [];
+          grouped[a]!.push(e);
+        }
+        setJournalByAgent(grouped);
+      })
+      .catch(() => setJournalByAgent({}));
+  }, []);
 
   const handleExpand = async (name: string) => {
     if (expanded === name) {
@@ -82,17 +106,6 @@ export default function SentinelPageClient() {
       return;
     }
     setExpanded(name);
-
-    const [journalResult] = await Promise.allSettled([
-      fetch(`/api/agents/journal?agent=${encodeURIComponent(name)}&limit=5`, { cache: 'no-store' })
-        .then((r) => r.json())
-        .catch(() => ({ entries: [] })),
-    ]);
-
-    if (journalResult.status === 'fulfilled') {
-      setJournal((journalResult.value.entries ?? []) as JournalEntry[]);
-    }
-
   };
 
   const latestByAgent = useMemo(() => {
@@ -106,13 +119,26 @@ export default function SentinelPageClient() {
   return (
     <div className="h-full overflow-y-auto p-4">
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-        {(agents.agents ?? []).map((agent) => (
+        {(agents.agents ?? []).map((agent) => {
+          const rows = journalByAgent[agent.name] ?? [];
+          const latestCycle = rows[0]?.cycle?.trim() || null;
+          const journalFresh = latestCycle === currentCycle;
+          return (
           <button key={agent.id} onClick={() => void handleExpand(agent.name)} className="rounded border border-slate-800 bg-slate-900/60 p-4 text-left">
             <div className="flex items-center justify-between">
               <div className="text-sm font-semibold">
                 {agent.name} <span className="text-cyan-300">{(latestByAgent[agent.name] ?? 0.9).toFixed(3)}</span>
               </div>
-              <span className={`h-2 w-2 rounded-full ${agent.status === 'active' ? 'bg-emerald-400' : 'bg-amber-400'}`} />
+              <div className="flex items-center gap-2">
+                <span
+                  className="flex items-center gap-1 text-[10px] text-slate-500"
+                  title="Latest committed journal cycle"
+                >
+                  <span className={`h-1.5 w-1.5 rounded-full ${journalFresh ? 'bg-emerald-400' : 'bg-slate-500'}`} />
+                  {journalFresh ? currentCycle : latestCycle ?? '—'}
+                </span>
+                <span className={`h-2 w-2 rounded-full ${agent.status === 'active' ? 'bg-emerald-400' : 'bg-amber-400'}`} />
+              </div>
             </div>
             <div className="text-xs text-slate-400">{agent.role} · {agent.tier ?? '—'}</div>
             <div className="mt-2 text-xs text-slate-500">{agent.lastAction ?? 'No action yet.'}</div>
@@ -128,12 +154,13 @@ export default function SentinelPageClient() {
               )}
             </div>
           </button>
-        ))}
+          );
+        })}
       </div>
       {expanded ? (
         <div className="mt-4 rounded border border-slate-800 bg-slate-900/60 p-3">
           <div className="mb-2 text-xs font-mono text-slate-400">{expanded} journal entries</div>
-          {journal.map((entry) => (
+          {(journalByAgent[expanded] ?? []).slice(0, 5).map((entry) => (
             <div key={entry.id} className="mb-2 text-xs text-slate-300">[{entry.cycle ?? 'C-—'}] {entry.observation ?? '—'}</div>
           ))}
         </div>

--- a/components/terminal/chambers/GlobeView3D.tsx
+++ b/components/terminal/chambers/GlobeView3D.tsx
@@ -48,6 +48,7 @@ function latLngToXYZ(THREE: any, lat: number, lng: number, r = 1.015) {
   );
 }
 function severityColor(pin: GlobePin): number {
+  if (pin.palette === 'seismic') return 0xa855f7;
   if (pin.palette === 'epicon') return 0x22d3ee;
   const sev = pin.severity;
   if (sev === 'critical') return 0xef4444;
@@ -397,7 +398,11 @@ export default function GlobeView3D({
     for (const sig of pins) {
       const pos = latLngToXYZ(THREE, sig.lat, sig.lng);
       const color = severityColor(sig);
-      const stemGeo = new THREE.CylinderGeometry(0.003, 0.003, 0.06, 6);
+      const magMeta = sig.meta.magnitude ?? sig.meta.mag;
+      const mag = typeof magMeta === 'number' && Number.isFinite(magMeta) ? magMeta : null;
+      const headScale =
+        sig.palette === 'seismic' && mag !== null ? 0.85 + Math.min(0.65, Math.max(0, mag - 4.5) * 0.35) : 1;
+      const stemGeo = new THREE.CylinderGeometry(0.003, 0.003, 0.06 * headScale, 6);
       const stemMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.7 });
       const stem = new THREE.Mesh(stemGeo, stemMat);
       stem.position.copy(pos.clone().multiplyScalar(0.97));
@@ -405,7 +410,7 @@ export default function GlobeView3D({
       stem.rotateX(Math.PI / 2);
       st.globe.add(stem);
       st.pinMeshes.push(stem);
-      const headGeo = new THREE.SphereGeometry(0.018, 8, 8);
+      const headGeo = new THREE.SphereGeometry(0.018 * headScale, 8, 8);
       const headMat = new THREE.MeshBasicMaterial({ color });
       const head = new THREE.Mesh(headGeo, headMat);
       head.position.copy(pos.clone().multiplyScalar(1.04));

--- a/components/terminal/chambers/WorldMapView.tsx
+++ b/components/terminal/chambers/WorldMapView.tsx
@@ -119,12 +119,18 @@ export default function WorldMapView({ micro = null, echoEpicon = [], cycleId = 
         {pins.map((pin) => {
           const x = ((pin.lng + 180) / 360) * MAP_WIDTH;
           const y = ((90 - pin.lat) / 180) * MAP_HEIGHT;
+          const magRaw = pin.meta.magnitude ?? pin.meta.mag;
+          const mag = typeof magRaw === 'number' && Number.isFinite(magRaw) ? magRaw : null;
+          const scale = pin.palette === 'seismic' && mag !== null ? 0.85 + Math.min(0.9, Math.max(0, mag - 4.5) * 0.4) : 1;
+          const rOuter = 7 * scale;
+          const rInner = 4 * scale;
           const tone = pinTone(`${pin.title} ${pin.severity}`);
-          const color = WORLD_STATE_THEME.signal[tone];
+          const color =
+            pin.palette === 'seismic' ? '#a855f7' : WORLD_STATE_THEME.signal[tone];
           return (
             <g key={pin.id}>
-              <circle cx={x} cy={y} r={7} fill={color} fillOpacity="0.14" />
-              <circle cx={x} cy={y} r={4} fill={color} fillOpacity="0.95" />
+              <circle cx={x} cy={y} r={rOuter} fill={color} fillOpacity="0.14" />
+              <circle cx={x} cy={y} r={rInner} fill={color} fillOpacity="0.95" />
             </g>
           );
         })}

--- a/lib/agents/sentinel-cycle-journals.ts
+++ b/lib/agents/sentinel-cycle-journals.ts
@@ -1,0 +1,114 @@
+/**
+ * ATLAS / ZEUS scheduled journal writes after EVE cycle synthesis (C-280).
+ */
+
+import { appendAgentJournalEntry } from '@/lib/agents/journal';
+import { loadSignalSnapshot } from '@/lib/kv/store';
+import type { AgentJournalEntry } from '@/lib/terminal/types';
+
+export type CronSentinelSource = 'cron' | 'post-eve-synthesis';
+
+export type AtlasObserveInput = {
+  cycle: string;
+  gi: number;
+  source: CronSentinelSource;
+};
+
+export type ZeusVerifyCronInput = {
+  cycle: string;
+  gi: number;
+  atlasEntry?: string | null;
+  source: CronSentinelSource;
+};
+
+function clampGi(n: number): number {
+  if (!Number.isFinite(n)) return 0.74;
+  return Math.max(0, Math.min(1, n));
+}
+
+export async function summarizeMicroAnomalies(): Promise<{ count: number; labels: string[] }> {
+  const snap = await loadSignalSnapshot();
+  if (!snap?.allSignals?.length) {
+    return { count: typeof snap?.anomalies === 'number' ? snap.anomalies : 0, labels: [] };
+  }
+  const hot = snap.allSignals.filter((s) => {
+    const sev = String(s.severity).toLowerCase();
+    return sev === 'critical' || sev === 'elevated' || sev === 'watch';
+  });
+  const count = typeof snap.anomalies === 'number' ? snap.anomalies : hot.length;
+  const labels = hot.slice(0, 6).map((s) => `${s.agentName}: ${s.label}`);
+  return { count, labels };
+}
+
+export async function appendAtlasCronJournal(input: AtlasObserveInput): Promise<AgentJournalEntry> {
+  const { count, labels } = await summarizeMicroAnomalies();
+  const gi = clampGi(input.gi);
+  const labelText = labels.length > 0 ? labels.join('; ') : 'No elevated micro-agent anomalies in cached signal snapshot.';
+
+  return appendAgentJournalEntry({
+    agent: 'ATLAS',
+    cycle: input.cycle,
+    observation: `ATLAS cycle observation (${input.source}) for ${input.cycle}. Micro snapshot anomalies: ${count}.`,
+    inference: `Signal surface review complete. ${labelText}`,
+    recommendation:
+      count > 0
+        ? 'Prioritize corroboration on flagged micro-agent lanes and ensure ZEUS verification queue stays current.'
+        : 'Maintain standard verification cadence; continue monitoring governance synthesis outputs.',
+    confidence: Number((0.88 + gi * 0.08).toFixed(4)),
+    derivedFrom: ['signal-snapshot:kv', `eve-synthesis:${input.cycle}`, `source:${input.source}`],
+    relatedAgents: ['EVE', 'ZEUS'],
+    status: 'committed',
+    category: 'observation',
+    severity: count > 4 ? 'elevated' : 'nominal',
+  });
+}
+
+export async function appendZeusCronJournal(input: ZeusVerifyCronInput): Promise<AgentJournalEntry> {
+  const gi = clampGi(input.gi);
+  const atlasRef = input.atlasEntry?.trim() ? input.atlasEntry.trim() : 'pending';
+
+  return appendAgentJournalEntry({
+    agent: 'ZEUS',
+    cycle: input.cycle,
+    observation: `ZEUS verification pass (${input.source}) after EVE cycle synthesis for ${input.cycle}. ATLAS journal reference: ${atlasRef}.`,
+    inference:
+      gi >= 0.72
+        ? 'Global integrity within operational band; governance synthesis and ledger commits may proceed under standard gates.'
+        : 'Global integrity stressed; tighten promotion gates and require explicit ATLAS review on contested EPICONs.',
+    recommendation:
+      'Continue ledger attestation with AGENT_SERVICE_TOKEN present; escalate contested rows before broad promotion.',
+    confidence: Number((0.85 + gi * 0.06).toFixed(4)),
+    derivedFrom: ['eve-synthesis:verify', `atlas-journal:${atlasRef}`, `source:${input.source}`],
+    relatedAgents: ['EVE', 'ATLAS'],
+    status: 'committed',
+    category: 'inference',
+    severity: gi < 0.72 ? 'elevated' : 'nominal',
+    verifiedBy: 'ZEUS',
+  });
+}
+
+export function parseAtlasObserveBody(body: unknown): AtlasObserveInput | null {
+  if (body === null || typeof body !== 'object') return null;
+  const o = body as Record<string, unknown>;
+  const cycle = typeof o.cycle === 'string' && o.cycle.trim() ? o.cycle.trim() : null;
+  const giRaw = o.gi;
+  const gi = typeof giRaw === 'number' && Number.isFinite(giRaw) ? giRaw : 0.74;
+  const sourceRaw = o.source;
+  const source: CronSentinelSource = sourceRaw === 'cron' ? 'cron' : 'post-eve-synthesis';
+  if (!cycle) return null;
+  return { cycle, gi, source };
+}
+
+export function parseZeusCronBody(body: unknown): ZeusVerifyCronInput | null {
+  if (body === null || typeof body !== 'object') return null;
+  const o = body as Record<string, unknown>;
+  const cycle = typeof o.cycle === 'string' && o.cycle.trim() ? o.cycle.trim() : null;
+  const giRaw = o.gi;
+  const gi = typeof giRaw === 'number' && Number.isFinite(giRaw) ? giRaw : 0.74;
+  const atlasEntry = typeof o.atlasEntry === 'string' ? o.atlasEntry : null;
+  const sourceRaw = o.source;
+  const source: CronSentinelSource = sourceRaw === 'cron' ? 'cron' : 'post-eve-synthesis';
+  if (!cycle) return null;
+  return { cycle, gi, atlasEntry, source };
+}
+

--- a/lib/echo/kv-persist-ingest.ts
+++ b/lib/echo/kv-persist-ingest.ts
@@ -1,0 +1,154 @@
+/**
+ * Persist ECHO ingest side-effects to Upstash (ECHO_STATE, epicon:feed, mii:feed).
+ * Used by POST /api/echo/ingest and stale GET /api/echo/feed so cold starts still populate KV.
+ */
+
+import { Redis } from '@upstash/redis';
+import type { IngestResult } from '@/lib/echo/transform';
+import { getEchoStatus } from '@/lib/echo/store';
+import { saveEchoState, loadGIState, kvSet, KV_KEYS } from '@/lib/kv/store';
+import { readMiiFeed, type MiiEntry } from '@/lib/kv/mii';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
+
+type KvEpiconEntry = {
+  id: string;
+  timestamp: string;
+  author: string;
+  title: string;
+  type: 'epicon';
+  severity: 'nominal' | 'elevated' | 'critical' | 'degraded' | 'info';
+  source: 'kv-ledger';
+  tags: string[];
+  verified: boolean;
+};
+
+function getRedisClient(): Redis | null {
+  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  try {
+    return new Redis({ url, token });
+  } catch {
+    return null;
+  }
+}
+
+function toFeedSeverity(confidenceTier: number): KvEpiconEntry['severity'] {
+  if (confidenceTier >= 3) return 'critical';
+  if (confidenceTier >= 2) return 'elevated';
+  if (confidenceTier >= 1) return 'nominal';
+  return 'info';
+}
+
+function toFeedTimestamp(rawTimestamp: string): string {
+  const ts = new Date(rawTimestamp);
+  if (Number.isNaN(ts.getTime())) return new Date().toISOString();
+  return ts.toISOString();
+}
+
+export async function flushEpiconFeedToKv(entries: KvEpiconEntry[]): Promise<void> {
+  const redis = getRedisClient();
+  if (!redis || entries.length === 0) return;
+  try {
+    const payload = entries.map((entry) => JSON.stringify(entry));
+    await redis.lpush('epicon:feed', ...payload);
+    await redis.ltrim('epicon:feed', 0, 99);
+    console.log('[echo] epicon:feed LPUSH', { count: entries.length });
+  } catch (error) {
+    console.error('[echo] epicon feed flush failed:', error);
+  }
+}
+
+export async function writeEchoKvHeartbeatToMobius(
+  status: ReturnType<typeof getEchoStatus>,
+  healthy = true,
+): Promise<void> {
+  const now = new Date().toISOString();
+  const payload = {
+    cycleId: currentCycleId(),
+    lastIngest: now,
+    totalIngested: status.totalIngested,
+    duplicateSuppressed: status.duplicateSuppressedCount,
+    healthy,
+    timestamp: now,
+  };
+  try {
+    console.log('[ECHO] writing ECHO_STATE...');
+    await kvSet(KV_KEYS.ECHO_STATE_KV, payload, 7200);
+  } catch (error) {
+    console.error('[echo] ECHO_STATE KV heartbeat failed:', error);
+  }
+}
+
+async function writeMiiFeedBatch(entries: MiiEntry[]): Promise<void> {
+  const redis = getRedisClient();
+  if (!redis || entries.length === 0) return;
+  try {
+    const packed = entries.map((entry) => JSON.stringify(entry));
+    await Promise.all(entries.map((entry) => redis.set(`mii:${entry.agent.toUpperCase()}:${entry.cycle}`, JSON.stringify(entry))));
+    await redis.lpush('mii:feed', ...packed);
+    await redis.ltrim('mii:feed', 0, 199);
+  } catch (error) {
+    console.error('[echo] mii batch write failed:', error);
+  }
+}
+
+/**
+ * After pushIngestResult(result): KV heartbeat, echo:state summary, epicon feed, MII batch.
+ */
+export async function persistEchoIngestSideEffects(result: IngestResult): Promise<void> {
+  const status = getEchoStatus();
+  await writeEchoKvHeartbeatToMobius(status);
+  const dedupDenominator = Math.max(1, status.totalIngested + status.duplicateSuppressedCount);
+  const dedupRate = Number((status.duplicateSuppressedCount / dedupDenominator).toFixed(3));
+  await saveEchoState({
+    lastIngest: status.lastIngest,
+    cycleId: status.cycleId,
+    totalIngested: status.totalIngested,
+    healthy: true,
+    epiconCount: status.counts.epicon,
+    ledgerCount: status.counts.ledger,
+    alertCount: status.counts.alerts,
+    timestamp: new Date().toISOString(),
+    dedupRate,
+  }).catch(() => {});
+
+  const kvFeedEntries: KvEpiconEntry[] = result.epicon.map((entry) => ({
+    id: entry.id,
+    timestamp: toFeedTimestamp(entry.timestamp),
+    author: entry.ownerAgent,
+    title: entry.title,
+    type: 'epicon',
+    severity: entry.status === 'contradicted' ? 'degraded' : toFeedSeverity(entry.confidenceTier),
+    source: 'kv-ledger',
+    tags: entry.sources,
+    verified: entry.status === 'verified',
+  }));
+  await flushEpiconFeedToKv(kvFeedEntries);
+
+  try {
+    const giState = await loadGIState();
+    const currentGi = Number((giState?.global_integrity ?? 0.74).toFixed(4));
+    const miiTimestamp = new Date().toISOString();
+    const agentAverages = result.integrity.agentAverages;
+    const agents = ['ATLAS', 'ZEUS', 'JADE', 'EVE'] as const;
+    const recentFeed = await readMiiFeed();
+    const lastKnown: Record<string, number> = {};
+    for (const entry of recentFeed) {
+      if (!(entry.agent in lastKnown)) {
+        lastKnown[entry.agent] = entry.mii;
+      }
+    }
+    const batch: MiiEntry[] = agents.map((agent) => ({
+      agent,
+      mii: Number((typeof agentAverages[agent] === 'number' ? agentAverages[agent] : (lastKnown[agent] ?? 0.9)).toFixed(4)),
+      gi: currentGi,
+      cycle: result.cycleId,
+      timestamp: miiTimestamp,
+      source: 'live',
+    }));
+    await writeMiiFeedBatch(batch);
+  } catch (err) {
+    console.error('[echo] mii write failed:', err instanceof Error ? err.message : err);
+  }
+}

--- a/lib/integrity/buildStatus.ts
+++ b/lib/integrity/buildStatus.ts
@@ -157,3 +157,39 @@ export async function getLiveIntegritySnapshot(): Promise<{ global_integrity: nu
   const p = await computeIntegrityPayload();
   return { global_integrity: p.global_integrity, mii_baseline: p.mii_baseline };
 }
+
+/**
+ * Recompute GI from in-process heartbeat + ECHO store and persist to KV (C-280 cron).
+ * Bypasses KV read cache so freshness signal updates on a schedule.
+ */
+export async function recomputeAndSaveGIState(): Promise<GIState | null> {
+  if (!isRedisAvailable()) return null;
+
+  const freshness = getStalenessStatus(getHeartbeat());
+  const tripwire = getTripwireState();
+  const signalData = resolveSignalQuality();
+
+  const effectiveFreshness =
+    signalData.source === 'mock' && freshness.status === 'fresh' ? ('degraded' as const) : freshness.status;
+
+  const computed = computeGI({
+    zeusScores: signalData.scores,
+    freshness: effectiveFreshness,
+    tripwire: normalizeTripwireLevel(tripwire.level),
+    activeAgents: resolveActiveAgentCount(),
+  });
+
+  const source: 'live' | 'mock' | 'cached' = signalData.source;
+
+  const giState: GIState = {
+    global_integrity: computed.global_integrity,
+    mode: computed.mode,
+    terminal_status: computed.terminal_status,
+    primary_driver: computed.primary_driver,
+    source,
+    signals: computed.signals,
+    timestamp: computed.timestamp,
+  };
+  await saveGIState(giState);
+  return giState;
+}

--- a/lib/kv/store.ts
+++ b/lib/kv/store.ts
@@ -148,8 +148,15 @@ export const KV_KEYS = {
   GI_STATE: 'gi:latest',
   /** ECHO store state (epicon, ledger, alerts) */
   ECHO_STATE: 'echo:state',
+  /**
+   * ECHO ingest heartbeat — mirrors legacy `ECHO_STATE` string key checks in ops tooling.
+   * Written alongside `echo:state` on each ingest.
+   */
+  ECHO_STATE_KV: 'echo:kv:heartbeat',
   /** Tripwire state */
   TRIPWIRE_STATE: 'tripwire:state',
+  /** Tripwire heartbeat for KV key-exists diagnostics (mirrors legacy TRIPWIRE_STATE string key) */
+  TRIPWIRE_STATE_KV: 'tripwire:kv:heartbeat',
   /** Last heartbeat timestamp */
   HEARTBEAT: 'heartbeat:last',
   /** Last ingest timestamp */

--- a/lib/terminal/globePins.ts
+++ b/lib/terminal/globePins.ts
@@ -27,7 +27,7 @@ export type GlobePin = {
   provenance: string;
   narrativeWhy: string;
   visualAsset?: GlobeVisualAsset | null;
-  palette?: 'default' | 'epicon';
+  palette?: 'default' | 'epicon' | 'seismic';
 };
 
 export type SentimentDomainKey =
@@ -334,12 +334,19 @@ export function buildGlobePinsFromMicro(
     if (!ingest) continue;
     const src = ingest.source;
     const meta = ingest.metadata ?? {};
+    const magRaw = meta.magnitude;
+    const magnitude = typeof magRaw === 'number' && Number.isFinite(magRaw) ? magRaw : null;
+    const isUsgsQuake = src === 'USGS' && magnitude !== null && magnitude >= 4.5;
     const metaLat = typeof meta.lat === 'number' ? meta.lat : null;
     const metaLng = typeof meta.lng === 'number' ? meta.lng : null;
     let lat: number;
     let lng: number;
-    let palette: 'default' | 'epicon' = 'default';
-    if (metaLat !== null && metaLng !== null) {
+    let palette: 'default' | 'epicon' | 'seismic' = 'default';
+    if (isUsgsQuake && metaLat !== null && metaLng !== null) {
+      lat = metaLat;
+      lng = metaLng;
+      palette = 'seismic';
+    } else if (metaLat !== null && metaLng !== null) {
       lat = metaLat;
       lng = metaLng;
       palette = 'epicon';
@@ -360,30 +367,49 @@ export function buildGlobePinsFromMicro(
     const id = `echo-${item.id}`;
     const echoSev = echoSeverityToGlobe(ingest.severity);
     const change = typeof meta.change24h === 'number' ? meta.change24h : 0;
-    const value = Math.max(0, Math.min(1, 1 - Math.min(1, Math.abs(change) / 12)));
+    const value =
+      isUsgsQuake && magnitude !== null
+        ? Math.max(0, Math.min(1, (magnitude - 4) / 2))
+        : Math.max(0, Math.min(1, 1 - Math.min(1, Math.abs(change) / 12)));
 
     const agent = item.ownerAgent ?? 'ECHO';
 
     const echoTs = parseEpiconTimestamp(item.timestamp);
 
+    const pinSev: GlobePinSeverity =
+      isUsgsQuake && magnitude !== null
+        ? magnitude >= 5.5
+          ? 'critical'
+          : magnitude >= 5
+            ? 'elevated'
+            : 'nominal'
+        : echoSev;
+
     pushPin(pins, seen, {
       id,
       lat,
       lng,
-      source: `${agent} · ${src}`,
-      title,
+      source: isUsgsQuake ? `SEISMIC · EPICON · ${agent}` : `${agent} · ${src}`,
+      title: isUsgsQuake && magnitude !== null ? `M${magnitude.toFixed(1)} · ${title}` : title,
       value,
-      confidence: Math.min(1, 0.4 + Math.abs(change) / 15),
-      severity: echoSev,
+      confidence: isUsgsQuake && magnitude !== null ? Math.min(1, 0.5 + magnitude / 10) : Math.min(1, 0.4 + Math.abs(change) / 15),
+      severity: pinSev,
       agent,
       domainKey: sourceDomain(src),
       palette,
       signalTimestamp: echoTs,
-      provenance: 'CoinGecko · ECHO ingest · EPICON pipeline',
-      narrativeWhy: 'Market pulse on financial lane — ECHO routes to HERMES narrative coupling.',
+      provenance: isUsgsQuake
+        ? 'USGS · ECHO EPICON ingest (seismic layer)'
+        : 'CoinGecko · ECHO ingest · EPICON pipeline',
+      narrativeWhy: isUsgsQuake
+        ? 'Seismic EPICON with coordinates — verify civic and infrastructure coupling in the Pacific Rim and adjacent corridors.'
+        : 'Market pulse on financial lane — ECHO routes to HERMES narrative coupling.',
+      clusterKey: isUsgsQuake ? 'seismic_epicon' : undefined,
+      clusterLabel: isUsgsQuake ? 'SEISMIC · EPICON' : undefined,
       meta: {
         ...flattenRaw(meta),
         epiconId: item.id,
+        layer: isUsgsQuake ? 'SEISMIC · EPICON' : 'ECHO EPICON',
         ledger: 'ECHO EPICON row (see Events chamber)',
         freshnessSec: Math.max(0, Math.floor((Date.now() - new Date(echoTs).getTime()) / 1000)),
       },

--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,10 @@
     {
       "path": "/api/cron/promote",
       "schedule": "30 0 * * *"
+    },
+    {
+      "path": "/api/cron/gi-refresh",
+      "schedule": "*/30 * * * *"
     }
   ],
   "installCommand": "pnpm install --no-frozen-lockfile"

--- a/vercel.json
+++ b/vercel.json
@@ -20,7 +20,7 @@
     },
     {
       "path": "/api/cron/gi-refresh",
-      "schedule": "*/30 * * * *"
+      "schedule": "45 0 * * *"
     }
   ],
   "installCommand": "pnpm install --no-frozen-lockfile"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR implements the C-280 optimization batch: overnight ATLAS and ZEUS journal writes after EVE cycle synthesis, durable ECHO ingest side-effects (including when `/api/echo/feed` re-ingests on stale traffic), KV health visibility for ECHO/TRIPWIRE heartbeats, clearer promotion failure behavior when the agent token is missing, a daily GI refresh cron (Hobby-compatible: `45 0 * * *` UTC; sub-daily requires Pro), journal cycle tabs, seismic EPICON pins on the globe/map, and Sentinel journal-recency indicators. `CURRENT_CYCLE.md` is updated to C-280 ground truth.

## Details

- **Opt 1:** After Vercel cron (and authenticated POST) on `/api/eve/cycle-synthesize`, the handler fans out to `POST /api/agents/atlas/observe` then `POST /api/agents/zeus/verify` with service `Authorization` when configured. Both routes append KV journals (`journal:{AGENT}:{CYCLE}`) and write MII rows.
- **Opt 2 / 5:** `lib/echo/kv-persist-ingest.ts` centralizes ECHO_STATE-style heartbeat (`kvSet` on `ECHO_STATE_KV`), `saveEchoState`, `epicon:feed` LPUSH (with log), and the MII batch. `/api/echo/feed` calls this after stale re-ingest so KV is not stuck at zero when only the feed path runs.
- **Opt 3:** Promotion skips `pushLedgerEntry` / substrate when `AGENT_SERVICE_TOKEN` and `RENDER_API_KEY` are both empty, with an explicit error log (Vercel must still set the token for real commits).
- **Opt 4:** ATLAS and ZEUS MII entries are written from the new sentinel routes; ECHO ingest still batches all four agents.
- **Opt 6:** `GET /api/cron/gi-refresh` runs `runSignalEngine` then `recomputeAndSaveGIState()`. **Vercel Hobby:** scheduled once daily at `45 0 * * *` UTC (after synthesis/promote). For 30-minute refresh, use Pro or an external scheduler hitting the same route with cron auth.
- **Opt 7–9:** Journal cycle tabs (default current cycle), merged echo+epicon EPICONs for globe pins, USGS M4.5+ seismic layer (violet, magnitude-scaled), Sentinel cards show latest journal cycle vs snapshot cycle.
- **Opt 10:** `CURRENT_CYCLE.md` refreshed for C-280.

## Locked behaviors

- Journal key schema unchanged (`journal:{AGENT}:{CYCLE}`).
- EPICON LPUSH/LTRIM to `epicon:feed` preserved; only factored into a shared helper.
- MII entry shape and GI weighting unchanged.

## Tests

- `pnpm exec tsc --noEmit` — pass
- `pnpm build` — pass
- `pnpm lint` — fails: `next lint` prompts for interactive ESLint setup (no project ESLint config); not run to completion

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-636b1cfd-9101-4d42-b374-addadfac770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-636b1cfd-9101-4d42-b374-addadfac770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

