### PR TITLE
fix(terminal): Signals chamber shows micro agent names and posture

### DIFF
--- a/app/terminal/signals/SignalsPageClient.tsx
+++ b/app/terminal/signals/SignalsPageClient.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 import ChamberSkeleton from '@/components/terminal/ChamberSkeleton';
-import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
+import { useTerminalSnapshot, type SnapshotLaneState } from '@/hooks/useTerminalSnapshot';
 
 type SignalEntry = {
   agentName: string;
@@ -19,6 +19,7 @@ type AgentResult = {
   healthy: boolean;
   polledAt?: string;
   errors?: string[];
+  mode?: string;
 };
 
 type MicroSweepPayload = {
@@ -27,7 +28,12 @@ type MicroSweepPayload = {
   instrumentCount?: number;
   composite?: number;
   timestamp?: string;
+  ok?: boolean;
+  cached?: boolean;
+  source?: string;
 };
+
+type AgentPosture = 'live' | 'degraded' | 'standby';
 
 const FAMILIES: Array<{
   id: string;
@@ -41,21 +47,41 @@ const FAMILIES: Array<{
   { id: 'ZEUS', label: 'ZEUS', focus: 'Verification / Knowledge', color: 'text-yellow-300', borderColor: 'border-yellow-500/30', bgColor: 'bg-yellow-500/5' },
   { id: 'HERMES', label: 'HERMES', focus: 'Narrative / Information', color: 'text-rose-300', borderColor: 'border-rose-500/30', bgColor: 'bg-rose-500/5' },
   { id: 'AUREA', label: 'AUREA', focus: 'Governance / Civic', color: 'text-amber-300', borderColor: 'border-amber-500/30', bgColor: 'bg-amber-500/5' },
+  { id: 'THEMIS', label: 'THEMIS', focus: 'Governance / Transparency', color: 'text-amber-200', borderColor: 'border-amber-400/30', bgColor: 'bg-amber-400/5' },
   { id: 'JADE', label: 'JADE', focus: 'Memory / Culture', color: 'text-emerald-300', borderColor: 'border-emerald-500/30', bgColor: 'bg-emerald-500/5' },
   { id: 'DAEDALUS', label: 'DAEDALUS', focus: 'Infrastructure / Build', color: 'text-violet-300', borderColor: 'border-violet-500/30', bgColor: 'bg-violet-500/5' },
   { id: 'ECHO', label: 'ECHO', focus: 'Events / Markets', color: 'text-slate-300', borderColor: 'border-slate-500/30', bgColor: 'bg-slate-500/5' },
   { id: 'EVE', label: 'EVE', focus: 'Observer / Civic', color: 'text-rose-200', borderColor: 'border-rose-400/30', bgColor: 'bg-rose-400/5' },
+  { id: 'GAIA', label: 'GAIA', focus: 'Environmental / Planetary', color: 'text-teal-300', borderColor: 'border-teal-500/30', bgColor: 'bg-teal-500/5' },
 ];
 
-function familyFromAgent(name: string): string {
-  const m = /^([A-Z]+)-µ\d+$/.exec(name);
-  return m ? m[1] : name;
+const UNKNOWN_FAMILY_STYLE = {
+  id: '',
+  label: '',
+  focus: 'Micro instruments',
+  color: 'text-slate-300',
+  borderColor: 'border-slate-600/40',
+  bgColor: 'bg-slate-900/40',
+};
+
+function normalizeAgentKey(name: string): string {
+  return name.replace(/\u03bc/g, 'u');
 }
 
-function severityDot(sev: string) {
-  if (sev === 'critical') return 'bg-rose-400';
-  if (sev === 'elevated' || sev === 'watch') return 'bg-amber-400';
-  return 'bg-emerald-400';
+/** Parent family id for grouping (handles µ / u and legacy names like GAIA, HERMES-µ). */
+function familyFromAgent(name: string): string {
+  const n = normalizeAgentKey(name);
+  const numbered = /^([A-Z]+)-u\d+$/i.exec(n);
+  if (numbered) return numbered[1]!.toUpperCase();
+  const legacy = /^([A-Z]+)-u$/i.exec(n);
+  if (legacy) return legacy[1]!.toUpperCase();
+  const bare = /^([A-Z]+)$/i.exec(n.trim());
+  if (bare) return bare[1]!.toUpperCase();
+  return n.split(/[-\s]/)[0]?.toUpperCase() ?? 'UNKNOWN';
+}
+
+function familyStyle(id: string) {
+  return FAMILIES.find((f) => f.id === id) ?? { ...UNKNOWN_FAMILY_STYLE, id, label: id };
 }
 
 function relTime(ts?: string): string {
@@ -68,37 +94,116 @@ function relTime(ts?: string): string {
   return `${Math.floor(m / 60)}h ago`;
 }
 
+function synthesizeAgentsFromSignals(allSignals: SignalEntry[]): AgentResult[] {
+  const byName = new Map<string, SignalEntry[]>();
+  for (const s of allSignals) {
+    const key = s.agentName || 'unknown';
+    const arr = byName.get(key) ?? [];
+    arr.push(s);
+    byName.set(key, arr);
+  }
+  return [...byName.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([agentName, signals]) => ({
+      agentName,
+      signals,
+      healthy: signals.length > 0,
+    }));
+}
+
+function resolveAgents(payload: MicroSweepPayload): AgentResult[] {
+  const direct = payload.agents ?? [];
+  if (direct.length > 0) return direct;
+  const flat = payload.allSignals ?? [];
+  if (flat.length === 0) return [];
+  return synthesizeAgentsFromSignals(flat);
+}
+
+function worstSeverity(signals: SignalEntry[]): string {
+  const order = ['nominal', 'watch', 'elevated', 'critical'];
+  let worst = 0;
+  for (const s of signals) {
+    const i = order.indexOf(s.severity);
+    if (i >= 0 && i > worst) worst = i;
+  }
+  return order[worst] ?? 'nominal';
+}
+
+function agentPosture(agent: AgentResult, signalsLane: SnapshotLaneState | undefined): AgentPosture {
+  if (!signalsLane?.ok || signalsLane.state === 'offline') return 'standby';
+  if (signalsLane.state === 'degraded' || signalsLane.state === 'stale') {
+    if (!agent.healthy && agent.signals.length === 0) return 'standby';
+    return 'degraded';
+  }
+  if (!agent.healthy || agent.signals.length === 0) return 'degraded';
+  const sev = worstSeverity(agent.signals);
+  if (sev === 'elevated' || sev === 'critical') return 'degraded';
+  return 'live';
+}
+
+function PostureBadge({ posture, laneStale }: { posture: AgentPosture; laneStale: boolean }) {
+  if (posture === 'live') {
+    return (
+      <span className="rounded border border-emerald-600/50 bg-emerald-950/50 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-emerald-300">
+        live
+      </span>
+    );
+  }
+  if (posture === 'standby') {
+    return (
+      <span className="rounded border border-slate-600/60 bg-slate-900/80 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-slate-500">
+        standby
+      </span>
+    );
+  }
+  return (
+    <span
+      className="rounded border border-amber-600/50 bg-amber-950/40 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-amber-200"
+      title={laneStale ? 'Sweep or lane is stale' : undefined}
+    >
+      degraded{laneStale ? ' · stale' : ''}
+    </span>
+  );
+}
+
 export default function SignalsPageClient() {
-  const { snapshot, loading } = useTerminalSnapshot();
+  const { snapshot, loading, error } = useTerminalSnapshot();
   if (loading && !snapshot) return <ChamberSkeleton blocks={4} />;
 
-  const signalsData = snapshot?.signals?.data;
-  const signals = (signalsData && typeof signalsData === 'object' ? signalsData : {}) as MicroSweepPayload;
-  const agents = signals.agents ?? [];
-  const expected = signals.instrumentCount ?? agents.length;
+  const signalsLeaf = snapshot?.signals;
+  const signalsData = signalsLeaf?.data;
+  const payload = (signalsData && typeof signalsData === 'object' ? signalsData : {}) as MicroSweepPayload;
+  const agents = useMemo(() => resolveAgents(payload), [payload]);
+
+  const signalsLane = snapshot?.lanes?.find((l) => l.key === 'signals');
+  const laneStale = signalsLane?.state === 'stale';
 
   const grouped = useMemo(() => {
     const map = new Map<string, AgentResult[]>();
-    for (const family of FAMILIES) map.set(family.id, []);
     for (const agent of agents) {
       const fam = familyFromAgent(agent.agentName);
-      const arr = map.get(fam);
-      if (arr) arr.push(agent);
-      else map.set(fam, [agent]);
+      const arr = map.get(fam) ?? [];
+      arr.push(agent);
+      map.set(fam, arr);
+    }
+    for (const [, list] of map) {
+      list.sort((a, b) => a.agentName.localeCompare(b.agentName));
     }
     return map;
   }, [agents]);
 
-  const familyComposites = useMemo(() => {
-    const out: Record<string, { avg: number; healthy: number; total: number }> = {};
-    for (const [fam, members] of grouped) {
-      const vals = members.flatMap((a) => a.signals.map((s) => s.value));
-      const avg = vals.length > 0 ? vals.reduce((a, b) => a + b, 0) / vals.length : 0;
-      const healthy = members.filter((a) => a.healthy).length;
-      out[fam] = { avg, healthy, total: members.length };
-    }
-    return out;
+  const displayFamilyIds = useMemo(() => {
+    const preferred = FAMILIES.map((f) => f.id);
+    const keysWithMembers = [...grouped.entries()].filter(([, m]) => m.length > 0).map(([k]) => k);
+    const ordered = [
+      ...preferred.filter((k) => keysWithMembers.includes(k)),
+      ...keysWithMembers.filter((k) => !preferred.includes(k)).sort(),
+    ];
+    return ordered;
   }, [grouped]);
+
+  const expected = payload.instrumentCount ?? agents.length;
+  const sweepOk = payload.ok !== false && signalsLeaf?.ok !== false;
 
   return (
     <div className="flex h-full flex-col gap-3 overflow-hidden p-4">
@@ -108,78 +213,71 @@ export default function SignalsPageClient() {
           {expected && agents.length !== expected ? (
             <span className="text-amber-400/90"> / {expected} instruments</span>
           ) : expected ? (
-            <span> instruments · composite {typeof signals.composite === 'number' ? signals.composite.toFixed(3) : '—'}</span>
+            <span> micro instruments</span>
+          ) : null}
+          {typeof payload.composite === 'number' && sweepOk ? (
+            <span className="ml-2 text-slate-500">· sweep composite {payload.composite.toFixed(3)}</span>
           ) : null}
         </div>
-        {signals.timestamp ? (
-          <span className="text-[10px] text-slate-500">sweep {relTime(signals.timestamp)}</span>
-        ) : null}
+        <div className="flex flex-wrap items-center gap-2 text-[10px] text-slate-500">
+          {payload.timestamp ? <span>sweep {relTime(payload.timestamp)}</span> : null}
+          {payload.cached ? <span className="text-slate-600">· cached sweep</span> : null}
+          {payload.source === 'kv-fallback' ? <span className="text-amber-500/90">· KV fallback</span> : null}
+        </div>
       </div>
 
+      {error ? (
+        <div className="rounded border border-rose-900/50 bg-rose-950/20 px-3 py-2 text-[11px] text-rose-200">{error}</div>
+      ) : null}
+
+      {!signalsLeaf?.ok && signalsLeaf?.error ? (
+        <div className="rounded border border-amber-900/40 bg-amber-950/10 px-3 py-2 text-[11px] text-amber-100/90">
+          Signals lane: {signalsLeaf.error}
+        </div>
+      ) : null}
+
       <div className="min-h-0 flex-1 space-y-4 overflow-y-auto">
-        {FAMILIES.map((family) => {
-          const members = grouped.get(family.id) ?? [];
+        {agents.length === 0 ? (
+          <div className="rounded-lg border border-slate-800 bg-slate-950/40 p-4 text-[11px] text-slate-500">
+            No micro-agent sweep in this snapshot yet. When the full terminal snapshot loads, instrument names appear here.
+            {snapshot?.lite ? ' (Lite snapshot has no per-instrument list.)' : null}
+          </div>
+        ) : null}
+
+        {displayFamilyIds.map((familyId) => {
+          const members = grouped.get(familyId) ?? [];
           if (members.length === 0) return null;
-          const comp = familyComposites[family.id];
+          const style = familyStyle(familyId);
+          const healthyN = members.filter((a) => a.healthy).length;
 
           return (
-            <section key={family.id} className={`rounded-lg border ${family.borderColor} ${family.bgColor} p-3`}>
-              <div className="mb-2 flex items-center justify-between">
+            <section key={familyId} className={`rounded-lg border ${style.borderColor} ${style.bgColor} p-3`}>
+              <div className="mb-2 flex items-center justify-between gap-2">
                 <div>
-                  <span className={`font-mono text-sm font-bold ${family.color}`}>{family.label}</span>
-                  <span className="ml-2 text-[10px] text-slate-500">{family.focus}</span>
+                  <span className={`font-mono text-sm font-bold ${style.color}`}>{style.label}</span>
+                  {style.focus ? <span className="ml-2 text-[10px] text-slate-500">{style.focus}</span> : null}
                 </div>
-                <div className="flex items-center gap-3 text-[10px] font-mono text-slate-400">
-                  <span>{comp?.healthy ?? 0}/{comp?.total ?? 0} healthy</span>
-                  <span className={comp && comp.avg >= 0.7 ? 'text-emerald-400' : comp && comp.avg >= 0.4 ? 'text-amber-400' : 'text-rose-400'}>
-                    avg {comp ? (comp.avg * 100).toFixed(0) : '—'}%
-                  </span>
+                <div className="text-[10px] font-mono text-slate-500">
+                  {healthyN}/{members.length} reporting
                 </div>
               </div>
 
-              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+              <ul className="grid grid-cols-1 gap-1.5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                 {members.map((agent) => {
-                  const sig = agent.signals[0];
-                  const score = sig?.value ?? (agent.healthy ? 0.85 : 0);
-                  const pct = Math.max(5, Math.round(score * 100));
-
+                  const posture = agentPosture(agent, signalsLane);
                   return (
-                    <div key={agent.agentName} className="rounded border border-slate-800 bg-slate-950/60 p-2.5">
-                      <div className="flex items-center justify-between">
-                        <span className="font-mono text-[11px] font-semibold text-slate-200">{agent.agentName}</span>
-                        <span className={`h-2 w-2 rounded-full ${agent.healthy ? 'bg-emerald-400' : 'bg-rose-400'}`} />
-                      </div>
-                      {sig ? (
-                        <>
-                          <div className="mt-1.5 flex items-center gap-1.5">
-                            <div className="h-1.5 flex-1 overflow-hidden rounded bg-slate-800">
-                              <div
-                                className={`h-full rounded ${severityDot(sig.severity)}`}
-                                style={{ width: `${pct}%` }}
-                              />
-                            </div>
-                            <span className="font-mono text-[10px] text-slate-400">{pct}%</span>
-                          </div>
-                          <div className="mt-1 text-[10px] leading-snug text-slate-400 line-clamp-2" title={sig.label}>
-                            {sig.source}
-                          </div>
-                          <div className="mt-0.5 flex items-center justify-between text-[9px] text-slate-600">
-                            <span className="flex items-center gap-1">
-                              <span className={`h-1.5 w-1.5 rounded-full ${severityDot(sig.severity)}`} />
-                              {sig.severity}
-                            </span>
-                            <span>{relTime(sig.timestamp)}</span>
-                          </div>
-                        </>
-                      ) : (
-                        <div className="mt-1.5 text-[10px] text-slate-500">
-                          {agent.errors?.[0] ?? 'No signal'}
-                        </div>
-                      )}
-                    </div>
+                    <li
+                      key={agent.agentName}
+                      className="flex items-center justify-between gap-2 rounded border border-slate-800/80 bg-slate-950/50 px-2.5 py-2"
+                    >
+                      <span className="min-w-0 truncate font-mono text-[11px] font-medium text-slate-200" title={agent.agentName}>
+                        {agent.agentName}
+                      </span>
+                      <PostureBadge posture={posture} laneStale={laneStale && posture === 'degraded'} />
+                    </li>
                   );
                 })}
-              </div>
+              </ul>
             </section>
           );
         })}

--- a/hooks/useTerminalSnapshot.ts
+++ b/hooks/useTerminalSnapshot.ts
@@ -9,6 +9,16 @@ type SnapshotLeaf = {
   error: string | null;
 };
 
+export type SnapshotLaneState = {
+  key: string;
+  ok: boolean;
+  state: string;
+  statusCode?: number;
+  message?: string;
+  lastUpdated?: string | null;
+  fallbackMode?: string | null;
+};
+
 export type TerminalSnapshot = {
   ok: boolean;
   timestamp?: string;
@@ -17,6 +27,7 @@ export type TerminalSnapshot = {
   mode?: string | null;
   degraded?: boolean;
   meta?: { total_ms?: number };
+  lanes?: SnapshotLaneState[];
   integrity?: SnapshotLeaf;
   signals?: SnapshotLeaf;
   kvHealth?: SnapshotLeaf;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Cycle:** C-151 (per workspace convention)
- **Type:** fix
- **Primary area:** signals / ui

**What changed**

The Signals chamber (`/terminal/signals`) showed only a leading `0` when the snapshot used Redis-backed signal data: that path spreads `allSignals` but not `agents[]`, so the UI had zero rows. The page also grouped only on a regex that did not match every instrument naming variant.

The chamber now builds one row per micro instrument from `allSignals` when `agents` is missing, normalizes `µ` vs `u` for family grouping, adds THEMIS and GAIA to the family style map, and replaces per-signal value UI with each instrument’s **name** plus a small **live / degraded / standby** badge derived from agent health, worst signal severity, and the terminal snapshot **signals** lane state (`lanes` typing added to `useTerminalSnapshot`).

**Why**

Operator-visible truth: cold-start / cached snapshots must still enumerate micro sub-agents; posture should reflect lane + instrument state without implying extra precision from raw signal values on this surface.

## Risk

- **Tier:** 1 — client-only presentation + hook typing; no API or KV schema changes.

## Verification

- `pnpm exec tsc --noEmit` — pass
- `pnpm build` — pass (includes typecheck during build)
- `pnpm lint` — **not completed** (Next.js 15 `next lint` entered interactive ESLint setup prompt and exited non-zero)

## EPICON intent (short)

- **Problem:** Signals page empty or misleading when `agents` absent from cached payload.
- **Decision:** Derive rows from `allSignals`; show names + posture; use snapshot lane for sweep-level degradation.
- **Boundaries:** Does not change micro sweep logic, Redis shape, or `/api/signals/micro`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae19bdc8-4403-41fc-ba86-450bcb1cc19b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae19bdc8-4403-41fc-ba86-450bcb1cc19b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

