### PR TITLE
Sensor federation: 40 public micro-instruments + endpoint map

### DIFF
--- a/docs/architecture/microagent-public-endpoints.md
+++ b/docs/architecture/microagent-public-endpoints.md
@@ -1,0 +1,91 @@
+# Microagent public endpoints (40 instruments)
+
+Canonical mapping for `lib/agents/micro/instrument-polls.ts`: eight parent families × five bounded instruments. Each row is a **public HTTP API** (no Mobius-specific keys unless noted). Third-party terms and rate limits apply; this list is for operator transparency, not a guarantee of availability.
+
+Curated public API indexes: [public-apis/public-apis](https://github.com/public-apis/public-apis), [public-api-lists/public-api-lists](https://github.com/public-api-lists/public-api-lists).
+
+## ATLAS (strategic / planetary)
+
+| ID | Primary endpoint (representative) | Notes |
+|----|-----------------------------------|--------|
+| ATLAS-µ1 | `https://api.worldbank.org/v2/country/WLD/indicator/NY.GDP.MKTP.KD.ZG?format=json&per_page=8&mrnev=1` | World Bank open data |
+| ATLAS-µ2 | `https://api.reliefweb.int/v1/disasters?appname=mobius-terminal&limit=8` | ReliefWeb API |
+| ATLAS-µ3 | `https://restcountries.com/v3.1/alpha/us` | REST Countries |
+| ATLAS-µ4 | `https://api.weather.gov/alerts/active?area=US` | NWS (requires identifiable User-Agent) |
+| ATLAS-µ5 | `https://api.open-meteo.com/v1/forecast?latitude=40.66&longitude=-73.55&current=...` | Open-Meteo |
+
+## ZEUS (verification / corroboration proxies)
+
+| ID | Primary endpoint | Notes |
+|----|------------------|--------|
+| ZEUS-µ1 | `https://api.crossref.org/works?query=integrity+governance&rows=5` | Scholarly metadata |
+| ZEUS-µ2 | `https://export.arxiv.org/api/query?search_query=all:verification&start=0&max_results=5` | arXiv Atom API |
+| ZEUS-µ3 | `https://api.coincap.io/v2/assets?limit=8` | Market volatility proxy |
+| ZEUS-µ4 | `https://api.frankfurter.app/latest?from=USD&to=EUR,GBP,JPY` | ECB-backed FX |
+| ZEUS-µ5 | `https://openlibrary.org/search.json?q=governance&limit=5` | Open Library |
+
+## HERMES (velocity / attention)
+
+| ID | Primary endpoint | Notes |
+|----|------------------|--------|
+| HERMES-µ1 | `https://hacker-news.firebaseio.com/v0/topstories.json` + item JSON | HN Firebase API |
+| HERMES-µ2 | `https://en.wikipedia.org/w/api.php?action=query&list=recentchanges&...&origin=*` | Wikipedia RC |
+| HERMES-µ3 | `https://api.gdeltproject.org/api/v2/doc/doc?query=governance&mode=artlist&...` | GDELT |
+| HERMES-µ4 | `https://www.reddit.com/r/worldnews/hot.json?limit=8` | Reddit JSON |
+| HERMES-µ5 | `https://api.spacexdata.com/v4/launches/upcoming` | SpaceX public API |
+
+## AUREA (governance / institutions)
+
+| ID | Primary endpoint | Notes |
+|----|------------------|--------|
+| AUREA-µ1 | `https://www.federalregister.gov/api/v1/documents.json?...` | Federal Register |
+| AUREA-µ2 | `https://catalog.data.gov/api/3/action/package_search?rows=5&...` | data.gov CKAN |
+| AUREA-µ3 | `https://api.fda.gov/drug/event.json?limit=5` | openFDA |
+| AUREA-µ4 | `https://api.census.gov/data/2021/pep/natmonthly?get=POP,NAME&for=us:*` | US Census |
+| AUREA-µ5 | `https://api.usaspending.gov/api/v2/references/toptier_agencies/?limit=10` | USAspending |
+
+## JADE (memory / culture)
+
+| ID | Primary endpoint | Notes |
+|----|------------------|--------|
+| JADE-µ1 | `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=Q42&format=json&origin=*` | Wikidata |
+| JADE-µ2 | `https://api.quotable.io/random` | Quotable |
+| JADE-µ3 | `https://collectionapi.metmuseum.org/public/collection/v1/objects/45734` | Met Museum |
+| JADE-µ4 | `https://openlibrary.org/authors/OL23466A.json` | Open Library author |
+| JADE-µ5 | `https://poetrydb.org/random/1` | Poetry DB |
+
+## DAEDALUS (build / infra health)
+
+| ID | Primary endpoint | Notes |
+|----|------------------|--------|
+| DAEDALUS-µ1 | `https://api.github.com/repos/vercel/next.js` | GitHub REST |
+| DAEDALUS-µ2 | `https://registry.npmjs.org/react/latest` | npm registry |
+| DAEDALUS-µ3 | `https://registry.npmjs.org/typescript/latest` | npm registry |
+| DAEDALUS-µ4 | `https://status.npmjs.org/api/v2/status.json` | npm status |
+| DAEDALUS-µ5 | `https://{VERCEL_URL}/api/integrity-status` | Self-ping (requires `VERCEL_URL` or `NEXT_PUBLIC_SITE_URL`) |
+
+## ECHO (events / markets / environment)
+
+| ID | Primary endpoint | Notes |
+|----|------------------|--------|
+| ECHO-µ1 | `https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum,solana&...` | CoinGecko |
+| ECHO-µ2 | `https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_day.geojson` | USGS feeds |
+| ECHO-µ3 | NASA EONET (via `fetchEonetEvents` in codebase) | Shared EONET client |
+| ECHO-µ4 | `https://api.open-notify.org/astros.json` | Open Notify |
+| ECHO-µ5 | `https://api.nasa.gov/planetary/apod?api_key=...` | APOD (`NASA_APOD_KEY` or `DEMO_KEY`) |
+
+## EVE (civic / demographic demos)
+
+| ID | Primary endpoint | Notes |
+|----|------------------|--------|
+| EVE-µ1 | `https://datausa.io/api/data?drilldowns=Nation&measures=Population&year=latest` | Data USA |
+| EVE-µ2 | `https://api.agify.io?name=alex` | Agify |
+| EVE-µ3 | `https://api.genderize.io?name=alex` | Genderize |
+| EVE-µ4 | `https://api.nationalize.io?name=smith` | Nationalize |
+| EVE-µ5 | `https://randomuser.me/api/?results=5&nat=us` | RandomUser |
+
+## Operator notes
+
+- **EVE-µ2–µ5** are lightweight public demos, not civic ground truth; replace with governance-grade sources when wiring family journals.
+- **GitHub** unauthenticated REST is rate-limited; heavy use may need a token (out of scope for keyless micro sweep).
+- **Legacy four** (`pollGaia`, `pollHermes`, `pollThemis`, `pollDaedalus`) remain for tests; production `/api/signals/micro` uses `pollAllMicroAgents()`.

--- a/lib/agents/micro/core.ts
+++ b/lib/agents/micro/core.ts
@@ -70,15 +70,37 @@ export function normalizeDirect(value: number, min: number, max: number): number
   return (clamped - min) / (max - min);
 }
 
-/** Safe JSON fetch with timeout */
-export async function safeFetch<T>(url: string, timeoutMs = 8000): Promise<T | null> {
+/** Safe JSON fetch with timeout. `signal` on `init` is ignored in favor of the internal timeout controller. */
+export async function safeFetch<T>(url: string, timeoutMs = 8000, init?: RequestInit): Promise<T | null> {
   try {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
-    const res = await fetch(url, { signal: controller.signal, cache: 'no-store' });
+    const res = await fetch(url, {
+      ...(init ?? {}),
+      signal: controller.signal,
+      cache: init?.cache ?? 'no-store',
+    });
     clearTimeout(timer);
     if (!res.ok) return null;
-    return await res.json();
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Safe text fetch with timeout (RSS, XML, plain). */
+export async function safeFetchText(url: string, timeoutMs = 8000, init?: RequestInit): Promise<string | null> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(url, {
+      ...(init ?? {}),
+      signal: controller.signal,
+      cache: init?.cache ?? 'no-store',
+    });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    return await res.text();
   } catch {
     return null;
   }

--- a/lib/agents/micro/index.ts
+++ b/lib/agents/micro/index.ts
@@ -1,7 +1,8 @@
 // ============================================================================
-// Mobius Micro Sub-Agent Orchestrator
+// Mobius Micro Sub-Agent Orchestrator — Sensor Federation (40 instruments)
 //
-// Polls all four micro-agents and aggregates results.
+// Polls 8 parent families × 5 public API instruments (see instrument-polls.ts).
+// Legacy exports kept for tests and direct imports.
 // CC0 Public Domain
 // ============================================================================
 
@@ -10,33 +11,81 @@ export { pollGaia, GAIA_CONFIG } from './gaia';
 export { pollHermes, HERMES_CONFIG } from './hermes';
 export { pollThemis, THEMIS_CONFIG } from './themis';
 export { pollDaedalus, DAEDALUS_CONFIG } from './daedalus';
+export { ALL_INSTRUMENT_POLLS } from './instrument-polls';
 
 import { type AgentPollResult, type MicroSignal } from './core';
 import { pollGaia } from './gaia';
 import { pollHermes } from './hermes';
 import { pollThemis } from './themis';
 import { pollDaedalus } from './daedalus';
+import { ALL_INSTRUMENT_POLLS } from './instrument-polls';
 
 export interface MicroAgentSweepResult {
   timestamp: string;
   agents: AgentPollResult[];
   allSignals: MicroSignal[];
-  composite: number;       // 0–1 aggregate health
+  composite: number; // 0–1 aggregate health
   anomalies: MicroSignal[];
   healthy: boolean;
+  /** Total micro-instruments configured (8 families × 5). */
+  instrumentCount: number;
+}
+
+const CONCURRENCY = 8;
+
+async function mapLimit<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let idx = 0;
+  async function worker(): Promise<void> {
+    for (;;) {
+      const i = idx++;
+      if (i >= items.length) return;
+      out[i] = await fn(items[i]!);
+    }
+  }
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () => worker());
+  await Promise.all(workers);
+  return out;
 }
 
 /**
- * Run a full sweep of all micro sub-agents.
- * Returns aggregated signals, a composite health score, and any anomalies.
+ * Run a full sweep of all 40 micro-instruments (public APIs).
  */
 export async function pollAllMicroAgents(): Promise<MicroAgentSweepResult> {
-  const results = await Promise.allSettled([
-    pollGaia(),
-    pollHermes(),
-    pollThemis(),
-    pollDaedalus(),
-  ]);
+  const results = await mapLimit(ALL_INSTRUMENT_POLLS, CONCURRENCY, (poll) => poll());
+
+  const agents: AgentPollResult[] = results;
+  const allSignals = agents.flatMap((a) => a.signals);
+
+  const compositeByAgent = agents.map((agent) => {
+    if (agent.signals.length === 0) return 0.5;
+    return Number((agent.signals.reduce((sum, signal) => sum + signal.value, 0) / agent.signals.length).toFixed(3));
+  });
+
+  const composite =
+    compositeByAgent.length > 0
+      ? Number((compositeByAgent.reduce((sum, value) => sum + value, 0) / compositeByAgent.length).toFixed(3))
+      : 0.5;
+
+  const anomalies = allSignals.filter((s) => s.severity === 'elevated' || s.severity === 'critical');
+
+  return {
+    timestamp: new Date().toISOString(),
+    agents,
+    allSignals,
+    composite,
+    anomalies,
+    healthy: agents.some((a) => a.healthy),
+    instrumentCount: ALL_INSTRUMENT_POLLS.length,
+  };
+}
+
+/**
+ * Legacy: original 4-agent sweep (GAIA, HERMES-µ, THEMIS, DAEDALUS-µ).
+ * Prefer `pollAllMicroAgents` in production.
+ */
+export async function pollLegacyFourMicroAgents(): Promise<MicroAgentSweepResult> {
+  const results = await Promise.allSettled([pollGaia(), pollHermes(), pollThemis(), pollDaedalus()]);
 
   const agents: AgentPollResult[] = results
     .filter((r): r is PromiseFulfilledResult<AgentPollResult> => r.status === 'fulfilled')
@@ -44,7 +93,6 @@ export async function pollAllMicroAgents(): Promise<MicroAgentSweepResult> {
 
   const allSignals = agents.flatMap((a) => a.signals);
 
-  // Composite: average by agent, with GAIA source-aware weighting.
   const compositeByAgent = agents.map((agent) => {
     if (agent.signals.length === 0) return 0.5;
 
@@ -69,11 +117,11 @@ export async function pollAllMicroAgents(): Promise<MicroAgentSweepResult> {
     return Number((agent.signals.reduce((sum, signal) => sum + signal.value, 0) / agent.signals.length).toFixed(3));
   });
 
-  const composite = compositeByAgent.length > 0
-    ? Number((compositeByAgent.reduce((sum, value) => sum + value, 0) / compositeByAgent.length).toFixed(3))
-    : 0.5;
+  const composite =
+    compositeByAgent.length > 0
+      ? Number((compositeByAgent.reduce((sum, value) => sum + value, 0) / compositeByAgent.length).toFixed(3))
+      : 0.5;
 
-  // Anomalies: anything elevated or critical
   const anomalies = allSignals.filter((s) => s.severity === 'elevated' || s.severity === 'critical');
 
   return {
@@ -83,5 +131,6 @@ export async function pollAllMicroAgents(): Promise<MicroAgentSweepResult> {
     composite,
     anomalies,
     healthy: agents.some((a) => a.healthy),
+    instrumentCount: 4,
   };
 }

--- a/lib/agents/micro/instrument-polls.ts
+++ b/lib/agents/micro/instrument-polls.ts
@@ -1,0 +1,813 @@
+/**
+ * Mobius Sensor Federation — 40 micro-instruments (8 parent families × 5).
+ * Each poll hits a documented public HTTP API (no keys unless env already used elsewhere).
+ * See: docs/architecture/microagent-public-endpoints.md
+ */
+
+import type { AgentPollResult, MicroSignal } from './core';
+import { classifySeverity, normalizeDirect, normalizeInverse, safeFetch, safeFetchText } from './core';
+import { fetchEonetEvents, scoreEonetEvents } from '@/lib/signals/eonet';
+
+const UA_HEADERS: HeadersInit = {
+  'User-Agent': 'MobiusTerminal/1.0 (+https://github.com/kaizencycle/mobius-civic-ai-terminal)',
+};
+
+function wrap(agentName: string, signal: MicroSignal | null, err?: string): AgentPollResult {
+  return {
+    agentName,
+    signals: signal ? [signal] : [],
+    polledAt: new Date().toISOString(),
+    errors: signal ? [] : [err ?? `${agentName}: no signal`],
+    healthy: Boolean(signal),
+  };
+}
+
+// ── ATLAS (strategic / planetary) ───────────────────────────────────────────
+
+export async function pollAtlasU1(): Promise<AgentPollResult> {
+  type Row = { date: string; value: string | number | null };
+  const url =
+    'https://api.worldbank.org/v2/country/WLD/indicator/NY.GDP.MKTP.KD.ZG?format=json&per_page=8&mrnev=1';
+  const data = await safeFetch<[unknown, Row[]]>(url);
+  const rows = Array.isArray(data?.[1]) ? data![1]! : [];
+  const vals = rows
+    .map((r) => (typeof r.value === 'number' ? r.value : Number.parseFloat(String(r.value ?? ''))))
+    .filter((n) => Number.isFinite(n));
+  if (vals.length === 0) return wrap('ATLAS-µ1', null);
+  const latest = vals[0]!;
+  const value = Number(normalizeDirect(Math.max(-5, Math.min(10, latest)), -3, 8).toFixed(3));
+  return wrap('ATLAS-µ1', {
+    agentName: 'ATLAS-µ1',
+    source: 'World Bank · WLD real GDP growth',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `WB WLD GDP growth latest: ${latest.toFixed(2)}% (y/y)`,
+    severity: classifySeverity(value, { watch: 0.45, elevated: 0.28, critical: 0.12 }),
+    raw: { samples: rows.slice(0, 3) },
+  });
+}
+
+export async function pollAtlasU2(): Promise<AgentPollResult> {
+  const url = 'https://api.reliefweb.int/v1/disasters?appname=mobius-terminal&limit=8';
+  const data = await safeFetch<{ data?: Array<{ id?: number; fields?: { name?: string } }> }>(url, 12000);
+  const n = data?.data?.length ?? 0;
+  const value = Number(normalizeInverse(n, 0, 40).toFixed(3));
+  const top = data?.data?.[0]?.fields?.name ?? 'n/a';
+  return wrap('ATLAS-µ2', {
+    agentName: 'ATLAS-µ2',
+    source: 'ReliefWeb · disasters',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `ReliefWeb: ${n} open disasters · ${top}`,
+    severity: classifySeverity(value, { watch: 0.45, elevated: 0.28, critical: 0.12 }),
+    raw: { count: n },
+  });
+}
+
+export async function pollAtlasU3(): Promise<AgentPollResult> {
+  const url = 'https://restcountries.com/v3.1/alpha/us';
+  const data = await safeFetch<Array<{ population?: number; name?: { common?: string } }>>(url);
+  const pop = data?.[0]?.population;
+  if (typeof pop !== 'number') return wrap('ATLAS-µ3', null);
+  const value = Number(normalizeDirect(Math.log10(pop + 1), 8, 9.6).toFixed(3));
+  return wrap('ATLAS-µ3', {
+    agentName: 'ATLAS-µ3',
+    source: 'REST Countries · US',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `Population context: ${data![0]!.name?.common ?? 'US'} ≈ ${(pop / 1e6).toFixed(1)}M`,
+    severity: 'nominal',
+    raw: { population: pop },
+  });
+}
+
+export async function pollAtlasU4(): Promise<AgentPollResult> {
+  const url = 'https://api.weather.gov/alerts/active?area=US';
+  const data = await safeFetch<{ features?: unknown[] }>(url, 12000, { headers: UA_HEADERS });
+  const n = data?.features?.length ?? 0;
+  const value = Number(normalizeInverse(n, 0, 200).toFixed(3));
+  return wrap('ATLAS-µ4', {
+    agentName: 'ATLAS-µ4',
+    source: 'NWS · active alerts US',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `NWS: ${n} active alerts (US area)`,
+    severity: classifySeverity(value, { watch: 0.42, elevated: 0.25, critical: 0.1 }),
+    raw: { count: n },
+  });
+}
+
+async function openMeteoNyc(): Promise<MicroSignal | null> {
+  type OpenMeteoResponse = { current?: { temperature_2m?: number; wind_speed_10m?: number; weather_code?: number } };
+  const url =
+    'https://api.open-meteo.com/v1/forecast?latitude=40.66&longitude=-73.55&current=temperature_2m,wind_speed_10m,weather_code&temperature_unit=fahrenheit&wind_speed_unit=mph';
+  const data = await safeFetch<OpenMeteoResponse>(url);
+  if (!data?.current) return null;
+  const temp = data.current.temperature_2m ?? 65;
+  const wind = data.current.wind_speed_10m ?? 5;
+  const code = data.current.weather_code ?? 0;
+  const tempScore =
+    temp >= 55 && temp <= 80 ? 1.0 : temp < 55 ? normalizeDirect(temp, 0, 55) : normalizeInverse(temp, 80, 115);
+  const windScore = normalizeInverse(wind, 0, 75);
+  const codeScore = code < 50 ? 1.0 : code < 80 ? 0.7 : code < 95 ? 0.4 : 0.2;
+  const value = Number((0.4 * tempScore + 0.3 * windScore + 0.3 * codeScore).toFixed(3));
+  return {
+    agentName: 'ATLAS-µ5',
+    source: 'Open-Meteo · NYC corridor',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `Meteo NYC: ${Math.round(temp)}°F, wind ${Math.round(wind)}mph, wx ${code}`,
+    severity: classifySeverity(value),
+    raw: data.current,
+  };
+}
+
+export async function pollAtlasU5(): Promise<AgentPollResult> {
+  const s = await openMeteoNyc();
+  return wrap('ATLAS-µ5', s ? { ...s, agentName: 'ATLAS-µ5' } : null);
+}
+
+// ── ZEUS (verification / corroboration surfaces) ───────────────────────────
+
+export async function pollZeusU1(): Promise<AgentPollResult> {
+  const url = 'https://api.crossref.org/works?query=integrity+governance&rows=5';
+  const data = await safeFetch<{ message?: { items?: unknown[] } }>(url);
+  const n = data?.message?.items?.length ?? 0;
+  const value = Number(normalizeDirect(Math.min(n, 5), 0, 5).toFixed(3));
+  return wrap('ZEUS-µ1', {
+    agentName: 'ZEUS-µ1',
+    source: 'CrossRef · scholarly works',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `CrossRef: ${n} work hits for integrity+governance`,
+    severity: 'nominal',
+    raw: { count: n },
+  });
+}
+
+export async function pollZeusU2(): Promise<AgentPollResult> {
+  const url =
+    'https://export.arxiv.org/api/query?search_query=all:verification&start=0&max_results=5';
+  const text = await safeFetchText(url, 12000);
+  const entries = (text?.match(/<entry>/g) ?? []).length;
+  const value = Number(normalizeDirect(entries, 0, 5).toFixed(3));
+  return wrap('ZEUS-µ2', {
+    agentName: 'ZEUS-µ2',
+    source: 'arXiv · API',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `arXiv: ${entries} results (verification query)`,
+    severity: 'nominal',
+    raw: { entries },
+  });
+}
+
+export async function pollZeusU3(): Promise<AgentPollResult> {
+  const url = 'https://api.coincap.io/v2/assets?limit=8';
+  const data = await safeFetch<{ data?: Array<{ id?: string; changePercent24Hr?: string }> }>(url);
+  const rows = data?.data ?? [];
+  if (rows.length === 0) return wrap('ZEUS-µ3', null);
+  const changes = rows
+    .map((r) => Number.parseFloat(r.changePercent24Hr ?? '0'))
+    .filter((n) => Number.isFinite(n));
+  const avg = changes.length ? changes.reduce((a, b) => a + b, 0) / changes.length : 0;
+  const value = Number(normalizeInverse(Math.abs(avg), 0, 15).toFixed(3));
+  return wrap('ZEUS-µ3', {
+    agentName: 'ZEUS-µ3',
+    source: 'CoinCap · crypto volatility',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `CoinCap: avg 24h Δ across top ${rows.length} ≈ ${avg.toFixed(2)}%`,
+    severity: classifySeverity(value, { watch: 0.45, elevated: 0.28, critical: 0.12 }),
+    raw: { top: rows[0]?.id },
+  });
+}
+
+export async function pollZeusU4(): Promise<AgentPollResult> {
+  const url = 'https://api.frankfurter.app/latest?from=USD&to=EUR,GBP,JPY';
+  const data = await safeFetch<{ rates?: Record<string, number> }>(url);
+  const rates = data?.rates;
+  if (!rates) return wrap('ZEUS-µ4', null);
+  const spread =
+    Math.max(...Object.values(rates)) - Math.min(...Object.values(rates));
+  const value = Number(normalizeInverse(spread, 0, 2).toFixed(3));
+  return wrap('ZEUS-µ4', {
+    agentName: 'ZEUS-µ4',
+    source: 'Frankfurter · FX cross-check',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `FX: USD vs basket spread ≈ ${spread.toFixed(4)}`,
+    severity: classifySeverity(value),
+    raw: rates,
+  });
+}
+
+export async function pollZeusU5(): Promise<AgentPollResult> {
+  const url = 'https://openlibrary.org/search.json?q=governance&limit=5';
+  const data = await safeFetch<{ numFound?: number }>(url);
+  const n = data?.numFound;
+  if (typeof n !== 'number') return wrap('ZEUS-µ5', null);
+  const value = Number(normalizeDirect(Math.min(n, 5000), 0, 5000).toFixed(3));
+  return wrap('ZEUS-µ5', {
+    agentName: 'ZEUS-µ5',
+    source: 'Open Library · corpus',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `OpenLibrary: governance query → ${n} hits`,
+    severity: 'nominal',
+    raw: { numFound: n },
+  });
+}
+
+// ── HERMES (information velocity) ──────────────────────────────────────────
+
+export async function pollHermesU1(): Promise<AgentPollResult> {
+  const top = await safeFetch<number[]>('https://hacker-news.firebaseio.com/v0/topstories.json');
+  if (!top?.length) return wrap('HERMES-µ1', null);
+  const id = top[0]!;
+  const item = await safeFetch<{ score?: number; title?: string }>(`https://hacker-news.firebaseio.com/v0/item/${id}.json`);
+  const score = item?.score ?? 0;
+  const value = Number(normalizeDirect(score, 20, 600).toFixed(3));
+  return wrap('HERMES-µ1', {
+    agentName: 'HERMES-µ1',
+    source: 'Hacker News · top story',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `HN #1 score ${score}: ${(item?.title ?? '').slice(0, 80)}`,
+    severity: classifySeverity(value, { watch: 0.4, elevated: 0.2, critical: 0.05 }),
+    raw: { id, score },
+  });
+}
+
+export async function pollHermesU2(): Promise<AgentPollResult> {
+  const url =
+    'https://en.wikipedia.org/w/api.php?action=query&list=recentchanges&rclimit=30&rctype=edit&rcprop=timestamp&format=json&origin=*';
+  const data = await safeFetch<{ query?: { recentchanges?: { timestamp: string }[] } }>(url);
+  const rc = data?.query?.recentchanges;
+  if (!rc?.length) return wrap('HERMES-µ2', null);
+  const span = (Date.now() - new Date(rc[rc.length - 1]!.timestamp).getTime()) / 60000;
+  const epm = span > 0 ? rc.length / span : 0;
+  const value =
+    epm < 1
+      ? Number((normalizeDirect(epm, 0, 1) * 0.5).toFixed(3))
+      : Number((0.5 + normalizeDirect(Math.min(epm, 12), 1, 12) * 0.5).toFixed(3));
+  return wrap('HERMES-µ2', {
+    agentName: 'HERMES-µ2',
+    source: 'Wikipedia · recent changes',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `Wiki: ~${epm.toFixed(1)} edits/min (sample ${rc.length})`,
+    severity: classifySeverity(value, { watch: 0.4, elevated: 0.2, critical: 0.05 }),
+    raw: { epm },
+  });
+}
+
+export async function pollHermesU3(): Promise<AgentPollResult> {
+  const url =
+    'https://api.gdeltproject.org/api/v2/doc/doc?query=governance&mode=artlist&maxrecords=8&format=json&timespan=1d';
+  const data = await safeFetch<{ articles?: unknown[] }>(url, 12000);
+  const n = data?.articles?.length ?? 0;
+  const value = Number(normalizeDirect(n, 0, 10).toFixed(3));
+  return wrap('HERMES-µ3', {
+    agentName: 'HERMES-µ3',
+    source: 'GDELT · governance artlist',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `GDELT: ${n} articles (24h governance)`,
+    severity: classifySeverity(value, { watch: 0.45, elevated: 0.3, critical: 0.15 }),
+    raw: { count: n },
+  });
+}
+
+export async function pollHermesU4(): Promise<AgentPollResult> {
+  const url = 'https://www.reddit.com/r/worldnews/hot.json?limit=8';
+  const data = await safeFetch<{ data?: { children?: Array<{ data?: { score?: number; title?: string } }> } }>(
+    url,
+    12000,
+    { headers: { ...UA_HEADERS, Accept: 'application/json' } },
+  );
+  const kids = data?.data?.children ?? [];
+  const scores = kids.map((c) => c.data?.score ?? 0);
+  const avg = scores.length ? scores.reduce((a, b) => a + b, 0) / scores.length : 0;
+  const value = Number(normalizeDirect(avg, 0, 2000).toFixed(3));
+  return wrap('HERMES-µ4', {
+    agentName: 'HERMES-µ4',
+    source: 'Reddit · r/worldnews hot',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `Reddit worldnews: avg score ${Math.round(avg)} on ${kids.length} posts`,
+    severity: classifySeverity(value, { watch: 0.4, elevated: 0.22, critical: 0.08 }),
+    raw: { count: kids.length },
+  });
+}
+
+export async function pollHermesU5(): Promise<AgentPollResult> {
+  const url = 'https://api.spacexdata.com/v4/launches/upcoming';
+  const data = await safeFetch<unknown[]>(url);
+  const n = Array.isArray(data) ? data.length : 0;
+  const value = Number(normalizeDirect(n, 0, 10).toFixed(3));
+  return wrap('HERMES-µ5', {
+    agentName: 'HERMES-µ5',
+    source: 'SpaceX · launches API',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `SpaceX: ${n} upcoming launches in public feed`,
+    severity: 'nominal',
+    raw: { count: n },
+  });
+}
+
+// ── AUREA (governance / institutions) ─────────────────────────────────────
+
+export async function pollAureaU1(): Promise<AgentPollResult> {
+  const today = new Date().toISOString().split('T')[0];
+  const url = `https://www.federalregister.gov/api/v1/documents.json?conditions[publication_date][is]=${today}&per_page=10&order=newest`;
+  const data = await safeFetch<{ count?: number }>(url);
+  const count = data?.count ?? 0;
+  const value = Number(
+    (count === 0 ? 0.5 : count <= 100 ? normalizeDirect(count, 0, 100) : Math.max(0.7, 1 - (count - 100) / 500)).toFixed(3),
+  );
+  return wrap('AUREA-µ1', {
+    agentName: 'AUREA-µ1',
+    source: 'Federal Register · volume',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `FR today: ${count} documents`,
+    severity: classifySeverity(value, { watch: 0.4, elevated: 0.2, critical: 0.05 }),
+    raw: { date: today, count },
+  });
+}
+
+export async function pollAureaU2(): Promise<AgentPollResult> {
+  const url = 'https://catalog.data.gov/api/3/action/package_search?rows=5&sort=metadata_modified+desc';
+  const data = await safeFetch<{ result?: { count?: number } }>(url);
+  const n = data?.result?.count;
+  if (typeof n !== 'number') return wrap('AUREA-µ2', null);
+  const value = Number(normalizeDirect(Math.min(n, 500_000), 0, 500_000).toFixed(3));
+  return wrap('AUREA-µ2', {
+    agentName: 'AUREA-µ2',
+    source: 'data.gov · catalog size',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `data.gov catalog: ${n.toLocaleString()} datasets indexed`,
+    severity: 'nominal',
+    raw: { count: n },
+  });
+}
+
+export async function pollAureaU3(): Promise<AgentPollResult> {
+  const url = 'https://api.fda.gov/drug/event.json?limit=5';
+  const data = await safeFetch<{ results?: unknown[]; meta?: { results?: { limit?: number } } }>(url);
+  const n = data?.results?.length ?? 0;
+  const value = n > 0 ? 0.75 : 0.45;
+  return wrap('AUREA-µ3', {
+    agentName: 'AUREA-µ3',
+    source: 'openFDA · drug events sample',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `openFDA: ${n} adverse event rows (sample query)`,
+    severity: n > 0 ? 'nominal' : 'watch',
+    raw: { count: n },
+  });
+}
+
+export async function pollAureaU4(): Promise<AgentPollResult> {
+  const url =
+    'https://api.census.gov/data/2021/pep/natmonthly?get=POP,NAME&for=us:*';
+  const data = await safeFetch<string[][]>(url);
+  const row = data?.[1];
+  const pop = row && row[0] ? Number.parseInt(row[0], 10) : NaN;
+  if (!Number.isFinite(pop)) return wrap('AUREA-µ4', null);
+  const value = Number(normalizeDirect(Math.log10(pop), 8.5, 9.1).toFixed(3));
+  return wrap('AUREA-µ4', {
+    agentName: 'AUREA-µ4',
+    source: 'US Census · national monthly PEP',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `US POP estimate: ${(pop / 1e6).toFixed(2)}M`,
+    severity: 'nominal',
+    raw: { pop },
+  });
+}
+
+export async function pollAureaU5(): Promise<AgentPollResult> {
+  const url = 'https://api.usaspending.gov/api/v2/references/toptier_agencies/?limit=10';
+  const data = await safeFetch<{ results?: unknown[] }>(url);
+  const n = data?.results?.length ?? 0;
+  const value = Number(normalizeDirect(n, 0, 10).toFixed(3));
+  return wrap('AUREA-µ5', {
+    agentName: 'AUREA-µ5',
+    source: 'USAspending · agency reference',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `USAspending: ${n} toptier agencies in reference slice`,
+    severity: 'nominal',
+    raw: { count: n },
+  });
+}
+
+// ── JADE (memory / culture / precedent signals) ───────────────────────────
+
+export async function pollJadeU1(): Promise<AgentPollResult> {
+  const url = 'https://www.wikidata.org/w/api.php?action=wbgetentities&ids=Q42&format=json&origin=*';
+  const data = await safeFetch<{ entities?: Record<string, { labels?: { en?: { value?: string } } }> }>(url);
+  const label = data?.entities?.Q42?.labels?.en?.value;
+  if (!label) return wrap('JADE-µ1', null);
+  return wrap('JADE-µ1', {
+    agentName: 'JADE-µ1',
+    source: 'Wikidata · entity probe',
+    timestamp: new Date().toISOString(),
+    value: 0.88,
+    label: `Wikidata Q42 label: ${label}`,
+    severity: 'nominal',
+    raw: { id: 'Q42', label },
+  });
+}
+
+export async function pollJadeU2(): Promise<AgentPollResult> {
+  const url = 'https://api.quotable.io/random';
+  const data = await safeFetch<{ content?: string; author?: string }>(url);
+  if (!data?.content) return wrap('JADE-µ2', null);
+  return wrap('JADE-µ2', {
+    agentName: 'JADE-µ2',
+    source: 'Quotable · random quote',
+    timestamp: new Date().toISOString(),
+    value: 0.72,
+    label: `Quote: “${data.content.slice(0, 70)}…” — ${data.author ?? 'unknown'}`,
+    severity: 'nominal',
+    raw: { author: data.author },
+  });
+}
+
+export async function pollJadeU3(): Promise<AgentPollResult> {
+  const url = 'https://collectionapi.metmuseum.org/public/collection/v1/objects/45734';
+  const data = await safeFetch<{ title?: string; objectDate?: string }>(url);
+  if (!data?.title) return wrap('JADE-µ3', null);
+  return wrap('JADE-µ3', {
+    agentName: 'JADE-µ3',
+    source: 'Met Museum · public collection',
+    timestamp: new Date().toISOString(),
+    value: 0.85,
+    label: `Met: ${data.title} (${data.objectDate ?? 'date n/a'})`,
+    severity: 'nominal',
+    raw: data,
+  });
+}
+
+export async function pollJadeU4(): Promise<AgentPollResult> {
+  const url = 'https://openlibrary.org/authors/OL23466A.json';
+  const data = await safeFetch<{ name?: string; work_count?: number }>(url);
+  if (!data?.name) return wrap('JADE-µ4', null);
+  const wc = data.work_count ?? 0;
+  const value = Number(normalizeDirect(Math.min(wc, 200), 0, 200).toFixed(3));
+  return wrap('JADE-µ4', {
+    agentName: 'JADE-µ4',
+    source: 'Open Library · author record',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `OL author ${data.name}: ${wc} works`,
+    severity: 'nominal',
+    raw: { work_count: wc },
+  });
+}
+
+export async function pollJadeU5(): Promise<AgentPollResult> {
+  const url = 'https://poetrydb.org/random/1';
+  const data = await safeFetch<Array<{ title?: string; author?: string }>>(url);
+  const row = data?.[0];
+  if (!row?.title) return wrap('JADE-µ5', null);
+  return wrap('JADE-µ5', {
+    agentName: 'JADE-µ5',
+    source: 'Poetry DB · random',
+    timestamp: new Date().toISOString(),
+    value: 0.78,
+    label: `Poetry: ${row.title} — ${row.author ?? 'unknown'}`,
+    severity: 'nominal',
+    raw: row,
+  });
+}
+
+// ── DAEDALUS (systems / build health) ─────────────────────────────────────
+
+export async function pollDaedalusU1(): Promise<AgentPollResult> {
+  const url = 'https://api.github.com/repos/vercel/next.js';
+  const data = await safeFetch<{ stargazers_count?: number; open_issues_count?: number }>(url, 10000, {
+    headers: UA_HEADERS,
+  });
+  if (!data) return wrap('DAEDALUS-µ1', null);
+  const stars = data.stargazers_count ?? 0;
+  const issues = data.open_issues_count ?? 0;
+  const value = Number((0.6 * normalizeDirect(Math.log10(stars + 1), 4, 6) + 0.4 * normalizeInverse(issues, 500, 5000)).toFixed(3));
+  return wrap('DAEDALUS-µ1', {
+    agentName: 'DAEDALUS-µ1',
+    source: 'GitHub · next.js repo',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `next.js: ★${stars.toLocaleString()} · ${issues} open issues`,
+    severity: classifySeverity(value, { watch: 0.45, elevated: 0.28, critical: 0.12 }),
+    raw: { stars, issues },
+  });
+}
+
+export async function pollDaedalusU2(): Promise<AgentPollResult> {
+  const url = 'https://registry.npmjs.org/react/latest';
+  const data = await safeFetch<{ time?: Record<string, string> }>(url);
+  const t = data?.time?.modified;
+  if (!t) return wrap('DAEDALUS-µ2', null);
+  const days = (Date.now() - new Date(t).getTime()) / 86400000;
+  const value = Number(normalizeInverse(days, 0, 45).toFixed(3));
+  return wrap('DAEDALUS-µ2', {
+    agentName: 'DAEDALUS-µ2',
+    source: 'npm · react@latest',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `react latest modified ${Math.round(days)}d ago`,
+    severity: classifySeverity(value, { watch: 0.5, elevated: 0.3, critical: 0.1 }),
+    raw: { modified: t },
+  });
+}
+
+export async function pollDaedalusU3(): Promise<AgentPollResult> {
+  const url = 'https://registry.npmjs.org/typescript/latest';
+  const data = await safeFetch<{ 'dist-tags'?: { latest?: string } }>(url);
+  const v = data?.['dist-tags']?.latest;
+  if (!v) return wrap('DAEDALUS-µ3', null);
+  return wrap('DAEDALUS-µ3', {
+    agentName: 'DAEDALUS-µ3',
+    source: 'npm · typescript latest tag',
+    timestamp: new Date().toISOString(),
+    value: 0.82,
+    label: `TypeScript latest: ${v}`,
+    severity: 'nominal',
+    raw: { version: v },
+  });
+}
+
+export async function pollDaedalusU4(): Promise<AgentPollResult> {
+  const url = 'https://status.npmjs.org/api/v2/status.json';
+  const data = await safeFetch<{ status?: { indicator?: string; description?: string } }>(url);
+  const ind = data?.status?.indicator ?? 'unknown';
+  const value = ind === 'none' ? 1.0 : ind === 'minor' ? 0.75 : ind === 'major' ? 0.45 : 0.25;
+  return wrap('DAEDALUS-µ4', {
+    agentName: 'DAEDALUS-µ4',
+    source: 'npm · status API',
+    timestamp: new Date().toISOString(),
+    value: Number(value.toFixed(3)),
+    label: `npm status: ${ind} — ${data?.status?.description ?? ''}`,
+    severity: ind === 'none' ? 'nominal' : 'watch',
+    raw: data?.status,
+  });
+}
+
+export async function pollDaedalusU5(): Promise<AgentPollResult> {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || process.env.VERCEL_URL;
+  if (!baseUrl) {
+    return wrap('DAEDALUS-µ5', {
+      agentName: 'DAEDALUS-µ5',
+      source: 'Self-ping',
+      timestamp: new Date().toISOString(),
+      value: 0.5,
+      label: 'Self-ping: no VERCEL_URL',
+      severity: 'watch',
+    });
+  }
+  const url = `https://${baseUrl.replace(/^https?:\/\//, '')}/api/integrity-status`;
+  const start = Date.now();
+  try {
+    const res = await fetch(url, { cache: 'no-store' });
+    const ms = Date.now() - start;
+    const value = Number(normalizeInverse(ms, 0, 3000).toFixed(3));
+    return wrap('DAEDALUS-µ5', {
+      agentName: 'DAEDALUS-µ5',
+      source: 'Self-ping · integrity-status',
+      timestamp: new Date().toISOString(),
+      value,
+      label: `Self-ping: ${res.status} in ${ms}ms`,
+      severity: res.ok ? classifySeverity(value) : 'elevated',
+      raw: { status: res.status, ms },
+    });
+  } catch {
+    return wrap('DAEDALUS-µ5', {
+      agentName: 'DAEDALUS-µ5',
+      source: 'Self-ping · integrity-status',
+      timestamp: new Date().toISOString(),
+      value: 0,
+      label: 'Self-ping: unreachable',
+      severity: 'critical',
+    });
+  }
+}
+
+// ── ECHO (raw events / markets / environment) ──────────────────────────────
+
+export async function pollEchoU1(): Promise<AgentPollResult> {
+  const url =
+    'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum,solana&vs_currencies=usd&include_24hr_change=true';
+  const data = await safeFetch<
+    Record<string, { usd?: number; usd_24h_change?: number }>
+  >(url, 12000);
+  if (!data?.bitcoin?.usd) return wrap('ECHO-µ1', null);
+  const ch = Math.abs(data.bitcoin.usd_24h_change ?? 0);
+  const value = Number(normalizeInverse(ch, 0, 12).toFixed(3));
+  return wrap('ECHO-µ1', {
+    agentName: 'ECHO-µ1',
+    source: 'CoinGecko · majors',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `CoinGecko: BTC $${data.bitcoin.usd} (24h ${(data.bitcoin.usd_24h_change ?? 0).toFixed(2)}%)`,
+    severity: classifySeverity(value, { watch: 0.45, elevated: 0.28, critical: 0.12 }),
+    raw: data,
+  });
+}
+
+export async function pollEchoU2(): Promise<AgentPollResult> {
+  const url = 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_day.geojson';
+  const data = await safeFetch<{ features?: { properties: { mag: number; place: string } }[] }>(url);
+  const feats = data?.features ?? [];
+  const n = feats.length;
+  const maxMag = feats.reduce((m, f) => Math.max(m, f.properties.mag), 0);
+  const value = Number((0.5 * normalizeInverse(n, 0, 30) + 0.5 * normalizeInverse(maxMag, 4.5, 8)).toFixed(3));
+  return wrap('ECHO-µ2', {
+    agentName: 'ECHO-µ2',
+    source: 'USGS · M4.5+ day feed',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `USGS M4.5+: ${n} events, max M${maxMag.toFixed(1)}`,
+    severity: classifySeverity(value, { watch: 0.45, elevated: 0.28, critical: 0.1 }),
+    raw: { count: n, maxMag },
+  });
+}
+
+export async function pollEchoU3(): Promise<AgentPollResult> {
+  const events = await fetchEonetEvents(5).catch(() => []);
+  const v = scoreEonetEvents(events);
+  return wrap('ECHO-µ3', {
+    agentName: 'ECHO-µ3',
+    source: 'NASA EONET · events',
+    timestamp: new Date().toISOString(),
+    value: v,
+    label: `EONET: ${events.length} open events (7d window)`,
+    severity: events.length > 25 ? 'elevated' : 'nominal',
+    raw: { count: events.length },
+  });
+}
+
+export async function pollEchoU4(): Promise<AgentPollResult> {
+  const url = 'https://api.open-notify.org/astros.json';
+  const data = await safeFetch<{ number?: number; people?: { name: string }[] }>(url);
+  const n = data?.number ?? 0;
+  const value = Number(normalizeDirect(n, 0, 12).toFixed(3));
+  return wrap('ECHO-µ4', {
+    agentName: 'ECHO-µ4',
+    source: 'Open Notify · ISS crew',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `People in space right now: ${n}`,
+    severity: 'nominal',
+    raw: { sample: data?.people?.slice(0, 3).map((p) => p.name) },
+  });
+}
+
+export async function pollEchoU5(): Promise<AgentPollResult> {
+  const key = process.env.NASA_APOD_KEY?.trim() || 'DEMO_KEY';
+  const url = `https://api.nasa.gov/planetary/apod?api_key=${encodeURIComponent(key)}`;
+  const data = await safeFetch<{ title?: string; url?: string; media_type?: string }>(url);
+  if (!data?.title) return wrap('ECHO-µ5', null);
+  return wrap('ECHO-µ5', {
+    agentName: 'ECHO-µ5',
+    source: 'NASA APOD',
+    timestamp: new Date().toISOString(),
+    value: 0.9,
+    label: `APOD: ${data.title}`,
+    severity: 'nominal',
+    raw: { media_type: data.media_type },
+  });
+}
+
+// ── EVE (civic / demographic / participation proxies) ─────────────────────
+
+export async function pollEveU1(): Promise<AgentPollResult> {
+  const url = 'https://datausa.io/api/data?drilldowns=Nation&measures=Population&year=latest';
+  const data = await safeFetch<{ data?: Array<{ Population?: number; Year?: string }> }>(url);
+  const pop = data?.data?.[0]?.Population;
+  if (typeof pop !== 'number') return wrap('EVE-µ1', null);
+  const value = Number(normalizeDirect(Math.log10(pop + 1), 8.5, 9.1).toFixed(3));
+  return wrap('EVE-µ1', {
+    agentName: 'EVE-µ1',
+    source: 'Data USA · national population',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `DataUSA nation POP: ${(pop / 1e6).toFixed(2)}M`,
+    severity: 'nominal',
+    raw: { year: data?.data?.[0]?.Year },
+  });
+}
+
+export async function pollEveU2(): Promise<AgentPollResult> {
+  const url = 'https://api.agify.io?name=alex';
+  const data = await safeFetch<{ age?: number | null; count?: number }>(url);
+  if (data?.age == null) return wrap('EVE-µ2', null);
+  return wrap('EVE-µ2', {
+    agentName: 'EVE-µ2',
+    source: 'Agify · demographic probe',
+    timestamp: new Date().toISOString(),
+    value: 0.7,
+    label: `Agify “alex” inferred age ${data.age} (n=${data.count ?? '?'})`,
+    severity: 'nominal',
+    raw: data,
+  });
+}
+
+export async function pollEveU3(): Promise<AgentPollResult> {
+  const url = 'https://api.genderize.io?name=alex';
+  const data = await safeFetch<{ gender?: string; probability?: number }>(url);
+  if (!data?.gender) return wrap('EVE-µ3', null);
+  const p = data.probability ?? 0;
+  const value = Number(p.toFixed(3));
+  return wrap('EVE-µ3', {
+    agentName: 'EVE-µ3',
+    source: 'Genderize · name signal',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `Genderize: alex → ${data.gender} (p=${p.toFixed(2)})`,
+    severity: 'nominal',
+    raw: data,
+  });
+}
+
+export async function pollEveU4(): Promise<AgentPollResult> {
+  const url = 'https://api.nationalize.io?name=smith';
+  const data = await safeFetch<{ country?: Array<{ country_id: string; probability: number }> }>(url);
+  const top = data?.country?.[0];
+  if (!top) return wrap('EVE-µ4', null);
+  const value = Number(top.probability.toFixed(3));
+  return wrap('EVE-µ4', {
+    agentName: 'EVE-µ4',
+    source: 'Nationalize · surname geography',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `Nationalize “smith”: top ${top.country_id} (${(top.probability * 100).toFixed(1)}%)`,
+    severity: 'nominal',
+    raw: top,
+  });
+}
+
+export async function pollEveU5(): Promise<AgentPollResult> {
+  const url = 'https://randomuser.me/api/?results=5&nat=us';
+  const data = await safeFetch<{ results?: unknown[] }>(url);
+  const n = data?.results?.length ?? 0;
+  const value = Number(normalizeDirect(n, 0, 5).toFixed(3));
+  return wrap('EVE-µ5', {
+    agentName: 'EVE-µ5',
+    source: 'RandomUser · synthetic civic sample',
+    timestamp: new Date().toISOString(),
+    value,
+    label: `RandomUser: pulled ${n} US profiles (public demo API)`,
+    severity: 'nominal',
+    raw: { count: n },
+  });
+}
+
+/** All 40 instrument poll functions in family order */
+export const ALL_INSTRUMENT_POLLS: Array<() => Promise<AgentPollResult>> = [
+  pollAtlasU1,
+  pollAtlasU2,
+  pollAtlasU3,
+  pollAtlasU4,
+  pollAtlasU5,
+  pollZeusU1,
+  pollZeusU2,
+  pollZeusU3,
+  pollZeusU4,
+  pollZeusU5,
+  pollHermesU1,
+  pollHermesU2,
+  pollHermesU3,
+  pollHermesU4,
+  pollHermesU5,
+  pollAureaU1,
+  pollAureaU2,
+  pollAureaU3,
+  pollAureaU4,
+  pollAureaU5,
+  pollJadeU1,
+  pollJadeU2,
+  pollJadeU3,
+  pollJadeU4,
+  pollJadeU5,
+  pollDaedalusU1,
+  pollDaedalusU2,
+  pollDaedalusU3,
+  pollDaedalusU4,
+  pollDaedalusU5,
+  pollEchoU1,
+  pollEchoU2,
+  pollEchoU3,
+  pollEchoU4,
+  pollEchoU5,
+  pollEveU1,
+  pollEveU2,
+  pollEveU3,
+  pollEveU4,
+  pollEveU5,
+];

--- a/lib/terminal/globePins.ts
+++ b/lib/terminal/globePins.ts
@@ -63,6 +63,8 @@ function echoSeverityToGlobe(s: string): GlobePinSeverity {
 function agentLabel(agentName: string): string {
   if (agentName === 'HERMES-µ') return 'HERMES';
   if (agentName === 'DAEDALUS-µ') return 'DAEDALUS';
+  const m = /^([A-Z]+)-µ\d+$/.exec(agentName);
+  if (m) return m[1]!;
   return agentName;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change completes the **8 × 5 = 40** micro-instrument sweep using **public HTTP APIs only** (aligned with [public-apis](https://github.com/public-apis/public-apis) style sources). Production `/api/signals/micro` already imports `pollAllMicroAgents`; this branch supplies the full poll registry, bounded concurrency, and operator documentation of every endpoint.

## Details

- **`lib/agents/micro/instrument-polls.ts`**: One poll per instrument (World Bank, ReliefWeb, CrossRef, arXiv, CoinGecko, USGS, GDELT, Federal Register, etc.) with normalized `MicroSignal` output.
- **`lib/agents/micro/index.ts`**: `pollAllMicroAgents()` runs all polls via `mapLimit` (8 workers); legacy four-agent sweep retained for tests.
- **`lib/agents/micro/core.ts`**: `safeFetch` accepts `RequestInit`; `safeFetchText` for XML/plain responses.
- **`lib/terminal/globePins.ts`**: `agentLabel` maps `FAMILY-µN` IDs to parent family names for globe UI.
- **`docs/architecture/microagent-public-endpoints.md`**: Canonical table of URLs and notes (including EVE demo APIs and self-ping requirements).

**HTTPS**: arXiv and Open Notify polls use `https://` for better compatibility with strict fetch environments.

## Integrity & safety

- **GI impact**: No formula changes; more diverse upstream fetches may affect composite micro signal health only where consumed.
- **Risk**: External API availability and rate limits; several EVE instruments are **demographic demo APIs**, not civic truth — documented for replacement in a later cycle.

## Tests

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- `pnpm lint` — **not run** (Next.js 15 prompts interactive ESLint setup; same as BUILD.md caveat)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-636b1cfd-9101-4d42-b374-addadfac770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-636b1cfd-9101-4d42-b374-addadfac770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

