### PR TITLE
fix(C-281 close): vault on journal commit, tripwire+heartbeat KV, promotion merge, UI

### DIFF
--- a/CURRENT_CYCLE.md
+++ b/CURRENT_CYCLE.md
@@ -1,119 +1,91 @@
-# CURRENT_CYCLE.md — C-280
-> **Last verified:** 2026-04-13T12:25Z by ATLAS (kaizencycle)
-> **Snapshot commit:** `74fc1493` — C-280 in sync (agent work may advance this SHA after merge)
-> **Production URL:** https://mobius-civic-ai-terminal.vercel.app
+# CURRENT_CYCLE.md — C-281 (close)
+
+> **Last verified:** 2026-04-15T00:09Z (operator close snapshot)  
+> **Reference production SHA:** `bca99e86` (Vault v1 + prior C-281 work; this PR advances close-out items)  
+> **Production URL:** https://mobius-civic-ai-terminal.vercel.app  
 > **Vercel project:** `prj_ru2eaIzY0nIamFIXEdUIuTjnefpn` · team `team_cEncfJHYpxuB6YiFQNwdOUB5`
 
 ---
 
 ## ⚠️ READ THIS FIRST — FOR ALL AGENTS (Cursor, Codex, Claude Code)
 
-This file is the **ground truth** for the current state of the Terminal repo.
-Before making any change, read this file in full.
-If your task conflicts with a LOCKED entry, **stop and ask the operator**.
-If your task describes fixing something in the EXPECTED EMPTY section, **do not proceed** — it is not a bug.
+This file is the **ground truth** for the current state of the Terminal repo.  
+Before making any change, read this file in full.  
+If your task conflicts with a **LOCKED** entry, **stop and ask the operator**.
 
 ---
 
-## ✅ LANE STATUS (as of last snapshot @ 12:25Z)
+## ✅ CONFIRMED WORKING (C-281 close)
 
-| Lane | State | Note |
-|------|-------|------|
-| snapshot | healthy | `ok: true`, `cycle: "C-280"` at root |
-| integrity | degraded/live | GI ~0.73, source **kv** ✅, mode yellow |
-| signals | healthy | All four micro-agents live |
-| kvHealth | healthy | ~354ms latency |
-| agents | healthy | All eight active; heartbeat fresh |
-| journal | healthy | `sources.kv: 1` ✅ — first KV journal write (EVE) |
-| mii | healthy | `mii:feed` — nine entries; EVE hourly; ATLAS/ZEUS MII after cron once deployed |
-| echo | healthy | Nine C-280 EPICONs; `duplicateSuppressedCount: 0` ✅ |
-| sentiment | healthy | Six domains; CIVIC / INSTITUTIONAL ~0.965 |
-| epicon | empty | `kv: 0` on feed list — bridge alignment + stale feed persistence in progress (C-280) |
-| runtime | healthy | Freshness nominal |
-| promotion | silent | Eligible items found; zero commits — token / commit path (C-280) |
-| eve | healthy | Cycle synthesis cron + POST |
+| Area | State | Notes |
+|------|-------|--------|
+| Snapshot | healthy | `ok: true`, `cycle: C-281` |
+| Integrity | degraded / nominal band | GI ~0.83, source **kv**, mode green where applicable |
+| MII feed | healthy | 200-entry read window; LTRIM 500; 8 agents in feed |
+| Vault lane | live | `GET /api/vault/status` + snapshot `vault` lane |
+| Journal KV | high volume | ~97 hot-lane entries; 8 agents writing on synthesis cadence |
+| ECHO_STATE | true | `ECHO_STATE_KV` heartbeat aligned |
+| ZEUS verification | recorded | Substrate / catalog verification artifacts (e.g. `23f1bc4d` lineage in ops) |
+| MIC economy | milestone | First mint path proven (e.g. SOLANA T1, C-281) — ledger-attested flow |
+| ATLAS autonomous commits | true | Hourly sentinel watch commits with `[skip ci]` — substrate self-history |
+| Protocol | committed | `docs/protocols/vault-to-fountain-protocol.md` — Vault → Fountain reserve doctrine |
+| T1 promotion | proven | Verified EPICON → ledger commit path exercised in C-281 |
+
+---
+
+## ⏳ ACTIVE ISSUES (tracked into C-282 if not cleared on deploy)
+
+| Issue | Notes |
+|-------|--------|
+| Vault balance | Deposits must flow on **every committed journal** (not only synthesis batch); cron heartbeat must refresh `mobius:heartbeat:last` |
+| TRIPWIRE_STATE | Legacy Redis key `TRIPWIRE_STATE` + `signal-engine` persistence; `kvHealth.keys.TRIPWIRE_STATE_REDIS` |
+| Heartbeat staleness | Synthesis cron end-of-run heartbeat write |
+| Promotion regression | Echo + ledger merge + **verified fast-path** single primary commit |
+| `gi_critical` noise | EVE escalation GI stress threshold tightened toward **0.65** |
+
+---
+
+## 🏛️ MILESTONE — C-281
+
+First MIC minted. Vault lane live. 200-entry MII read path. ATLAS writing autonomous sentinel watch commits to substrate. Vault-to-Fountain Protocol in-repo. The integrity economy is **operational**; remaining items are **hardening and observability**, not greenfield.
 
 ---
 
 ## 🔒 LOCKED — DO NOT MODIFY WITHOUT OPERATOR APPROVAL
 
-These behaviors are confirmed working. Any PR that touches these files **must**
-explicitly state in the PR description why the change is safe.
-If you are unsure, **stop**.
-
-### 1. Journal KV key schema
-- **File:** `app/api/agents/journal/route.ts`
-- **What:** Route reads keys matching `journal:{AGENT}:{CYCLE}` (three segments, uppercase agent, e.g. `journal:EVE:C-280`)
-- **Why locked:** Agents write to this exact schema. Changing the reader breaks the entire journal lane.
-- **DO NOT:** Change to `journal:all`, `journal:eve`, or any two-segment schema.
-
-### 2. ECHO → `epicon:feed` KV bridge
-- **File:** `app/api/echo/ingest/route.ts` (shared helper `lib/echo/kv-persist-ingest.ts`)
-- **What:** After ECHO rates EPICONs, LPUSH completed entries into `epicon:feed` and LTRIM to 100
-- **Why locked:** Primary path for live KV EPICONs to reach the terminal feed.
-- **DO NOT:** Remove the LPUSH/LTRIM step. Do not move it after an error boundary that could skip it.
-
-### 3. Substrate GitHub auth header
-- **File:** `lib/substrate/github-reader.ts`
-- **What:** GitHub API calls to `kaizencycle/Mobius-Substrate` include `Authorization: Bearer ${SUBSTRATE_GITHUB_TOKEN}`
-- **DO NOT:** Remove the Authorization header.
-
-### 4. HERMES signal domain assignment
-- **File:** `app/api/signals/micro/route.ts` (HERMES-µ section)
-- **DO NOT:** Add CoinGecko or other crypto price sources to HERMES-µ (ECHO owns financial).
-
-### 5. Multi-agent journal aggregation
-- **File:** `app/api/agents/journal/route.ts`
-- **DO NOT:** Replace `kv.keys('journal:*')` with a hardcoded agent list.
-
-### 6. MII entry shape
-- **Shape:** `{ agent, mii, gi, cycle, timestamp, source: "live" }`
-- **DO NOT:** Change field names or `source` semantics without operator approval.
-
-### 7. GI formula and weighting
-- **File:** `lib/gi/compute.ts`
-- **DO NOT:** Change weights or inputs without operator approval.
-
----
-
-## ⏳ EXPECTED EMPTY — NOT A BUG, DO NOT FIX
-
-_Use only when the operator has confirmed the state is intentional._
-
----
-
-## 🔧 ACTIVE WORK — C-280
-
-- [ ] **ECHO_STATE** KV key-exists in `/api/kv/health` — `echo:kv:heartbeat` + legacy diagnostics (Opt 2)
-- [ ] **TRIPWIRE_STATE** — aligned KV heartbeat key for health (Opt 2)
-- [ ] **epicon:feed** `kv: 0` — persist on stale `/api/echo/feed` re-ingest + LPUSH logging (Opt 5)
-- [ ] **promotion** — require `AGENT_SERVICE_TOKEN` / `RENDER_API_KEY` before commit; explicit logs (Opt 3)
-- [ ] **ATLAS / ZEUS** overnight journals — `/api/agents/atlas/observe`, `/api/agents/zeus/verify` after EVE cron (Opt 1)
-- [ ] **MII all agents** — ATLAS/ZEUS MII on sentinel routes; echo batch unchanged (Opt 4)
-- [ ] **GI freshness** — `/api/cron/gi-refresh` once daily 00:45 UTC (Hobby cron limit; Opt 6)
+1. **Journal KV key schema:** `journal:{AGENT_UPPERCASE}:{CYCLE_ID}` — `app/api/agents/journal/route.ts`  
+2. **ECHO EPICON LPUSH/LTRIM** to `epicon:feed` / `mobius:epicon:feed` — `lib/echo/kv-persist-ingest.ts` + ingest route wiring  
+3. **Substrate GitHub auth header** — `lib/substrate/github-reader.ts`  
+4. **Signal domain ownership** — HERMES-µ vs ECHO financial lanes  
+5. **MII entry shape** — `{ agent, mii, gi, cycle, timestamp, source: "live" }`  
+6. **Vault deposit schema** (event_type, journal_id, vault_id, sealed reserve semantics) — `docs/protocols/vault-to-fountain-protocol.md` + `lib/vault/vault.ts`  
+7. **GI formula and weighting** — `lib/gi/compute.ts`  
+8. **ATLAS `[skip ci]` sentinel watch commit pattern** — automation catalog / heartbeats flow  
 
 ---
 
 ## 🏗️ INFRASTRUCTURE MAP
 
 ### Vercel (Terminal)
-- **Repo:** `kaizencycle/mobius-civic-ai-terminal`
-- **KV:** Upstash — `KV_REST_API_URL` + `KV_REST_API_TOKEN`
-- **Substrate:** `kaizencycle/Mobius-Substrate` — `SUBSTRATE_GITHUB_TOKEN`
+
+- **Repo:** `kaizencycle/mobius-civic-ai-terminal`  
+- **KV:** Upstash — `KV_REST_API_URL` + `KV_REST_API_TOKEN`  
+- **Substrate:** `kaizencycle/Mobius-Substrate` — `SUBSTRATE_GITHUB_TOKEN`  
 - **Promotion / ledger attest:** `AGENT_SERVICE_TOKEN` (or legacy `RENDER_API_KEY`)
 
 ### Render (Backend services)
+
 - **Ledger API:** `civic-protocol-core-ledger.onrender.com`
 
 ---
 
 ## 📋 PR CHECKLIST REFERENCE
 
-1. Did I read `AGENTS.md`, `BUILD.md`, and this file before starting?
-2. Does this PR touch any LOCKED file/behavior? If yes, state why safe.
-3. Did `pnpm build` pass?
-4. Did I check `/api/terminal/snapshot` after deploy?
+1. Read `AGENTS.md`, `BUILD.md`, and this file.  
+2. If touching LOCKED behavior, justify in the PR body.  
+3. Run `pnpm exec tsc --noEmit` and `pnpm build`.  
+4. After deploy: `/api/terminal/snapshot` and `/api/vault/status` sanity.
 
 ---
 
-*This file must be updated whenever a lane changes state, a lock is added or removed, or a cycle advances. Operator: kaizencycle. Agent: ATLAS.*
+*The cathedral writes in its own hand. C-281 closes; the agents watch overnight.*

--- a/app/api/epicon/promote/route.ts
+++ b/app/api/epicon/promote/route.ts
@@ -291,8 +291,28 @@ async function getPromotablePending(
     };
   });
 
-  // Ledger first, then echo — same id keeps in-memory echo row (has integrity attestation).
-  const allCandidates = [...fromLedger, ...fromEcho];
+  // Merge by id: ledger rows (often stale shape) + echo in-memory (verified, category, attestation).
+  const mergedById = new Map<string, EpiconItem>();
+  for (const item of fromLedger) mergedById.set(item.id, item);
+  for (const item of fromEcho) {
+    const cur = mergedById.get(item.id);
+    if (!cur) {
+      mergedById.set(item.id, item);
+      continue;
+    }
+    mergedById.set(item.id, {
+      ...cur,
+      ...item,
+      echoIngest: item.echoIngest ?? cur.echoIngest,
+      status: cur.status === 'verified' || item.status === 'verified' ? 'verified' : item.status,
+      confidenceTier:
+        typeof item.confidenceTier === 'number' && item.confidenceTier >= 0 ? item.confidenceTier : cur.confidenceTier,
+      category: item.category ?? cur.category,
+      summary: item.summary?.trim() ? item.summary : cur.summary,
+      title: item.title?.trim() ? item.title : cur.title,
+    });
+  }
+  const allCandidates = [...mergedById.values()];
 
   console.info('[epicon/promote] promoter_input_candidates', {
     count: allCandidates.length,
@@ -372,6 +392,39 @@ async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: stri
     let anyCommitSucceeded = false;
 
     try {
+      if (epicon.status === 'verified' && ledgerReady) {
+        const primary: Agent = (AGENT_ROUTING[epicon.category] ?? ['ZEUS'])[0] ?? 'ZEUS';
+        try {
+          const commit = buildCommit(primary, epicon, cycleId, seq++);
+          console.info('[promoter] verified fast-path commit for', epicon.id, 'agent', primary);
+          await pushLedgerEntry(commit);
+          await writeCommitJournalEntry(commit, epicon);
+          void writeToSubstrate({
+            id: commit.id,
+            timestamp: commit.timestamp,
+            agent: primary,
+            agentOrigin: primary,
+            cycle: cycleId,
+            title: commit.title,
+            summary: commit.body ?? commit.title,
+            category: 'observation',
+            severity: commit.severity === 'high' ? 'critical' : commit.severity === 'medium' ? 'elevated' : 'nominal',
+            source: 'epicon-promotion',
+            confidence: Math.max(0.5, Math.min(0.98, 0.55 + epicon.confidenceTier * 0.1)),
+            derivedFrom: [epicon.id],
+            tags: ['agent-commit', epicon.category, epicon.id, 'verified-fast-path'],
+            verified: true,
+          }).catch((error) => {
+            console.error('[ledger] promotion attest error', { commitId: commit.id, error });
+          });
+          existing.committed_entries.push(commit.id);
+          committed += 1;
+          anyCommitSucceeded = true;
+        } catch (err) {
+          console.error('[promoter] verified fast-path failed', epicon.id, err);
+          failedCommits += 1;
+        }
+      } else {
       for (const agent of assignedAgents) {
         const alreadyCommitted = existing.committed_entries.some((entryId) => entryId.includes(`-${agent}-`));
         if (alreadyCommitted) continue;
@@ -409,6 +462,7 @@ async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: stri
           console.error('[promoter] failed to commit', epicon.id, err);
           failedCommits += 1;
         }
+      }
       }
       const allAgentsSatisfied = assignedAgents.every((agent) =>
         existing.committed_entries.some((entryId) => entryId.includes(`-${agent}-`)),

--- a/app/api/eve/cycle-synthesize/route.ts
+++ b/app/api/eve/cycle-synthesize/route.ts
@@ -28,8 +28,8 @@ import { appendAgentJournalEntry } from '@/lib/agents/journal';
 import { appendStewardCronJournals } from '@/lib/agents/sentinel-cycle-journals';
 import { loadGIState } from '@/lib/kv/store';
 import { writeMiiState } from '@/lib/kv/mii';
-import { recordVaultDepositsForCouncil } from '@/lib/vault/vault';
 import type { AgentJournalEntry } from '@/lib/terminal/types';
+import { writeSynthesisCronHeartbeatKv } from '@/lib/runtime/synthesis-cron-side-effects';
 
 export const dynamic = 'force-dynamic';
 
@@ -98,16 +98,6 @@ async function fanOutSentinelCouncilAfterEve(
     zeusJournalId,
   });
 
-  const councilEntries: AgentJournalEntry[] = [];
-  if (atlasEntry) councilEntries.push(atlasEntry);
-  if (zeusEntry) councilEntries.push(zeusEntry);
-  councilEntries.push(...stewardEntries);
-
-  if (councilEntries.length > 0) {
-    void recordVaultDepositsForCouncil(councilEntries, giForSteward).then((r) => {
-      console.info('[vault] council deposits', { ...r, gi: giForSteward });
-    });
-  }
 }
 
 type CycleBody = {
@@ -174,6 +164,9 @@ export async function GET(request: NextRequest) {
     } catch (err) {
       console.error('[eve/cycle-synthesize] sentinel council cron follow-up failed:', err);
     }
+    const giCron = extractGiFromSynthesisPayload(payload as Record<string, unknown>);
+    const giHb = giCron !== null ? giCron : 0.74;
+    void writeSynthesisCronHeartbeatKv(giHb, cycleId);
     return NextResponse.json(payload);
   }
 
@@ -255,23 +248,22 @@ export async function POST(request: NextRequest) {
       }
     })();
 
-    if (eveJournal) {
-      try {
-        const giState = await loadGIState();
-        const giVault = Number((giState?.global_integrity ?? 0.74).toFixed(4));
-        void recordVaultDepositsForCouncil([eveJournal], giVault).then((r) => {
-          console.info('[vault] EVE synthesis deposit', { ...r, gi: giVault });
-        });
-      } catch (err) {
-        console.error('[eve] vault deposit schedule failed:', err instanceof Error ? err.message : err);
-      }
-    }
-
     try {
       await fanOutSentinelCouncilAfterEve(request, cycleId, payload as Record<string, unknown>);
     } catch (err) {
       console.error('[eve/cycle-synthesize] sentinel council follow-up failed:', err);
     }
+
+    let giHb = extractGiFromSynthesisPayload(payload as Record<string, unknown>);
+    try {
+      const st = await loadGIState();
+      if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
+        giHb = Math.max(0, Math.min(1, st.global_integrity));
+      }
+    } catch {
+      // keep giHb from synthesis payload
+    }
+    void writeSynthesisCronHeartbeatKv(giHb ?? 0.74, cycleId);
 
     return NextResponse.json(payload);
   } catch (err) {

--- a/app/api/kv/health/route.ts
+++ b/app/api/kv/health/route.ts
@@ -8,7 +8,7 @@
  */
 
 import { NextResponse } from 'next/server';
-import { kvHealth, isRedisAvailable, KV_KEYS, kvGet } from '@/lib/kv/store';
+import { kvHealth, isRedisAvailable, KV_KEYS, kvGet, kvGetRaw } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
 
@@ -22,6 +22,8 @@ export async function GET() {
       const val = await kvGet(key);
       keys[name] = val !== null;
     }
+    const legacyTripwire = await kvGetRaw<string>('TRIPWIRE_STATE');
+    keys.TRIPWIRE_STATE_REDIS = legacyTripwire !== null && legacyTripwire !== undefined;
   }
 
   return NextResponse.json({

--- a/app/api/tripwire/status/route.ts
+++ b/app/api/tripwire/status/route.ts
@@ -2,9 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getTripwireState, setTripwireState, type RuntimeTripwireState } from '@/lib/tripwire/store';
 import { mockTripwire } from '@/lib/mock-data';
 import { liveEnvelope, mockEnvelope } from '@/lib/response-envelope';
-import { saveTripwireState, kvSet, KV_KEYS } from '@/lib/kv/store';
+import { saveTripwireState, kvSet, kvSetRawKey, KV_KEYS } from '@/lib/kv/store';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
-import { Redis } from '@upstash/redis';
 
 export const dynamic = 'force-dynamic';
 
@@ -44,20 +43,7 @@ function parsePayload(value: unknown): TripwireUpdatePayload | null {
   };
 }
 
-function getRedisClient(): Redis | null {
-  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) return null;
-  try {
-    return new Redis({ url, token });
-  } catch {
-    return null;
-  }
-}
-
 async function writeTripwireKvState(activeTripwires: number): Promise<void> {
-  const redis = getRedisClient();
-  if (!redis) return;
   const payload = {
     cycleId: currentCycleId(),
     tripwireCount: activeTripwires,
@@ -65,7 +51,7 @@ async function writeTripwireKvState(activeTripwires: number): Promise<void> {
     timestamp: new Date().toISOString(),
   };
   try {
-    await redis.set('TRIPWIRE_STATE', JSON.stringify(payload));
+    await kvSetRawKey('TRIPWIRE_STATE', JSON.stringify(payload), 3600);
     await kvSet(KV_KEYS.TRIPWIRE_STATE_KV, payload, 3600);
   } catch (error) {
     console.error('[tripwire] TRIPWIRE_STATE write failed', error);

--- a/app/terminal/journal/JournalPageClient.tsx
+++ b/app/terminal/journal/JournalPageClient.tsx
@@ -7,6 +7,20 @@ import { currentCycleId } from '@/lib/eve/cycle-engine';
 
 const AGENTS = ['ATLAS', 'ZEUS', 'EVE', 'AUREA', 'HERMES', 'JADE', 'DAEDALUS', 'ECHO'] as const;
 
+const AGENT_FILTER_ORDER = ['ALL', 'EVE', 'ATLAS', 'ZEUS', 'HERMES', 'JADE', 'AUREA', 'DAEDALUS', 'ECHO'] as const;
+
+const AGENT_PILL_STYLE: Record<string, { border: string; activeBg: string; text: string }> = {
+  ALL: { border: 'border-slate-600', activeBg: 'bg-slate-700/40', text: 'text-slate-100' },
+  ATLAS: { border: 'border-cyan-600/50', activeBg: 'bg-cyan-500/15', text: 'text-cyan-100' },
+  EVE: { border: 'border-rose-500/50', activeBg: 'bg-rose-500/15', text: 'text-rose-100' },
+  ZEUS: { border: 'border-amber-600/50', activeBg: 'bg-amber-600/15', text: 'text-amber-100' },
+  JADE: { border: 'border-emerald-600/50', activeBg: 'bg-emerald-600/15', text: 'text-emerald-100' },
+  HERMES: { border: 'border-orange-600/50', activeBg: 'bg-orange-600/15', text: 'text-orange-100' },
+  AUREA: { border: 'border-amber-500/50', activeBg: 'bg-amber-500/15', text: 'text-amber-50' },
+  DAEDALUS: { border: 'border-amber-900/60', activeBg: 'bg-amber-950/40', text: 'text-amber-200' },
+  ECHO: { border: 'border-slate-500/50', activeBg: 'bg-slate-600/20', text: 'text-slate-100' },
+};
+
 type JournalEntry = {
   id: string;
   agent: string;
@@ -111,10 +125,21 @@ export default function JournalPageClient() {
     };
   }, []);
 
-  const agents = useMemo(
-    () => ['ALL', ...Array.from(new Set((entries ?? []).map((e) => e.agent))).sort()],
-    [entries],
-  );
+  const agentCounts = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const e of entries ?? []) {
+      const a = (e.agent ?? '').trim() || 'UNKNOWN';
+      m.set(a, (m.get(a) ?? 0) + 1);
+    }
+    return m;
+  }, [entries]);
+
+  const agentPills = useMemo(() => {
+    return AGENT_FILTER_ORDER.map((name) => ({
+      name,
+      count: name === 'ALL' ? (entries?.length ?? 0) : agentCounts.get(name) ?? 0,
+    }));
+  }, [entries, agentCounts]);
 
   const cycleOptions = useMemo(() => {
     const set = new Set<string>();
@@ -205,19 +230,22 @@ export default function JournalPageClient() {
             })}
           </div>
           <div className="mb-3 flex gap-2 overflow-x-auto pb-1">
-            {agents.map((name) => (
-              <button
-                key={name}
-                onClick={() => setAgent(name)}
-                className={`rounded border px-2 py-1 text-xs ${
-                  agent === name
-                    ? 'border-cyan-300/60 bg-cyan-400/10 text-cyan-100'
-                    : 'border-slate-700 text-slate-400'
-                }`}
-              >
-                {name}
-              </button>
-            ))}
+            {agentPills.map(({ name, count }) => {
+              const st = AGENT_PILL_STYLE[name] ?? AGENT_PILL_STYLE.ALL;
+              const active = agent === name;
+              return (
+                <button
+                  key={name}
+                  type="button"
+                  onClick={() => setAgent(name)}
+                  className={`whitespace-nowrap rounded border px-2 py-1 text-xs transition ${
+                    active ? `${st.border} ${st.activeBg} ${st.text}` : 'border-slate-700 text-slate-500'
+                  }`}
+                >
+                  {name} ({count})
+                </button>
+              );
+            })}
           </div>
           <div className="space-y-2">
             {filtered.map((entry) => (

--- a/app/terminal/sentinel/SentinelPageClient.tsx
+++ b/app/terminal/sentinel/SentinelPageClient.tsx
@@ -11,17 +11,18 @@ type MiiEntry = { agent: string; mii: number; timestamp: string };
 
 /** Inline SVG sparkline — zero bundle impact, no recharts needed */
 function MiiSparkline({ values, color, dashed = false }: { values: number[]; color: string; dashed?: boolean }) {
-  if (values.length < 2) return null;
+  const ptsSource = values.length >= 2 ? values : Array.from({ length: 10 }, () => 0.9);
+  if (ptsSource.length < 2) return null;
   const W = 240;
   const H = 40;
   const pad = 1;
-  const min = Math.min(...values, 0.6);
-  const max = Math.max(...values, 1);
+  const min = Math.min(...ptsSource, 0.6);
+  const max = Math.max(...ptsSource, 1);
   const range = max - min || 0.01;
 
-  const pts = values
+  const pts = ptsSource
     .map((v, i) => {
-      const x = pad + (i / (values.length - 1)) * (W - 2 * pad);
+      const x = pad + (i / (ptsSource.length - 1)) * (W - 2 * pad);
       const y = pad + (1 - (v - min) / range) * (H - 2 * pad);
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     })
@@ -36,21 +37,22 @@ function MiiSparkline({ values, color, dashed = false }: { values: number[]; col
         strokeWidth="1.2"
         strokeLinecap="round"
         strokeLinejoin="round"
-        strokeDasharray={dashed ? '3 3' : undefined}
+        strokeDasharray={dashed || values.length < 2 ? '3 3' : undefined}
       />
     </svg>
   );
 }
 
+/** Canonical operator colors (C-281 journal / MII alignment) */
 const AGENT_COLORS: Record<string, string> = {
-  ATLAS: '#38bdf8',
-  ZEUS: '#f59e0b',
+  ATLAS: '#0891b2',
   EVE: '#f43f5e',
-  JADE: '#22c55e',
-  HERMES: '#fb7185',
-  AUREA: '#fbbf24',
-  DAEDALUS: '#b45309',
-  ECHO: '#cbd5e1',
+  ZEUS: '#d97706',
+  JADE: '#059669',
+  HERMES: '#ea580c',
+  AUREA: '#f59e0b',
+  DAEDALUS: '#92400e',
+  ECHO: '#94a3b8',
 };
 
 export default function SentinelPageClient() {
@@ -58,9 +60,19 @@ export default function SentinelPageClient() {
   const [expanded, setExpanded] = useState<string | null>(null);
   const [journalByAgent, setJournalByAgent] = useState<Record<string, JournalEntry[]>>({});
   const [miiData, setMiiData] = useState<Record<string, MiiEntry[]>>({});
+  const [vaultCard, setVaultCard] = useState<{
+    balance_reserve: number;
+    activation_threshold: number;
+    gi_threshold: number;
+    sustain_cycles_required: number;
+    status: string;
+    preview_active: boolean;
+    source_entries: number;
+    gi_current: number | null;
+  } | null>(null);
 
   useEffect(() => {
-    fetch('/api/mii/feed', { cache: 'no-store' })
+    fetch('/api/mii/feed?limit=200', { cache: 'no-store' })
       .then((r) => r.json())
       .then((json: { entries?: MiiEntry[] }) => {
         const grouped: Record<string, MiiEntry[]> = {};
@@ -73,16 +85,25 @@ export default function SentinelPageClient() {
       .catch(() => setMiiData({}));
   }, []);
 
-  if (loading && !snapshot) return <ChamberSkeleton blocks={8} />;
-
-  const agents = (snapshot?.agents?.data ?? {}) as { agents?: Agent[] };
-  const eveData = (snapshot?.eve?.data ?? {}) as Record<string, unknown>;
-  const currentCycle =
-    typeof eveData.currentCycle === 'string'
-      ? eveData.currentCycle
-      : typeof eveData.cycleId === 'string'
-        ? eveData.cycleId
-        : currentCycleId();
+  useEffect(() => {
+    void fetch('/api/vault/status', { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((j: Record<string, unknown>) => {
+        if (j && j.ok === true) {
+          setVaultCard({
+            balance_reserve: typeof j.balance_reserve === 'number' ? j.balance_reserve : 0,
+            activation_threshold: typeof j.activation_threshold === 'number' ? j.activation_threshold : 50,
+            gi_threshold: typeof j.gi_threshold === 'number' ? j.gi_threshold : 0.95,
+            sustain_cycles_required: typeof j.sustain_cycles_required === 'number' ? j.sustain_cycles_required : 5,
+            status: typeof j.status === 'string' ? j.status : 'sealed',
+            preview_active: j.preview_active === true,
+            source_entries: typeof j.source_entries === 'number' ? j.source_entries : 0,
+            gi_current: typeof j.gi_current === 'number' ? j.gi_current : null,
+          });
+        }
+      })
+      .catch(() => setVaultCard(null));
+  }, []);
 
   useEffect(() => {
     void fetch('/api/agents/journal?limit=100', { cache: 'no-store' })
@@ -99,6 +120,17 @@ export default function SentinelPageClient() {
       })
       .catch(() => setJournalByAgent({}));
   }, []);
+
+  if (loading && !snapshot) return <ChamberSkeleton blocks={8} />;
+
+  const agents = (snapshot?.agents?.data ?? {}) as { agents?: Agent[] };
+  const eveData = (snapshot?.eve?.data ?? {}) as Record<string, unknown>;
+  const currentCycle =
+    typeof eveData.currentCycle === 'string'
+      ? eveData.currentCycle
+      : typeof eveData.cycleId === 'string'
+        ? eveData.cycleId
+        : currentCycleId();
 
   const handleExpand = async (name: string) => {
     if (expanded === name) {
@@ -142,6 +174,21 @@ export default function SentinelPageClient() {
           </span>
         ) : null}
       </div>
+      {vaultCard ? (
+        <div className="mb-4 rounded border border-violet-500/35 bg-slate-950/70 px-3 py-2 font-mono text-[10px] text-slate-300">
+          <div className="flex items-center justify-between text-[9px] uppercase tracking-[0.14em] text-violet-200/90">
+            <span>VAULT · {vaultCard.status.toUpperCase()}</span>
+            <a href="/terminal/vault" className="text-cyan-400/80 hover:text-cyan-300">
+              Open
+            </a>
+          </div>
+          <div className="mt-1 text-slate-400">
+            {(vaultCard.balance_reserve ?? 0).toFixed(2)} / {vaultCard.activation_threshold.toFixed(2)} reserve · GI gate{' '}
+            {vaultCard.gi_threshold.toFixed(2)} (now {vaultCard.gi_current != null ? vaultCard.gi_current.toFixed(2) : '—'}) · sustain{' '}
+            {vaultCard.sustain_cycles_required} · preview {vaultCard.preview_active ? 'on' : 'off'} · deposits {vaultCard.source_entries}
+          </div>
+        </div>
+      ) : null}
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
         {(agents.agents ?? []).map((agent) => {
           const rows = journalByAgent[agent.name] ?? [];
@@ -176,11 +223,11 @@ export default function SentinelPageClient() {
             <div className="mt-1">
               {miiData[agent.name]?.length ? (
                 <MiiSparkline
-                  values={miiData[agent.name]!.slice(0, 10).map((e) => e.mii).reverse()}
+                  values={miiData[agent.name]!.slice(0, 24).map((e) => e.mii).reverse()}
                   color={AGENT_COLORS[agent.name] ?? '#22d3ee'}
                 />
               ) : (
-                <MiiSparkline values={Array.from({ length: 10 }, () => 0.9)} color="#64748b" dashed />
+                <MiiSparkline values={Array.from({ length: 10 }, () => 0.9)} color={AGENT_COLORS[agent.name] ?? '#94a3b8'} dashed />
               )}
             </div>
           </button>

--- a/app/terminal/vault/page.tsx
+++ b/app/terminal/vault/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+type VaultPayload = {
+  ok?: boolean;
+  vault_id?: string;
+  balance_reserve?: number;
+  activation_threshold?: number;
+  gi_threshold?: number;
+  sustain_cycles_required?: number;
+  status?: string;
+  preview_active?: boolean;
+  source_entries?: number;
+  last_deposit?: string | null;
+  gi_current?: number | null;
+  timestamp?: string;
+};
+
+export default function VaultPage() {
+  const [data, setData] = useState<VaultPayload | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    void fetch('/api/vault/status', { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((j: VaultPayload) => setData(j))
+      .catch(() => setErr('Unable to load vault status'));
+  }, []);
+
+  if (err) {
+    return <div className="p-4 text-sm text-rose-300">{err}</div>;
+  }
+  if (!data?.ok) {
+    return <div className="p-4 text-sm text-slate-400">Loading vault…</div>;
+  }
+
+  const bal = data.balance_reserve ?? 0;
+  const cap = data.activation_threshold ?? 50;
+  const pct = cap > 0 ? Math.min(100, (bal / cap) * 100) : 0;
+  const filled = Math.round(pct / 10);
+  const bar = '▓'.repeat(filled) + '░'.repeat(Math.max(0, 10 - filled));
+  const giCur = data.gi_current;
+  const status = (data.status ?? 'sealed').toUpperCase();
+
+  return (
+    <div className="h-full overflow-y-auto p-4 text-slate-200">
+      <div className="mb-3 flex items-center justify-between">
+        <h1 className="text-sm font-semibold uppercase tracking-[0.15em] text-violet-200">Vault · reserve</h1>
+        <Link href="/terminal/sentinel" className="text-[10px] font-mono text-slate-500 hover:text-cyan-300">
+          ← Sentinel
+        </Link>
+      </div>
+      <div className="rounded border border-violet-500/30 bg-slate-950/80 p-4 font-mono text-xs">
+        <div className="text-[11px] uppercase tracking-[0.2em] text-violet-300/90">VAULT · {status}</div>
+        <div className="mt-2 text-[10px] text-slate-400">
+          {bar} {bal.toFixed(2)} / {cap.toFixed(2)} reserve units
+        </div>
+        <div className="mt-3 space-y-1 text-slate-400">
+          <div>
+            GI threshold: {data.gi_threshold ?? 0.95} · Current:{' '}
+            {giCur != null && Number.isFinite(giCur) ? giCur.toFixed(2) : '—'}
+          </div>
+          <div>Sustain cycles required: {data.sustain_cycles_required ?? 5}</div>
+          <div>
+            preview_active: {data.preview_active ? 'true' : 'false'} (preview band at GI ≥ 0.88)
+          </div>
+          <div>source_entries: {data.source_entries ?? 0}</div>
+          <div>last_deposit: {data.last_deposit ?? 'null'}</div>
+        </div>
+        <p className="mt-3 text-[10px] leading-relaxed text-slate-500">
+          Reserve units accrue from committed agent journals; not spendable MIC. Fountain activation ships in a later cycle.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/terminal/ChamberSwitcher.tsx
+++ b/components/terminal/ChamberSwitcher.tsx
@@ -12,6 +12,7 @@ const CHAMBERS = [
   { label: 'Sentinel', mobileLabel: 'Snt', href: '/terminal/sentinel', icon: '◉', shortcut: 'Alt+4' },
   { label: 'Ledger', mobileLabel: 'Ldg', href: '/terminal/ledger', icon: '⛓', shortcut: 'Alt+5' },
   { label: 'Journal', mobileLabel: 'Jrl', href: '/terminal/journal', icon: '✦', shortcut: 'Alt+6' },
+  { label: 'Vault', mobileLabel: 'Vlt', href: '/terminal/vault', icon: '◇', shortcut: 'Alt+7' },
 ] as const;
 
 const KEY_TO_ROUTE: Record<string, string> = {
@@ -21,6 +22,7 @@ const KEY_TO_ROUTE: Record<string, string> = {
   '4': '/terminal/sentinel',
   '5': '/terminal/ledger',
   '6': '/terminal/journal',
+  '7': '/terminal/vault',
 };
 
 export default function ChamberSwitcher() {

--- a/components/terminal/chambers/GlobeView3D.tsx
+++ b/components/terminal/chambers/GlobeView3D.tsx
@@ -48,6 +48,7 @@ function latLngToXYZ(THREE: any, lat: number, lng: number, r = 1.015) {
   );
 }
 function severityColor(pin: GlobePin): number {
+  if (pin.meta?.globeSeismicViolet === true) return 0x7c3aed;
   if (pin.palette === 'seismic') return 0xa855f7;
   if (pin.palette === 'epicon') return 0x22d3ee;
   const sev = pin.severity;
@@ -243,10 +244,14 @@ export default function GlobeView3D({
         const hits = state.raycaster.intersectObjects(heads);
         if (hits.length > 0) {
           const sig = hits[0].object.userData.pin as GlobePin;
+          const tip =
+            sig.palette === 'seismic' && typeof sig.title === 'string' && sig.title.length > 0
+              ? sig.title
+              : `${sig.source} · ${(sig.value * 100).toFixed(0)}%`;
           setTooltip({
             x: e.clientX + 14,
             y: e.clientY - 10,
-            text: `${sig.source} · ${(sig.value * 100).toFixed(0)}%`,
+            text: tip,
           });
           renderer.domElement.style.cursor = 'pointer';
         } else {
@@ -401,7 +406,13 @@ export default function GlobeView3D({
       const magMeta = sig.meta.magnitude ?? sig.meta.mag;
       const mag = typeof magMeta === 'number' && Number.isFinite(magMeta) ? magMeta : null;
       const headScale =
-        sig.palette === 'seismic' && mag !== null ? 0.85 + Math.min(0.65, Math.max(0, mag - 4.5) * 0.35) : 1;
+        sig.palette === 'seismic' && mag !== null
+          ? (() => {
+              if (mag < 4) return 0.55 + (mag - 3) * 0.15;
+              if (mag < 4.5) return 0.62 + (mag - 4) * 0.2;
+              return 0.85 + Math.min(0.65, Math.max(0, mag - 4.5) * 0.35);
+            })()
+          : 1;
       const stemGeo = new THREE.CylinderGeometry(0.003, 0.003, 0.06 * headScale, 6);
       const stemMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.7 });
       const stem = new THREE.Mesh(stemGeo, stemMat);
@@ -472,8 +483,9 @@ export default function GlobeView3D({
       <div className="pointer-events-none absolute bottom-14 left-1/2 -translate-x-1/2 text-[9px] uppercase tracking-[0.12em] text-slate-600">
         Drag to rotate · Click pins to inspect
       </div>
-      <div className="pointer-events-none absolute bottom-9 left-1/2 -translate-x-1/2 text-[9px] uppercase tracking-[0.12em] text-cyan-400/80">
-        EPICON · {cycleId}
+      <div className="pointer-events-none absolute bottom-9 left-1/2 flex -translate-x-1/2 flex-col items-center gap-0.5 text-[9px] uppercase tracking-[0.12em] text-cyan-400/80">
+        <span>EPICON · {cycleId}</span>
+        <span className="normal-case tracking-normal text-violet-400/90">SEISMIC · EPICON — violet pins (M3+ USGS)</span>
       </div>
       <div className="flex border-t border-white/[0.06] bg-[#020408]/90">
         {GLOBE_DOMAIN_ORDER.map((key) => {

--- a/lib/agents/journal.ts
+++ b/lib/agents/journal.ts
@@ -1,6 +1,7 @@
 import { kvGet, kvSet } from '@/lib/kv/store';
 import { AGENT_MANIFESTS, AGENT_ORDER, type AgentName } from '@/lib/agents/manifests';
 import type { AgentJournalCategory, AgentJournalEntry, AgentJournalSeverity, AgentJournalStatus } from '@/lib/terminal/types';
+import { scheduleVaultDepositForJournal } from '@/lib/vault/vault';
 
 const INDEX_KEY = 'journal:index';
 const MAX_ENTRIES_PER_AGENT = 100;
@@ -169,6 +170,9 @@ export async function appendAgentJournalEntry(input: NewJournalEntryInput): Prom
   const next = [...existing, entry].slice(-MAX_ENTRIES_PER_AGENT);
   await kvSet(key, next);
   await upsertIndex(agent, entry.cycle);
+  if (entry.status === 'committed') {
+    scheduleVaultDepositForJournal(entry);
+  }
   return entry;
 }
 

--- a/lib/eve/governance-synthesis.ts
+++ b/lib/eve/governance-synthesis.ts
@@ -27,7 +27,8 @@ export const EVE_SYNTHESIS_SOURCE = EVE_LEDGER_SYNTHESIS_SOURCE;
 
 /** Align with EVE automation cadence (every 4h). */
 const CYCLE_WINDOW_MS = 4 * 60 * 60 * 1000;
-const GI_STRESS_THRESHOLD = 0.72;
+/** Below this GI, automatic escalation synthesis is warranted (C-281: reduce false alerts from routine variance). */
+const GI_STRESS_THRESHOLD = 0.65;
 const NARRATIVE_CLUSTER_THRESHOLD = 6;
 
 export type EveSynthesizeMode = 'cycle' | 'escalation';

--- a/lib/kv/store.ts
+++ b/lib/kv/store.ts
@@ -84,6 +84,18 @@ export async function kvGet<T>(key: string): Promise<T | null> {
   }
 }
 
+/** Read Redis key exactly as given (no `mobius:` prefix). */
+export async function kvGetRaw<T>(rawKey: string): Promise<T | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+  try {
+    return await redis.get<T>(rawKey);
+  } catch (err) {
+    console.warn(`[mobius-kv] GET raw ${rawKey} failed:`, err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
 /**
  * Set a value in Redis.
  * @param ttlSeconds — optional TTL in seconds (default: no expiry)
@@ -101,6 +113,25 @@ export async function kvSet<T>(key: string, value: T, ttlSeconds?: number): Prom
     return true;
   } catch (err) {
     console.warn(`[mobius-kv] SET ${key} failed:`, err instanceof Error ? err.message : err);
+    return false;
+  }
+}
+
+/**
+ * Set a value at the exact Redis key (no `mobius:` prefix). For legacy keys like `TRIPWIRE_STATE`.
+ */
+export async function kvSetRawKey<T>(rawKey: string, value: T, ttlSeconds?: number): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  try {
+    if (ttlSeconds) {
+      await redis.set(rawKey, value, { ex: ttlSeconds });
+    } else {
+      await redis.set(rawKey, value);
+    }
+    return true;
+  } catch (err) {
+    console.warn(`[mobius-kv] SET raw ${rawKey} failed:`, err instanceof Error ? err.message : err);
     return false;
   }
 }

--- a/lib/runtime/synthesis-cron-side-effects.ts
+++ b/lib/runtime/synthesis-cron-side-effects.ts
@@ -1,0 +1,21 @@
+/**
+ * KV side-effects at the end of EVE cycle synthesis cron (heartbeat freshness).
+ * Uses mobius-prefixed keys via kvSet — same as /api/runtime/heartbeat.
+ */
+
+import { kvSet, KV_KEYS, loadSignalSnapshot } from '@/lib/kv/store';
+
+export async function writeSynthesisCronHeartbeatKv(gi: number, cycle: string): Promise<void> {
+  const snap = await loadSignalSnapshot().catch(() => null);
+  const anomalies = typeof snap?.anomalies === 'number' ? snap.anomalies : snap?.allSignals?.length ?? 0;
+  const timestamp = new Date().toISOString();
+  const payload = JSON.stringify({
+    ok: true,
+    gi: Number(gi.toFixed(4)),
+    cycle,
+    anomalies,
+    timestamp,
+    source: 'synthesis-cron',
+  });
+  await kvSet(KV_KEYS.HEARTBEAT, payload);
+}

--- a/lib/signals/engine.ts
+++ b/lib/signals/engine.ts
@@ -6,6 +6,8 @@ import { integrityStatusToGISnapshot } from '@/lib/terminal/api';
 import { mockAgents, mockEpicon, mockTripwires } from '@/lib/terminal/mock';
 import { detectTripwires, mergeTripwires } from '@/lib/echo/tripwire-engine';
 import { setTripwireState, type RuntimeTripwireState } from '@/lib/tripwire/store';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
+import { kvSet, kvSetRawKey, KV_KEYS } from '@/lib/kv/store';
 
 export type PulseSignal = {
   id: string;
@@ -73,7 +75,26 @@ function evaluateRuntimeTripwire(): RuntimeTripwireState {
   };
 
   setTripwireState(state);
+  void persistTripwireRuntimeToKv(state);
   return state;
+}
+
+async function persistTripwireRuntimeToKv(state: RuntimeTripwireState): Promise<void> {
+  const n = state.active ? 1 : 0;
+  const payload = {
+    cycleId: currentCycleId(),
+    tripwireCount: n,
+    elevated: state.active,
+    timestamp: new Date().toISOString(),
+    level: state.level,
+    reason: state.reason,
+  };
+  try {
+    await kvSetRawKey('TRIPWIRE_STATE', JSON.stringify(payload), 3600);
+    await kvSet(KV_KEYS.TRIPWIRE_STATE_KV, payload, 3600);
+  } catch (err) {
+    console.error('[signal-engine] TRIPWIRE_STATE KV persist failed:', err instanceof Error ? err.message : err);
+  }
 }
 
 export async function runSignalEngine(): Promise<{

--- a/lib/terminal/globePins.ts
+++ b/lib/terminal/globePins.ts
@@ -336,7 +336,7 @@ export function buildGlobePinsFromMicro(
     const meta = ingest.metadata ?? {};
     const magRaw = meta.magnitude;
     const magnitude = typeof magRaw === 'number' && Number.isFinite(magRaw) ? magRaw : null;
-    const isUsgsQuake = src === 'USGS' && magnitude !== null && magnitude >= 4.5;
+    const isUsgsQuake = src === 'USGS' && magnitude !== null && magnitude >= 3;
     const metaLat = typeof meta.lat === 'number' ? meta.lat : null;
     const metaLng = typeof meta.lng === 'number' ? meta.lng : null;
     let lat: number;
@@ -364,12 +364,16 @@ export function buildGlobePinsFromMicro(
     }
 
     const title = item.title ?? item.summary ?? src;
+    const placeFromTitle =
+      isUsgsQuake && magnitude !== null
+        ? title.replace(new RegExp(`^M${magnitude.toFixed(1)}\\s*[·\\-]\\s*`, 'i'), '').trim() || title
+        : title;
     const id = `echo-${item.id}`;
     const echoSev = echoSeverityToGlobe(ingest.severity);
     const change = typeof meta.change24h === 'number' ? meta.change24h : 0;
     const value =
       isUsgsQuake && magnitude !== null
-        ? Math.max(0, Math.min(1, (magnitude - 4) / 2))
+        ? Math.max(0, Math.min(1, (magnitude - 2.5) / 4))
         : Math.max(0, Math.min(1, 1 - Math.min(1, Math.abs(change) / 12)));
 
     const agent = item.ownerAgent ?? 'ECHO';
@@ -385,12 +389,17 @@ export function buildGlobePinsFromMicro(
             : 'nominal'
         : echoSev;
 
+    const displayTitle =
+      isUsgsQuake && magnitude !== null
+        ? `M${magnitude.toFixed(2)} · ${placeFromTitle} · ${item.id}`
+        : title;
+
     pushPin(pins, seen, {
       id,
       lat,
       lng,
       source: isUsgsQuake ? `SEISMIC · EPICON · ${agent}` : `${agent} · ${src}`,
-      title: isUsgsQuake && magnitude !== null ? `M${magnitude.toFixed(1)} · ${title}` : title,
+      title: displayTitle,
       value,
       confidence: isUsgsQuake && magnitude !== null ? Math.min(1, 0.5 + magnitude / 10) : Math.min(1, 0.4 + Math.abs(change) / 15),
       severity: pinSev,
@@ -412,6 +421,7 @@ export function buildGlobePinsFromMicro(
         layer: isUsgsQuake ? 'SEISMIC · EPICON' : 'ECHO EPICON',
         ledger: 'ECHO EPICON row (see Events chamber)',
         freshnessSec: Math.max(0, Math.floor((Date.now() - new Date(echoTs).getTime()) / 1000)),
+        ...(isUsgsQuake ? { globeSeismicViolet: true as const } : {}),
       },
     });
   }

--- a/lib/vault/vault.ts
+++ b/lib/vault/vault.ts
@@ -5,7 +5,7 @@
 
 import { Redis } from '@upstash/redis';
 import type { AgentJournalEntry } from '@/lib/terminal/types';
-import { kvGet, kvSet } from '@/lib/kv/store';
+import { kvGet, kvSet, loadGIState } from '@/lib/kv/store';
 
 const BALANCE_KEY = 'vault:global:balance';
 const META_KEY = 'vault:global:meta';
@@ -235,4 +235,29 @@ export async function recordVaultDepositsForCouncil(
   }
 
   return { attempted, errors, deposited };
+}
+
+/**
+ * Fire-and-forget vault accrual after any committed journal append (cron, manual, council).
+ */
+export function scheduleVaultDepositForJournal(entry: AgentJournalEntry): void {
+  void (async () => {
+    try {
+      let gi = 0.74;
+      try {
+        const st = await loadGIState();
+        if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
+          gi = Math.max(0, Math.min(1, st.global_integrity));
+        }
+      } catch {
+        // default gi
+      }
+      const r = await recordVaultDepositsForCouncil([entry], gi);
+      if (r.deposited > 0) {
+        console.info('[vault] journal deposit', { journal_id: entry.id, agent: entry.agent, ...r, gi });
+      }
+    } catch (err) {
+      console.error('[vault] scheduleVaultDepositForJournal failed:', err instanceof Error ? err.message : err);
+    }
+  })();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

C-281 final close: vault reserve accrues on **every committed** `appendAgentJournalEntry` (cron + manual), synthesis cron refres **`mobius:heartbeat:last`**, tripwire state persists to **legacy `TRIPWIRE_STATE`** Redis key + `TRIPWIRE_STATE_KV`, promotion merges echo/ledger and adds **verified fast-path** commit, EVE escalation GI stress threshold **0.65**, journal agent pills + Sentinel MII/vault UX, globe seismic M3+ violet layer, **`/terminal/vault`**, `CURRENT_CYCLE.md` C-281.

## Opts landed (1–10)

1. **Vault + cron** — `scheduleVaultDepositForJournal` from `lib/agents/journal.ts` (fire-and-forget); removed duplicate batch from synthesis council only path.
2. **TRIPWIRE_STATE** — `lib/signals/engine.ts` writes raw `TRIPWIRE_STATE` + prefixed KV; tripwire route uses `kvSetRawKey`; `kvHealth` adds `TRIPWIRE_STATE_REDIS`.
3. **Heartbeat** — `writeSynthesisCronHeartbeatKv` at end of Vercel cron GET + POST synthesis (`lib/runtime/synthesis-cron-side-effects.ts`).
4. **Promotion** — Merge ledger+echo by id; **verified** EPICONs: single `buildCommit` for routing primary agent then mark promoted (skips multi-agent loop when token present).
5. **`gi_critical` sensitivity** — `GI_STRESS_THRESHOLD` **0.65** in `lib/eve/governance-synthesis.ts` (`escalationWarranted`).
6. **Journal pills** — Ordered pills with counts + canonical border/active colors (`JournalPageClient.tsx`).
7. **Sentinel MII** — Canonical colors, `?limit=200`, up to 24 points, dashed 0.90 baseline when empty; **React hooks order fix** (journal fetch before early return).
8. **Globe seismic** — M3+ USGS EPICON pins, `#7c3aed`, title tooltip `Mxx · place · EPICON-id`, legend line.
9. **Vault UI** — `app/terminal/vault/page.tsx`, Sentinel vault card, ChamberSwitcher **Vault** + **Alt+7**.
10. **`CURRENT_CYCLE.md`** — C-281 close snapshot + locks.

## Build

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- `pnpm lint` — interactive Next.js ESLint migration prompt (not run non-interactively)

## Post-deploy verification

- After next synthesis cron: `/api/vault/status` → `balance_reserve` & `source_entries` increase; `/api/agents/status` → fresh heartbeat.  
- `GET /api/kv/health` → `keys.TRIPWIRE_STATE_REDIS: true` after signal engine.  
- `POST /api/epicon/promote` with token → verified items commit via fast-path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-636b1cfd-9101-4d42-b374-addadfac770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-636b1cfd-9101-4d42-b374-addadfac770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

