### PR TITLE
fix(epicon): promoter must not mark promoted without successful commits (C-281 Opt 1)

### DIFF
--- a/app/api/epicon/promote/route.ts
+++ b/app/api/epicon/promote/route.ts
@@ -322,6 +322,8 @@ async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: stri
     existing.assigned_agents = assignedAgents;
     existing.last_attempt_at = nowIso;
 
+    let anyCommitSucceeded = false;
+
     try {
       for (const agent of assignedAgents) {
         const alreadyCommitted = existing.committed_entries.some((entryId) => entryId.includes(`-${agent}-`));
@@ -329,6 +331,7 @@ async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: stri
 
         const commit = buildCommit(agent, epicon, cycleId, seq++);
         try {
+          console.info('[promoter] attempting commit for', epicon.id, 'agent', agent);
           if (!ledgerReady) {
             throw new Error('AGENT_SERVICE_TOKEN not configured');
           }
@@ -354,14 +357,25 @@ async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: stri
           });
           existing.committed_entries.push(commit.id);
           committed += 1;
+          anyCommitSucceeded = true;
         } catch (err) {
           console.error('[promoter] failed to commit', epicon.id, err);
           failedCommits += 1;
         }
       }
-      existing.promotion_state = 'promoted';
-      promoted += 1;
-      promotedIdsThisCycle.push(epicon.id);
+      const allAgentsSatisfied = assignedAgents.every((agent) =>
+        existing.committed_entries.some((entryId) => entryId.includes(`-${agent}-`)),
+      );
+
+      if (anyCommitSucceeded || allAgentsSatisfied) {
+        existing.promotion_state = 'promoted';
+        promoted += 1;
+        promotedIdsThisCycle.push(epicon.id);
+      } else {
+        existing.promotion_state = ledgerReady ? 'failed' : 'pending';
+        existing.failed_attempts += 1;
+        failed += 1;
+      }
     } catch {
       existing.promotion_state = 'failed';
       existing.failed_attempts += 1;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 1. Summary

- **Cycle:** C-281
- **Type:** fix
- **Primary area:** epicon / ledger promotion
- **Files changed:** `app/api/epicon/promote/route.ts`
- **Files deliberately NOT changed:** promotion KV key schema (`lib/epicon/promotion.ts`), EPICON feed ingest paths, substrate client auth

**What changed?** The promotion cycle now marks an EPICON as `promoted` only when at least one ledger commit succeeds **or** every assigned agent already has a matching commit id in `committed_entries`. If the service token is missing (ledger not ready), each run increments `failed_attempts`, sets state to `pending`, and logs each attempted commit instead of silently leaving `failed_attempts` at 0 while showing `promoted`.

**Why?** C-281 Opt 1: eligible EPICONs showed `failed_attempts: 0` while never attempting commits when `AGENT_SERVICE_TOKEN` was absent, and state could read as promoted without any ledger work—blocking honest retries and hiding misconfiguration.

---

## 2. Risk Tier

- [ ] Tier 0
- [x] **Tier 1** — App logic in promotion route; no new KV keys; promotion state values still use existing union (pending path uses same string as default)

---

## 3. EPICON Intent

```text
epicon_id: EPICON_C-281_epicon_promoter_truth
scope: epicon-promotion
mode: normal

justification:
  PROBLEM:
    Promoter could exit with promoted-like outcomes without successful commits when AGENT_SERVICE_TOKEN was missing; failed_attempts stayed 0.

  CONTEXT:
    C-281 optimization list — operator truth over illusion for ledger promotion.

  DECISION:
    Gate promoted on anyCommitSucceeded; if token missing use pending + failed_attempts; log each commit attempt; if all agents already satisfied via committed_entries, still mark promoted.

  BOUNDARIES:
    Does not change journal key schema, echo ingest, or substrate auth headers.

  TRADEOFFS:
    - Removed: implied success when zero commits ran
    - Kept: agent routing, commit id shape, KV promotion map key
    - Risk: existing KV rows wrongly marked promoted without commits remain excluded until cleared (pre-existing data issue)

  COUNTERFACTUALS:
    - If token is restored, next POST /api/epicon/promote should attempt commits and increment committed count.
    - If all agents already committed, state becomes promoted without new commits (idempotent completion).
```

---

## 4. LOCKED BEHAVIOR AUDIT

- Journal KV key schema: **not changed** (checked)
- ECHO LPUSH: **not changed** (checked)
- Substrate GitHub auth in github-reader: **not changed** (checked)
- Signal domain ownership: **not changed** (checked)
- EXPECTED EMPTY: **not changed** — no seed data added (checked)

---

## 5. Integrity Impact

- **Estimated MII for this PR:** 0.92
- **Risk level:** Low
- **Lanes affected:** EPICON promotion status / ledger promotion counters when operator triggers promote cron or POST

---

## 6. Verification

- [x] `pnpm exec tsc --noEmit` — pass
- [x] `pnpm build` — pass
- [ ] `pnpm lint` — **fails non-interactively**: Next.js 15 prompts for ESLint migration (`next lint` interactive); use ESLint CLI migration when ready

**Evidence:**

```text
pnpm exec tsc --noEmit  # exit 0
pnpm build              # exit 0, Next.js 15.5.14
```

---

## 7. Rollback Plan

```bash
git revert 18ef22a
```

---

## 8. Stop Conditions

- [x] No stop condition triggered

---

## 9. Final Checklist

- [x] Risk tier assessed
- [x] EPICON intent completed
- [x] Locked behavior audit
- [x] Rollback plan
- [x] Read AGENTS.md / BUILD.md before validation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-636b1cfd-9101-4d42-b374-addadfac770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-636b1cfd-9101-4d42-b374-addadfac770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

