### PR TITLE
C-282: Ledger flood fix + responsive mobile + promotion ceiling 50

### DIFF
--- a/app/api/kv/health/route.ts
+++ b/app/api/kv/health/route.ts
@@ -9,15 +9,12 @@
 
 import { NextResponse } from 'next/server';
 import { kvHealth, isRedisAvailable, KV_KEYS, kvGet, kvGetRaw } from '@/lib/kv/store';
-import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
-import { currentCycleId } from '@/lib/eve/cycle-engine';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
   const health = await kvHealth();
 
-  // Check what keys are populated
   const keys: Record<string, boolean> = {};
   if (health.available) {
     for (const [name, key] of Object.entries(KV_KEYS)) {
@@ -26,26 +23,6 @@ export async function GET() {
     }
     const legacyTripwire = await kvGetRaw<string>('TRIPWIRE_STATE');
     keys.TRIPWIRE_STATE_REDIS = legacyTripwire !== null && legacyTripwire !== undefined;
-  }
-
-  const populatedCount = Object.values(keys).filter(Boolean).length;
-  const totalChecked = Object.keys(keys).length;
-
-  if (health.available) {
-    void pushLedgerEntry({
-      id: `kv-health-${currentCycleId()}-${Date.now()}`,
-      timestamp: new Date().toISOString(),
-      author: 'DAEDALUS',
-      title: `KV health: ${populatedCount}/${totalChecked} keys populated, latency ${health.latencyMs ?? '?'}ms`,
-      type: 'epicon',
-      severity: populatedCount < totalChecked / 2 ? 'elevated' : 'nominal',
-      source: 'kv-ledger',
-      tags: ['kv-health', 'infrastructure', currentCycleId()],
-      verified: false,
-      category: 'heartbeat',
-      status: 'committed',
-      agentOrigin: 'DAEDALUS',
-    }).catch(() => {});
   }
 
   return NextResponse.json({

--- a/app/api/signals/micro/route.ts
+++ b/app/api/signals/micro/route.ts
@@ -13,9 +13,10 @@ import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
 
 export const dynamic = 'force-dynamic';
 
-// Simple in-memory cache to avoid hammering public APIs
 let cached: { data: Awaited<ReturnType<typeof pollAllMicroAgents>>; timestamp: number } | null = null;
-const CACHE_TTL_MS = 60_000; // 1 minute
+const CACHE_TTL_MS = 60_000;
+let lastLedgerPushMs = 0;
+const LEDGER_PUSH_INTERVAL_MS = 10 * 60 * 1000;
 
 export async function GET() {
   const now = Date.now();
@@ -74,20 +75,23 @@ export async function GET() {
         timestamp: result.timestamp,
       }, 300).catch(() => {});
 
-      pushLedgerEntry({
-        id: `micro-sweep-${currentCycleId()}-${Date.now()}`,
-        timestamp: result.timestamp,
-        author: 'DAEDALUS',
-        title: `Sensor sweep: ${result.instrumentCount ?? 40} instruments, composite ${result.composite.toFixed(3)}, ${result.anomalies?.length ?? 0} anomalies`,
-        type: 'epicon',
-        severity: (result.anomalies?.length ?? 0) > 5 ? 'elevated' : 'nominal',
-        source: 'kv-ledger',
-        tags: ['micro-sweep', 'heartbeat', currentCycleId()],
-        verified: false,
-        category: 'heartbeat',
-        status: 'committed',
-        agentOrigin: 'DAEDALUS',
-      }).catch(() => {});
+      if (now - lastLedgerPushMs > LEDGER_PUSH_INTERVAL_MS) {
+        lastLedgerPushMs = now;
+        pushLedgerEntry({
+          id: `micro-sweep-${currentCycleId()}-${Date.now()}`,
+          timestamp: result.timestamp,
+          author: 'DAEDALUS',
+          title: `Sensor sweep: ${result.instrumentCount ?? 40} instruments, composite ${result.composite.toFixed(3)}, ${result.anomalies?.length ?? 0} anomalies`,
+          type: 'epicon',
+          severity: (result.anomalies?.length ?? 0) > 5 ? 'elevated' : 'nominal',
+          source: 'kv-ledger',
+          tags: ['micro-sweep', 'heartbeat', currentCycleId()],
+          verified: false,
+          category: 'heartbeat',
+          status: 'committed',
+          agentOrigin: 'DAEDALUS',
+        }).catch(() => {});
+      }
     }
 
     return NextResponse.json({

--- a/app/api/tripwire/status/route.ts
+++ b/app/api/tripwire/status/route.ts
@@ -4,7 +4,6 @@ import { mockTripwire } from '@/lib/mock-data';
 import { liveEnvelope, mockEnvelope } from '@/lib/response-envelope';
 import { saveTripwireState, kvSet, kvSetRawKey, KV_KEYS } from '@/lib/kv/store';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
-import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
 
 export const dynamic = 'force-dynamic';
 
@@ -68,21 +67,6 @@ export async function GET() {
       tripwireCount: tripwire.active ? 1 : 0,
       elevated: tripwire.active,
       timestamp: new Date().toISOString(),
-    }).catch(() => {});
-
-    void pushLedgerEntry({
-      id: `tripwire-${currentCycleId()}-${Date.now()}`,
-      timestamp: new Date().toISOString(),
-      author: 'ATLAS',
-      title: `Tripwire: ${tripwire.active ? 'ACTIVE' : 'clear'} — ${tripwire.reason}`,
-      type: 'epicon',
-      severity: tripwire.active ? 'elevated' : 'nominal',
-      source: 'kv-ledger',
-      tags: ['tripwire', 'sentinel', currentCycleId()],
-      verified: false,
-      category: 'heartbeat',
-      status: 'committed',
-      agentOrigin: 'ATLAS',
     }).catch(() => {});
 
     return NextResponse.json({

--- a/app/terminal/ledger/LedgerPageClient.tsx
+++ b/app/terminal/ledger/LedgerPageClient.tsx
@@ -20,6 +20,30 @@ function statusBadge(status: string) {
   return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
 }
 
+function agentColor(agent: string): string {
+  const a = agent.toUpperCase();
+  if (a === 'ATLAS') return 'text-cyan-400';
+  if (a === 'ZEUS') return 'text-yellow-400';
+  if (a === 'HERMES') return 'text-rose-400';
+  if (a === 'AUREA') return 'text-amber-400';
+  if (a === 'JADE') return 'text-emerald-400';
+  if (a === 'DAEDALUS') return 'text-violet-400';
+  if (a === 'ECHO') return 'text-slate-300';
+  if (a === 'EVE') return 'text-rose-300';
+  return 'text-cyan-400/80';
+}
+
+function relTime(ts: string): string {
+  const ms = Date.now() - new Date(ts).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return '';
+  const m = Math.floor(ms / 60000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
 function sortRows(rows: LedgerEntry[], key: SortKey, dir: SortDir): LedgerEntry[] {
   const m = dir === 'asc' ? 1 : -1;
   return [...rows].sort((a, b) => {
@@ -73,13 +97,22 @@ export default function LedgerPageClient() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden p-4 text-xs">
-      <div className="mb-3 flex items-center justify-between">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
         <span className="text-slate-400">
           {feed.status?.cycleId ?? 'C-—'} · {rows.length} ledger rows
         </span>
-        <span className="text-[10px] text-slate-500">
-          sorted by {sortKey} {sortDir === 'asc' ? '↑' : '↓'}
-        </span>
+        <div className="flex gap-1">
+          {(['timestamp', 'agent', 'delta', 'status'] as SortKey[]).map((k) => (
+            <button
+              key={k}
+              type="button"
+              onClick={() => toggleSort(k)}
+              className={`rounded border px-1.5 py-0.5 text-[9px] font-mono ${sortKey === k ? 'border-cyan-600/50 bg-cyan-500/10 text-cyan-200' : 'border-slate-700 text-slate-500'}`}
+            >
+              {k}{arrow(k)}
+            </button>
+          ))}
+        </div>
       </div>
       {rows.length === 0 ? (
         <div className="rounded border border-slate-800 bg-slate-900/60 p-4 text-slate-400">
@@ -87,7 +120,8 @@ export default function LedgerPageClient() {
         </div>
       ) : (
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-slate-800">
-          <div className="grid grid-cols-[100px_80px_1fr_100px_70px_90px_80px] bg-slate-950/80 px-3 py-2 text-[11px] uppercase tracking-wide text-slate-400">
+          {/* Desktop header — hidden on mobile */}
+          <div className="hidden md:grid grid-cols-[90px_70px_1fr_90px_50px_80px_70px] bg-slate-950/80 px-3 py-2 text-[10px] uppercase tracking-wide text-slate-400">
             <button type="button" onClick={() => toggleSort('timestamp')} className="text-left hover:text-slate-200">
               Time{arrow('timestamp')}
             </button>
@@ -99,7 +133,7 @@ export default function LedgerPageClient() {
               Category{arrow('category')}
             </button>
             <button type="button" onClick={() => toggleSort('tier')} className="text-left hover:text-slate-200">
-              Tier{arrow('tier')}
+              T{arrow('tier')}
             </button>
             <button type="button" onClick={() => toggleSort('delta')} className="text-left hover:text-slate-200">
               GI Δ{arrow('delta')}
@@ -108,28 +142,59 @@ export default function LedgerPageClient() {
               Status{arrow('status')}
             </button>
           </div>
+
           <div className="min-h-0 flex-1 divide-y divide-slate-800 overflow-y-auto bg-slate-900/50">
-            {sorted.map((row) => (
-              <div key={row.id} className="grid grid-cols-[100px_80px_1fr_100px_70px_90px_80px] items-center gap-2 px-3 py-2 text-slate-200">
-                <span className="font-mono text-[11px] text-slate-400">{row.timestamp.slice(11, 19)}Z</span>
-                <span className="truncate font-mono text-[10px] text-cyan-400/80" title={row.agentOrigin}>
-                  {row.agentOrigin}
-                </span>
-                <span className="truncate" title={`${row.id} · ${row.title ?? row.summary}`}>
-                  {row.title ?? row.summary}
-                </span>
-                <span className="text-[10px] text-slate-400">{row.category ?? '—'}</span>
-                <span className="text-center">{row.confidenceTier ?? '—'}</span>
-                <span className={`font-mono ${(row.integrityDelta ?? 0) >= 0 ? 'text-emerald-300' : 'text-rose-300'}`}>
-                  {(row.integrityDelta ?? 0) >= 0 ? '+' : ''}
-                  {(row.integrityDelta ?? 0).toFixed(4)}
-                </span>
-                <span className={`inline-flex w-fit rounded border px-2 py-0.5 text-[10px] ${statusBadge(row.status)}`}>{row.status}</span>
-              </div>
-            ))}
+            {sorted.map((row) => {
+              const delta = row.integrityDelta ?? 0;
+              const hasDelta = Math.abs(delta) > 0.0001;
+              return (
+                <div key={row.id}>
+                  {/* Desktop row */}
+                  <div className="hidden md:grid grid-cols-[90px_70px_1fr_90px_50px_80px_70px] items-center gap-1 px-3 py-1.5 text-slate-200">
+                    <span className="font-mono text-[10px] text-slate-500">{row.timestamp.slice(11, 19)}Z</span>
+                    <span className={`truncate font-mono text-[10px] ${agentColor(row.agentOrigin)}`} title={row.agentOrigin}>
+                      {row.agentOrigin}
+                    </span>
+                    <span className="truncate text-[11px]" title={row.title ?? row.summary}>
+                      {row.title ?? row.summary}
+                    </span>
+                    <span className="text-[9px] text-slate-500">{row.category ?? '—'}</span>
+                    <span className="text-center text-[10px] text-slate-500">{row.confidenceTier ?? '—'}</span>
+                    <span className={`font-mono text-[10px] ${delta >= 0 ? 'text-emerald-400' : 'text-rose-400'}`}>
+                      {hasDelta ? `${delta >= 0 ? '+' : ''}${delta.toFixed(4)}` : '—'}
+                    </span>
+                    <span className={`inline-flex w-fit rounded border px-1.5 py-0.5 text-[9px] ${statusBadge(row.status)}`}>{row.status}</span>
+                  </div>
+                  {/* Mobile card */}
+                  <div className="md:hidden px-3 py-2.5 space-y-1">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className={`font-mono text-[11px] font-semibold ${agentColor(row.agentOrigin)}`}>
+                        {row.agentOrigin}
+                      </span>
+                      <div className="flex items-center gap-2">
+                        {hasDelta ? (
+                          <span className={`font-mono text-[10px] ${delta >= 0 ? 'text-emerald-400' : 'text-rose-400'}`}>
+                            {delta >= 0 ? '+' : ''}{delta.toFixed(4)}
+                          </span>
+                        ) : null}
+                        <span className={`rounded border px-1.5 py-0.5 text-[9px] ${statusBadge(row.status)}`}>{row.status}</span>
+                      </div>
+                    </div>
+                    <div className="text-[11px] leading-snug text-slate-200">{row.title ?? row.summary}</div>
+                    <div className="flex items-center gap-3 text-[9px] text-slate-500">
+                      <span className="font-mono">{row.timestamp.slice(11, 19)}Z</span>
+                      <span>{relTime(row.timestamp)}</span>
+                      {row.category ? <span>{row.category}</span> : null}
+                      {row.confidenceTier != null ? <span>T{row.confidenceTier}</span> : null}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
           </div>
-          <div className="border-t border-slate-800 bg-slate-950/70 px-3 py-2 text-right text-slate-300">
-            {rows.length} entries · Total GI delta:{' '}
+
+          <div className="border-t border-slate-800 bg-slate-950/70 px-3 py-2 text-right text-[11px] text-slate-300">
+            {rows.length} entries · GI Δ{' '}
             <span className={totalDelta >= 0 ? 'text-emerald-300' : 'text-rose-300'}>
               {totalDelta >= 0 ? '+' : ''}
               {totalDelta.toFixed(4)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Mobius Terminal PR — C-282

## 1. Summary

- **Cycle:** C-282
- **Type:** `fix`
- **Primary area:** `ledger` + `ui`
- **Files changed:**
  - `app/api/kv/health/route.ts` — removed ledger push (fired every poll)
  - `app/api/signals/micro/route.ts` — throttled sweep push to 10min interval
  - `app/api/tripwire/status/route.ts` — removed ledger push (fired every poll)
  - `app/terminal/ledger/LedgerPageClient.tsx` — responsive mobile cards + richer display

**Problem:** KV health and tripwire status routes fire on every terminal snapshot poll (~every 30-60s). Each call pushed a ledger entry, flooding the 100-entry ledger with identical DAEDALUS KV health entries. The actual ECHO/EPICON events were buried. Mobile showed only the agent column with no scrolling.

**Fix:**
1. Removed ledger push from KV health route entirely (diagnostic data, not ledger-worthy)
2. Removed ledger push from tripwire status (same reason)
3. Throttled micro sweep push to max once per 10 minutes (still provides time-series visibility)
4. Rebuilt ledger UI with responsive mobile card layout showing full entry detail

## 4. LOCKED BEHAVIOR AUDIT
- [x] No KV key schemas changed
- [x] No EPICON LPUSH logic changed
- [x] No auth removed

## 6. Verification
- [x] `pnpm exec tsc --noEmit` — pass
- [x] `pnpm build` — pass

*"Let me update my consensus."*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dcbde0f-826e-46d6-be38-dca42c20d2f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dcbde0f-826e-46d6-be38-dca42c20d2f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

