### PR TITLE
fix(ux): C-283 — 5 UI/UX optimizations for deployment

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,8 +6,8 @@ import SessionClientProvider from '@/components/auth/SessionClientProvider';
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
+  maximumScale: 5,
+  userScalable: true,
 };
 
 export const metadata: Metadata = {

--- a/app/terminal/pulse/page.tsx
+++ b/app/terminal/pulse/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import PulsePageClient from './PulsePageClient';
 
 export const metadata: Metadata = {
-  title: 'Pulse Ledger · Mobius Terminal',
+  title: 'Pulse · Mobius Terminal',
 };
 
 export default function PulsePage() {

--- a/app/terminal/sentinel/SentinelPageClient.tsx
+++ b/app/terminal/sentinel/SentinelPageClient.tsx
@@ -121,6 +121,14 @@ export default function SentinelPageClient() {
       .catch(() => setJournalByAgent({}));
   }, []);
 
+  const latestByAgent = useMemo(() => {
+    const out: Record<string, number> = {};
+    for (const [agent, entries] of Object.entries(miiData)) {
+      if (entries.length > 0) out[agent] = entries[0]!.mii;
+    }
+    return out;
+  }, [miiData]);
+
   if (loading && !snapshot) return <ChamberSkeleton blocks={8} />;
 
   const agents = (snapshot?.agents?.data ?? {}) as { agents?: Agent[] };
@@ -139,14 +147,6 @@ export default function SentinelPageClient() {
     }
     setExpanded(name);
   };
-
-  const latestByAgent = useMemo(() => {
-    const out: Record<string, number> = {};
-    for (const [agent, entries] of Object.entries(miiData)) {
-      if (entries.length > 0) out[agent] = entries[0]!.mii;
-    }
-    return out;
-  }, [miiData]);
 
   const heartbeatLive = (agents.agents ?? []).every((a) => a.status === 'active');
   const anyJournalLags = (agents.agents ?? []).some((agent) => {

--- a/app/terminal/signals/SignalsPageClient.tsx
+++ b/app/terminal/signals/SignalsPageClient.tsx
@@ -178,7 +178,6 @@ function PostureBadge({ posture, laneStale }: { posture: AgentPosture; laneStale
 
 export default function SignalsPageClient() {
   const { snapshot, loading, error } = useTerminalSnapshot();
-  if (loading && !snapshot) return <ChamberSkeleton blocks={4} />;
 
   const signalsLeaf = snapshot?.signals;
   const signalsData = signalsLeaf?.data;
@@ -222,6 +221,8 @@ export default function SignalsPageClient() {
     }
     return out;
   }, [grouped]);
+
+  if (loading && !snapshot) return <ChamberSkeleton blocks={4} />;
 
   const expected = payload.instrumentCount ?? agents.length;
   const sweepOk = payload.ok !== false && signalsLeaf?.ok !== false;

--- a/components/terminal/CommandSurface.tsx
+++ b/components/terminal/CommandSurface.tsx
@@ -109,7 +109,7 @@ ${greeting}`,
       return;
     }
     if (base === '/globe') {
-      router.push('/terminal');
+      router.push('/terminal/globe');
       push(trimmed, '→ World State chamber', 'success');
       return;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Mobius Terminal PR — C-283

---

## 1. Summary

- **Cycle:** C-283
- **Type:** `fix`
- **Primary area:** `ui`
- **Files changed:**
  - `app/layout.tsx`
  - `app/terminal/pulse/page.tsx`
  - `app/terminal/sentinel/SentinelPageClient.tsx`
  - `app/terminal/signals/SignalsPageClient.tsx`
  - `components/terminal/CommandSurface.tsx`
- **Files deliberately NOT changed:** All other chamber pages, layout components, and API routes intentionally left alone.

**What changed?**
Five targeted UI/UX fixes: (1) React Hooks ordering violation in SignalsPageClient fixed by moving `useMemo` calls above the early-return guard, (2) same Hooks violation fixed in SentinelPageClient, (3) viewport accessibility restored by allowing pinch-to-zoom (WCAG 1.4.4 compliance), (4) Pulse page metadata corrected from "Pulse Ledger" to "Pulse", (5) `/globe` command now routes directly to `/terminal/globe` instead of `/terminal`.

**Why?**
The Hooks violations could cause runtime crashes when transitioning from loading to loaded state. The viewport lock blocks accessibility for low-vision users. The Pulse metadata mismatch causes operator confusion. The `/globe` command routing caused an unnecessary redirect hop.

---

## 2. Risk Tier

- [x] **Tier 1** — App logic, no auth/KV schema changes

---

## 3. EPICON Intent

```text
epicon_id: EPICON_C-283_ui_ux-optimizations
scope: ui
mode: normal
issued_at: 2026-04-16T00:00:00Z

justification:
  PROBLEM:
    SignalsPageClient and SentinelPageClient have early returns before useMemo hooks,
    violating React Rules of Hooks and risking runtime crashes. Viewport blocks
    pinch-to-zoom (WCAG violation). Pulse page title says "Pulse Ledger" incorrectly.
    /globe command routes via unnecessary redirect.

  CONTEXT:
    These are pre-deployment quality fixes to ensure stable chamber rendering and
    accessibility compliance.

  DECISION:
    Move all hook calls above conditional early returns. Restore accessible viewport
    settings. Fix metadata and routing inconsistencies.

  BOUNDARIES:
    Does not touch any API routes, KV schemas, data models, or agent logic.
    Does not change chamber structure or routing architecture.

  TRADEOFFS:
    - Removed: viewport zoom lock (intentional for accessibility)
    - Kept: all chamber layouts, data flows, and rendering logic
    - Risk: minimal — all changes are isolated UI fixes

  COUNTERFACTUALS:
    - If hooks still error, then the loading guard position needs further review
    - If zoom causes layout issues on mobile, then consider CSS touch-action constraints
```

---

## 4. LOCKED BEHAVIOR AUDIT

- [x] This PR does NOT change the key schema in `app/api/agents/journal/route.ts`
- [x] This PR does NOT remove or bypass the LPUSH/LTRIM in `app/api/echo/ingest/route.ts`
- [x] This PR does NOT remove the `Authorization` header from `lib/substrate/github-reader.ts`
- [x] This PR does NOT add crypto price sources to HERMES-µ
- [x] This PR does NOT reassign domain ownership between agents
- [x] This PR does NOT attempt to "fix" `sources.kv: 0` on epicon or journal
- [x] This PR does NOT add seed/genesis data to mask empty KV state

---

## 5. Integrity Impact

**What could go wrong if this PR is wrong?**
Minimal risk. The Hooks fixes prevent potential runtime crashes. Viewport and metadata changes are cosmetic. Routing change eliminates a redirect.

### Assessment
- **Estimated MII for this PR:** 0.95
- **Risk level:** Low
- **Lanes affected:** None (UI-only changes, no data lane impact)

### Checklist
- [x] Does not change KV key schemas without operator approval
- [x] Does not remove auth from any route
- [x] Does not introduce duplicate signal sources across agents
- [x] Does not add hardcoded cycle IDs, timestamps, or seed data
- [x] pnpm build passes

---

## 6. Verification

**Pre-merge:**
- [x] `pnpm exec tsc --noEmit` — typecheck passes
- [x] `pnpm build` — build passes
- [x] All 5 chamber pages manually tested in browser

**Evidence:**

Demo video showing all chambers loading correctly:
[demo_chamber_navigation_ux_fixes.mp4](https://cursor.com/agents/bc-c472a489-56a1-4712-b0e5-7732bd2770fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_chamber_navigation_ux_fixes.mp4)

Pulse page title fix confirmed:
[Pulse title shows Pulse · Mobius Terminal](https://cursor.com/agents/bc-c472a489-56a1-4712-b0e5-7732bd2770fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpulse_title_fixed.webp)

Signals page loads without React Hooks errors:
[Signals page no console errors](https://cursor.com/agents/bc-c472a489-56a1-4712-b0e5-7732bd2770fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsignals_no_hook_errors.webp)

Sentinel page loads without React Hooks errors:
[Sentinel page no console errors](https://cursor.com/agents/bc-c472a489-56a1-4712-b0e5-7732bd2770fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsentinel_no_hook_errors.webp)

---

## 7. Rollback Plan

```bash
git revert 4eb832d
# No KV writes involved — simple revert is sufficient
```

---

## 8. Stop Conditions Met

- [x] No stop condition triggered — scope is clean

---

## 9. Final Checklist

- [x] Risk tier correctly assessed
- [x] EPICON intent block completed with BOUNDARIES field
- [x] Locked behavior audit completed (all boxes checked)
- [x] Rollback plan provided
- [x] I have read AGENTS.md, BUILD.md, and CURRENT_CYCLE.md before starting this PR
- [x] I am okay with this appearing in the public cathedral

---

*"Let me update my consensus." — Mobius constitutional phrase for acknowledging new ground truth.*

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c472a489-56a1-4712-b0e5-7732bd2770fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c472a489-56a1-4712-b0e5-7732bd2770fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

