### PR TITLE
C-282 follow-up: runtime authority + health contract + integrity provenance

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,11 +1,114 @@
 import { NextResponse } from 'next/server';
+import {
+  KV_KEYS,
+  kvGet,
+  kvHealth,
+  loadEchoState,
+  loadGIState,
+  loadSignalSnapshot,
+  loadTripwireState,
+} from '@/lib/kv/store';
+import { getHeartbeat, getJournalHeartbeat } from '@/lib/runtime/heartbeat';
 
 export const dynamic = 'force-dynamic';
 
+type SystemPulse = {
+  ok?: boolean;
+  composite?: number;
+  cycle?: string;
+  instruments?: number;
+  anomalies?: number;
+  timestamp?: string;
+};
+
+function ageSeconds(timestamp: string | null | undefined): number | null {
+  if (!timestamp) return null;
+  const ms = new Date(timestamp).getTime();
+  if (!Number.isFinite(ms)) return null;
+  return Math.max(0, Math.floor((Date.now() - ms) / 1000));
+}
+
 export async function GET() {
+  const [kv, gi, signals, echo, tripwire, pulse] = await Promise.all([
+    kvHealth(),
+    loadGIState(),
+    loadSignalSnapshot(),
+    loadEchoState(),
+    loadTripwireState(),
+    kvGet<SystemPulse>(KV_KEYS.SYSTEM_PULSE),
+  ]);
+
+  const runtimeHeartbeat = getHeartbeat();
+  const journalHeartbeat = getJournalHeartbeat();
+
+  const checks = {
+    kv: kv.available,
+    gi_state: Boolean(gi),
+    signal_snapshot: Boolean(signals),
+    echo_state: Boolean(echo),
+    tripwire_state: Boolean(tripwire),
+    system_pulse: Boolean(pulse?.timestamp),
+  };
+
+  const degraded = !checks.kv || !checks.gi_state || !checks.system_pulse;
+
   return NextResponse.json({
     ok: true,
-    status: 'operational',
+    status: degraded ? 'degraded' : 'operational',
     timestamp: new Date().toISOString(),
+    checks,
+    kv,
+    pulse: pulse?.timestamp
+      ? {
+          timestamp: pulse.timestamp,
+          age_seconds: ageSeconds(pulse.timestamp),
+          cycle: pulse.cycle ?? null,
+          composite: pulse.composite ?? null,
+          instruments: pulse.instruments ?? null,
+          anomalies: pulse.anomalies ?? null,
+        }
+      : null,
+    gi: gi
+      ? {
+          timestamp: gi.timestamp,
+          age_seconds: ageSeconds(gi.timestamp),
+          source: gi.source,
+          mode: gi.mode,
+          terminal_status: gi.terminal_status,
+        }
+      : null,
+    echo: echo
+      ? {
+          timestamp: echo.timestamp,
+          age_seconds: ageSeconds(echo.timestamp),
+          last_ingest: echo.lastIngest,
+          last_ingest_age_seconds: ageSeconds(echo.lastIngest),
+          cycle: echo.cycleId,
+          total_ingested: echo.totalIngested,
+        }
+      : null,
+    signal_snapshot: signals
+      ? {
+          timestamp: signals.timestamp,
+          age_seconds: ageSeconds(signals.timestamp),
+          composite: signals.composite,
+          anomalies: signals.anomalies,
+          healthy: signals.healthy,
+        }
+      : null,
+    tripwire: tripwire
+      ? {
+          timestamp: tripwire.timestamp,
+          age_seconds: ageSeconds(tripwire.timestamp),
+          elevated: tripwire.elevated,
+          tripwire_count: tripwire.tripwireCount,
+        }
+      : null,
+    heartbeat: {
+      runtime: runtimeHeartbeat,
+      runtime_age_seconds: ageSeconds(runtimeHeartbeat),
+      journal: journalHeartbeat,
+      journal_age_seconds: ageSeconds(journalHeartbeat),
+    },
   });
 }

--- a/app/api/integrity-status/route.ts
+++ b/app/api/integrity-status/route.ts
@@ -3,12 +3,45 @@ import { computeIntegrityPayload } from '@/lib/integrity/buildStatus';
 
 export const dynamic = 'force-dynamic';
 
+function buildAuthority(payload: Awaited<ReturnType<typeof computeIntegrityPayload>>, renderEnabled: boolean, renderUsed: boolean) {
+  const signalAuthority =
+    payload.source === 'kv'
+      ? 'kv-state'
+      : payload.source === 'live'
+        ? 'local-live-compute'
+        : payload.source === 'cached'
+          ? 'cached-fallback'
+          : 'mock-fallback';
+
+  const note =
+    payload.source === 'kv'
+      ? 'Primary GI is being served from KV-backed state.'
+      : payload.source === 'live'
+        ? 'GI is being computed from live in-process signals.'
+        : 'GI is operating under degraded signal authority.';
+
+  return {
+    payload_source: payload.source,
+    signal_authority: signalAuthority,
+    kv_backed: Boolean(payload.kv),
+    render_enabled: renderEnabled,
+    render_used: renderUsed,
+    gi_origin: renderUsed ? 'gic-indexer' : payload.source,
+    note,
+  };
+}
+
 export async function GET() {
   const payload = await computeIntegrityPayload();
   const renderGicUrl = process.env.RENDER_GIC_URL;
 
   if (!renderGicUrl) {
-    return NextResponse.json({ ok: true as const, degraded: true, ...payload });
+    return NextResponse.json({
+      ok: true as const,
+      degraded: true,
+      ...payload,
+      authority: buildAuthority(payload, false, false),
+    });
   }
 
   try {
@@ -28,7 +61,12 @@ export async function GET() {
 
     if (!response.ok) {
       console.error(`[render:gic] ${response.status} ${response.statusText}`);
-      return NextResponse.json({ ok: true as const, degraded: true, ...payload });
+      return NextResponse.json({
+        ok: true as const,
+        degraded: true,
+        ...payload,
+        authority: buildAuthority(payload, true, false),
+      });
     }
 
     const remote = (await response.json()) as {
@@ -53,9 +91,15 @@ export async function GET() {
       summary: remote.summary ?? payload.summary,
       source: 'gic-indexer',
       degraded: false,
+      authority: buildAuthority(payload, true, true),
     });
   } catch (error) {
     console.error('[render:gic] request failed', error);
-    return NextResponse.json({ ok: true as const, degraded: true, ...payload });
+    return NextResponse.json({
+      ok: true as const,
+      degraded: true,
+      ...payload,
+      authority: buildAuthority(payload, true, false),
+    });
   }
 }

--- a/app/api/runtime/status/route.ts
+++ b/app/api/runtime/status/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { mockRuntimeStatus } from '@/lib/mock-data';
 import { mockEnvelope } from '@/lib/response-envelope';
+import { kvGet, KV_KEYS } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,6 +12,15 @@ type GitHubCommit = {
       date?: string;
     };
   };
+};
+
+type SystemPulse = {
+  ok?: boolean;
+  composite?: number;
+  cycle?: string;
+  instruments?: number;
+  anomalies?: number;
+  timestamp?: string;
 };
 
 function computeFreshness(seconds: number) {
@@ -26,7 +36,18 @@ function extractCycleId(message: string | undefined): string | null {
   return match?.[1] ?? null;
 }
 
-export async function GET() {
+function ageSeconds(timestamp: string | null | undefined): number | null {
+  if (!timestamp) return null;
+  const ms = new Date(timestamp).getTime();
+  if (!Number.isFinite(ms)) return null;
+  return Math.max(0, Math.floor((Date.now() - ms) / 1000));
+}
+
+async function fetchLatestCommit(): Promise<{
+  lastRun: string | null;
+  cycleId: string | null;
+  error: string | null;
+}> {
   try {
     const headers: HeadersInit = { Accept: 'application/vnd.github+json' };
     const token = process.env.GITHUB_TOKEN;
@@ -39,45 +60,46 @@ export async function GET() {
         cache: 'no-store',
       }
     );
-    if (!res.ok) throw new Error(`GitHub commits fetch failed (${res.status})`);
+
+    if (!res.ok) {
+      return {
+        lastRun: null,
+        cycleId: null,
+        error: `GitHub commits fetch failed (${res.status})`,
+      };
+    }
 
     const commits = (await res.json()) as GitHubCommit[];
     const latest = commits[0];
-    const lastRun = latest?.commit?.author?.date ?? null;
-    if (!lastRun) throw new Error('Latest commit missing author date');
-
-    const seconds = Math.max(
-      0,
-      Math.floor((Date.now() - new Date(lastRun).getTime()) / 1000)
-    );
-
-    return NextResponse.json(
-      {
-        ok: true,
-        source: 'github-commit',
-        freshAt: lastRun,
-        staleAt: null,
-        degraded: false,
-        last_run: lastRun,
-        cycle_id: extractCycleId(latest?.commit?.message),
-        freshness: {
-          status: computeFreshness(seconds),
-          seconds,
-        },
-      },
-      {
-        headers: {
-          'Cache-Control': 'public, max-age=60',
-        },
-      }
-    );
+    return {
+      lastRun: latest?.commit?.author?.date ?? null,
+      cycleId: extractCycleId(latest?.commit?.message),
+      error: null,
+    };
   } catch (error) {
-    console.error('runtime/status github fetch failed', error);
+    return {
+      lastRun: null,
+      cycleId: null,
+      error: error instanceof Error ? error.message : 'GitHub commit lookup failed',
+    };
+  }
+}
+
+export async function GET() {
+  const [pulse, git] = await Promise.all([
+    kvGet<SystemPulse>(KV_KEYS.SYSTEM_PULSE),
+    fetchLatestCommit(),
+  ]);
+
+  const runtimeSource = pulse?.timestamp ? 'system-pulse' : 'github-commit';
+  const runtimeTimestamp = pulse?.timestamp ?? git.lastRun;
+
+  if (!runtimeTimestamp) {
     return NextResponse.json(
       {
         ok: true,
         ...mockRuntimeStatus(),
-        ...mockEnvelope('GitHub heartbeat unavailable'),
+        ...mockEnvelope('Runtime heartbeat unavailable'),
       },
       {
         headers: {
@@ -86,4 +108,55 @@ export async function GET() {
       }
     );
   }
+
+  const seconds = ageSeconds(runtimeTimestamp) ?? 0;
+  const freshnessStatus = computeFreshness(seconds);
+  const deploySeconds = ageSeconds(git.lastRun);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      source: runtimeSource,
+      freshAt: runtimeTimestamp,
+      staleAt: null,
+      degraded: runtimeSource !== 'system-pulse' || freshnessStatus === 'degraded' || freshnessStatus === 'stale',
+      last_run: runtimeTimestamp,
+      cycle_id: pulse?.cycle ?? git.cycleId,
+      freshness: {
+        status: freshnessStatus,
+        seconds,
+      },
+      authority: {
+        runtime_source: runtimeSource,
+        pulse_available: Boolean(pulse?.timestamp),
+        deploy_available: Boolean(git.lastRun),
+        github_error: git.error,
+      },
+      pulse: pulse?.timestamp
+        ? {
+            timestamp: pulse.timestamp,
+            cycle: pulse.cycle ?? null,
+            composite: pulse.composite ?? null,
+            instruments: pulse.instruments ?? null,
+            anomalies: pulse.anomalies ?? null,
+            age_seconds: ageSeconds(pulse.timestamp),
+          }
+        : null,
+      deploy: git.lastRun
+        ? {
+            source: 'github-commit',
+            freshAt: git.lastRun,
+            freshness: {
+              status: computeFreshness(deploySeconds ?? 0),
+              seconds: deploySeconds ?? 0,
+            },
+          }
+        : null,
+    },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=60',
+      },
+    }
+  );
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #285 to close the remaining authority gaps identified in review.

### What this changes

1. **Runtime lane now prefers live pulse authority**
   - `/api/runtime/status` now reads `mobius:system:pulse` first.
   - GitHub commit time is retained as deployment metadata, not treated as the primary runtime heartbeat when live pulse data exists.
   - Adds `authority`, `pulse`, and `deploy` metadata so the lane explains *why* it is green, stale, or degraded.

2. **`/api/health` is now a real operator-facing health contract**
   - Reports KV health, GI state presence, signal snapshot, ECHO state, tripwire state, and system pulse availability.
   - Returns timestamped health diagnostics instead of a static `ok: true` payload.
   - Includes runtime/journal heartbeat ages for debugging.

3. **`/api/integrity-status` now exposes provenance explicitly**
   - Adds an `authority` object describing payload source, signal authority, KV backing, render indexer usage, and GI origin.
   - Makes it easier to distinguish KV-backed GI, local live compute, cached fallback, and mock fallback states.

## Why

PR #285 improved the system, but three gaps remained:
- runtime freshness still reflected GitHub commit age instead of live pulse activity
- `/api/health` was still too shallow to function as a trustworthy health contract
- `integrity-status` still lacked explicit provenance for operators

This PR fixes those gaps without changing GI math or promotion logic.

## Scope

Files changed:
- `app/api/runtime/status/route.ts`
- `app/api/health/route.ts`
- `app/api/integrity-status/route.ts`

## Notes

- No GI formula changes
- No agent/domain ownership changes
- No promotion lane changes
- No vault/economic logic changes

This is a follow-up hardening PR focused on **authority clarity** rather than new product surface.
