### PR TITLE
feat(vault): Vault v1 deposits from synthesis council + protocol spec

### DIFF
--- a/app/api/agents/atlas/observe/route.ts
+++ b/app/api/agents/atlas/observe/route.ts
@@ -61,6 +61,7 @@ export async function POST(request: NextRequest) {
       ok: true,
       agent: 'ATLAS',
       journalId: entry.id,
+      journal: entry,
       cycle: parsed.cycle,
       gi,
       source: parsed.source,

--- a/app/api/agents/zeus/verify/route.ts
+++ b/app/api/agents/zeus/verify/route.ts
@@ -62,6 +62,7 @@ export async function POST(request: NextRequest) {
       ok: true,
       agent: 'ZEUS',
       journalId: entry.id,
+      journal: entry,
       cycle: parsed.cycle,
       gi,
       atlasEntry: parsed.atlasEntry ?? null,

--- a/app/api/eve/cycle-synthesize/route.ts
+++ b/app/api/eve/cycle-synthesize/route.ts
@@ -28,6 +28,8 @@ import { appendAgentJournalEntry } from '@/lib/agents/journal';
 import { appendStewardCronJournals } from '@/lib/agents/sentinel-cycle-journals';
 import { loadGIState } from '@/lib/kv/store';
 import { writeMiiState } from '@/lib/kv/mii';
+import { recordVaultDepositsForCouncil } from '@/lib/vault/vault';
+import type { AgentJournalEntry } from '@/lib/terminal/types';
 
 export const dynamic = 'force-dynamic';
 
@@ -59,8 +61,9 @@ async function fanOutSentinelCouncilAfterEve(
     cache: 'no-store',
     signal: AbortSignal.timeout(20_000),
   });
-  const atlasJson = (await atlasRes.json().catch(() => null)) as { journalId?: string } | null;
+  const atlasJson = (await atlasRes.json().catch(() => null)) as { journalId?: string; journal?: AgentJournalEntry } | null;
   const atlasJournalId = typeof atlasJson?.journalId === 'string' ? atlasJson.journalId : null;
+  const atlasEntry = atlasJson?.journal && typeof atlasJson.journal === 'object' ? atlasJson.journal : null;
 
   const zeusRes = await fetch(`${base}/api/agents/zeus/verify`, {
     method: 'POST',
@@ -74,8 +77,9 @@ async function fanOutSentinelCouncilAfterEve(
     cache: 'no-store',
     signal: AbortSignal.timeout(20_000),
   });
-  const zeusJson = (await zeusRes.json().catch(() => null)) as { journalId?: string } | null;
+  const zeusJson = (await zeusRes.json().catch(() => null)) as { journalId?: string; journal?: AgentJournalEntry } | null;
   const zeusJournalId = typeof zeusJson?.journalId === 'string' ? zeusJson.journalId : null;
+  const zeusEntry = zeusJson?.journal && typeof zeusJson.journal === 'object' ? zeusJson.journal : null;
 
   let giForSteward = giVal;
   try {
@@ -87,12 +91,23 @@ async function fanOutSentinelCouncilAfterEve(
     // keep giVal
   }
 
-  await appendStewardCronJournals({
+  const stewardEntries = await appendStewardCronJournals({
     cycle: cycleId,
     gi: giForSteward,
     source: 'cron',
     zeusJournalId,
   });
+
+  const councilEntries: AgentJournalEntry[] = [];
+  if (atlasEntry) councilEntries.push(atlasEntry);
+  if (zeusEntry) councilEntries.push(zeusEntry);
+  councilEntries.push(...stewardEntries);
+
+  if (councilEntries.length > 0) {
+    void recordVaultDepositsForCouncil(councilEntries, giForSteward).then((r) => {
+      console.info('[vault] council deposits', { ...r, gi: giForSteward });
+    });
+  }
 }
 
 type CycleBody = {
@@ -154,9 +169,11 @@ export async function GET(request: NextRequest) {
   if (isVercelCronInvocation(request)) {
     await runSignalEngine();
     const payload = await processEveCycleWindowSynthesis(cycleId, false);
-    void fanOutSentinelCouncilAfterEve(request, cycleId, payload as Record<string, unknown>).catch((err) => {
+    try {
+      await fanOutSentinelCouncilAfterEve(request, cycleId, payload as Record<string, unknown>);
+    } catch (err) {
       console.error('[eve/cycle-synthesize] sentinel council cron follow-up failed:', err);
-    });
+    }
     return NextResponse.json(payload);
   }
 
@@ -197,25 +214,30 @@ export async function POST(request: NextRequest) {
 
     const eveMii = inferEveConfidence(payload);
 
-    void appendAgentJournalEntry({
-      agent: 'EVE',
-      cycle: cycleId,
-      observation: `EVE ${mode} synthesis executed${reason ? ` for reason ${reason}` : ''}.`,
-      inference:
-        mode === 'escalation'
-          ? 'Civic risk required escalation-class synthesis output.'
-          : 'Cycle-window synthesis completed and published to the live EPICON ledger.',
-      recommendation:
-        mode === 'escalation'
-          ? 'Prioritize ZEUS verification and ATLAS oversight checks.'
-          : 'Continue normal verification cadence across ZEUS and ATLAS.',
-      confidence: eveMii,
-      derivedFrom: ['signal-engine:run', `eve-synthesis:${cycleId}`],
-      relatedAgents: ['ZEUS', 'ATLAS'],
-      status: 'committed',
-      category: mode === 'escalation' ? 'alert' : 'inference',
-      severity: inferEveSeverity(payload),
-    }).catch(() => {});
+    let eveJournal: AgentJournalEntry | null = null;
+    try {
+      eveJournal = await appendAgentJournalEntry({
+        agent: 'EVE',
+        cycle: cycleId,
+        observation: `EVE ${mode} synthesis executed${reason ? ` for reason ${reason}` : ''}.`,
+        inference:
+          mode === 'escalation'
+            ? 'Civic risk required escalation-class synthesis output.'
+            : 'Cycle-window synthesis completed and published to the live EPICON ledger.',
+        recommendation:
+          mode === 'escalation'
+            ? 'Prioritize ZEUS verification and ATLAS oversight checks.'
+            : 'Continue normal verification cadence across ZEUS and ATLAS.',
+        confidence: eveMii,
+        derivedFrom: ['signal-engine:run', `eve-synthesis:${cycleId}`],
+        relatedAgents: ['ZEUS', 'ATLAS'],
+        status: 'committed',
+        category: mode === 'escalation' ? 'alert' : 'inference',
+        severity: inferEveSeverity(payload),
+      });
+    } catch (err) {
+      console.error('[eve] journal append failed:', err instanceof Error ? err.message : err);
+    }
 
     void (async () => {
       try {
@@ -233,9 +255,23 @@ export async function POST(request: NextRequest) {
       }
     })();
 
-    void fanOutSentinelCouncilAfterEve(request, cycleId, payload as Record<string, unknown>).catch((err) => {
+    if (eveJournal) {
+      try {
+        const giState = await loadGIState();
+        const giVault = Number((giState?.global_integrity ?? 0.74).toFixed(4));
+        void recordVaultDepositsForCouncil([eveJournal], giVault).then((r) => {
+          console.info('[vault] EVE synthesis deposit', { ...r, gi: giVault });
+        });
+      } catch (err) {
+        console.error('[eve] vault deposit schedule failed:', err instanceof Error ? err.message : err);
+      }
+    }
+
+    try {
+      await fanOutSentinelCouncilAfterEve(request, cycleId, payload as Record<string, unknown>);
+    } catch (err) {
       console.error('[eve/cycle-synthesize] sentinel council follow-up failed:', err);
-    });
+    }
 
     return NextResponse.json(payload);
   } catch (err) {

--- a/app/api/terminal/snapshot/route.ts
+++ b/app/api/terminal/snapshot/route.ts
@@ -11,6 +11,7 @@ import { GET as getRuntime } from '@/app/api/runtime/status/route';
 import { GET as getPromotion } from '@/app/api/epicon/promotion-status/route';
 import { GET as getEve } from '@/app/api/eve/cycle-advance/route';
 import { GET as getMii } from '@/app/api/mii/feed/route';
+import { GET as getVault } from '@/app/api/vault/status/route';
 import {
   normalizeAllSnapshotLanes,
   type SnapshotLaneKey,
@@ -55,7 +56,7 @@ export async function GET(request: NextRequest) {
   const journalPath = cycle ? `/api/agents/journal?cycle=${encodeURIComponent(cycle)}` : '/api/agents/journal';
   const epiconPath = includeCatalog === 'true' ? '/api/epicon/feed?include_catalog=true' : '/api/epicon/feed';
 
-  const [integrity, signals, kvHealth, agents, epicon, echo, journal, sentiment, runtime, promotion, eve, mii] = await Promise.all([
+  const [integrity, signals, kvHealth, agents, epicon, echo, journal, sentiment, runtime, promotion, eve, mii, vault] = await Promise.all([
     callHandler(makeRequest(baseUrl, '/api/integrity-status'), getIntegrity),
     callHandler(makeRequest(baseUrl, '/api/signals/micro'), getSignals),
     callHandler(makeRequest(baseUrl, '/api/kv/health'), getKvHealth),
@@ -68,6 +69,7 @@ export async function GET(request: NextRequest) {
     callHandler(makeRequest(baseUrl, '/api/epicon/promotion-status'), getPromotion),
     callHandler(makeRequest(baseUrl, '/api/eve/cycle-advance'), getEve),
     callHandler(makeRequest(baseUrl, '/api/mii/feed'), getMii),
+    callHandler(makeRequest(baseUrl, '/api/vault/status'), getVault),
   ]);
 
   type SubstrateAgentRow = {
@@ -130,6 +132,7 @@ export async function GET(request: NextRequest) {
     promotion,
     eve,
     mii,
+    vault,
   };
 
   const lanes: SnapshotLaneState[] = normalizeAllSnapshotLanes(leaves);
@@ -175,6 +178,7 @@ export async function GET(request: NextRequest) {
       promotion,
       eve,
       mii,
+      vault,
       substrate,
     },
     {

--- a/app/api/vault/status/route.ts
+++ b/app/api/vault/status/route.ts
@@ -1,0 +1,26 @@
+/**
+ * GET /api/vault/status — global vault reserve (v1: deposits only, no Fountain).
+ */
+
+import { NextResponse } from 'next/server';
+import { loadGIState } from '@/lib/kv/store';
+import { getVaultStatusPayload } from '@/lib/vault/vault';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  let gi: number | null = null;
+  try {
+    const st = await loadGIState();
+    if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
+      gi = Math.max(0, Math.min(1, st.global_integrity));
+    }
+  } catch {
+    gi = null;
+  }
+
+  const body = await getVaultStatusPayload(gi);
+  return NextResponse.json(body, {
+    headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'vault-status' },
+  });
+}

--- a/docs/protocols/vault-to-fountain-protocol.md
+++ b/docs/protocols/vault-to-fountain-protocol.md
@@ -1,0 +1,189 @@
+# Vault-to-Fountain Protocol
+
+# Mobius Integrity Credits — Reserve Emission Framework
+
+**Cycle draft:** C-281  
+**Status:** Protocol Spec v1  
+**Author:** kaizencycle  
+**CC0 Public Domain**
+
+---
+
+## 0. Purpose
+
+The Vault-to-Fountain Protocol turns validated agent reasoning into **delayed** civic value, not instant extraction.
+
+A journal entry should not immediately mint spendable MIC. Instead, it may contribute to a **Vault**, where value is held in reserve until the system proves enough integrity to support public release.
+
+This creates a healthier loop:
+
+**journaled reasoning → quality review → reserve accrual → integrity stability check → controlled public flow**
+
+The protocol exists to reward:
+
+- durable reasoning  
+- verified usefulness  
+- system-wide stability  
+- civic trust  
+
+It exists to prevent:
+
+- spam journals  
+- empty synthesis farming  
+- reward extraction during degraded conditions  
+- short-term opportunism  
+
+---
+
+## 1. Core doctrine
+
+- **A journal is not money.** A journal is a **claim of value**.  
+- **A Vault** is stored trust. It holds unrealized value earned by reasoning that has not yet matured.  
+- **A Fountain** is public release. It emits value only when the whole system is healthy enough to carry it.
+
+**One-line canon:** Reserve becomes flow only after integrity proves it can hold the weight.
+
+---
+
+## 2. Main objects
+
+### Journal entry
+
+Structured agent output: observation, inference, recommendation, confidence, provenance, timestamp, agent origin.
+
+### Vault
+
+Reserve account accumulating **non-spendable** value derived from journal contributions. Not liquid, not directly distributable.
+
+### Fountain
+
+Release state for a Vault. When activated, value flows outward under constrained rules.
+
+### GI gate
+
+Integrity threshold for release. Base threshold: **GI ≥ 0.95**.
+
+**Sustain window:** GI must remain above threshold for **N** cycles before Fountain activation (suggested **N = 3 to 7**).
+
+**Operational note:** Live GI often runs below 0.95. A **preview** tier at **GI ≥ 0.88** may surface “what would flow” without unlocking full emission (implementation detail).
+
+---
+
+## 3. Lifecycle (stages)
+
+1. **Journal creation** — agent writes structured entry.  
+2. **Journal scoring** — merit across quality, novelty, corroboration, impact, survival, duplication.  
+3. **Vault deposit** — small **reserve** amount (not spendable MIC).  
+4. **Maturity review** — reserve accrues only while entries and system remain trustworthy.  
+5. **Fountain activation** — threshold + sustained GI + low contradiction + healthy tripwires.  
+6. **Controlled emission** — gradual flow to downstream pools.
+
+---
+
+## 4. Journal scoring model
+
+Composite score **J** from factors **Q, N, C, I, S, D** (quality, novelty, corroboration, impact, survival, duplication penalty), normalized where appropriate.
+
+**Implementation refinement (v1 code):** Pure multiplication can collapse when any factor is near zero. Use a **floor** on **J** (e.g. 0.15) so honest, low-novelty but accurate journals still contribute a small reserve.
+
+---
+
+## 5. Vault deposit formula
+
+```
+vault_deposit = B × J × Wg × Wa
+```
+
+- **B** — base reserve rate (v1: `1.0`)  
+- **J** — journal merit score `[0, 1]`  
+- **Wg** — `clamp(GI / 0.95, 0.25, 1.0)`  
+- **Wa** — agent trust multiplier (v1: `1.0` for all agents)
+
+Reserve is credited to the Vault, **not** released as spendable MIC.
+
+---
+
+## 6. Vault structure (conceptual)
+
+Fields include: `vault_id`, scope, `balance_reserve`, `status` (`sealed` | `preview` | `activating`), `activation_threshold`, `gi_threshold`, `sustain_cycles_required`, contradiction/tripwire signals, `source_entries`, timestamps.
+
+**v1 repo keys (global vault only):**
+
+| Key | Role |
+|-----|------|
+| `mobius:vault:global:balance` | Running reserve total (via `kvSet`) |
+| `mobius:vault:global:meta` | `VaultState` JSON |
+| `vault:deposits` | LPUSH list of `VaultDeposit` JSON (max 200) |
+
+---
+
+## 7. Fountain activation rules (future phase)
+
+Activate only when **all** required conditions hold, for example:
+
+- Vault balance ≥ threshold  
+- GI ≥ 0.95  
+- GI sustained ≥ N cycles  
+- Contradiction rate ≤ maximum  
+- Critical tripwires below threshold  
+- No emergency integrity lock  
+
+**Not implemented in v1** — deposits and status only.
+
+---
+
+## 8. Fountain emission and distribution (future phase)
+
+Gradual emission; split across citizen / operator / civic reserve / stability / burn (e.g. 40 / 25 / 20 / 10 / 5). Caps per cycle.
+
+---
+
+## 9. Pausing and failure modes
+
+- GI &lt; 0.95 — pause new emissions  
+- GI &lt; 0.90 — hard freeze  
+- GI &lt; 0.85 — emergency lock, optional reabsorption  
+
+---
+
+## 10. Anti-gaming rules
+
+1. No instant liquidity from journal text alone.  
+2. Duplication decay on repeated patterns.  
+3. Challenge window (cycles).  
+4. Cross-agent validation bonus; copied entries do not compound.  
+5. Operator override (pause vault, freeze fountain, quarantine).  
+6. Rate caps per agent per cycle.
+
+---
+
+## 11. Ledger event shapes (reference)
+
+**vault_deposit** — `journal_id`, `vault_id`, `agent`, `deposit_amount`, `journal_score`, `gi_at_deposit`, `timestamp`, `status: sealed`, plus `content_signature` for dedup in v1 implementation.
+
+**fountain_activation** / **fountain_emission** — defined in a later spec revision when Fountain ships.
+
+---
+
+## 12. Repository implementation (v1 skeleton)
+
+| Piece | Location |
+|-------|----------|
+| Scoring, deposit, KV writes | `lib/vault/vault.ts` |
+| Operator read | `GET /api/vault/status` → `app/api/vault/status/route.ts` |
+| Deposit trigger | After EVE journal + sentinel council journals on `POST/GET` cron path in `app/api/eve/cycle-synthesize/route.ts` |
+| Snapshot lane | `vault` in `app/api/terminal/snapshot/route.ts` + `lib/terminal/snapshotLanes.ts` |
+
+**Intentionally not in v1:** Fountain activation, emission math, distribution pools, multiple vault scopes beyond global, per-agent `Wa` variation.
+
+---
+
+## 13. Canon (short)
+
+**The Vault remembers what proved itself. The Fountain releases what can be trusted to flow.**
+
+Reserve becomes flow when integrity holds.
+
+---
+
+*When reasoning proves itself over time, reserve becomes flow. That is when the Vault becomes a Fountain.*

--- a/lib/agents/sentinel-cycle-journals.ts
+++ b/lib/agents/sentinel-cycle-journals.ts
@@ -136,7 +136,7 @@ export async function appendStewardCronJournals(input: {
   gi: number;
   source: CronSentinelSource;
   zeusJournalId?: string | null;
-}): Promise<void> {
+}): Promise<AgentJournalEntry[]> {
   const gi = clampGi(input.gi);
   const { count, labels } = await summarizeMicroAnomalies();
   const labelShort = labels.slice(0, 5).join('; ') || 'No elevated micro-agent lines in snapshot.';
@@ -144,10 +144,13 @@ export async function appendStewardCronJournals(input: {
   const echo = await loadEchoState().catch(() => null);
   const zeusRef = input.zeusJournalId?.trim() || 'pending';
 
+  const written: AgentJournalEntry[] = [];
+
   const appendOne = async (fn: () => Promise<AgentJournalEntry>, agent: string) => {
     try {
       const entry = await fn();
       await writeMiiForEntry(entry, gi);
+      written.push(entry);
     } catch (err) {
       console.error(`[steward-journal] ${agent} append failed:`, err instanceof Error ? err.message : err);
     }
@@ -251,4 +254,6 @@ export async function appendStewardCronJournals(input: {
       }),
     'ECHO',
   );
+
+  return written;
 }

--- a/lib/terminal/snapshotLanes.ts
+++ b/lib/terminal/snapshotLanes.ts
@@ -15,7 +15,8 @@ export type SnapshotLaneKey =
   | 'runtime'
   | 'promotion'
   | 'eve'
-  | 'mii';
+  | 'mii'
+  | 'vault';
 
 export type SnapshotLaneSemanticState = 'healthy' | 'degraded' | 'offline' | 'stale' | 'empty';
 
@@ -55,6 +56,7 @@ export const SNAPSHOT_LANE_KEYS: readonly SnapshotLaneKey[] = [
   'promotion',
   'eve',
   'mii',
+  'vault',
 ] as const;
 
 function asRecord(data: unknown): Record<string, unknown> | null {
@@ -137,6 +139,8 @@ export function extractLaneLastUpdated(key: SnapshotLaneKey, data: unknown): str
       return pick('timestamp');
     case 'mii':
       return pick('timestamp');
+    case 'vault':
+      return pick('timestamp', 'last_deposit');
     default:
       return null;
   }
@@ -667,6 +671,40 @@ function normalizeEveLane(leaf: SnapshotLeaf): SnapshotLaneState {
   };
 }
 
+function normalizeVaultLane(leaf: SnapshotLeaf): SnapshotLaneState {
+  const lastUpdated = extractLaneLastUpdated('vault', leaf.data);
+  if (!leaf.ok) {
+    const { state, message } = classifyHttpFailure(leaf.status, leaf.error);
+    return { key: 'vault', ok: false, state, statusCode: leaf.status, message, lastUpdated, fallbackMode: 'offline' };
+  }
+  const row = asRecord(leaf.data);
+  if (row?.ok !== true) {
+    return {
+      key: 'vault',
+      ok: false,
+      state: 'degraded',
+      statusCode: leaf.status,
+      message: 'Vault status not ok',
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const balance = typeof row.balance_reserve === 'number' ? row.balance_reserve : 0;
+  const status = typeof row.status === 'string' ? row.status : 'sealed';
+  const preview = row.preview_active === true;
+  const b = balance.toFixed(2);
+  const message = `Vault · ${b} reserve units · ${status}${preview ? ' · preview' : ''}`;
+  return {
+    key: 'vault',
+    ok: true,
+    state: 'healthy',
+    statusCode: leaf.status,
+    message,
+    lastUpdated,
+    fallbackMode: 'live',
+  };
+}
+
 function normalizeMiiLane(leaf: SnapshotLeaf): SnapshotLaneState {
   const lastUpdated = extractLaneLastUpdated('mii', leaf.data);
   if (!leaf.ok) {
@@ -724,6 +762,8 @@ export function normalizeSnapshotLane(key: SnapshotLaneKey, leaf: SnapshotLeaf):
       return normalizeEveLane(leaf);
     case 'mii':
       return normalizeMiiLane(leaf);
+    case 'vault':
+      return normalizeVaultLane(leaf);
     default:
       return {
         key,

--- a/lib/vault/vault.ts
+++ b/lib/vault/vault.ts
@@ -1,0 +1,238 @@
+/**
+ * Vault v1 — reserve accrual from agent journals (no Fountain activation yet).
+ * Reserve units are not spendable MIC; they accumulate until a future protocol phase.
+ */
+
+import { Redis } from '@upstash/redis';
+import type { AgentJournalEntry } from '@/lib/terminal/types';
+import { kvGet, kvSet } from '@/lib/kv/store';
+
+const BALANCE_KEY = 'vault:global:balance';
+const META_KEY = 'vault:global:meta';
+/** Raw list key (matches MII / epicon pattern — not mobius-prefixed for LPUSH). */
+const DEPOSITS_LIST_KEY = 'vault:deposits';
+const DEPOSITS_MAX = 200;
+
+const ACTIVATION_THRESHOLD = 50;
+const GI_THRESHOLD = 0.95;
+const SUSTAIN_CYCLES_REQUIRED = 5;
+const PREVIEW_GI = 0.88;
+
+export type VaultDeposit = {
+  event_type: 'vault_deposit';
+  journal_id: string;
+  vault_id: 'vault-global';
+  agent: string;
+  deposit_amount: number;
+  journal_score: number;
+  gi_at_deposit: number;
+  timestamp: string;
+  status: 'sealed';
+  /** Normalized text fingerprint for v1 duplication decay (not spendable MIC). */
+  content_signature: string;
+};
+
+export type VaultState = {
+  vault_id: 'vault-global';
+  activation_threshold: number;
+  gi_threshold: number;
+  sustain_cycles_required: number;
+  source_entries: number;
+  last_deposit: string | null;
+  updated_at: string;
+};
+
+export type JournalScoreBreakdown = {
+  Q: number;
+  N: number;
+  C: number;
+  I: number;
+  S: number;
+  D: number;
+  J: number;
+};
+
+function getRedis(): Redis | null {
+  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  try {
+    return new Redis({ url, token });
+  } catch {
+    return null;
+  }
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+function textSig(entry: AgentJournalEntry): string {
+  return `${entry.observation}|${entry.inference}|${entry.recommendation}`.slice(0, 400).toLowerCase();
+}
+
+/**
+ * v1 scoring: multiplicative core with a floor so honest low-novelty entries still accrue a small reserve.
+ */
+export function scoreJournal(entry: AgentJournalEntry, recentSignatures: string[]): JournalScoreBreakdown {
+  const Q = clamp01(entry.confidence);
+  const text = textSig(entry);
+  const dupCount = recentSignatures.filter((s) => s === text).length;
+  const N = dupCount === 0 ? 0.85 : clamp01(0.85 / (1 + dupCount * 1.4));
+  const C = 0.5;
+  const I = 0.5;
+  const S = 1.0;
+  const D = dupCount === 0 ? 1.0 : clamp01(1 / (1 + dupCount * 0.5));
+  const multiplicative = Q * N * C * I * S * D;
+  const floor = 0.15;
+  const J = Math.max(floor, multiplicative);
+  return { Q, N, C, I, S, D, J: clamp01(J) };
+}
+
+export function computeVaultDeposit(entry: AgentJournalEntry, gi: number, recentSignatures: string[]): number {
+  const { J } = scoreJournal(entry, recentSignatures);
+  const Wg = Math.max(0.25, Math.min(1.0, gi / 0.95));
+  const amount = 1.0 * J * Wg * 1.0;
+  return Number(amount.toFixed(6));
+}
+
+export async function getRecentContentSignatures(limit: number): Promise<string[]> {
+  const redis = getRedis();
+  if (!redis) return [];
+  try {
+    const raw = await redis.lrange<string>(DEPOSITS_LIST_KEY, 0, limit - 1);
+    const sigs: string[] = [];
+    for (const row of raw) {
+      try {
+        const o = typeof row === 'string' ? (JSON.parse(row) as VaultDeposit) : (row as unknown as VaultDeposit);
+        if (o && typeof o.content_signature === 'string') {
+          sigs.push(o.content_signature);
+        }
+      } catch {
+        // skip
+      }
+    }
+    return sigs;
+  } catch {
+    return [];
+  }
+}
+
+export async function writeVaultDeposit(deposit: VaultDeposit): Promise<void> {
+  const redis = getRedis();
+  const prevBalance = (await kvGet<number>(BALANCE_KEY)) ?? 0;
+  const nextBalance = Number((prevBalance + deposit.deposit_amount).toFixed(6));
+
+  await kvSet(BALANCE_KEY, nextBalance);
+
+  const now = new Date().toISOString();
+  const prevMeta = await kvGet<VaultState>(META_KEY);
+  const sourceEntries = (prevMeta?.source_entries ?? 0) + 1;
+
+  const meta: VaultState = {
+    vault_id: 'vault-global',
+    activation_threshold: ACTIVATION_THRESHOLD,
+    gi_threshold: GI_THRESHOLD,
+    sustain_cycles_required: SUSTAIN_CYCLES_REQUIRED,
+    source_entries: sourceEntries,
+    last_deposit: deposit.timestamp,
+    updated_at: now,
+  };
+  await kvSet(META_KEY, meta);
+
+  if (redis) {
+    try {
+      await redis.lpush(DEPOSITS_LIST_KEY, JSON.stringify(deposit));
+      await redis.ltrim(DEPOSITS_LIST_KEY, 0, DEPOSITS_MAX - 1);
+    } catch (err) {
+      console.error('[vault] deposit list write failed:', err instanceof Error ? err.message : err);
+    }
+  }
+}
+
+export type VaultStatusPayload = {
+  ok: true;
+  vault_id: 'vault-global';
+  balance_reserve: number;
+  activation_threshold: number;
+  gi_threshold: number;
+  sustain_cycles_required: number;
+  status: 'sealed' | 'preview' | 'activating';
+  preview_active: boolean;
+  source_entries: number;
+  last_deposit: string | null;
+  gi_current: number | null;
+  timestamp: string;
+};
+
+export async function getVaultStatusPayload(giCurrent: number | null): Promise<VaultStatusPayload> {
+  const balance = (await kvGet<number>(BALANCE_KEY)) ?? 0;
+  const meta = await kvGet<VaultState>(META_KEY);
+  const gi = giCurrent !== null && Number.isFinite(giCurrent) ? Math.max(0, Math.min(1, giCurrent)) : null;
+
+  const preview_active = gi !== null && gi >= PREVIEW_GI;
+  const activating = gi !== null && gi >= GI_THRESHOLD && balance >= ACTIVATION_THRESHOLD;
+
+  let status: VaultStatusPayload['status'] = 'sealed';
+  if (activating) status = 'activating';
+  else if (preview_active) status = 'preview';
+
+  return {
+    ok: true,
+    vault_id: 'vault-global',
+    balance_reserve: balance,
+    activation_threshold: ACTIVATION_THRESHOLD,
+    gi_threshold: GI_THRESHOLD,
+    sustain_cycles_required: SUSTAIN_CYCLES_REQUIRED,
+    status,
+    preview_active,
+    source_entries: meta?.source_entries ?? 0,
+    last_deposit: meta?.last_deposit ?? null,
+    gi_current: gi,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * Sequential vault accrual for a batch of council journals (single GI snapshot).
+ */
+export async function recordVaultDepositsForCouncil(
+  entries: AgentJournalEntry[],
+  gi: number,
+): Promise<{ attempted: number; errors: number; deposited: number }> {
+  let attempted = 0;
+  let errors = 0;
+  let deposited = 0;
+  const recentSigs = await getRecentContentSignatures(120);
+
+  for (const entry of entries) {
+    attempted += 1;
+    try {
+      const sig = textSig(entry);
+      const recentForScore = [...recentSigs];
+      const amount = computeVaultDeposit(entry, gi, recentForScore);
+      recentSigs.push(sig);
+      if (amount <= 0) continue;
+
+      const deposit: VaultDeposit = {
+        event_type: 'vault_deposit',
+        journal_id: entry.id,
+        vault_id: 'vault-global',
+        agent: entry.agent,
+        deposit_amount: amount,
+        journal_score: scoreJournal(entry, recentForScore).J,
+        gi_at_deposit: Number(gi.toFixed(4)),
+        timestamp: new Date().toISOString(),
+        status: 'sealed',
+        content_signature: sig,
+      };
+      await writeVaultDeposit(deposit);
+      deposited += 1;
+    } catch {
+      errors += 1;
+    }
+  }
+
+  return { attempted, errors, deposited };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Vault v1** only: journal-backed **reserve units** accrue to a global vault after EVE synthesis + sentinel council journals. **No Fountain activation or spendable MIC** in this PR.

Adds canonical protocol documentation at `docs/protocols/vault-to-fountain-protocol.md` (C-281 draft, CC0).

## Why

Operator-requested “Vault → Fountain” economy: v1 establishes **deposit pipeline + observability** without touching locked journal keys, MII shape, ECHO LPUSH/LTRIM, or promotion logic.

## Changed

- `lib/vault/vault.ts` — `scoreJournal` (multiplicative core + **0.15 floor**), `computeVaultDeposit`, `writeVaultDeposit`, `recordVaultDepositsForCouncil`, `getVaultStatusPayload`
- `app/api/vault/status/route.ts` — public GET for operators
- `app/api/eve/cycle-synthesize/route.ts` — await `fanOutSentinelCouncilAfterEve`; EVE journal awaited then vault deposit; council batch vault deposit
- `app/api/agents/atlas/observe/route.ts`, `app/api/agents/zeus/verify/route.ts` — include `journal` in JSON for internal synthesis fetch
- `lib/agents/sentinel-cycle-journals.ts` — `appendStewardCronJournals` returns `AgentJournalEntry[]`
- `app/api/terminal/snapshot/route.ts`, `lib/terminal/snapshotLanes.ts` — **`vault` lane**
- `docs/protocols/vault-to-fountain-protocol.md`

## KV keys (v1)

| Key | Notes |
|-----|--------|
| `mobius:vault:global:balance` | `kvSet` — running total |
| `mobius:vault:global:meta` | `VaultState` JSON |
| `vault:deposits` | Raw Redis LPUSH + LTRIM 200 (same pattern as `mii:feed` / `epicon:feed` lists) |

## Verification

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- `pnpm lint` — not completed (interactive Next.js ESLint migration prompt)

## Post-merge check

- `GET /api/vault/status` — `balance_reserve`, `source_entries`, `last_deposit` after a successful `POST /api/eve/cycle-synthesize` (or Vercel cron GET with council fan-out)
- `/api/terminal/snapshot` — `vault` leaf + `lanes` entry with message `Vault · … reserve units · …`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-636b1cfd-9101-4d42-b374-addadfac770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-636b1cfd-9101-4d42-b374-addadfac770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

