### PR TITLE
C-282: Expand Ledger to 100 entries with scroll box and sort controls

### DIFF
--- a/app/api/echo/feed/route.ts
+++ b/app/api/echo/feed/route.ts
@@ -16,6 +16,9 @@ import { getEchoEpicon, getEchoLedger, getEchoAlerts, getEchoIntegrity, getEchoS
 import { fetchAllSources } from '@/lib/echo/sources';
 import { transformBatch } from '@/lib/echo/transform';
 import { persistEchoIngestSideEffects } from '@/lib/echo/kv-persist-ingest';
+import { isRedisAvailable } from '@/lib/kv/store';
+import { Redis } from '@upstash/redis';
+import type { LedgerEntry } from '@/lib/terminal/types';
 
 export const dynamic = 'force-dynamic';
 
@@ -42,9 +45,62 @@ export async function GET() {
     }
   }
 
+  const echoLedger = getEchoLedger();
+  let kvLedgerEntries: LedgerEntry[] = [];
+
+  if (isRedisAvailable()) {
+    try {
+      const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+      const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+      if (url && token) {
+        const redis = new Redis({ url, token });
+        const raw = await redis.lrange<string>('mobius:epicon:feed', 0, 99);
+        for (const item of raw) {
+          try {
+            const parsed: Record<string, unknown> = typeof item === 'string' ? JSON.parse(item) : (item as Record<string, unknown>);
+            if (!parsed.id || !parsed.timestamp) continue;
+            kvLedgerEntries.push({
+              id: String(parsed.id),
+              cycleId: String(parsed.cycle ?? parsed.category ?? ''),
+              type: 'attestation',
+              agentOrigin: String(parsed.author ?? parsed.agentOrigin ?? 'SYSTEM'),
+              timestamp: String(parsed.timestamp),
+              title: String(parsed.title ?? ''),
+              summary: String(parsed.title ?? parsed.body ?? ''),
+              integrityDelta: 0,
+              status: (parsed.status === 'committed' || parsed.status === 'pending' || parsed.status === 'reverted')
+                ? parsed.status as 'committed' | 'pending' | 'reverted'
+                : 'committed',
+              category: typeof parsed.category === 'string' && ['geopolitical', 'market', 'governance', 'infrastructure', 'narrative', 'ethics', 'civic-risk'].includes(parsed.category)
+                ? parsed.category as LedgerEntry['category']
+                : undefined,
+              confidenceTier: typeof parsed.confidenceTier === 'number' ? parsed.confidenceTier : undefined,
+              tags: Array.isArray(parsed.tags) ? parsed.tags.filter((t): t is string => typeof t === 'string') : undefined,
+              source: 'agent_commit',
+            });
+          } catch {
+            // skip malformed entries
+          }
+        }
+      }
+    } catch {
+      // KV read failure — continue with echo-only data
+    }
+  }
+
+  const seenIds = new Set<string>();
+  const merged: LedgerEntry[] = [];
+  for (const row of [...echoLedger, ...kvLedgerEntries]) {
+    if (seenIds.has(row.id)) continue;
+    seenIds.add(row.id);
+    merged.push(row);
+  }
+  merged.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+  const capped = merged.slice(0, 100);
+
   return NextResponse.json({
     epicon: getEchoEpicon(),
-    ledger: getEchoLedger(),
+    ledger: capped,
     alerts: getEchoAlerts(),
     integrity: getEchoIntegrity(),
     status: getEchoStatus(),

--- a/app/terminal/ledger/LedgerPageClient.tsx
+++ b/app/terminal/ledger/LedgerPageClient.tsx
@@ -11,14 +11,41 @@ type EchoFeedResponse = {
   };
 };
 
+type SortKey = 'timestamp' | 'agent' | 'category' | 'tier' | 'delta' | 'status';
+type SortDir = 'asc' | 'desc';
+
 function statusBadge(status: string) {
   if (status === 'committed') return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200';
   if (status === 'flagged') return 'border-rose-500/40 bg-rose-500/10 text-rose-200';
   return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
 }
 
+function sortRows(rows: LedgerEntry[], key: SortKey, dir: SortDir): LedgerEntry[] {
+  const m = dir === 'asc' ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    switch (key) {
+      case 'timestamp':
+        return m * (new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+      case 'agent':
+        return m * (a.agentOrigin ?? '').localeCompare(b.agentOrigin ?? '');
+      case 'category':
+        return m * (a.category ?? '').localeCompare(b.category ?? '');
+      case 'tier':
+        return m * ((a.confidenceTier ?? 0) - (b.confidenceTier ?? 0));
+      case 'delta':
+        return m * ((a.integrityDelta ?? 0) - (b.integrityDelta ?? 0));
+      case 'status':
+        return m * a.status.localeCompare(b.status);
+      default:
+        return 0;
+    }
+  });
+}
+
 export default function LedgerPageClient() {
   const [feed, setFeed] = useState<EchoFeedResponse | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>('timestamp');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
 
   useEffect(() => {
     fetch('/api/echo/feed', { cache: 'no-store' })
@@ -28,49 +55,81 @@ export default function LedgerPageClient() {
   }, []);
 
   const rows = useMemo(() => feed?.ledger ?? [], [feed]);
+  const sorted = useMemo(() => sortRows(rows, sortKey, sortDir), [rows, sortKey, sortDir]);
   const totalDelta = useMemo(() => rows.reduce((sum, row) => sum + (row.integrityDelta ?? 0), 0), [rows]);
+
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir('desc');
+    }
+  };
+
+  const arrow = (key: SortKey) => (sortKey === key ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '');
 
   if (!feed) return <ChamberSkeleton blocks={10} />;
 
   return (
-    <div className="h-full overflow-y-auto p-4 text-xs">
-      <div className="mb-3 text-slate-400">
-        {feed.status?.cycleId ?? 'C-—'} · {rows.length} ledger rows
+    <div className="flex h-full flex-col overflow-hidden p-4 text-xs">
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-slate-400">
+          {feed.status?.cycleId ?? 'C-—'} · {rows.length} ledger rows
+        </span>
+        <span className="text-[10px] text-slate-500">
+          sorted by {sortKey} {sortDir === 'asc' ? '↑' : '↓'}
+        </span>
       </div>
       {rows.length === 0 ? (
         <div className="rounded border border-slate-800 bg-slate-900/60 p-4 text-slate-400">
           No ledger rows available yet.
         </div>
       ) : (
-        <div className="overflow-hidden rounded border border-slate-800">
-          <div className="grid grid-cols-[120px_1fr_110px_110px_120px_110px] bg-slate-950/80 px-3 py-2 text-[11px] uppercase tracking-wide text-slate-400">
-            <span>Timestamp</span>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-slate-800">
+          <div className="grid grid-cols-[100px_80px_1fr_100px_70px_90px_80px] bg-slate-950/80 px-3 py-2 text-[11px] uppercase tracking-wide text-slate-400">
+            <button type="button" onClick={() => toggleSort('timestamp')} className="text-left hover:text-slate-200">
+              Time{arrow('timestamp')}
+            </button>
+            <button type="button" onClick={() => toggleSort('agent')} className="text-left hover:text-slate-200">
+              Agent{arrow('agent')}
+            </button>
             <span>Title</span>
-            <span>Category</span>
-            <span>Tier</span>
-            <span>Integrity Δ</span>
-            <span>Status</span>
+            <button type="button" onClick={() => toggleSort('category')} className="text-left hover:text-slate-200">
+              Category{arrow('category')}
+            </button>
+            <button type="button" onClick={() => toggleSort('tier')} className="text-left hover:text-slate-200">
+              Tier{arrow('tier')}
+            </button>
+            <button type="button" onClick={() => toggleSort('delta')} className="text-left hover:text-slate-200">
+              GI Δ{arrow('delta')}
+            </button>
+            <button type="button" onClick={() => toggleSort('status')} className="text-left hover:text-slate-200">
+              Status{arrow('status')}
+            </button>
           </div>
-          <div className="divide-y divide-slate-800 bg-slate-900/50">
-            {rows.map((row) => (
-              <div key={row.id} className="grid grid-cols-[120px_1fr_110px_110px_120px_110px] items-center gap-2 px-3 py-2 text-slate-200">
+          <div className="min-h-0 flex-1 divide-y divide-slate-800 overflow-y-auto bg-slate-900/50">
+            {sorted.map((row) => (
+              <div key={row.id} className="grid grid-cols-[100px_80px_1fr_100px_70px_90px_80px] items-center gap-2 px-3 py-2 text-slate-200">
                 <span className="font-mono text-[11px] text-slate-400">{row.timestamp.slice(11, 19)}Z</span>
+                <span className="truncate font-mono text-[10px] text-cyan-400/80" title={row.agentOrigin}>
+                  {row.agentOrigin}
+                </span>
                 <span className="truncate" title={`${row.id} · ${row.title ?? row.summary}`}>
-                  <span className="mr-2 font-mono text-slate-400">{row.id}</span>
                   {row.title ?? row.summary}
                 </span>
-                <span>{row.category ?? '—'}</span>
-                <span>{row.confidenceTier ?? '—'}</span>
-                <span className={row.integrityDelta >= 0 ? 'text-emerald-300' : 'text-rose-300'}>
-                  {row.integrityDelta >= 0 ? '+' : ''}
-                  {row.integrityDelta.toFixed(4)}
+                <span className="text-[10px] text-slate-400">{row.category ?? '—'}</span>
+                <span className="text-center">{row.confidenceTier ?? '—'}</span>
+                <span className={`font-mono ${(row.integrityDelta ?? 0) >= 0 ? 'text-emerald-300' : 'text-rose-300'}`}>
+                  {(row.integrityDelta ?? 0) >= 0 ? '+' : ''}
+                  {(row.integrityDelta ?? 0).toFixed(4)}
                 </span>
-                <span className={`inline-flex w-fit rounded border px-2 py-0.5 ${statusBadge(row.status)}`}>{row.status}</span>
+                <span className={`inline-flex w-fit rounded border px-2 py-0.5 text-[10px] ${statusBadge(row.status)}`}>{row.status}</span>
               </div>
             ))}
           </div>
           <div className="border-t border-slate-800 bg-slate-950/70 px-3 py-2 text-right text-slate-300">
-            Total GI delta:{' '}
+            {rows.length} entries · Total GI delta:{' '}
             <span className={totalDelta >= 0 ? 'text-emerald-300' : 'text-rose-300'}>
               {totalDelta >= 0 ? '+' : ''}
               {totalDelta.toFixed(4)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Mobius Terminal PR — C-282

---

## 1. Summary

- **Cycle:** C-282
- **Type:** `feat`
- **Primary area:** `ledger` + `ui`
- **Files changed:**
  - `app/api/echo/feed/route.ts` — merges in-memory ECHO ledger with KV `epicon:feed`, caps at 100
  - `app/terminal/ledger/LedgerPageClient.tsx` — sortable columns, scroll box, agent column
- **Files deliberately NOT changed:**
  - `lib/echo/store.ts` (MAX_LEDGER already 100)
  - `lib/epicon/ledgerPush.ts` (LPUSH logic unchanged)
  - `lib/echo/kv-persist-ingest.ts` (locked)

**What changed?**

The Ledger chamber was capped at ~9 entries because it only read from the in-memory ECHO store (which contained only deduped ECHO ingest events). Now:

1. **`/api/echo/feed`** merges two sources:
   - In-memory ECHO ledger entries (from `getEchoLedger()`)
   - KV-backed `mobius:epicon:feed` entries (up to 100 from Redis LRANGE)
   - Deduplicates by ID, sorts by timestamp descending, caps at 100

2. **Ledger UI** rebuilt with:
   - Sortable column headers: Time, Agent, Category, Tier, GI Δ, Status — click to toggle asc/desc
   - Scrollable body (`overflow-y-auto`) with sticky header and footer
   - Added Agent column showing entry origin (ATLAS, ZEUS, ECHO, DAEDALUS, etc.)
   - Footer shows total entry count alongside GI delta sum
   - Sort indicator shows current sort key and direction

---

## 2. Risk Tier

- [x] **Tier 1** — App logic, no auth/KV schema changes

---

## 4. LOCKED BEHAVIOR AUDIT

- [x] This PR does NOT change the key schema in `app/api/agents/journal/route.ts`
- [x] This PR does NOT remove or bypass the LPUSH/LTRIM in `app/api/echo/ingest/route.ts`
- [x] This PR does NOT remove the `Authorization` header from `lib/substrate/github-reader.ts`
- [x] This PR does NOT add crypto price sources to HERMES-µ
- [x] This PR does NOT reassign domain ownership between agents
- [x] This PR does NOT attempt to "fix" expected empty states

---

## 5. Integrity Impact

- **Risk level:** Low
- **Lanes affected:** ledger (UI only + feed merge)

### Checklist
- [x] Does not change KV key schemas
- [x] Does not remove auth from any route
- [x] Does not introduce duplicate signal sources
- [x] pnpm build passes

---

## 6. Verification

- [x] `pnpm exec tsc --noEmit` — pass
- [x] `pnpm build` — pass
- [ ] `/terminal/ledger` shows up to 100 entries with sort controls

---

## 7. Rollback Plan

```bash
git revert <commit-sha>
# Reverts to ~9-entry ECHO-only ledger view
```

---

## 9. Final Checklist

- [x] Risk tier correctly assessed
- [x] Locked behavior audit completed
- [x] Rollback plan provided
- [x] I have read AGENTS.md, BUILD.md, and CURRENT_CYCLE.md

---

*"Let me update my consensus."*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dcbde0f-826e-46d6-be38-dca42c20d2f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dcbde0f-826e-46d6-be38-dca42c20d2f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

