### PR TITLE
fix(terminal): Signals page — define familyComposites and severityDot for Vercel build

### DIFF
--- a/app/terminal/signals/SignalsPageClient.tsx
+++ b/app/terminal/signals/SignalsPageClient.tsx
@@ -129,6 +129,16 @@ function worstSeverity(signals: SignalEntry[]): string {
   return order[worst] ?? 'nominal';
 }
 
+function severityDot(severity: string): string {
+  const s = severity.toLowerCase();
+  if (s === 'critical') return 'bg-rose-400';
+  if (s === 'elevated') return 'bg-amber-400';
+  if (s === 'watch') return 'bg-yellow-400';
+  return 'bg-emerald-400';
+}
+
+type FamilyComposite = { healthy: number; total: number; avg: number };
+
 function agentPosture(agent: AgentResult, signalsLane: SnapshotLaneState | undefined): AgentPosture {
   if (!signalsLane?.ok || signalsLane.state === 'offline') return 'standby';
   if (signalsLane.state === 'degraded' || signalsLane.state === 'stale') {
@@ -192,14 +202,25 @@ export default function SignalsPageClient() {
     return map;
   }, [agents]);
 
-  const displayFamilyIds = useMemo(() => {
-    const preferred = FAMILIES.map((f) => f.id);
-    const keysWithMembers = [...grouped.entries()].filter(([, m]) => m.length > 0).map(([k]) => k);
-    const ordered = [
-      ...preferred.filter((k) => keysWithMembers.includes(k)),
-      ...keysWithMembers.filter((k) => !preferred.includes(k)).sort(),
-    ];
-    return ordered;
+  const familyComposites = useMemo(() => {
+    const out: Record<string, FamilyComposite> = {};
+    for (const [familyId, members] of grouped) {
+      if (members.length === 0) continue;
+      let sum = 0;
+      let healthy = 0;
+      for (const agent of members) {
+        if (agent.healthy) healthy += 1;
+        const sig = agent.signals[0];
+        const score = sig?.value ?? (agent.healthy ? 0.85 : 0);
+        sum += score;
+      }
+      out[familyId] = {
+        healthy,
+        total: members.length,
+        avg: sum / members.length,
+      };
+    }
+    return out;
   }, [grouped]);
 
   const expected = payload.instrumentCount ?? agents.length;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Cycle:** C-283
- **Type:** fix
- **Primary area:** signals / ui

**What changed:** `SignalsPageClient.tsx` referenced `familyComposites` and `severityDot` without defining them, which fails `next build` type checking (as on Vercel). This PR adds a `useMemo` that derives per-family healthy count, total, and average score from grouped agents, adds a small `severityDot()` mapper for micro sweep severities, and removes an unused `displayFamilyIds` memo.

**Why:** Unblocks production deploy; error was `Cannot find name 'familyComposites'` at line ~268.

## Risk

- **Tier 1** — UI-only derived stats; no API or KV schema changes.

## Tests

- `pnpm exec tsc --noEmit` — pass
- `pnpm build` — pass
- ESLint — not configured in repo (per BUILD.md)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://mobius-substrate.slack.com/archives/D0AU7DJDL9W/p1776353340953419?thread_ts=1776353340.953419&cid=D0AU7DJDL9W)

<div><a href="https://cursor.com/agents/bc-dc846d27-14bd-5e6a-9964-39cc4ba1847f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc846d27-14bd-5e6a-9964-39cc4ba1847f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

