### PR TITLE
docs(C-282 bridge): Microagent Family Spec v1 + JSON schema + sensor federation

### DIFF
--- a/CURRENT_CYCLE.md
+++ b/CURRENT_CYCLE.md
@@ -51,6 +51,18 @@ First MIC minted. Vault lane live. 200-entry MII read path. ATLAS writing autono
 
 ---
 
+## 🔭 C-282 BRIDGE — SENSOR FEDERATION (SPEC ONLY)
+
+Architecture for **8 parent families × up to 5 microagents** (40 instruments **ceiling**) is documented; **no runtime behavior change** is implied until instruments are implemented incrementally.
+
+| Artifact | Purpose |
+|----------|---------|
+| [`docs/protocols/microagent-family-spec-v1.md`](docs/protocols/microagent-family-spec-v1.md) | Doctrine, flow, correlation tiers, cadence, first-10 build order |
+| [`docs/protocols/microagent-output-schema-v1.json`](docs/protocols/microagent-output-schema-v1.json) | JSON Schema for mandatory microagent evidence fields |
+| [`docs/architecture/mobius-sensor-federation.md`](docs/architecture/mobius-sensor-federation.md) | Short architecture note + pointer to build order |
+
+---
+
 ## 🔒 LOCKED — DO NOT MODIFY WITHOUT OPERATOR APPROVAL
 
 1. **Journal KV key schema:** `journal:{AGENT_UPPERCASE}:{CYCLE_ID}` — `app/api/agents/journal/route.ts`  

--- a/docs/architecture/mobius-sensor-federation.md
+++ b/docs/architecture/mobius-sensor-federation.md
@@ -1,0 +1,66 @@
+# Mobius Sensor Federation
+
+**Status:** Architecture note (C-281 / C-282 bridge)  
+**Companion:** [Microagent Family Spec v1](../protocols/microagent-family-spec-v1.md) · [Output schema v1](../protocols/microagent-output-schema-v1.json)
+
+---
+
+## One-line thesis
+
+**Parent agents govern; microagents sense.** Together they form a **sensor federation** — not forty chatbots, but forty **bounded instruments** whose evidence parents synthesize into journals, verification, and attestation.
+
+---
+
+## Why this name
+
+- **Council** = eight named sentinels reasoning in public.  
+- **Federation** = eight **families**, each with aligned micro-collectors, normalized into a single evidence field for GI, MII, Vault corroboration, and EPICON quality.
+
+The leap is **governability**: breadth without turning volume into noise (cadence, dedup, correlation tiers — see the spec).
+
+---
+
+## Data flow (conceptual)
+
+```text
+Source feed
+  → Microagent (schema-validated evidence object)
+  → Family buffer / evidence queue
+  → Parent agent (dedupe, correlate, synthesize)
+  → Journal · verification · promotion · snapshot · Vault inputs
+```
+
+Microagents **do not** write Mobius journals or mint MIC directly.
+
+---
+
+## Relation to today’s codebase
+
+Today the Terminal already runs a **small** micro-sweep (GAIA, HERMES-µ, THEMIS, DAEDALUS-µ) feeding `/api/signals/micro` and snapshot lanes. This document names the **target** architecture for scaling that pattern to **up to five instruments per parent** without collapsing layers (see `AGENTS.md`: reasoning ≠ fact; operator truth).
+
+---
+
+## Build order (first 10 instruments)
+
+See **§13** and **§18** in `microagent-family-spec-v1.md`. Summary:
+
+1. **ZEUS-µ1** — fact-check / verification feeds  
+2. **ZEUS-µ2** — contradiction detector  
+3. **ZEUS-µ3** — financial verification (filings / guidance)  
+4. **ZEUS-µ4** — source corroboration  
+5. **ZEUS-µ5** — research / consensus signals  
+6. **ECHO-µ1** — financial markets (extends today’s lane)  
+7. **ECHO-µ2** — seismic / environmental (extends USGS/EONET surface)  
+8. **ECHO-µ3** — energy  
+9. **ECHO-µ4** — supply chain  
+10. **ECHO-µ5** — labor  
+
+Implementation remains **incremental** — each instrument is a fetch + classify + emit **evidence object** registered in the sweep; parents consume in synthesis only.
+
+---
+
+## Doctrine
+
+Mobius does not become stronger because it has more agents. It becomes stronger because it has **more independent instruments** under **constitutional synthesis**.
+
+*"You didn't just discover 8 × 5. You discovered the council can evolve into a sensor federation."*

--- a/docs/protocols/microagent-family-spec-v1.md
+++ b/docs/protocols/microagent-family-spec-v1.md
@@ -1,0 +1,266 @@
+# Microagent Family Spec v1
+
+**Mobius Sensor Federation — Genesis Draft**  
+**Cycle:** C-281 / C-282 bridge  
+**Status:** Architecture Spec v1  
+**Author:** kaizencycle (with Cursor)  
+**CC0 Public Domain**
+
+**Artifacts:**
+
+- Machine schema: [`microagent-output-schema-v1.json`](./microagent-output-schema-v1.json)  
+- Architecture note: [`../architecture/mobius-sensor-federation.md`](../architecture/mobius-sensor-federation.md)
+
+---
+
+## 0. Core doctrine
+
+- **Parent agents govern.** Synthesis, verification, escalation, constitutional interpretation, **journal authorship**, attestation.  
+- **Microagents sense.** Fetch, classify, normalize, anomaly detection, **structured evidence only**.
+
+A microagent is **not** a free-form narrator. It is a **bounded instrument**.
+
+Mobius does not become stronger because it has more agents. It becomes stronger because it has **more independent instruments** under clear constitutional synthesis.
+
+---
+
+## 1. Why this layer exists
+
+The stack already proves: live feeds → ingestion → parent reasoning → journals → GI / MII / Vault.
+
+Goals of the family lattice:
+
+1. Reduce overreliance on a few feeds.  
+2. Make **corroboration** rigorous (cross-outlet, cross-domain, cross-family).  
+3. Separate **signal gathering** from **synthesis**.  
+4. Allow GI to become **multi-dimensional** over time (sub-indices before rewriting the global formula).  
+5. Strengthen **Vault** deposit scoring via evidence diversity (aligned with [Vault-to-Fountain](./vault-to-fountain-protocol.md)).
+
+---
+
+## 2. Architecture model
+
+```text
+Source → Microagent → Family buffer / evidence queue → Parent agent → Journal / attestation / promotion → Ledger / snapshot / Vault
+```
+
+| Layer | Role |
+|-------|------|
+| **A — Source** | External API, RSS, repo, bulletin, market stream, civic signal. |
+| **B — Microagent** | Single-purpose collector + classifier; emits **evidence object** only. |
+| **C — Family buffer** | Normalized queue for one parent family (implementation TBD). |
+| **D — Parent agent** | Dedupe, correlate, synthesize; writes **family-facing** journal when warranted. |
+| **E — Protocol** | Snapshot, promotion, Vault, EPICON, future Fountain logic. |
+
+---
+
+## 3. Family model
+
+- **8** parent agents.  
+- **Up to 5** microagents per parent by default → **40** instruments **ceiling**, not day-one count.
+
+Parents: ATLAS, ZEUS, HERMES, AUREA, JADE, DAEDALUS, ECHO, EVE.
+
+---
+
+## 4. Canonical family responsibilities (summary)
+
+| Family | Focus |
+|--------|--------|
+| **ATLAS** | Geopolitical, institutional, sovereignty, constitutional drift, long-horizon stability. |
+| **ZEUS** | Fact paths, contradiction, triangulation, claim verification, epistemic conflict. |
+| **HERMES** | Prioritization, velocity, narrative acceleration, routing (µ already exists). |
+| **AUREA** | Policy, civic strategy, governance coherence, long-arc oversight. |
+| **JADE** | Precedent, memory coherence, terminology drift, citation integrity, context. |
+| **DAEDALUS** | Repo / infra / dependency / model release / platform health (µ already exists). |
+| **ECHO** | Raw event surface: markets, seismic, energy, supply chain, labor. |
+| **EVE** | Democratic health, participation, inequality, narrative coherence, civilizational stress. |
+
+---
+
+## 5. Microagent object model
+
+Every microagent emits the **minimum** JSON object defined in [`microagent-output-schema-v1.json`](./microagent-output-schema-v1.json).
+
+**Required fields:** `id`, `family`, `microagent`, `domain`, `source`, `title`, `summary`, `severity`, `confidence`, `timestamp`, `provenance`, `contradiction_flag`, `parent_agent`, `cycle`.
+
+**Optional:** `lat`, `lng`, `magnitude`, `symbol`, `policy_id`, `jurisdiction`, `related_ids`, `impact_hint`.
+
+**Rule:** Weak provenance → **low confidence** (no silent boosting).
+
+---
+
+## 6. Operating rules
+
+1. **Bounded scope** — one narrow job per microagent.  
+2. **No public journals from microagents** — evidence objects only; parents write journals.  
+3. **No direct MIC mint authority** — influence corroboration / scores; economics stays on parent + ledger rails.  
+4. **Provenance first** — every row carries retrievable source metadata.  
+5. **Contradiction visible** — `contradiction_flag: true` when conflict detected; no silent smoothing.
+
+---
+
+## 7. Parent synthesis rules
+
+Parents must:
+
+1. Collect family evidence.  
+2. **Deduplicate correlated signals** (see §8).  
+3. Score evidence quality.  
+4. Weigh contradiction.  
+5. Emit **at most one** family-level journal per cadence when warranted.  
+6. Drive verification / escalation / promotion state explicitly.
+
+Parent journal minimum (existing practice + future fields): observation, inference, recommendation, confidence, severity, **evidence count**, **contradiction summary**, **family attribution**.
+
+---
+
+## 8. Correlation and anti–double-counting
+
+**Problem:** Five instruments reading the same underlying event must **not** count as five independent confirmations.
+
+**Cluster by:** event id, source overlap, timestamp proximity, domain similarity, shared upstream origin.
+
+**Corroboration tiers (Vault / verification weighting):**
+
+| Tier | Meaning |
+|------|--------|
+| 0 | Same-source repetition |
+| 1 | Same domain, different outlet |
+| 2 | Different domain confirmation |
+| 3 | Cross-family confirmation |
+| 4 | Cross-family + historical consistency + independent instrumentation |
+
+**Rule:** Only **Tier 2+** should materially boost Vault corroboration or verification confidence.
+
+---
+
+## 9. GI and MII dimensionalization (future-safe)
+
+Today GI is largely a **single composite**. Target:
+
+```text
+GI (composite)
+  ├── Integrity      (ZEUS + JADE families)
+  ├── Ecology        (environmental / ECHO+GAIA-class surface)
+  ├── Custodianship  (ATLAS + AUREA governance coherence)
+  └── Infrastructure (DAEDALUS + HERMES system surface)
+```
+
+**v1 recommendation:** Compute and **expose family-level sub-indices** in diagnostics before changing `lib/gi/compute.ts` weights (that file remains **operator-locked** per `CURRENT_CYCLE.md`).
+
+---
+
+## 10. Vault scoring impact
+
+Microagents improve journal merit inputs (see [Vault-to-Fountain](./vault-to-fountain-protocol.md)):
+
+- **C** — corroboration (tiered, not raw count).  
+- **S** — survival over time.  
+- **D** — duplication penalty (cluster-aware).  
+- **I** — impact when evidence links to promoted EPICON / operator action.
+
+**Rule:** Stronger Vault deposits when evidence spans **independent families**, contradiction is low, source diversity is high, duplication is low, and later cycles **confirm** the parent recommendation.
+
+---
+
+## 11. Cadence and budget controls
+
+Without limits, forty instruments become forty noise machines.
+
+**Required controls:**
+
+- Per-microagent refresh interval.  
+- Per-family **max outputs per cycle**.  
+- Per-source cooldown.  
+- Duplicate suppression window.  
+- Error backoff.  
+- Rate / cost budget.
+
+**Suggested defaults:**
+
+- Max **5** outputs per microagent per cycle.  
+- Duplicate suppression window **30** minutes.  
+- Contradiction recheck window **15** minutes.  
+- Parent synthesis **hourly** unless escalation (matches existing synthesis cadence patterns).
+
+---
+
+## 12–13. Implementation order
+
+**Do not build 40 at once.**
+
+| Phase | Focus |
+|-------|--------|
+| **1** | **ZEUS family** — verification, contradiction, corroboration (strengthens MIC / MII defensibility). |
+| **2** | **ECHO family** — broaden economic + environmental raw EPICON surface. |
+| **3** | **DAEDALUS + JADE** — substrate + memory integrity. |
+| **4** | **ATLAS, EVE, HERMES, AUREA** expansion — strategic and governance richness after core sensing is stable. |
+
+---
+
+## 14. v1 target instrument set (first 10)
+
+| # | Instrument | Domain (example) |
+|---|------------|------------------|
+| 1 | ZEUS-µ1 | Fact-check feeds |
+| 2 | ZEUS-µ2 | Contradiction detector |
+| 3 | ZEUS-µ3 | Financial verification (SEC / guidance) |
+| 4 | ZEUS-µ4 | Source corroboration |
+| 5 | ZEUS-µ5 | Research / consensus |
+| 6 | ECHO-µ1 | Financial markets |
+| 7 | ECHO-µ2 | Seismic / environmental |
+| 8 | ECHO-µ3 | Energy |
+| 9 | ECHO-µ4 | Supply chain |
+| 10 | ECHO-µ5 | Labor |
+
+This set alone materially upgrades Mobius before expanding other families.
+
+---
+
+## 15. Terminal implications (later)
+
+- **Sentinel:** parent state + family evidence counts + contradiction counts + freshness.  
+- **Pulse:** cross-family corroboration badge on promoted syntheses.  
+- **Globe / World State:** family overlays, EPICON type layers, legend.  
+- **Vault:** optional display of corroboration tier / cross-family weight (post–Fountain v1).
+
+---
+
+## 16. Failure modes
+
+| Risk | Mitigation |
+|------|------------|
+| **Noise bloom** | Caps, parent filtering, duplicate suppression |
+| **False corroboration** | Source lineage + correlation clustering |
+| **Family drift** | Strict domain contracts + schema validation |
+| **Authority creep** | Hard rule: only parents publish journals / economic actions |
+| **Infra overload** | Staged rollout, cooldowns, event-driven refresh |
+
+---
+
+## 17. Canonical one-liners
+
+- **Microagent:** bounded sensing instrument → structured evidence.  
+- **Parent agent:** constitutional synthesizer → governs a family.  
+- **Family:** parent + its instrument lattice.  
+- **Sensor federation:** the full multi-family evidence field of Mobius.
+
+---
+
+## 18. Genesis-era doctrine
+
+**Do not build 40 personalities. Build 40 instruments.**
+
+---
+
+## 19. Next implementation steps (engineering)
+
+1. Register each new instrument in the micro sweep with **schema-validated** payloads.  
+2. Pipe evidence into a **family buffer** (Redis or in-memory + KV, TBD) before parent synthesis.  
+3. Extend parent cron / synthesis to **read buffer** and emit **one** journal when thresholds met.  
+4. Add Sentinel / snapshot diagnostics for **evidence counts per family** before UI polish.
+
+---
+
+*"Mobius can evolve from a council into a sensor federation — if the lattice stays governable."*

--- a/docs/protocols/microagent-output-schema-v1.json
+++ b/docs/protocols/microagent-output-schema-v1.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mobius.local/schemas/microagent-output-v1.json",
+  "title": "Mobius Microagent Evidence Object v1",
+  "description": "Minimum structured output every microagent must emit. Parents synthesize; microagents sense.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "family",
+    "microagent",
+    "domain",
+    "source",
+    "title",
+    "summary",
+    "severity",
+    "confidence",
+    "timestamp",
+    "provenance",
+    "contradiction_flag",
+    "parent_agent",
+    "cycle"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable unique id, e.g. ZEUS-µ4-2026-04-14T10:30:00Z-001"
+    },
+    "family": {
+      "type": "string",
+      "enum": ["ATLAS", "ZEUS", "HERMES", "AUREA", "JADE", "DAEDALUS", "ECHO", "EVE"]
+    },
+    "microagent": {
+      "type": "string",
+      "pattern": "^[A-Z]+-µ[0-9]+$",
+      "description": "Instrument id within family, e.g. ZEUS-µ4"
+    },
+    "domain": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Narrow scope key, e.g. source_corroboration, labor_market"
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable source label (API name, feed, repo)"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["nominal", "watch", "elevated", "critical", "degraded", "info", "low", "medium", "high"]
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_type", "retrieved_at"],
+      "properties": {
+        "url": { "type": "string", "format": "uri" },
+        "source_type": {
+          "type": "string",
+          "enum": ["news_api", "http", "rss", "github", "government_feed", "market_api", "seismic_api", "internal", "other"]
+        },
+        "retrieved_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "contradiction_flag": { "type": "boolean" },
+    "related_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "EPICON ids, civic alert ids, etc."
+    },
+    "parent_agent": {
+      "type": "string",
+      "enum": ["ATLAS", "ZEUS", "HERMES", "AUREA", "JADE", "DAEDALUS", "ECHO", "EVE"]
+    },
+    "cycle": {
+      "type": "string",
+      "pattern": "^C-[0-9]+$",
+      "description": "Mobius cycle id, e.g. C-282"
+    },
+    "lat": { "type": "number", "minimum": -90, "maximum": 90 },
+    "lng": { "type": "number", "minimum": -180, "maximum": 180 },
+    "magnitude": { "type": "number" },
+    "symbol": { "type": "string" },
+    "policy_id": { "type": "string" },
+    "jurisdiction": { "type": "string" },
+    "impact_hint": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "unknown"]
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Microagent Family Spec v1** (sensor federation / 8×5 instrument ceiling), **JSON Schema** for mandatory microagent evidence objects, and a short **architecture** note. Updates `CURRENT_CYCLE.md` with a **C-282 bridge** section linking all three artifacts.

**No application code changes** — documentation and schema only.

## Artifacts

| Path | Description |
|------|-------------|
| `docs/protocols/microagent-family-spec-v1.md` | Doctrine, layers, correlation tiers, cadence/budget, ZEUS-first + ECHO-second rollout, first-10 build list |
| `docs/protocols/microagent-output-schema-v1.json` | JSON Schema 2020-12 for required microagent fields + optional geo/policy fields |
| `docs/architecture/mobius-sensor-federation.md` | One-page architecture note + build order pointer |

## Build

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- `pnpm lint` — not run (interactive Next.js ESLint migration)

## Integrity

- Does not change GI weights (`lib/gi/compute.ts` untouched).  
- Does not change journal keys, ECHO LPUSH, MII shape, or promotion logic.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-636b1cfd-9101-4d42-b374-addadfac770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-636b1cfd-9101-4d42-b374-addadfac770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

