### PR TITLE
fix(c282): snapshot hardening + globe crash + signals family + KV TTL + final polish

### DIFF
--- a/app/api/cron/watchdog/route.ts
+++ b/app/api/cron/watchdog/route.ts
@@ -92,9 +92,9 @@ export async function GET(request: NextRequest) {
         timestamp: new Date().toISOString(),
       };
       await Promise.all([
-        kvSetRawKey('TRIPWIRE_STATE', JSON.stringify(seedPayload), 3600),
-        kvSet(KV_KEYS.TRIPWIRE_STATE, seedPayload, 3600),
-        kvSet(KV_KEYS.TRIPWIRE_STATE_KV, seedPayload, 3600),
+        kvSetRawKey('TRIPWIRE_STATE', JSON.stringify(seedPayload), 1800),
+        kvSet(KV_KEYS.TRIPWIRE_STATE, seedPayload, 1800),
+        kvSet(KV_KEYS.TRIPWIRE_STATE_KV, seedPayload, 1800),
       ]).catch(() => {});
       actions.push('tripwire-seed:ok');
     }

--- a/app/api/echo/feed/route.ts
+++ b/app/api/echo/feed/route.ts
@@ -90,7 +90,7 @@ export async function GET() {
 
   const seenIds = new Set<string>();
   const merged: LedgerEntry[] = [];
-  for (const row of [...echoLedger, ...kvLedgerEntries]) {
+  for (const row of [...kvLedgerEntries, ...echoLedger]) {
     if (seenIds.has(row.id)) continue;
     seenIds.add(row.id);
     merged.push(row);

--- a/app/api/health/ping/route.ts
+++ b/app/api/health/ping/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({ ok: true, ts: Date.now() });
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -50,7 +50,7 @@ export async function GET() {
     system_pulse: Boolean(pulse?.timestamp),
   };
 
-  const degraded = !checks.kv || !checks.gi_state || !checks.system_pulse;
+  const degraded = !checks.kv || !checks.gi_state || !checks.system_pulse || !checks.echo_state || !checks.signal_snapshot;
 
   return NextResponse.json({
     ok: true,

--- a/app/terminal/pulse/PulsePageClient.tsx
+++ b/app/terminal/pulse/PulsePageClient.tsx
@@ -56,6 +56,13 @@ type VaultData = {
 };
 
 function mapEventType(item: PulseItem): (typeof EVENT_TYPES)[number] | 'OTHER' {
+  const cat = (item.category ?? '').toLowerCase();
+  if (cat === 'market') return 'SIGNAL';
+  if (cat === 'infrastructure') return 'SIGNAL';
+  if (cat === 'governance' || cat === 'civic-risk') return 'WATCH';
+  if (cat === 'geopolitical') return 'WATCH';
+  if (cat === 'narrative') return 'ROUTING';
+
   const raw = [item.type, item.category, item.title, ...(item.tags ?? [])]
     .filter((v): v is string => Boolean(v))
     .join(' ')

--- a/components/terminal/chambers/GlobeView3D.tsx
+++ b/components/terminal/chambers/GlobeView3D.tsx
@@ -324,8 +324,7 @@ export default function GlobeView3D({
           if (disposed) return;
 
           const tf = topo.transform as { scale: [number, number]; translate: [number, number] } | undefined;
-          const borderMat = new THREE.LineBasicMaterial({ color: 0x1a4d30, transparent: true, opacity: 0.6 });
-          const landMat = new THREE.MeshBasicMaterial({ color: 0x0a2a14, transparent: true, opacity: 0.85, side: THREE.FrontSide });
+          const borderMat = new THREE.LineBasicMaterial({ color: 0x1a4d30, transparent: true, opacity: 0.7 });
 
           const arcCoords = (idx: number): [number, number][] => {
             const raw: [number, number][] = topo.arcs[idx < 0 ? ~idx : idx];
@@ -340,33 +339,19 @@ export default function GlobeView3D({
           };
 
           const R = 1.002;
-          const FILL_R = 1.001;
           for (const geo of topo.objects.countries.geometries as any[]) {
             const rings: number[][] =
               geo.type === 'Polygon' ? (geo.arcs as number[][]) :
               geo.type === 'MultiPolygon' ? (geo.arcs as number[][][]).flat() : [];
             for (const ring of rings) {
               const pts3d: any[] = [];
-              const fillPts: any[] = [];
               for (const arcIdx of ring) {
                 for (const [lng, lat] of arcCoords(arcIdx)) {
                   pts3d.push(latLngToXYZ(THREE, lat, lng, R));
-                  fillPts.push(latLngToXYZ(THREE, lat, lng, FILL_R));
                 }
               }
-              if (pts3d.length < 3) continue;
+              if (pts3d.length < 2) continue;
               globe.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(pts3d), borderMat));
-
-              try {
-                const shape = new THREE.ShapeGeometry(new THREE.Shape(
-                  fillPts.map((p: { x: number; y: number }) => new THREE.Vector2(p.x, p.y))
-                ));
-                const fill = new THREE.Mesh(shape, landMat);
-                fill.lookAt(fillPts[0]);
-                globe.add(fill);
-              } catch {
-                // complex polygons may fail triangulation — border lines are sufficient
-              }
             }
           }
         } catch {

--- a/hooks/useTerminalCommands.ts
+++ b/hooks/useTerminalCommands.ts
@@ -102,9 +102,7 @@ export function useTerminalCommands({
               const accuracy = profile.verificationHits + profile.verificationMisses > 0
                 ? `${profile.verificationHits}/${profile.verificationHits + profile.verificationMisses}`
                 : 'n/a';
-              console.log(
-                `[PROFILE] ${profile.login} | MII: ${profile.miiScore} | Tier: ${profile.nodeTier} | EPICONs: ${profile.epiconCount} | Accuracy: ${accuracy}`,
-              );
+              void accuracy;
             }
           })
           .catch(() => undefined);

--- a/lib/agents/micro/instrument-polls.ts
+++ b/lib/agents/micro/instrument-polls.ts
@@ -603,19 +603,21 @@ export async function pollDaedalusU5(): Promise<AgentPollResult> {
     });
   }
   const host = baseUrl.replace(/^https?:\/\//, '');
-  const url = `https://${host}/api/health`;
+  const url = `https://${host}/api/health/ping`;
   const start = Date.now();
   try {
     const res = await fetch(url, { cache: 'no-store' });
     const ms = Date.now() - start;
     const value = Number(normalizeInverse(ms, 0, 3000).toFixed(3));
+    const isDeploymentAuth = res.status === 401 || res.status === 403;
+    const reachable = res.ok || isDeploymentAuth;
     return wrap('DAEDALUS-µ5', {
       agentName: 'DAEDALUS-µ5',
       source: 'Self-ping · health',
       timestamp: new Date().toISOString(),
       value,
-      label: `Self-ping: ${res.status} in ${ms}ms`,
-      severity: res.ok ? classifySeverity(value) : 'elevated',
+      label: `Self-ping: ${res.status} in ${ms}ms${isDeploymentAuth ? ' (deploy auth)' : ''}`,
+      severity: reachable ? classifySeverity(value) : 'elevated',
       raw: { status: res.status, ms },
     });
   } catch {

--- a/lib/echo/kv-persist-ingest.ts
+++ b/lib/echo/kv-persist-ingest.ts
@@ -60,7 +60,7 @@ export async function flushEpiconFeedToKv(entries: KvEpiconEntry[]): Promise<voi
     const payload = entries.map((entry) => JSON.stringify(entry));
     await redis.lpush('epicon:feed', ...payload);
     await redis.ltrim('epicon:feed', 0, 99);
-    console.log('[echo] epicon:feed LPUSH', { count: entries.length });
+    // epicon:feed LPUSH count: entries.length
   } catch (error) {
     console.error('[echo] epicon feed flush failed:', error);
   }
@@ -80,7 +80,7 @@ export async function writeEchoKvHeartbeatToMobius(
     timestamp: now,
   };
   try {
-    console.log('[ECHO] writing ECHO_STATE...');
+    // ECHO_STATE write
     await kvSet(KV_KEYS.ECHO_STATE_KV, payload, 7200);
   } catch (error) {
     console.error('[echo] ECHO_STATE KV heartbeat failed:', error);

--- a/lib/integrity/buildStatus.ts
+++ b/lib/integrity/buildStatus.ts
@@ -117,16 +117,19 @@ export async function computeIntegrityPayload(): Promise<IntegrityPayload> {
   });
 
   const isKv = isRedisAvailable();
-  const source: 'live' | 'mock' | 'cached' = isKv && signalData.source === 'mock' ? 'live' : signalData.source;
+  const source: 'live' | 'mock' | 'cached' = signalData.source;
+
+  const coldStart = signalData.source === 'mock' && isKv;
+  const driver = coldStart
+    ? 'GI computed from baseline signals (ECHO cold-start — awaiting fresh ingest)'
+    : computed.primary_driver;
 
   if (isKv) {
     const giState: GIState = {
       global_integrity: computed.global_integrity,
       mode: computed.mode,
       terminal_status: computed.terminal_status,
-      primary_driver: signalData.source === 'mock'
-        ? 'Live computation from KV-backed signals (ECHO cold-start — awaiting fresh ingest)'
-        : computed.primary_driver,
+      primary_driver: driver,
       source,
       signals: computed.signals,
       timestamp: computed.timestamp,
@@ -142,9 +145,7 @@ export async function computeIntegrityPayload(): Promise<IntegrityPayload> {
     mii_baseline: integrityStatus.mii_baseline,
     mic_supply: integrityStatus.mic_supply,
     terminal_status: computed.terminal_status,
-    primary_driver: signalData.source === 'mock' && isKv
-      ? 'Live computation from KV-backed signals (ECHO cold-start — awaiting fresh ingest)'
-      : computed.primary_driver,
+    primary_driver: driver,
     summary: computed.summary,
     source,
     kv: isKv,
@@ -185,12 +186,16 @@ export async function recomputeAndSaveGIState(): Promise<GIState | null> {
   });
 
   const source: 'live' | 'mock' | 'cached' = signalData.source;
+  const coldStartCron = signalData.source === 'mock';
+  const driver = coldStartCron
+    ? 'GI computed from baseline signals (ECHO cold-start — awaiting fresh ingest)'
+    : computed.primary_driver;
 
   const giState: GIState = {
     global_integrity: computed.global_integrity,
     mode: computed.mode,
     terminal_status: computed.terminal_status,
-    primary_driver: computed.primary_driver,
+    primary_driver: driver,
     source,
     signals: computed.signals,
     timestamp: computed.timestamp,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Mobius Terminal PR — C-282

## 1. Summary

- **Cycle:** C-282
- **Type:** `fix` + `feat`
- **Primary area:** `infra` + `signals` + `ui` + `integrity`

Two commits:

**Commit 1 — 10 issue fixes:**
GI source truth, globe ShapeGeometry removal, health quality checks, DAEDALUS self-ping 401 fix, tripwire TTL alignment, echo feed merge order, debug log removal, recompute alignment, /api/health/ping, pulse event type mapping.

**Commit 2 — 10 snapshot hardening optimizations:**

| # | Optimization | Impact |
|---|-------------|--------|
| 1 | `/api/terminal/snapshot-lite` | KV-only read, no fan-out, sub-500ms |
| 2 | Snapshot reads persisted signals from KV first | Eliminates 40-instrument sweep on page load |
| 3 | Substrate behind `include_substrate=true` | Default snapshot skips 8 GitHub API reads |
| 4 | Per-lane 5s time budgets | Timed-out lanes return 408, don't stall response |
| 5 | `/api/signals/status` | Read-only KV endpoint for signal state |
| 6 | Health quality checks | Degraded on GI yellow/red, tripwire, freshness |
| 7 | Runtime prefers KV pulse | GitHub fetch only fires as 3s-timeout fallback |
| 8 | Timing telemetry | `meta.total_ms` + `meta.lane_ms` per response |
| 9 | Terminal hook tries lite first | Shell shows GI/cycle immediately from lite bootstrap |
| 10 | Deploy noise filtered | Agent watch/heartbeat/docs-only commits skip build |

**Files changed:**
- `app/api/terminal/snapshot/route.ts` — per-lane timeouts, persisted signals, optional substrate, timing
- `app/api/terminal/snapshot-lite/route.ts` (new) — KV-only fast read
- `app/api/signals/status/route.ts` (new) — read-only signal snapshot
- `app/api/health/ping/route.ts` (new) — lightweight self-ping
- `app/api/health/route.ts` — quality-based degradation
- `app/api/runtime/status/route.ts` — KV-first, GitHub as fallback
- `hooks/useTerminalSnapshot.ts` — lite bootstrap + timeout handling
- `scripts/ignore-build.sh` — agent commit filtering
- `lib/integrity/buildStatus.ts` — source truth + aligned logic
- `components/terminal/chambers/GlobeView3D.tsx` — removed broken ShapeGeometry
- `lib/agents/micro/instrument-polls.ts` — 401 as nominal, /ping endpoint
- `app/api/cron/watchdog/route.ts` — TTL alignment
- `app/api/echo/feed/route.ts` — KV-first merge order
- `lib/echo/kv-persist-ingest.ts` — removed debug logs
- `hooks/useTerminalCommands.ts` — removed debug log
- `app/terminal/pulse/PulsePageClient.tsx` — category-aware event mapping

## 4. LOCKED BEHAVIOR AUDIT
- [x] No KV key schemas changed
- [x] No journal/EPICON LPUSH logic changed
- [x] No GI formula changes in `lib/gi/compute.ts`
- [x] No auth removed from any route

## 6. Verification
- [x] `pnpm exec tsc --noEmit` — pass
- [x] `pnpm build` — pass

*"Let me update my consensus."*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dcbde0f-826e-46d6-be38-dca42c20d2f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dcbde0f-826e-46d6-be38-dca42c20d2f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

