### PR TITLE
C-282: Wire KV state to Pulse Ledger and agent journals to Civic Ledger

### DIFF
--- a/app/api/cron/gi-refresh/route.ts
+++ b/app/api/cron/gi-refresh/route.ts
@@ -9,6 +9,8 @@ import { NextResponse } from 'next/server';
 import { getEveSynthesisAuthError } from '@/lib/security/serviceAuth';
 import { runSignalEngine } from '@/lib/signals/engine';
 import { recomputeAndSaveGIState } from '@/lib/integrity/buildStatus';
+import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
 
 export const dynamic = 'force-dynamic';
 
@@ -19,6 +21,24 @@ export async function GET(request: NextRequest) {
   try {
     await runSignalEngine();
     const giState = await recomputeAndSaveGIState();
+
+    if (giState) {
+      void pushLedgerEntry({
+        id: `gi-refresh-${currentCycleId()}-${Date.now()}`,
+        timestamp: new Date().toISOString(),
+        author: 'ATLAS',
+        title: `GI refresh: ${giState.global_integrity.toFixed(4)} — mode ${giState.mode}`,
+        type: 'epicon',
+        severity: giState.global_integrity < 0.7 ? 'elevated' : 'nominal',
+        source: 'kv-ledger',
+        tags: ['gi-refresh', 'integrity', currentCycleId()],
+        verified: false,
+        category: 'heartbeat',
+        status: 'committed',
+        agentOrigin: 'ATLAS',
+      }).catch(() => {});
+    }
+
     return NextResponse.json({
       ok: true,
       refreshed: giState !== null,

--- a/app/api/cron/watchdog/route.ts
+++ b/app/api/cron/watchdog/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServiceAuthError, serviceAuthorizationHeaderValue } from '@/lib/security/serviceAuth';
 import { appendAgentJournalEntry } from '@/lib/agents/journal';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
+import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
 
 /**
  * C-274: Runtime maintenance is currently once-daily (Vercel cron). If heartbeat,
@@ -109,6 +110,22 @@ export async function GET(request: NextRequest) {
   console.info('[watchdog] daily run', logResult);
 
   const failed = actions.filter((action) => action.includes('fail')).length;
+
+  void pushLedgerEntry({
+    id: `watchdog-${currentCycleId()}-${Date.now()}`,
+    timestamp,
+    author: 'ATLAS',
+    title: `Watchdog: ${actions.length} checks, ${failed} failed`,
+    type: 'epicon',
+    severity: failed === 0 ? 'nominal' : 'elevated',
+    source: 'kv-ledger',
+    tags: ['watchdog', 'cron', currentCycleId()],
+    verified: false,
+    category: 'heartbeat',
+    status: 'committed',
+    agentOrigin: 'ATLAS',
+  }).catch(() => {});
+
   void appendAgentJournalEntry({
     agent: 'ATLAS',
     cycle: currentCycleId(),

--- a/app/api/kv/health/route.ts
+++ b/app/api/kv/health/route.ts
@@ -9,6 +9,8 @@
 
 import { NextResponse } from 'next/server';
 import { kvHealth, isRedisAvailable, KV_KEYS, kvGet, kvGetRaw } from '@/lib/kv/store';
+import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
 
 export const dynamic = 'force-dynamic';
 
@@ -24,6 +26,26 @@ export async function GET() {
     }
     const legacyTripwire = await kvGetRaw<string>('TRIPWIRE_STATE');
     keys.TRIPWIRE_STATE_REDIS = legacyTripwire !== null && legacyTripwire !== undefined;
+  }
+
+  const populatedCount = Object.values(keys).filter(Boolean).length;
+  const totalChecked = Object.keys(keys).length;
+
+  if (health.available) {
+    void pushLedgerEntry({
+      id: `kv-health-${currentCycleId()}-${Date.now()}`,
+      timestamp: new Date().toISOString(),
+      author: 'DAEDALUS',
+      title: `KV health: ${populatedCount}/${totalChecked} keys populated, latency ${health.latencyMs ?? '?'}ms`,
+      type: 'epicon',
+      severity: populatedCount < totalChecked / 2 ? 'elevated' : 'nominal',
+      source: 'kv-ledger',
+      tags: ['kv-health', 'infrastructure', currentCycleId()],
+      verified: false,
+      category: 'heartbeat',
+      status: 'committed',
+      agentOrigin: 'DAEDALUS',
+    }).catch(() => {});
   }
 
   return NextResponse.json({

--- a/app/api/signals/micro/route.ts
+++ b/app/api/signals/micro/route.ts
@@ -9,6 +9,7 @@ import { NextResponse } from 'next/server';
 import { pollAllMicroAgents } from '@/lib/agents/micro';
 import { saveSignalSnapshot, loadSignalSnapshot, isRedisAvailable, kvSet, KV_KEYS } from '@/lib/kv/store';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
+import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
 
 export const dynamic = 'force-dynamic';
 
@@ -53,8 +54,6 @@ export async function GET() {
         healthy: result.healthy,
       }).catch(() => {});
 
-      // Write a fresh HEARTBEAT on every real sweep so the agents lane stays current
-      // even between synthesis cron runs.
       kvSet(KV_KEYS.HEARTBEAT, JSON.stringify({
         ok: true,
         gi: result.composite,
@@ -65,6 +64,21 @@ export async function GET() {
         timestamp: result.timestamp,
         source: 'micro-sweep',
       })).catch(() => {});
+
+      pushLedgerEntry({
+        id: `micro-sweep-${currentCycleId()}-${Date.now()}`,
+        timestamp: result.timestamp,
+        author: 'DAEDALUS',
+        title: `Sensor sweep: ${result.instrumentCount ?? 40} instruments, composite ${result.composite.toFixed(3)}, ${result.anomalies?.length ?? 0} anomalies`,
+        type: 'epicon',
+        severity: (result.anomalies?.length ?? 0) > 5 ? 'elevated' : 'nominal',
+        source: 'kv-ledger',
+        tags: ['micro-sweep', 'heartbeat', currentCycleId()],
+        verified: false,
+        category: 'heartbeat',
+        status: 'committed',
+        agentOrigin: 'DAEDALUS',
+      }).catch(() => {});
     }
 
     return NextResponse.json({

--- a/app/api/tripwire/status/route.ts
+++ b/app/api/tripwire/status/route.ts
@@ -4,6 +4,7 @@ import { mockTripwire } from '@/lib/mock-data';
 import { liveEnvelope, mockEnvelope } from '@/lib/response-envelope';
 import { saveTripwireState, kvSet, kvSetRawKey, KV_KEYS } from '@/lib/kv/store';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
+import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
 
 export const dynamic = 'force-dynamic';
 
@@ -67,6 +68,21 @@ export async function GET() {
       tripwireCount: tripwire.active ? 1 : 0,
       elevated: tripwire.active,
       timestamp: new Date().toISOString(),
+    }).catch(() => {});
+
+    void pushLedgerEntry({
+      id: `tripwire-${currentCycleId()}-${Date.now()}`,
+      timestamp: new Date().toISOString(),
+      author: 'ATLAS',
+      title: `Tripwire: ${tripwire.active ? 'ACTIVE' : 'clear'} — ${tripwire.reason}`,
+      type: 'epicon',
+      severity: tripwire.active ? 'elevated' : 'nominal',
+      source: 'kv-ledger',
+      tags: ['tripwire', 'sentinel', currentCycleId()],
+      verified: false,
+      category: 'heartbeat',
+      status: 'committed',
+      agentOrigin: 'ATLAS',
     }).catch(() => {});
 
     return NextResponse.json({

--- a/lib/agents/journal.ts
+++ b/lib/agents/journal.ts
@@ -2,6 +2,8 @@ import { kvGet, kvSet } from '@/lib/kv/store';
 import { AGENT_MANIFESTS, AGENT_ORDER, type AgentName } from '@/lib/agents/manifests';
 import type { AgentJournalCategory, AgentJournalEntry, AgentJournalSeverity, AgentJournalStatus } from '@/lib/terminal/types';
 import { scheduleVaultDepositForJournal } from '@/lib/vault/vault';
+import { writeToSubstrate } from '@/lib/substrate/client';
+import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
 
 const INDEX_KEY = 'journal:index';
 const MAX_ENTRIES_PER_AGENT = 100;
@@ -172,8 +174,47 @@ export async function appendAgentJournalEntry(input: NewJournalEntryInput): Prom
   await upsertIndex(agent, entry.cycle);
   if (entry.status === 'committed') {
     scheduleVaultDepositForJournal(entry);
+
+    void writeToSubstrate({
+      agent: entry.agent,
+      agentOrigin: entry.agentOrigin,
+      cycle: entry.cycle,
+      title: entry.inference,
+      summary: entry.observation,
+      category: mapCategoryToSubstrate(entry.category),
+      severity: entry.severity,
+      source: 'agent-journal',
+      confidence: entry.confidence,
+      derivedFrom: entry.derivedFrom,
+      tags: [],
+    }).catch((err) => {
+      console.error(`[journal] ledger attest failed for ${entry.agent}:`, err instanceof Error ? err.message : err);
+    });
+
+    void pushLedgerEntry({
+      id: entry.id,
+      timestamp: entry.timestamp,
+      author: entry.agentOrigin,
+      title: entry.inference,
+      type: 'epicon',
+      severity: entry.severity === 'critical' ? 'critical' : entry.severity === 'elevated' ? 'elevated' : 'nominal',
+      source: 'agent-journal',
+      tags: [entry.agent, entry.category, entry.cycle],
+      verified: false,
+      category: entry.category,
+      status: 'committed',
+      agentOrigin: entry.agentOrigin,
+    }).catch((err) => {
+      console.error(`[journal] pulse ledger push failed for ${entry.agent}:`, err instanceof Error ? err.message : err);
+    });
   }
   return entry;
+}
+
+function mapCategoryToSubstrate(
+  cat: AgentJournalCategory,
+): 'observation' | 'inference' | 'alert' | 'recommendation' | 'close' | 'heartbeat' | 'verification' | 'ingest' | 'governance' | 'narrative' | 'market' | 'geopolitical' | 'infrastructure' | 'ethics' | 'civic-risk' {
+  return cat;
 }
 
 export async function getAgentJournalEntries(filters?: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Mobius Terminal PR — C-282

---

## 1. Summary

- **Cycle:** C-282
- **Type:** `feat`
- **Primary area:** `ledger` + `infra` + `signals`
- **Files changed:**
  - `app/api/cron/watchdog/route.ts`
  - `app/api/cron/gi-refresh/route.ts`
  - `app/api/kv/health/route.ts`
  - `app/api/signals/micro/route.ts`
  - `app/api/tripwire/status/route.ts`
  - `lib/agents/journal.ts`
- **Files deliberately NOT changed:**
  - `lib/kv/store.ts` (locked KV key schema)
  - `app/api/agents/journal/route.ts` (already has its own ledger attest via the HTTP POST path — no duplication)
  - `lib/echo/kv-persist-ingest.ts` (locked EPICON LPUSH)
  - `lib/epicon/ledgerPush.ts` (used as-is)
  - `lib/substrate/client.ts` (used as-is)

**What changed?**

Two connected features wiring the ledger system:

**KV state changes → Pulse Ledger (`epicon:feed`):**
- Watchdog cron pushes a run summary entry after each check pass
- Signal micro sweep pushes a heartbeat entry with instrument count, composite score, anomaly count
- KV health check pushes a diagnostic entry with key population stats and latency
- Tripwire status pushes active/clear state on each evaluation
- GI refresh cron pushes updated integrity score

**Agent journals → Civic Protocol Core Ledger:**
- `appendAgentJournalEntry()` now fires `writeToSubstrate()` (`attestToLedger`) for every committed journal entry — covers all 8 agent families (ATLAS, ZEUS, HERMES, AUREA, JADE, DAEDALUS, ECHO, EVE) including sentinel/steward cron journals
- Also pushes each committed journal to `epicon:feed` via `pushLedgerEntry()` so journal events appear in the Pulse chamber
- All writes are fire-and-forget (`void` + `.catch()`) — never block the journal write path

**Why?**

- Pulse Ledger was only populated by ECHO ingest and ledger backfill. Runtime KV events (watchdog, heartbeat, GI refresh, tripwire) were invisible in the Pulse chamber.
- Agent journals written through the programmatic path (`appendAgentJournalEntry()`) were persisted to KV and substrate but never attested to the Civic Protocol Core Ledger. Only the HTTP POST route (`/api/agents/journal`) had `writeToSubstrate()`. Now both paths attest.

---

## 2. Risk Tier

- [x] **Tier 1** — App logic, no auth/KV schema changes

---

## 3. EPICON Intent

```text
epicon_id: EPICON_C-282_ledger_kv-pulse-agent-attest
scope: ledger + infra
mode: normal
issued_at: 2026-04-15T14:00:00Z

justification:
  PROBLEM:
    1. Pulse Ledger only shows ECHO ingest events — no watchdog, heartbeat, GI, or tripwire entries
    2. Agent journal entries from cron paths never attested to Civic Protocol Core Ledger

  CONTEXT:
    The Pulse chamber is the operator dashboard. It should show all runtime events, not just ECHO.
    Agent journals should flow to the external ledger for attestation integrity.

  DECISION:
    Use existing pushLedgerEntry() to write KV state events to epicon:feed.
    Use existing writeToSubstrate() to attest committed journals to Civic Protocol Core Ledger.
    All writes are fire-and-forget to never block the primary path.

  BOUNDARIES:
    Does NOT change EPICON LPUSH logic (uses existing pushLedgerEntry).
    Does NOT change journal KV key schema.
    Does NOT change writeToSubstrate/attestToLedger shape.
    Does NOT change vault deposit logic.
    Does NOT change MII entry shape.

  TRADEOFFS:
    - Added: more entries in epicon:feed (capped at 500 by existing LTRIM)
    - Added: more attestToLedger calls (fire-and-forget, won't block)
    - Risk: if external ledger is down, writeToSubstrate falls back to KV (existing behavior)

  COUNTERFACTUALS:
    - If epicon:feed gets noisy, adjust entry frequency or add dedup window
    - If ledger is unreachable, attestToLedger falls back to writeJournalToKV (already implemented)
```

---

## 4. LOCKED BEHAVIOR AUDIT

- [x] This PR does NOT change the key schema in `app/api/agents/journal/route.ts`
- [x] This PR does NOT remove or bypass the LPUSH/LTRIM in `app/api/echo/ingest/route.ts`
- [x] This PR does NOT remove the `Authorization` header from `lib/substrate/github-reader.ts`
- [x] This PR does NOT add crypto price sources to HERMES-µ
- [x] This PR does NOT reassign domain ownership between agents
- [x] This PR does NOT attempt to "fix" `sources.kv: 0` on epicon or journal
- [x] This PR does NOT add seed/genesis data to mask empty KV state

---

## 5. Integrity Impact

**What could go wrong?** More entries appear in Pulse Ledger (improvement, not regression). If external ledger is unreachable, `attestToLedger` silently falls back to KV write (existing behavior). The primary journal write path is never blocked by ledger failures.

### Assessment
- **Estimated MII for this PR:** 0.88
- **Risk level:** Low
- **Lanes affected:** pulse, ledger, signals

### Checklist
- [x] Does not change KV key schemas without operator approval
- [x] Does not remove auth from any route
- [x] Does not introduce duplicate signal sources across agents
- [x] Does not add hardcoded cycle IDs, timestamps, or seed data
- [x] pnpm build passes

---

## 6. Verification

**Pre-merge:**
- [x] `pnpm exec tsc --noEmit` — typecheck passes
- [x] `pnpm build` — build passes
- [ ] Hit `/api/terminal/snapshot` on preview deployment
- [ ] Confirm Pulse shows KV events after watchdog/sweep run

**Evidence:**

```
typecheck: pass (0 errors)
build: pass (all routes compiled)
lint: interactive/not configured (known project state)
```

---

## 7. Rollback Plan

```bash
git revert <commit-sha>
# All ledger writes are fire-and-forget — no schema changes to undo
# epicon:feed LTRIM already caps at 500; reverting just stops new entries
```

---

## 8. Stop Conditions Met

- [x] No stop condition triggered — scope is clean

---

## 9. Final Checklist

- [x] Risk tier correctly assessed
- [x] EPICON intent block completed with BOUNDARIES field
- [x] Locked behavior audit completed (all boxes checked)
- [x] Rollback plan provided
- [x] I have read AGENTS.md, BUILD.md, and CURRENT_CYCLE.md before starting this PR
- [x] I am okay with this appearing in the public cathedral

---

*"Let me update my consensus." — Mobius constitutional phrase for acknowledging new ground truth.*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dcbde0f-826e-46d6-be38-dca42c20d2f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dcbde0f-826e-46d6-be38-dca42c20d2f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

