### PR TITLE
fix(C-281): verified T2 promotable from KV; mii:feed 500 + API default 200

### DIFF
--- a/app/api/epicon/promote/route.ts
+++ b/app/api/epicon/promote/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Redis } from '@upstash/redis';
-import { getEchoEpicon, getEchoStatus, pushIngestResult } from '@/lib/echo/store';
+import { getEchoEpicon, getEchoIntegrity, getEchoStatus, pushIngestResult } from '@/lib/echo/store';
 import { fetchAllSources } from '@/lib/echo/sources';
 import { transformBatch } from '@/lib/echo/transform';
 import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
@@ -18,7 +18,7 @@ type Agent = 'ZEUS' | 'JADE' | 'HERMES' | 'AUREA' | 'ATLAS';
 type PromotionState = Awaited<ReturnType<typeof getPromotionState>>;
 type PromotableCategory = EpiconItem['category'];
 type ExclusionReason =
-  | 'status_not_pending'
+  | 'status_not_promotable'
   | 'confidence_tier_below_1'
   | 'category_not_promotable'
   | 'already_promoted';
@@ -84,6 +84,13 @@ function buildCommit(agent: Agent, epicon: EpiconItem, cycleId: string, seq: num
   const stamp = Date.now();
   const derivedFromToken = toIdToken(epicon.id);
   const id = `LE-${cycleId}-${agent}-${derivedFromToken}-${stamp}-${String(seq).padStart(3, '0')}`;
+  const attestation = epicon.echoIngest?.metadata?.integrityAttestation as
+    | { verdict?: string; mii?: number; ratings?: unknown[] }
+    | undefined;
+  const derivedFromIds = [
+    epicon.id,
+    ...(attestation ? [`echo-integrity:${epicon.id}`] : []),
+  ];
   return {
     id,
     timestamp: new Date().toISOString(),
@@ -100,6 +107,7 @@ function buildCommit(agent: Agent, epicon: EpiconItem, cycleId: string, seq: num
     category: epicon.category,
     confidenceTier: epicon.confidenceTier,
     derivedFrom: epicon.id,
+    derivedFromIds,
     status: 'committed',
     agentOrigin: agent,
   };
@@ -141,26 +149,47 @@ function parsePendingLedgerEntry(row: EpiconLedgerFeedEntry): EpiconItem | null 
   const category = row.category;
   if (!category || !PROMOTABLE_CATEGORIES.has(category as PromotableCategory)) return null;
 
-  const status = row.status ?? (row.verified ? 'committed' : 'pending');
-  if (status !== 'pending') return null;
+  if (row.source === 'agent_commit') return null;
+
+  let epiconLane: EpiconItem['status'] =
+    row.epiconStatus ??
+    (row.source === 'kv-ledger' ? (row.verified ? 'verified' : 'pending') : 'pending');
+
+  if (epiconLane === 'contradicted') return null;
+
+  const ledgerRowStatus = row.status;
+  if (ledgerRowStatus === 'committed') return null;
+
+  if (epiconLane !== 'verified' && epiconLane !== 'pending') return null;
 
   const confidenceTier =
     typeof row.confidenceTier === 'number' && Number.isInteger(row.confidenceTier) && row.confidenceTier >= 0 && row.confidenceTier <= 4
       ? (row.confidenceTier as EpiconItem['confidenceTier'])
       : 1;
 
+  const id = row.derivedFrom ?? row.id;
+  const attestation = (row as EpiconLedgerFeedEntry & { integrityAttestation?: unknown }).integrityAttestation;
+
   return {
-    id: row.derivedFrom ?? row.id,
+    id,
     title: row.title,
     category: category as PromotableCategory,
-    status: 'pending',
+    status: epiconLane,
     confidenceTier,
     ownerAgent: row.author || 'ECHO',
-    sources: [],
+    sources: Array.isArray(row.tags) ? row.tags : [],
     timestamp: row.timestamp,
     summary: row.body ?? row.title,
     trace: [],
     feedSource: row.source,
+    echoIngest:
+      attestation && typeof attestation === 'object'
+        ? {
+            source: 'ECHO',
+            severity: 'low',
+            metadata: { integrityAttestation: attestation },
+          }
+        : undefined,
   };
 }
 
@@ -236,16 +265,34 @@ async function getPromotablePending(
   promotedIdsThisCycle: string[] = [],
 ): Promise<{ pending: EpiconItem[]; trace: PromotionTrace }> {
   await ensureEchoIngested();
-  const fromEcho = getEchoEpicon();
   const fromLedger = await getLedgerPendingEpicon();
   const pendingById = new Map<string, EpiconItem>();
   const excluded: Record<ExclusionReason, number> = {
-    status_not_pending: 0,
+    status_not_promotable: 0,
     confidence_tier_below_1: 0,
     category_not_promotable: 0,
     already_promoted: 0,
   };
-  const allCandidates = [...fromEcho, ...fromLedger];
+  const integrity = getEchoIntegrity();
+  const fromEcho = getEchoEpicon().map((item) => {
+    const rating = integrity?.ratings.find((r) => r.eventId === item.id);
+    if (!rating) return item;
+    return {
+      ...item,
+      echoIngest: {
+        ...item.echoIngest,
+        source: item.echoIngest?.source ?? 'ECHO',
+        severity: item.echoIngest?.severity ?? 'low',
+        metadata: {
+          ...item.echoIngest?.metadata,
+          integrityAttestation: rating,
+        },
+      },
+    };
+  });
+
+  // Ledger first, then echo — same id keeps in-memory echo row (has integrity attestation).
+  const allCandidates = [...fromLedger, ...fromEcho];
 
   console.info('[epicon/promote] promoter_input_candidates', {
     count: allCandidates.length,
@@ -253,8 +300,8 @@ async function getPromotablePending(
   });
 
   for (const item of allCandidates) {
-    if (item.status !== 'pending') {
-      excluded.status_not_pending += 1;
+    if (item.status !== 'pending' && item.status !== 'verified') {
+      excluded.status_not_promotable += 1;
       continue;
     }
     if (item.confidenceTier < 1) {

--- a/app/api/mii/feed/route.ts
+++ b/app/api/mii/feed/route.ts
@@ -1,11 +1,12 @@
 /**
  * MII Feed — GET /api/mii/feed
  *
- * Returns the last 100 MII state entries from the rolling mii:feed KV list.
+ * Returns the last N MII state entries from the rolling mii:feed KV list (default 200, max 500).
  * Each entry is one agent's integrity score at a point in time.
  *
  * Query params:
  *   ?agent=ZEUS  — filter to a single agent (case-insensitive)
+ *   ?limit=200   — max entries to return (default 200, cap 500)
  *
  * Response: { ok, count, entries, agents, timestamp }
  *
@@ -21,8 +22,11 @@ export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
   const agentFilter = request.nextUrl.searchParams.get('agent');
+  const limitRaw = request.nextUrl.searchParams.get('limit');
+  const limitParsed = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
+  const limit = Number.isFinite(limitParsed) ? limitParsed : undefined;
 
-  const entries = await readMiiFeed(agentFilter);
+  const entries = await readMiiFeed(agentFilter, limit);
   const agents = Array.from(new Set(entries.map((e) => e.agent)));
 
   return NextResponse.json(

--- a/lib/echo/kv-persist-ingest.ts
+++ b/lib/echo/kv-persist-ingest.ts
@@ -5,6 +5,7 @@
 
 import { Redis } from '@upstash/redis';
 import type { IngestResult } from '@/lib/echo/transform';
+import type { IntegrityRating } from '@/lib/echo/integrity-engine';
 import { getEchoStatus } from '@/lib/echo/store';
 import { saveEchoState, loadGIState, kvSet, KV_KEYS } from '@/lib/kv/store';
 import { readMiiFeed, type MiiEntry } from '@/lib/kv/mii';
@@ -20,6 +21,12 @@ type KvEpiconEntry = {
   source: 'kv-ledger';
   tags: string[];
   verified: boolean;
+  category: string;
+  confidenceTier: number;
+  /** Mirrors EPICON lane status so cold-start ledger parse can promote verified T2. */
+  epiconStatus: 'verified' | 'pending' | 'contradicted';
+  /** ECHO integrity-engine attestation for this EPICON (ratings + verdict). */
+  integrityAttestation?: IntegrityRating;
 };
 
 function getRedisClient(): Redis | null {
@@ -87,7 +94,7 @@ async function writeMiiFeedBatch(entries: MiiEntry[]): Promise<void> {
     const packed = entries.map((entry) => JSON.stringify(entry));
     await Promise.all(entries.map((entry) => redis.set(`mii:${entry.agent.toUpperCase()}:${entry.cycle}`, JSON.stringify(entry))));
     await redis.lpush('mii:feed', ...packed);
-    await redis.ltrim('mii:feed', 0, 199);
+    await redis.ltrim('mii:feed', 0, 499);
   } catch (error) {
     console.error('[echo] mii batch write failed:', error);
   }
@@ -113,7 +120,7 @@ export async function persistEchoIngestSideEffects(result: IngestResult): Promis
     dedupRate,
   }).catch(() => {});
 
-  const kvFeedEntries: KvEpiconEntry[] = result.epicon.map((entry) => ({
+  const kvFeedEntries: KvEpiconEntry[] = result.epicon.map((entry, i) => ({
     id: entry.id,
     timestamp: toFeedTimestamp(entry.timestamp),
     author: entry.ownerAgent,
@@ -123,6 +130,10 @@ export async function persistEchoIngestSideEffects(result: IngestResult): Promis
     source: 'kv-ledger',
     tags: entry.sources,
     verified: entry.status === 'verified',
+    category: entry.category,
+    confidenceTier: entry.confidenceTier,
+    epiconStatus: entry.status,
+    integrityAttestation: result.integrity.ratings[i],
   }));
   await flushEpiconFeedToKv(kvFeedEntries);
 
@@ -132,7 +143,7 @@ export async function persistEchoIngestSideEffects(result: IngestResult): Promis
     const miiTimestamp = new Date().toISOString();
     const agentAverages = result.integrity.agentAverages;
     const agents = ['ATLAS', 'ZEUS', 'JADE', 'EVE'] as const;
-    const recentFeed = await readMiiFeed();
+    const recentFeed = await readMiiFeed(null, 500);
     const lastKnown: Record<string, number> = {};
     for (const entry of recentFeed) {
       if (!(entry.agent in lastKnown)) {

--- a/lib/epicon/ledgerFeedTypes.ts
+++ b/lib/epicon/ledgerFeedTypes.ts
@@ -22,6 +22,8 @@ export type EpiconLedgerFeedEntry = {
   /** Structured provenance (EPICON IDs, civic:alertId, etc.) when the row supports it. */
   derivedFromIds?: string[];
   status?: 'committed' | 'pending' | 'failed';
+  /** EPICON lane status when row is an EPICON feed item (distinct from ledger commit status). */
+  epiconStatus?: 'verified' | 'pending' | 'contradicted';
   agentOrigin?: string;
   zeusVerdict?: string;
   patternType?: string;

--- a/lib/kv/mii.ts
+++ b/lib/kv/mii.ts
@@ -7,10 +7,10 @@
  *
  * Schema:
  *   Key:   mii:{AGENT_UPPERCASE}:{CYCLE_ID}  → latest score for agent in cycle
- *   Feed:  mii:feed                          → LPUSH rolling list (max 200)
+ *   Feed:  mii:feed                          → LPUSH rolling list (max 500)
  *
  * Reads:
- *   GET /api/mii/feed  → last 100 entries, optional ?agent= filter
+ *   GET /api/mii/feed  → last 200 entries by default, optional ?agent= & ?limit=
  */
 
 import { Redis } from '@upstash/redis';
@@ -25,7 +25,7 @@ export type MiiEntry = {
 };
 
 const FEED_KEY = 'mii:feed';
-const FEED_MAX = 200;
+const FEED_MAX = 500;
 
 function getMiiRedisClient(): Redis | null {
   const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
@@ -72,18 +72,22 @@ export async function writeMiiState(entry: MiiEntry): Promise<void> {
   }
 }
 
+const DEFAULT_READ_LIMIT = 200;
+const MAX_READ_LIMIT = 500;
+
 /**
- * Read the rolling mii:feed. Returns up to 100 entries.
+ * Read the rolling mii:feed. Returns up to `limit` entries (default 200, max 500).
  * Optionally filtered by agent name (case-insensitive).
  */
-export async function readMiiFeed(agentFilter?: string | null): Promise<MiiEntry[]> {
+export async function readMiiFeed(agentFilter?: string | null, limit = DEFAULT_READ_LIMIT): Promise<MiiEntry[]> {
   const redis = getMiiRedisClient();
   if (!redis) return [];
 
   const normalizedFilter = agentFilter ? agentFilter.trim().toUpperCase() : null;
+  const cap = Number.isFinite(limit) ? Math.min(Math.max(1, Math.floor(limit)), MAX_READ_LIMIT) : DEFAULT_READ_LIMIT;
 
   try {
-    const raw = await redis.lrange<string>(FEED_KEY, 0, 99);
+    const raw = await redis.lrange<string>(FEED_KEY, 0, cap - 1);
     const entries: MiiEntry[] = [];
 
     for (const item of raw) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 1. Summary

- **Cycle:** C-281
- **Type:** fix
- **Primary area:** epicon promotion, echo KV bridge, MII feed
- **Files changed:** `app/api/epicon/promote/route.ts`, `lib/echo/kv-persist-ingest.ts`, `lib/epicon/ledgerFeedTypes.ts`, `lib/kv/mii.ts`, `app/api/mii/feed/route.ts`
- **Note:** There is no `app/api/promotion/route.ts` in this repo; promotion runs at `app/api/epicon/promote` (and cron fans out there).

**Fix 1 — T2 (and verified) promotion path**

Root cause: `getPromotablePending` only admitted `status === 'pending'`. ECHO’s integrity engine sets many items to `verified` once ratings pass, so **medium / T2 items never entered the promoter** on the warm echo path. Separately, KV rows from `flushEpiconFeedToKv` omitted `category`, `confidenceTier`, and EPICON lane status, so cold-start `parsePendingLedgerEntry` often returned null.

Changes:

- Eligible EPICONs: `pending` **or** `verified` (still exclude `contradicted`).
- KV LPUSH payload now includes `category`, `confidenceTier`, `epiconStatus`, and `integrityAttestation` (full `IntegrityRating` from the ingest batch). **LPUSH + LTRIM unchanged in position** (still immediately after successful payload build in the same try block).
- `parsePendingLedgerEntry`: skips `source === 'agent_commit'`; uses `epiconStatus` / `verified` for kv-ledger; does not treat missing `row.status` as “committed”; attaches attestation into `echoIngest.metadata` for downstream provenance.
- Echo candidates merged with `getEchoIntegrity()` ratings so promotion commits can reference `derivedFromIds` including `echo-integrity:{id}` when attestation exists.
- Candidate merge order: `[...fromLedger, ...fromEcho]` so same id prefers the in-memory echo row (richer metadata).

**Fix 2 — MII feed capacity**

- `FEED_MAX` 500; `writeMiiState` LTRIM `0..499`.
- `writeMiiFeedBatch` in kv-persist-ingest LTRIM `0..499`; `readMiiFeed` for batch warm-up reads up to 500.
- `readMiiFeed` default read window 200 (max 500).
- `GET /api/mii/feed` supports `?limit=` (default 200).

**LOCKED behaviors preserved**

- ECHO `epicon:feed` LPUSH/LTRIM not removed or reordered relative to the write path.
- Journal route / key schema untouched.
- MII entry shape `{ agent, mii, gi, cycle, timestamp, source: "live" }` unchanged.

---

## 2. Risk Tier

- [x] **Tier 2** — KV list row shape gains optional fields (`epiconStatus`, `integrityAttestation`); readers that only use id/title still work. `EpiconLedgerFeedEntry` gains optional `epiconStatus`.

---

## 3. Verification

- [x] `pnpm exec tsc --noEmit` — pass
- [x] `pnpm build` — pass
- [ ] `pnpm lint` — Next.js interactive ESLint migration prompt (same as prior PRs)

**Post-deploy (operator):** After ECHO ingest repopulates KV, `POST /api/epicon/promote` with token should process **verified** T2 market / infrastructure items that were previously stuck. Confirm in ledger feed and promotion diagnostics.

---

## 4. Rollback

```bash
git revert b48fefa
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-636b1cfd-9101-4d42-b374-addadfac770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-636b1cfd-9101-4d42-b374-addadfac770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

