### PR TITLE
fix(ux): 5 terminal UI/UX optimizations + Cursor Cloud dev setup

### DIFF
--- a/app/terminal/sentinel/SentinelPageClient.tsx
+++ b/app/terminal/sentinel/SentinelPageClient.tsx
@@ -195,10 +195,14 @@ export default function SentinelPageClient() {
           const latestCycle = rows[0]?.cycle?.trim() || null;
           const journalFresh = latestCycle === currentCycle;
           return (
-          <button key={agent.id} onClick={() => void handleExpand(agent.name)} className="rounded border border-slate-800 bg-slate-900/60 p-4 text-left">
+          <button key={agent.id} onClick={() => void handleExpand(agent.name)} className="group rounded border border-slate-800 bg-slate-900/60 p-4 text-left transition-colors hover:border-slate-700 hover:bg-slate-900/80">
             <div className="flex items-center justify-between">
-              <div className="text-sm font-semibold">
-                {agent.name} <span className="text-cyan-300">{(latestByAgent[agent.name] ?? 0.9).toFixed(3)}</span>
+              <div className="flex items-center gap-2 text-sm font-semibold">
+                <span style={{ color: AGENT_COLORS[agent.name] ?? '#22d3ee' }}>{agent.name}</span>
+                <span className={`font-mono text-xs ${(latestByAgent[agent.name] ?? 0.9) >= 0.85 ? 'text-emerald-300' : (latestByAgent[agent.name] ?? 0.9) >= 0.7 ? 'text-amber-300' : 'text-rose-300'}`}>
+                  {(latestByAgent[agent.name] ?? 0.9).toFixed(3)}
+                </span>
+                <span className="text-[8px] text-slate-600" title="Mobius Integrity Index (0–1 scale)">/1.0</span>
               </div>
               <div className="flex flex-col items-end gap-0.5 text-[9px] font-mono text-slate-500">
                 <span
@@ -217,9 +221,16 @@ export default function SentinelPageClient() {
                 </span>
               </div>
             </div>
-            <div className="text-xs text-slate-400">{agent.role} · {agent.tier ?? '—'}</div>
-            <div className="mt-2 text-xs text-slate-500">{agent.lastAction ?? 'No action yet.'}</div>
-            <div className="mt-2 text-xs text-cyan-200">MII trend</div>
+            <div className="mt-1 text-xs text-slate-400">{agent.role} · {agent.tier ?? '—'}</div>
+            <div className="mt-2 text-xs text-slate-500">{agent.lastAction ?? 'Awaiting first action this cycle.'}</div>
+            <div className="mt-2 flex items-center gap-2">
+              <span className="text-[10px] font-mono uppercase tracking-[0.1em] text-slate-500">MII trend</span>
+              {miiData[agent.name]?.length ? (
+                <span className="text-[9px] text-emerald-400/70">{miiData[agent.name]!.length} data points</span>
+              ) : (
+                <span className="text-[9px] text-slate-600">no live data (placeholder)</span>
+              )}
+            </div>
             <div className="mt-1">
               {miiData[agent.name]?.length ? (
                 <MiiSparkline

--- a/app/terminal/signals/SignalsPageClient.tsx
+++ b/app/terminal/signals/SignalsPageClient.tsx
@@ -117,72 +117,98 @@ export default function SignalsPageClient() {
       </div>
 
       <div className="min-h-0 flex-1 space-y-4 overflow-y-auto">
-        {FAMILIES.map((family) => {
-          const members = grouped.get(family.id) ?? [];
-          if (members.length === 0) return null;
-          const comp = familyComposites[family.id];
-
-          return (
-            <section key={family.id} className={`rounded-lg border ${family.borderColor} ${family.bgColor} p-3`}>
-              <div className="mb-2 flex items-center justify-between">
-                <div>
-                  <span className={`font-mono text-sm font-bold ${family.color}`}>{family.label}</span>
-                  <span className="ml-2 text-[10px] text-slate-500">{family.focus}</span>
-                </div>
-                <div className="flex items-center gap-3 text-[10px] font-mono text-slate-400">
-                  <span>{comp?.healthy ?? 0}/{comp?.total ?? 0} healthy</span>
-                  <span className={comp && comp.avg >= 0.7 ? 'text-emerald-400' : comp && comp.avg >= 0.4 ? 'text-amber-400' : 'text-rose-400'}>
-                    avg {comp ? (comp.avg * 100).toFixed(0) : '—'}%
+        {agents.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full border border-slate-700 bg-slate-900/80">
+              <span className="text-2xl text-slate-500">⊕</span>
+            </div>
+            <div>
+              <h2 className="text-sm font-semibold text-slate-200">No micro-agent signals</h2>
+              <p className="mx-auto mt-2 max-w-md text-xs leading-relaxed text-slate-400">
+                The signal sweep has not returned instrument data yet. This is expected when KV is not configured
+                or the <code className="rounded bg-slate-800 px-1 py-0.5 text-[10px] text-slate-300">/api/signals/micro</code> endpoint
+                has no upstream data.
+              </p>
+            </div>
+            <div className="rounded border border-slate-800 bg-slate-900/50 px-4 py-3 text-left font-mono text-[10px] text-slate-500">
+              <div className="mb-1 text-[9px] uppercase tracking-[0.12em] text-slate-600">Agent families awaiting data</div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {FAMILIES.map((f) => (
+                  <span key={f.id} className={`rounded border ${f.borderColor} ${f.bgColor} px-2 py-0.5 ${f.color}`}>
+                    {f.label} <span className="text-slate-600">· {f.focus}</span>
                   </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        ) : (
+          FAMILIES.map((family) => {
+            const members = grouped.get(family.id) ?? [];
+            if (members.length === 0) return null;
+            const comp = familyComposites[family.id];
+
+            return (
+              <section key={family.id} className={`rounded-lg border ${family.borderColor} ${family.bgColor} p-3`}>
+                <div className="mb-2 flex items-center justify-between">
+                  <div>
+                    <span className={`font-mono text-sm font-bold ${family.color}`}>{family.label}</span>
+                    <span className="ml-2 text-[10px] text-slate-500">{family.focus}</span>
+                  </div>
+                  <div className="flex items-center gap-3 text-[10px] font-mono text-slate-400">
+                    <span>{comp?.healthy ?? 0}/{comp?.total ?? 0} healthy</span>
+                    <span className={comp && comp.avg >= 0.7 ? 'text-emerald-400' : comp && comp.avg >= 0.4 ? 'text-amber-400' : 'text-rose-400'}>
+                      avg {comp ? (comp.avg * 100).toFixed(0) : '—'}%
+                    </span>
+                  </div>
                 </div>
-              </div>
 
-              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
-                {members.map((agent) => {
-                  const sig = agent.signals[0];
-                  const score = sig?.value ?? (agent.healthy ? 0.85 : 0);
-                  const pct = Math.max(5, Math.round(score * 100));
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+                  {members.map((agent) => {
+                    const sig = agent.signals[0];
+                    const score = sig?.value ?? (agent.healthy ? 0.85 : 0);
+                    const pct = Math.max(5, Math.round(score * 100));
 
-                  return (
-                    <div key={agent.agentName} className="rounded border border-slate-800 bg-slate-950/60 p-2.5">
-                      <div className="flex items-center justify-between">
-                        <span className="font-mono text-[11px] font-semibold text-slate-200">{agent.agentName}</span>
-                        <span className={`h-2 w-2 rounded-full ${agent.healthy ? 'bg-emerald-400' : 'bg-rose-400'}`} />
-                      </div>
-                      {sig ? (
-                        <>
-                          <div className="mt-1.5 flex items-center gap-1.5">
-                            <div className="h-1.5 flex-1 overflow-hidden rounded bg-slate-800">
-                              <div
-                                className={`h-full rounded ${severityDot(sig.severity)}`}
-                                style={{ width: `${pct}%` }}
-                              />
-                            </div>
-                            <span className="font-mono text-[10px] text-slate-400">{pct}%</span>
-                          </div>
-                          <div className="mt-1 text-[10px] leading-snug text-slate-400 line-clamp-2" title={sig.label}>
-                            {sig.source}
-                          </div>
-                          <div className="mt-0.5 flex items-center justify-between text-[9px] text-slate-600">
-                            <span className="flex items-center gap-1">
-                              <span className={`h-1.5 w-1.5 rounded-full ${severityDot(sig.severity)}`} />
-                              {sig.severity}
-                            </span>
-                            <span>{relTime(sig.timestamp)}</span>
-                          </div>
-                        </>
-                      ) : (
-                        <div className="mt-1.5 text-[10px] text-slate-500">
-                          {agent.errors?.[0] ?? 'No signal'}
+                    return (
+                      <div key={agent.agentName} className="rounded border border-slate-800 bg-slate-950/60 p-2.5">
+                        <div className="flex items-center justify-between">
+                          <span className="font-mono text-[11px] font-semibold text-slate-200">{agent.agentName}</span>
+                          <span className={`h-2 w-2 rounded-full ${agent.healthy ? 'bg-emerald-400' : 'bg-rose-400'}`} />
                         </div>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            </section>
-          );
-        })}
+                        {sig ? (
+                          <>
+                            <div className="mt-1.5 flex items-center gap-1.5">
+                              <div className="h-1.5 flex-1 overflow-hidden rounded bg-slate-800">
+                                <div
+                                  className={`h-full rounded ${severityDot(sig.severity)}`}
+                                  style={{ width: `${pct}%` }}
+                                />
+                              </div>
+                              <span className="font-mono text-[10px] text-slate-400">{pct}%</span>
+                            </div>
+                            <div className="mt-1 text-[10px] leading-snug text-slate-400 line-clamp-2" title={sig.label}>
+                              {sig.source}
+                            </div>
+                            <div className="mt-0.5 flex items-center justify-between text-[9px] text-slate-600">
+                              <span className="flex items-center gap-1">
+                                <span className={`h-1.5 w-1.5 rounded-full ${severityDot(sig.severity)}`} />
+                                {sig.severity}
+                              </span>
+                              <span>{relTime(sig.timestamp)}</span>
+                            </div>
+                          </>
+                        ) : (
+                          <div className="mt-1.5 text-[10px] text-slate-500">
+                            {agent.errors?.[0] ?? 'No signal'}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          })
+        )}
       </div>
     </div>
   );

--- a/components/terminal/ChamberSwitcher.tsx
+++ b/components/terminal/ChamberSwitcher.tsx
@@ -56,8 +56,10 @@ export default function ChamberSwitcher() {
             href={tab.href}
             title={tab.shortcut}
             className={cn(
-              'whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-mono uppercase tracking-[0.12em] md:rounded md:px-2 md:py-1 md:text-[11px] md:tracking-wide',
-              active ? 'border-cyan-300/60 bg-cyan-400/10 text-cyan-100' : 'border-slate-700/80 bg-slate-900/50 text-slate-400',
+              'whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-mono uppercase tracking-[0.12em] transition-all duration-150 md:rounded md:px-2.5 md:py-1 md:text-[11px] md:tracking-wide',
+              active
+                ? 'border-cyan-400/70 bg-cyan-500/15 text-cyan-50 shadow-[0_0_8px_rgba(34,211,238,0.12)]'
+                : 'border-slate-700/80 bg-slate-900/50 text-slate-400 hover:border-slate-600 hover:bg-slate-800/60 hover:text-slate-200',
             )}
           >
             <span className="mr-1">{tab.icon}</span>

--- a/components/terminal/TerminalShell.tsx
+++ b/components/terminal/TerminalShell.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import ChamberSwitcher from '@/components/terminal/ChamberSwitcher';
+import SnapshotDiagnostics from '@/components/terminal/SnapshotDiagnostics';
+import { normalizeSnapshotLane, SNAPSHOT_LANE_KEYS, type SnapshotLaneState } from '@/lib/terminal/snapshotLanes';
 import { cn } from '@/lib/utils';
 
 type IntegrityStatus = {
@@ -27,13 +29,17 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
   const [showLaneDiagnostics, setShowLaneDiagnostics] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [consoleCollapsed, setConsoleCollapsed] = useState(false);
+  const [lanes, setLanes] = useState<SnapshotLaneState[]>([]);
+  const [snapshotAt, setSnapshotAt] = useState<string | null>(null);
+  const [deployment, setDeployment] = useState<{ commit_sha: string | null; environment: string | null } | null>(null);
 
   useEffect(() => {
     let mounted = true;
     const load = async () => {
-      const [integrityRes, runtimeRes] = await Promise.allSettled([
+      const [integrityRes, runtimeRes, snapshotRes] = await Promise.allSettled([
         fetch('/api/integrity-status', { cache: 'no-store' }).then((r) => r.json() as Promise<IntegrityStatus>),
         fetch('/api/runtime/status', { cache: 'no-store' }).then((r) => r.json() as Promise<RuntimeStatus>),
+        fetch('/api/terminal/snapshot-lite', { cache: 'no-store' }).then((r) => r.json() as Promise<Record<string, unknown>>),
       ]);
 
       if (!mounted) return;
@@ -51,6 +57,30 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
         }
       } else {
         setRuntime('offline');
+      }
+
+      if (snapshotRes.status === 'fulfilled') {
+        const snap = snapshotRes.value;
+        setSnapshotAt(typeof snap.timestamp === 'string' ? snap.timestamp : null);
+        const dep = snap.deployment as { commit_sha: string | null; environment: string | null } | undefined;
+        setDeployment(dep ?? null);
+        const laneStates: SnapshotLaneState[] = [];
+        const lanesObj = (snap.lanes ?? {}) as Record<string, unknown>;
+        for (const key of SNAPSHOT_LANE_KEYS) {
+          const leaf = lanesObj[key];
+          if (leaf && typeof leaf === 'object') {
+            const l = leaf as { ok?: boolean; status?: number; data?: unknown; error?: string | null };
+            laneStates.push(
+              normalizeSnapshotLane(key, {
+                ok: l.ok !== false,
+                status: typeof l.status === 'number' ? l.status : (l.ok !== false ? 200 : 500),
+                data: l,
+                error: typeof l.error === 'string' ? l.error : null,
+              }),
+            );
+          }
+        }
+        setLanes(laneStates);
       }
 
       setClock(new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC');
@@ -120,6 +150,12 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
           </button>
         </div>
       </header>
+
+      {showLaneDiagnostics && lanes.length > 0 ? (
+        <div className="border-b border-slate-800 bg-slate-950/80 px-3 py-2 md:px-4">
+          <SnapshotDiagnostics lanes={lanes} snapshotAt={snapshotAt} deployment={deployment} />
+        </div>
+      ) : null}
 
       <main className={cn('min-h-0 flex-1 overflow-hidden', consoleCollapsed ? 'pb-7' : 'pb-16 md:pb-28')}>{children}</main>
     </div>

--- a/components/terminal/chambers/GlobeView3D.tsx
+++ b/components/terminal/chambers/GlobeView3D.tsx
@@ -487,14 +487,14 @@ export default function GlobeView3D({
         <span>EPICON · {cycleId}</span>
         <span className="normal-case tracking-normal text-violet-400/90">SEISMIC · EPICON — violet pins (M3+ USGS)</span>
       </div>
-      <div className="flex border-t border-white/[0.06] bg-[#020408]/90">
+      <div className="flex border-t border-white/[0.08] bg-[#020408]/95">
         {GLOBE_DOMAIN_ORDER.map((key) => {
           const d = domainByKey[key];
           const score = d?.score;
           const label = d?.label ?? key.toUpperCase();
           const agent = d?.agent ?? '—';
           const scoreClass =
-            score == null ? 'text-slate-500'
+            score == null ? 'text-slate-400'
             : score >= 0.8 ? 'text-emerald-400'
             : score >= 0.6 ? 'text-amber-400'
             : 'text-rose-400';
@@ -503,11 +503,11 @@ export default function GlobeView3D({
               key={key}
               type="button"
               onClick={() => focusDomain(key)}
-              className="flex flex-1 flex-col items-center border-r border-white/[0.04] px-1 py-2 transition hover:bg-white/[0.04] sm:px-2"
+              className="flex flex-1 flex-col items-center border-r border-white/[0.06] px-1 py-2.5 transition hover:bg-white/[0.06] sm:px-2"
             >
-              <div className="text-[9px] uppercase tracking-[0.1em] text-slate-600">{label}</div>
-              <div className={cn('text-[13px] font-bold', scoreClass)}>{score != null ? score.toFixed(2) : '—'}</div>
-              <div className="text-[8px] text-slate-700">{agent}</div>
+              <div className="text-[9px] uppercase tracking-[0.12em] text-slate-400">{label}</div>
+              <div className={cn('text-[14px] font-bold', scoreClass)}>{score != null ? score.toFixed(2) : '—'}</div>
+              <div className="text-[8px] text-slate-500">{agent}</div>
             </button>
           );
         })}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Mobius Terminal PR — C-151

---

## 1. Summary

- **Cycle:** C-151
- **Type:** `fix`
- **Primary area:** `ui`
- **Files changed:** `AGENTS.md`, `app/terminal/signals/SignalsPageClient.tsx`, `app/terminal/sentinel/SentinelPageClient.tsx`, `components/terminal/TerminalShell.tsx`, `components/terminal/ChamberSwitcher.tsx`, `components/terminal/chambers/GlobeView3D.tsx`
- **Files deliberately NOT changed:** All API routes, data model files, KV schema, auth routes

**What changed?**
Five targeted UI/UX improvements to the terminal operator experience: (1) Signals chamber now shows a proper empty state with guidance instead of a blank void, (2) Lane Diagnostics button is wired to display SnapshotDiagnostics panel, (3) Sentinel agent cards have color-coded names, MII scale clarity, and hover states, (4) ChamberSwitcher tabs have improved active contrast and hover transitions, (5) Globe domain status bar has better label/score contrast.

**Why?**
UI audit revealed the Signals chamber was completely blank with no empty state, the Lane Diagnostics toggle did nothing, agent cards lacked visual hierarchy, tab contrast was low, and the Globe bottom bar had poor readability.

---

## 2. Risk Tier

- [x] **Tier 1** — App logic, no auth/KV schema changes

---

## 5. Integrity Impact

### Assessment
- **Estimated MII for this PR:** 0.00
- **Risk level:** Low
- **Lanes affected:** None (presentation-only)

### Checklist
- [x] Does not change KV key schemas
- [x] Does not remove auth from any route
- [x] Does not introduce duplicate signal sources
- [x] Does not add hardcoded cycle IDs or seed data
- [x] pnpm build passes

---

## 6. Verification

- [x] `pnpm exec tsc --noEmit` — typecheck passes
- [x] `pnpm build` — build passes

**Evidence:**

[five_ux_optimizations_demo.mp4](https://cursor.com/agents/bc-43465e59-f612-4235-83c8-f4342d88866f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffive_ux_optimizations_demo.mp4)

[Signals empty state improvement](https://cursor.com/agents/bc-43465e59-f612-4235-83c8-f4342d88866f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsignals_empty_state.webp)
[Lane diagnostics panel](https://cursor.com/agents/bc-43465e59-f612-4235-83c8-f4342d88866f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flane_diagnostics.webp)
[Sentinel improved agent cards](https://cursor.com/agents/bc-43465e59-f612-4235-83c8-f4342d88866f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsentinel_improved_cards.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43465e59-f612-4235-83c8-f4342d88866f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43465e59-f612-4235-83c8-f4342d88866f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

