### PR TITLE
fix(build): restore Lane Diagnostics imports for Vercel build

### DIFF
--- a/components/terminal/TerminalShell.tsx
+++ b/components/terminal/TerminalShell.tsx
@@ -2,7 +2,10 @@
 
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import ChamberSwitcher from '@/components/terminal/ChamberSwitcher';
+import SnapshotDiagnostics from '@/components/terminal/SnapshotDiagnostics';
 import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
+import type { SnapshotLaneState } from '@/lib/terminal/snapshotLanes';
+import { normalizeSnapshotLane, SNAPSHOT_LANE_KEYS } from '@/lib/terminal/snapshotLanes';
 import { cn } from '@/lib/utils';
 
 function runtimeBadgeClass(runtime: 'online' | 'degraded' | 'offline') {
@@ -28,9 +31,6 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
   const [clock, setClock] = useState('—');
   const [showLaneDiagnostics, setShowLaneDiagnostics] = useState(false);
   const [consoleCollapsed, setConsoleCollapsed] = useState(false);
-  const [lanes, setLanes] = useState<SnapshotLaneState[]>([]);
-  const [snapshotAt, setSnapshotAt] = useState<string | null>(null);
-  const [deployment, setDeployment] = useState<{ commit_sha: string | null; environment: string | null } | null>(null);
 
   useEffect(() => {
     const tick = () => setClock(new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC');
@@ -82,6 +82,36 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
           : 'text-rose-300 border-rose-500/40',
     [gi],
   );
+
+  const snapshotAt = snapshot?.timestamp ?? null;
+  const deployment = useMemo(() => {
+    const raw = (snapshot as Record<string, unknown> | null)?.deployment;
+    if (raw && typeof raw === 'object') {
+      const d = raw as { commit_sha?: string | null; environment?: string | null };
+      return { commit_sha: d.commit_sha ?? null, environment: d.environment ?? null };
+    }
+    return null;
+  }, [snapshot]);
+
+  const lanes = useMemo<SnapshotLaneState[]>(() => {
+    if (!snapshot) return [];
+    const out: SnapshotLaneState[] = [];
+    for (const key of SNAPSHOT_LANE_KEYS) {
+      const leaf = (snapshot as Record<string, unknown>)[key];
+      if (leaf && typeof leaf === 'object') {
+        const l = leaf as { ok?: boolean; status?: number; data?: unknown; error?: string | null };
+        out.push(
+          normalizeSnapshotLane(key, {
+            ok: l.ok !== false,
+            status: typeof l.status === 'number' ? l.status : (l.ok !== false ? 200 : 500),
+            data: l.data ?? l,
+            error: typeof l.error === 'string' ? l.error : null,
+          }),
+        );
+      }
+    }
+    return out;
+  }, [snapshot]);
 
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-[#020617] text-slate-100">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Mobius Terminal PR — C-151

---

## 1. Summary

- **Cycle:** C-151
- **Type:** `fix`
- **Primary area:** `ui` / `infra`
- **Files changed:** `components/terminal/TerminalShell.tsx`
- **Files deliberately NOT changed:** All other files

**What changed?**
The merge of PR #305 lost the `SnapshotDiagnostics` and `snapshotLanes` imports from `TerminalShell.tsx`, as well as the lane data population logic. The state variables (`lanes`, `snapshotAt`, `deployment`) survived the merge but had no imports or data flow. This fix restores the imports using a split `import type` pattern (avoids Vercel's stricter type elision) and derives lane data from the existing `useTerminalSnapshot()` hook via `useMemo` instead of a separate fetch.

**Why?**
Vercel deployment failed with `Cannot find name 'SnapshotLaneState'` because the type was referenced but never imported after the merge.

---

## 2. Risk Tier

- [x] **Tier 1** — App logic, no auth/KV schema changes

---

## 4. LOCKED BEHAVIOR AUDIT

- [x] This PR does NOT change the key schema
- [x] This PR does NOT remove or bypass LPUSH/LTRIM
- [x] This PR does NOT remove auth headers
- [x] This PR does NOT reassign signal domain ownership
- [x] This PR does NOT mask empty KV states

---

## 5. Integrity Impact

- **Estimated MII:** 0.00
- **Risk level:** Low
- **Lanes affected:** None

---

## 6. Verification

- [x] `pnpm exec tsc --noEmit` — typecheck passes
- [x] `pnpm build` — clean build passes (`.next` removed first)
- [x] `pnpm dev` — dev server responds 200 on `/terminal/globe`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43465e59-f612-4235-83c8-f4342d88866f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43465e59-f612-4235-83c8-f4342d88866f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

