### PR TITLE
docs(agents): add Cursor Cloud specific dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,3 +176,46 @@ When finishing a task, report in this format:
 
 Optimize **operator truth**, not illusion.
 Preserve **architecture**, not just appearance.
+
+---
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Required | Port | Start command |
+|---------|----------|------|---------------|
+| Next.js frontend | **Yes** | 3000 | `pnpm dev` |
+| FastAPI backend (`api/`) | Optional | 8000 | See below |
+
+The frontend gracefully degrades when the API or KV (Upstash Redis) are unavailable — it falls back to mock/in-memory data.
+
+### Frontend (primary)
+
+All canonical commands are documented in `BUILD.md`:
+- `pnpm install`, `pnpm dev`, `pnpm exec tsc --noEmit`, `pnpm build`, `pnpm lint`
+
+The dev server runs at `http://localhost:3000`. The terminal entry point is `/terminal` which redirects to `/terminal/globe` on desktop.
+
+### Lint caveat
+
+ESLint is **not configured** in this repo (no `.eslintrc` or `eslint.config.*`). Running `pnpm lint` triggers Next.js's interactive ESLint setup wizard, which blocks in non-TTY environments. Report lint as "not configured" rather than failing on it.
+
+### FastAPI backend (optional)
+
+The Python API in `api/` has mixed import paths — `app.*` (relative to `api/`) and `api.*` (relative to workspace root). To run it:
+
+```bash
+cd /workspace/api
+PYTHONPATH=/workspace:/workspace/api uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+Both `requirements.txt` (root) and `api/requirements.txt` must be installed. The root one has `httpx` which the API also needs.
+
+### Environment
+
+Copy `.env.example` to `.env.local`. Default values point to hosted Render services. The app works without any secrets configured (KV, auth, etc.) — it shows a "degraded" state with mock data.
+
+### No Docker or external services required
+
+The entire local dev stack runs without Docker, Redis, or any external service. Upstash Redis and GitHub OAuth are optional enhancements.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Mobius Terminal PR — C-151

---

## 1. Summary

- **Cycle:** C-151
- **Type:** `docs`
- **Primary area:** `docs`
- **Files changed:** `AGENTS.md`
- **Files deliberately NOT changed:** All source code files

**What changed?**
Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting non-obvious dev environment setup caveats for future cloud agents, including the ESLint configuration gap, the FastAPI dual-PYTHONPATH requirement, and service overview.

**Why?**
Future cloud agents need durable context about running this codebase locally — particularly the lint caveat (ESLint not configured, interactive wizard blocks CI), the Python API's mixed import paths requiring `PYTHONPATH=/workspace:/workspace/api`, and the fact that the entire stack runs without Docker or external services.

---

## 2. Risk Tier

- [x] **Tier 0** — Docs / comments / formatting only

---

## 5. Integrity Impact

### Assessment
- **Estimated MII for this PR:** 0.00
- **Risk level:** Low
- **Lanes affected:** None

### Checklist
- [x] Does not change KV key schemas without operator approval
- [x] Does not remove auth from any route
- [x] Does not introduce duplicate signal sources across agents
- [x] Does not add hardcoded cycle IDs, timestamps, or seed data
- [x] pnpm build passes

---

## 6. Verification

**Pre-merge:**
- [x] `pnpm exec tsc --noEmit` — typecheck passes
- [x] `pnpm build` — build passes

**Evidence:**

Dev environment fully verified:

[terminal_chamber_navigation_demo.mp4](https://cursor.com/agents/bc-43465e59-f612-4235-83c8-f4342d88866f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fterminal_chamber_navigation_demo.mp4)

[Globe World State chamber](https://cursor.com/agents/bc-43465e59-f612-4235-83c8-f4342d88866f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fglobe_view.webp)
[Pulse chamber](https://cursor.com/agents/bc-43465e59-f612-4235-83c8-f4342d88866f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpulse_chamber.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43465e59-f612-4235-83c8-f4342d88866f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43465e59-f612-4235-83c8-f4342d88866f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

