### PR TITLE
C-282: Performance optimizations (parallel I/O, Redis pipelines, bundle)

### DIFF
--- a/app/api/terminal/snapshot/route.ts
+++ b/app/api/terminal/snapshot/route.ts
@@ -70,20 +70,8 @@ export async function GET(request: NextRequest) {
   const epiconPath = includeCatalog === 'true' ? '/api/epicon/feed?include_catalog=true' : '/api/epicon/feed';
 
   const signalsStart = Date.now();
-  let signals: SnapshotLeaf;
-  let signalsDuration: number;
-  const cached = await loadSignalSnapshot();
-  if (cached) {
-    signals = { ok: true, status: 200, data: { ok: true, cached: true, kv: isRedisAvailable(), ...cached }, error: null };
-    signalsDuration = Date.now() - signalsStart;
-  } else {
-    const { GET: getSignals } = await import('@/app/api/signals/micro/route');
-    const result = await timedHandler(makeRequest(baseUrl, '/api/signals/micro'), getSignals);
-    signals = result.leaf;
-    signalsDuration = result.duration_ms;
-  }
-
-  const results = await Promise.all([
+  const cachedPromise = loadSignalSnapshot();
+  const lanesPromise = Promise.all([
     timedHandler(makeRequest(baseUrl, '/api/integrity-status'), getIntegrity),
     timedHandler(makeRequest(baseUrl, '/api/kv/health'), getKvHealth),
     timedHandler(makeRequest(baseUrl, '/api/agents/status'), getAgents),
@@ -97,6 +85,20 @@ export async function GET(request: NextRequest) {
     timedHandler(makeRequest(baseUrl, '/api/mii/feed'), getMii),
     timedHandler(makeRequest(baseUrl, '/api/vault/status'), getVault),
   ]);
+
+  const [cached, results] = await Promise.all([cachedPromise, lanesPromise]);
+
+  let signals: SnapshotLeaf;
+  let signalsDuration: number;
+  if (cached) {
+    signals = { ok: true, status: 200, data: { ok: true, cached: true, kv: isRedisAvailable(), ...cached }, error: null };
+    signalsDuration = Date.now() - signalsStart;
+  } else {
+    const { GET: getSignals } = await import('@/app/api/signals/micro/route');
+    const result = await timedHandler(makeRequest(baseUrl, '/api/signals/micro'), getSignals);
+    signals = result.leaf;
+    signalsDuration = Date.now() - signalsStart;
+  }
 
   const [integrity, kvHealth, agents, epicon, echo, journal, sentiment, runtime, promotion, eve, mii, vault] = results;
 

--- a/app/terminal/TerminalPageClient.tsx
+++ b/app/terminal/TerminalPageClient.tsx
@@ -451,8 +451,10 @@ function TerminalPage({ bootstrap }: TerminalPageWrapperProps) {
           fetch('/api/signals/micro', { cache: 'no-store' }),
           fetch('/api/echo/feed', { cache: 'no-store' }),
         ]);
-        const microJson = (await microRes.json()) as MicroSweepResponse;
-        const echoJson = (await echoRes.json()) as { epicon?: EpiconItem[] };
+        const [microJson, echoJson] = (await Promise.all([
+          microRes.json(),
+          echoRes.json(),
+        ])) as [MicroSweepResponse, { epicon?: EpiconItem[] }];
         if (!mounted) return;
         if (microJson?.ok) {
           microRef.current = microJson;

--- a/components/signals/PulseTimeline.tsx
+++ b/components/signals/PulseTimeline.tsx
@@ -133,12 +133,14 @@ export default function PulseTimeline() {
         fetch('/api/epicon/feed?limit=24&type=epicon', { cache: 'no-store' }),
       ]);
 
-      const pulseJson = await pulseRes.json();
-      const runtimeJson: RuntimeStatus = await runtimeRes.json();
-      const microJson: MicroSweepResponse = await microRes.json();
-      const feedJson: unknown = await feedRes.json();
+      const [pulseEnvelope, runtimeJson, microJson, feedJson] = (await Promise.all([
+        pulseRes.json(),
+        runtimeRes.json(),
+        microRes.json(),
+        feedRes.json(),
+      ])) as [{ signals?: Signal[] }, RuntimeStatus, MicroSweepResponse, unknown];
 
-      setSignals(pulseJson.signals || []);
+      setSignals(pulseEnvelope.signals ?? []);
       setRuntime(runtimeJson);
       setMicro(microJson.ok ? microJson : null);
 

--- a/components/terminal/AgentCortexPanel.tsx
+++ b/components/terminal/AgentCortexPanel.tsx
@@ -64,8 +64,10 @@ export default function AgentCortexPanel({
           fetch('/api/signals/micro', { cache: 'no-store' }),
           fetch('/api/agents/status', { cache: 'no-store' }),
         ]);
-        const json: MicroSweepResponse = await microRes.json();
-        const agentsJson: AgentStatusEnvelope = await agentsRes.json();
+        const [json, agentsJson] = (await Promise.all([
+          microRes.json(),
+          agentsRes.json(),
+        ])) as [MicroSweepResponse, AgentStatusEnvelope];
         if (!alive || !json.ok) return;
 
         const nextThemis = json.agents.find((agent) => agent.agentName === 'THEMIS') ?? null;

--- a/components/terminal/CommandSurface.tsx
+++ b/components/terminal/CommandSurface.tsx
@@ -34,7 +34,12 @@ export default function CommandSurface() {
   useEffect(() => {
     let active = true;
     async function boot() {
-      const integrity = await fetch('/api/integrity-status', { cache: 'no-store' }).then((r) => r.json()).catch(() => null);
+      const integrity = await fetch('/api/integrity-status', {
+        cache: 'no-store',
+        signal: AbortSignal.timeout(8000),
+      })
+        .then((r) => r.json())
+        .catch(() => null);
       if (!active || !integrity) return;
       const greeting = session?.user?.githubUsername
         ? `Welcome back, ${session.user.githubUsername}.`

--- a/components/terminal/FooterStatusBar.tsx
+++ b/components/terminal/FooterStatusBar.tsx
@@ -12,7 +12,10 @@ export default function FooterStatusBar() {
   useEffect(() => {
     let mounted = true;
     const load = async () => {
-      const kvHealth = await fetch('/api/kv/health', { cache: 'no-store' })
+      const kvHealth = await fetch('/api/kv/health', {
+        cache: 'no-store',
+        signal: AbortSignal.timeout(8000),
+      })
         .then((r) => r.json() as Promise<KvHealth>)
         .catch(() => ({ ok: false }));
       if (!mounted) return;

--- a/components/terminal/SentinelPulsePanel.tsx
+++ b/components/terminal/SentinelPulsePanel.tsx
@@ -97,11 +97,11 @@ export default function SentinelPulsePanel() {
         if (!zeusRes.ok) throw new Error(`ZEUS report fetch failed (${zeusRes.status})`);
         if (!aureaRes.ok) throw new Error(`AUREA report fetch failed (${aureaRes.status})`);
 
-        const [atlas, zeus, aurea] = (await Promise.all([
-          atlasRes.json(),
-          zeusRes.json(),
-          aureaRes.json(),
-        ])) as [AtlasHeartbeat, ZeusVerification, AureaReportResponse];
+        const [atlas, zeus, aurea] = await Promise.all([
+          atlasRes.json() as Promise<AtlasHeartbeat>,
+          zeusRes.json() as Promise<ZeusVerification>,
+          aureaRes.json() as Promise<AureaReportResponse>,
+        ]);
 
         const nextEvents: PulseEvent[] = [
           {

--- a/lib/echo/kv-persist-ingest.ts
+++ b/lib/echo/kv-persist-ingest.ts
@@ -29,13 +29,23 @@ type KvEpiconEntry = {
   integrityAttestation?: IntegrityRating;
 };
 
+let _echoRedis: Redis | null | undefined;
+
 function getRedisClient(): Redis | null {
+  if (_echoRedis === null) return null;
+  if (_echoRedis) return _echoRedis;
+
   const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) return null;
+  if (!url || !token) {
+    _echoRedis = null;
+    return null;
+  }
   try {
-    return new Redis({ url, token });
+    _echoRedis = new Redis({ url, token });
+    return _echoRedis;
   } catch {
+    _echoRedis = null;
     return null;
   }
 }
@@ -58,8 +68,10 @@ export async function flushEpiconFeedToKv(entries: KvEpiconEntry[]): Promise<voi
   if (!redis || entries.length === 0) return;
   try {
     const payload = entries.map((entry) => JSON.stringify(entry));
-    await redis.lpush('epicon:feed', ...payload);
-    await redis.ltrim('epicon:feed', 0, 99);
+    const pipe = redis.pipeline();
+    pipe.lpush('epicon:feed', ...payload);
+    pipe.ltrim('epicon:feed', 0, 99);
+    await pipe.exec();
     // epicon:feed LPUSH count: entries.length
   } catch (error) {
     console.error('[echo] epicon feed flush failed:', error);
@@ -92,9 +104,13 @@ async function writeMiiFeedBatch(entries: MiiEntry[]): Promise<void> {
   if (!redis || entries.length === 0) return;
   try {
     const packed = entries.map((entry) => JSON.stringify(entry));
-    await Promise.all(entries.map((entry) => redis.set(`mii:${entry.agent.toUpperCase()}:${entry.cycle}`, JSON.stringify(entry))));
-    await redis.lpush('mii:feed', ...packed);
-    await redis.ltrim('mii:feed', 0, 499);
+    const pipe = redis.pipeline();
+    for (const entry of entries) {
+      pipe.set(`mii:${entry.agent.toUpperCase()}:${entry.cycle}`, JSON.stringify(entry));
+    }
+    pipe.lpush('mii:feed', ...packed);
+    pipe.ltrim('mii:feed', 0, 499);
+    await pipe.exec();
   } catch (error) {
     console.error('[echo] mii batch write failed:', error);
   }
@@ -105,20 +121,22 @@ async function writeMiiFeedBatch(entries: MiiEntry[]): Promise<void> {
  */
 export async function persistEchoIngestSideEffects(result: IngestResult): Promise<void> {
   const status = getEchoStatus();
-  await writeEchoKvHeartbeatToMobius(status);
   const dedupDenominator = Math.max(1, status.totalIngested + status.duplicateSuppressedCount);
   const dedupRate = Number((status.duplicateSuppressedCount / dedupDenominator).toFixed(3));
-  await saveEchoState({
-    lastIngest: status.lastIngest,
-    cycleId: status.cycleId,
-    totalIngested: status.totalIngested,
-    healthy: true,
-    epiconCount: status.counts.epicon,
-    ledgerCount: status.counts.ledger,
-    alertCount: status.counts.alerts,
-    timestamp: new Date().toISOString(),
-    dedupRate,
-  }).catch(() => {});
+  await Promise.all([
+    writeEchoKvHeartbeatToMobius(status),
+    saveEchoState({
+      lastIngest: status.lastIngest,
+      cycleId: status.cycleId,
+      totalIngested: status.totalIngested,
+      healthy: true,
+      epiconCount: status.counts.epicon,
+      ledgerCount: status.counts.ledger,
+      alertCount: status.counts.alerts,
+      timestamp: new Date().toISOString(),
+      dedupRate,
+    }).catch(() => {}),
+  ]);
 
   const kvFeedEntries: KvEpiconEntry[] = result.epicon.map((entry, i) => ({
     id: entry.id,
@@ -138,12 +156,11 @@ export async function persistEchoIngestSideEffects(result: IngestResult): Promis
   await flushEpiconFeedToKv(kvFeedEntries);
 
   try {
-    const giState = await loadGIState();
+    const [giState, recentFeed] = await Promise.all([loadGIState(), readMiiFeed(null, 500)]);
     const currentGi = Number((giState?.global_integrity ?? 0.74).toFixed(4));
     const miiTimestamp = new Date().toISOString();
     const agentAverages = result.integrity.agentAverages;
     const agents = ['ATLAS', 'ZEUS', 'JADE', 'EVE'] as const;
-    const recentFeed = await readMiiFeed(null, 500);
     const lastKnown: Record<string, number> = {};
     for (const entry of recentFeed) {
       if (!(entry.agent in lastKnown)) {

--- a/lib/substrate/client.ts
+++ b/lib/substrate/client.ts
@@ -45,7 +45,10 @@ export async function probeSubstrateService(
   const healthPath = healthPathFor(service);
 
   try {
-    const response = await fetch(`${baseUrl}${healthPath}`, { cache: 'no-store' });
+    const response = await fetch(`${baseUrl}${healthPath}`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(5000),
+    });
     return {
       service,
       url: `${baseUrl}${healthPath}`,

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,9 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   bundlePagesRouterDependencies: true,
   serverExternalPackages: ['@mobius/integrity-core'],
+  experimental: {
+    optimizePackageImports: ['lucide-react', 'recharts'],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Mobius PR — Cycle

- **Cycle:** C-282
- **Type:** Fix (performance / resilience)
- **Primary Area(s):** apps / infra
- **Pulse Attached:** ⬜

---

## 1. Summary

Ten scoped optimizations reduce sequential latency: the terminal snapshot overlaps the signals KV read with other lanes; ECHO ingest uses Upstash pipelines and parallel KV work; substrate health probes time out; several client panels parse JSON in parallel after batched fetches; the command surface and footer bound fetch time; Next.js `optimizePackageImports` trims `lucide-react` and `recharts` client graphs.

## 2. Details

- **Motivation / Problem:** Extra round-trips and unbounded waits add tail latency on snapshot, ingest, and operator UI refreshes.
- **Solution / Approach:** `Promise.all` / pipelining where ordering is preserved; `AbortSignal.timeout` for outbound health and boot fetches; `optimizePackageImports` in `next.config.ts`.
- **Architecture Impact:** None to chamber routing or data semantics; ingest still writes the same Redis keys and shapes.
- **Breaking Changes:** No.

## 3. Integrity & Safety

- **GI Impact (Global Integrity):** _Estimated GI Delta:_ 0.00 — GI computation untouched.
- **MII Impact (Mobius Integrity Index):** Ingest path still emits the same MII entry shape; fewer HTTP hops to Upstash for batch writes.
- **Sentinel Review:** ⬜ (not applicable for this perf-only change)

## 4. Mobius Pulse

Not generated for this change set.

## 5. Tests

- [x] `pnpm exec tsc --noEmit`
- [ ] `pnpm lint` (blocked: `next lint` exits with interactive ESLint migration prompt on Next.js 15.5)
- [x] `pnpm build`

**Test Evidence:**

```text
pnpm exec tsc --noEmit  # exit 0
pnpm build              # exit 0, optimizePackageImports active
pnpm lint               # exit 1 — interactive ESLint setup prompt
```

## 6. Checklist

- [ ] MCP Enforcer passes (GI ≥ 0.95)
- [ ] Security / anti-nuke checks pass
- [ ] Docs updated (if behavior / API changed) — N/A
- [ ] Pulse generated — skipped
- [x] Ready for Sentinel + human review (pending lint infra follow-up)

*"We heal as we walk." — Mobius Systems*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97c13be3-96b5-4a40-8c3b-b7f2f510db88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97c13be3-96b5-4a40-8c3b-b7f2f510db88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

