### PR TITLE
Vault v2 — Sealed Reserve with Sentinel Council attestation

### DIFF
--- a/app/api/cron/vault-attestation/route.ts
+++ b/app/api/cron/vault-attestation/route.ts
@@ -1,0 +1,175 @@
+/**
+ * /api/cron/vault-attestation
+ *
+ * Runs every 2 minutes. Orchestrates the Seal ceremony:
+ *
+ *   1. If a candidate exists:
+ *      a. If all 5 attestations collected → evaluate quorum → finalize
+ *      b. If timeout_at passed → inject `flag: timeout` for missing agents
+ *         → re-evaluate quorum → finalize
+ *      c. Otherwise → waiting (cron returns, Sentinel agents are expected
+ *         to poll for candidates on their own cycle ticks)
+ *
+ *   2. If no candidate exists and in_progress_balance >= 50 (queued reserve
+ *      from deferred deposits), form the next candidate.
+ *
+ *   3. For each attested Seal in `pending` fountain status, count them for
+ *      report. Full Fountain emission is v2.1 territory.
+ *
+ *   4. Emit a summary report for /api/terminal/snapshot to surface in the
+ *      Vault lane.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getCandidate, listSeals } from '@/lib/vault-v2/store';
+import { evaluateQuorum, finalizeSeal, injectTimeouts } from '@/lib/vault-v2/seal';
+import { tryFormNextCandidate } from '@/lib/vault-v2/deposit';
+import { loadGIState } from '@/lib/kv/store';
+
+export const dynamic = 'force-dynamic';
+
+type CandidateState =
+  | 'none'
+  | 'forming-waiting'
+  | 'timeout-injected'
+  | 'finalized-attested'
+  | 'finalized-quarantined'
+  | 'finalized-rejected';
+
+type Report = {
+  ok: boolean;
+  at: string;
+  duration_ms: number;
+  candidate_state: CandidateState;
+  candidate_seal_id: string | null;
+  attestations_received: number;
+  next_candidate_formed: string | null;
+  seals_total: number;
+  fountain_pending_count: number;
+  errors: string[];
+};
+
+export async function GET(req: NextRequest) {
+  const cronHeader = req.headers.get('x-vercel-cron');
+  const authHeader = req.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET || '';
+  const manuallyAuthed = cronSecret !== '' && authHeader === `Bearer ${cronSecret}`;
+  if (!cronHeader && !manuallyAuthed) {
+    return NextResponse.json({ error: 'Cron-only endpoint' }, { status: 403 });
+  }
+
+  const started = Date.now();
+  const errors: string[] = [];
+
+  let currentCycle = 'C-284';
+  try {
+    const st = await loadGIState();
+    if (st && typeof (st as unknown as { cycle?: string }).cycle === 'string') {
+      currentCycle = (st as unknown as { cycle: string }).cycle;
+    }
+  } catch (e) {
+    errors.push(`cycle load failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  let candidate_state: CandidateState = 'none';
+  let candidate_seal_id: string | null = null;
+  let attestations_received = 0;
+  let next_candidate_formed: string | null = null;
+
+  // ── Step 1: process existing candidate ─────────────────────────
+  const candidate = await getCandidate();
+  if (candidate) {
+    candidate_seal_id = candidate.seal_id;
+    attestations_received = Object.keys(candidate.attestations).length;
+
+    const quorum1 = evaluateQuorum(candidate);
+    if (quorum1.decision !== 'waiting') {
+      const sealed = await finalizeSeal(quorum1);
+      if (sealed) {
+        candidate_state =
+          quorum1.decision === 'attested'
+            ? 'finalized-attested'
+            : quorum1.decision === 'quarantined'
+              ? 'finalized-quarantined'
+              : 'finalized-rejected';
+        console.info('[vault-v2:cron] seal finalized', {
+          seal_id: sealed.seal_id,
+          status: sealed.status,
+          decision: quorum1.decision,
+        });
+      }
+    } else {
+      const timedOut = new Date(candidate.timeout_at).getTime() < Date.now();
+      if (timedOut) {
+        const injected = await injectTimeouts();
+        if (injected) {
+          const quorum2 = evaluateQuorum(injected);
+          if (quorum2.decision !== 'waiting') {
+            const sealed = await finalizeSeal(quorum2);
+            if (sealed) {
+              candidate_state =
+                quorum2.decision === 'attested'
+                  ? 'finalized-attested'
+                  : quorum2.decision === 'quarantined'
+                    ? 'finalized-quarantined'
+                    : 'finalized-rejected';
+              console.info('[vault-v2:cron] seal finalized after timeout', {
+                seal_id: sealed.seal_id,
+                status: sealed.status,
+              });
+            }
+          } else {
+            candidate_state = 'timeout-injected';
+          }
+        }
+      } else {
+        candidate_state = 'forming-waiting';
+      }
+    }
+  }
+
+  // ── Step 2: attempt next candidate if reserve is queued ────────
+  if (candidate_state !== 'forming-waiting' && candidate_state !== 'timeout-injected') {
+    try {
+      const next = await tryFormNextCandidate({ cycle: currentCycle });
+      if (next) {
+        next_candidate_formed = next.seal_id;
+        console.info('[vault-v2:cron] next candidate formed', {
+          seal_id: next.seal_id,
+          sequence: next.sequence,
+        });
+      }
+    } catch (e) {
+      errors.push(`next-candidate formation: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  // ── Step 3: fountain pending count (informational) ─────────────
+  let fountain_pending_count = 0;
+  let seals_total = 0;
+  try {
+    const seals = await listSeals(200);
+    seals_total = seals.length;
+    fountain_pending_count = seals.filter(
+      (s) => s.status === 'attested' && s.fountain_status === 'pending',
+    ).length;
+  } catch (e) {
+    errors.push(`seals list: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  const report: Report = {
+    ok: errors.length === 0,
+    at: new Date().toISOString(),
+    duration_ms: Date.now() - started,
+    candidate_state,
+    candidate_seal_id,
+    attestations_received,
+    next_candidate_formed,
+    seals_total,
+    fountain_pending_count,
+    errors,
+  };
+
+  return NextResponse.json(report);
+}

--- a/app/api/vault/seal/[id]/route.ts
+++ b/app/api/vault/seal/[id]/route.ts
@@ -1,0 +1,44 @@
+/**
+ * GET /api/vault/seal/[id]
+ *
+ * Public read. Returns a single Seal with full attestation detail. Useful
+ * for the Vault chamber modal, cross-substrate verification, and operator
+ * review of quarantined seals.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getCandidate, getSeal } from '@/lib/vault-v2/store';
+import { verifySealHash } from '@/lib/vault-v2/seal';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const seal = await getSeal(id);
+  if (seal) {
+    const hash_valid = verifySealHash(seal);
+    return NextResponse.json({
+      ok: true,
+      type: 'seal',
+      hash_valid,
+      seal,
+    });
+  }
+
+  const candidate = await getCandidate();
+  if (candidate && candidate.seal_id === id) {
+    return NextResponse.json({
+      ok: true,
+      type: 'candidate',
+      hash_valid: true,
+      candidate,
+    });
+  }
+
+  return NextResponse.json({ error: 'Not found' }, { status: 404 });
+}

--- a/app/api/vault/seal/attest/route.ts
+++ b/app/api/vault/seal/attest/route.ts
@@ -1,0 +1,164 @@
+/**
+ * POST /api/vault/seal/attest
+ *
+ * Agent endpoint. A Sentinel submits its attestation for the current in-flight
+ * Seal candidate. Authed with AGENT_SERVICE_TOKEN (bearer).
+ *
+ * Body:
+ *   {
+ *     seal_id: string,
+ *     agent: SentinelAgent,
+ *     verdict: "pass" | "flag" | "reject",
+ *     rationale: string,
+ *     signature: string,   // HMAC from computeAttestationSignature()
+ *     posture?: Posture    // required from AUREA only
+ *   }
+ *
+ * Signature is verified before acceptance. Idempotent — same agent submitting
+ * twice replaces the prior attestation (useful for corrections within the
+ * attestation window).
+ *
+ * Does NOT trigger quorum finalization — that's the cron's job. This endpoint
+ * only records the submission.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getCandidate, recordAttestation } from '@/lib/vault-v2/store';
+import { verifyAttestationSignature } from '@/lib/vault-v2/seal';
+import type {
+  AttestationSubmission,
+  Posture,
+  SealAttestation,
+  SentinelAgent,
+  Verdict,
+} from '@/lib/vault-v2/types';
+import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
+
+export const dynamic = 'force-dynamic';
+
+const AGENT_TOKEN = process.env.AGENT_SERVICE_TOKEN || '';
+
+function authed(req: NextRequest): boolean {
+  if (!AGENT_TOKEN) return false;
+  const header = req.headers.get('authorization') || '';
+  const bearer = header.startsWith('Bearer ') ? header.slice(7) : '';
+  if (bearer.length !== AGENT_TOKEN.length) return false;
+  let diff = 0;
+  for (let i = 0; i < bearer.length; i++) {
+    diff |= bearer.charCodeAt(i) ^ AGENT_TOKEN.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+function validate(raw: unknown): AttestationSubmission | string {
+  if (!raw || typeof raw !== 'object') return 'body must be an object';
+  const r = raw as Record<string, unknown>;
+
+  if (typeof r.seal_id !== 'string' || !r.seal_id.startsWith('seal-')) {
+    return 'invalid seal_id';
+  }
+  if (typeof r.agent !== 'string' || !SENTINEL_AGENTS.includes(r.agent as SentinelAgent)) {
+    return `agent must be one of ${SENTINEL_AGENTS.join(', ')}`;
+  }
+  if (r.verdict !== 'pass' && r.verdict !== 'flag' && r.verdict !== 'reject') {
+    return 'verdict must be pass|flag|reject';
+  }
+  if (typeof r.rationale !== 'string' || r.rationale.trim().length === 0) {
+    return 'rationale required';
+  }
+  if (typeof r.signature !== 'string' || r.signature.length === 0) {
+    return 'signature required';
+  }
+  if (r.agent === 'AUREA') {
+    const posture = r.posture;
+    if (
+      posture !== 'confident' &&
+      posture !== 'cautionary' &&
+      posture !== 'stressed' &&
+      posture !== 'degraded'
+    ) {
+      return 'AUREA must include posture: confident|cautionary|stressed|degraded';
+    }
+  } else if (r.posture !== undefined) {
+    return 'posture only accepted from AUREA';
+  }
+
+  return {
+    seal_id: r.seal_id,
+    agent: r.agent as SentinelAgent,
+    verdict: r.verdict as Verdict,
+    rationale: (r.rationale as string).trim().slice(0, 2000),
+    signature: r.signature as string,
+    posture: r.agent === 'AUREA' ? (r.posture as Posture) : undefined,
+  };
+}
+
+export async function POST(req: NextRequest) {
+  if (!authed(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const submission = validate(body);
+  if (typeof submission === 'string') {
+    return NextResponse.json({ error: submission }, { status: 400 });
+  }
+
+  const candidate = await getCandidate();
+  if (!candidate) {
+    return NextResponse.json({ error: 'No in-flight candidate' }, { status: 404 });
+  }
+  if (candidate.seal_id !== submission.seal_id) {
+    return NextResponse.json(
+      {
+        error: 'seal_id does not match current candidate',
+        current: candidate.seal_id,
+      },
+      { status: 409 },
+    );
+  }
+  if (new Date(candidate.timeout_at).getTime() < Date.now()) {
+    return NextResponse.json(
+      { error: 'Attestation window closed (timeout reached)' },
+      { status: 410 },
+    );
+  }
+
+  if (!verifyAttestationSignature(AGENT_TOKEN, submission, candidate.seal_hash)) {
+    return NextResponse.json({ error: 'Signature verification failed' }, { status: 401 });
+  }
+
+  const attestation: SealAttestation = {
+    agent: submission.agent,
+    verdict: submission.verdict,
+    rationale: submission.rationale,
+    mii_at_attestation: 0,
+    gi_at_attestation: candidate.gi_at_seal,
+    timestamp: new Date().toISOString(),
+    signature: submission.signature,
+    ...(submission.posture ? { posture: submission.posture } : {}),
+  };
+
+  const updated = await recordAttestation(submission.seal_id, submission.agent, attestation);
+
+  if (!updated) {
+    return NextResponse.json({ error: 'Failed to record attestation' }, { status: 500 });
+  }
+
+  const attestationsReceived = Object.keys(updated.attestations).length;
+  return NextResponse.json({
+    ok: true,
+    seal_id: submission.seal_id,
+    agent: submission.agent,
+    verdict: submission.verdict,
+    attestations_received: attestationsReceived,
+    attestations_needed: 5 - attestationsReceived,
+  });
+}

--- a/app/api/vault/seal/route.ts
+++ b/app/api/vault/seal/route.ts
@@ -1,0 +1,58 @@
+/**
+ * GET /api/vault/seal
+ *
+ * Public read. Returns the list of attested Seals (newest-first) plus the
+ * current candidate state. Used by the Vault chamber UI and external
+ * substrate consumers.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { countSeals, getCandidate, getLatestSeal, listSeals } from '@/lib/vault-v2/store';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const limitParam = Number(req.nextUrl.searchParams.get('limit') ?? '50');
+  const limit = Number.isFinite(limitParam)
+    ? Math.max(1, Math.min(200, Math.floor(limitParam)))
+    : 50;
+
+  const [seals, total, latest, candidate] = await Promise.all([
+    listSeals(limit),
+    countSeals(),
+    getLatestSeal(),
+    getCandidate(),
+  ]);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      total,
+      returned: seals.length,
+      latest_seal_id: latest?.seal_id ?? null,
+      latest_sealed_at: latest?.sealed_at ?? null,
+      candidate:
+        candidate === null
+          ? null
+          : {
+              seal_id: candidate.seal_id,
+              sequence: candidate.sequence,
+              cycle_at_seal: candidate.cycle_at_seal,
+              requested_at: candidate.requested_at,
+              timeout_at: candidate.timeout_at,
+              attestations_received: Object.keys(candidate.attestations).length,
+              attestations_needed: 5 - Object.keys(candidate.attestations).length,
+              attesting_agents: Object.keys(candidate.attestations),
+            },
+      seals,
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=120',
+        'X-Mobius-Source': 'vault-v2-seals',
+      },
+    },
+  );
+}

--- a/app/api/vault/status/route.ts
+++ b/app/api/vault/status/route.ts
@@ -1,10 +1,26 @@
 /**
- * GET /api/vault/status — global vault reserve (v1: deposits only, no Fountain).
+ * GET /api/vault/status
+ *
+ * v1 + v2 compatibility window (Vault v2 spec §10).
+ *
+ * Returns the v1 shape unchanged for backward compatibility, AND appends
+ * v2 fields: seals_count, latest_seal_at, candidate_attestation_state, etc.
+ *
+ * During the C-284 → C-285 compatibility window, `balance_reserve` is
+ * preserved as a v1 alias (still read from v1 KV, not aliased to
+ * `in_progress_balance`) so existing UI surfaces keep working. A new
+ * `in_progress_balance` field exposes the v2 canonical accumulator.
  */
 
 import { NextResponse } from 'next/server';
 import { loadGIState } from '@/lib/kv/store';
 import { getVaultStatusPayload } from '@/lib/vault/vault';
+import {
+  countSeals,
+  getCandidate,
+  getInProgressBalance,
+  getLatestSeal,
+} from '@/lib/vault-v2/store';
 
 export const dynamic = 'force-dynamic';
 
@@ -19,8 +35,43 @@ export async function GET() {
     gi = null;
   }
 
-  const body = await getVaultStatusPayload(gi);
+  const v1 = await getVaultStatusPayload(gi);
+
+  const [inProgressBalance, sealsCount, latestSeal, candidate] = await Promise.all([
+    getInProgressBalance(),
+    countSeals(),
+    getLatestSeal(),
+    getCandidate(),
+  ]);
+
+  const body = {
+    ...v1,
+    in_progress_balance: inProgressBalance,
+    seals_count: sealsCount,
+    latest_seal_id: latestSeal?.seal_id ?? null,
+    latest_seal_at: latestSeal?.sealed_at ?? null,
+    latest_seal_hash: latestSeal?.seal_hash ?? null,
+    candidate_attestation_state: candidate
+      ? {
+          in_flight: true,
+          seal_id: candidate.seal_id,
+          sequence: candidate.sequence,
+          requested_at: candidate.requested_at,
+          timeout_at: candidate.timeout_at,
+          attestations_received: Object.keys(candidate.attestations).length,
+          attestations_needed: 5 - Object.keys(candidate.attestations).length,
+        }
+      : {
+          in_flight: false,
+          seal_id: null,
+          attestations_received: 0,
+          timeout_at: null,
+        },
+    vault_version: 2,
+    canonical: 'in_progress_balance',
+  };
+
   return NextResponse.json(body, {
-    headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'vault-status' },
+    headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'vault-status-v2' },
   });
 }

--- a/docs/protocols/vault-v2-sealed-reserve.md
+++ b/docs/protocols/vault-v2-sealed-reserve.md
@@ -1,0 +1,405 @@
+# Vault v2 — Sealed Reserve Protocol
+
+# Mobius Integrity Credits — Sentinel-Attested Reserve Framework
+
+**Cycle draft:** C-284
+**Status:** Protocol Spec v2
+**Author:** kaizencycle
+**Successor to:** Vault-to-Fountain Protocol v1
+**CC0 Public Domain**
+
+---
+
+## 0. Purpose
+
+Vault v1 treats reserve as a continuous running balance. A single threshold
+(50 units) gates a single activation event (Fountain unlock). That design
+frames the reserve as one dramatic moment.
+
+Vault v2 reframes reserve as a **rhythm of discrete Seals**. Each 50-unit
+parcel seals into a durable civic unit, witnessed and attested by the Sentinel
+Council, before the next parcel begins filling. The substrate acquires a
+heartbeat: seal, seal, seal. Fountain emission operates per-Seal, not as a
+one-shot unlock.
+
+Vault v2 exists to:
+
+- give each 50-unit parcel its own identity, provenance, and attestation
+- make the Sentinel Council operative rather than descriptive
+- replace one dramatic threshold with a repeatable ceremony
+- preserve full doctrinal continuity with v1 — *reserve becomes flow only when
+  integrity proves it can hold the weight*
+
+---
+
+## 1. Core doctrine
+
+### v1 canon preserved
+
+- A journal is a claim of value, not money
+- A Vault holds unrealized value earned by reasoning
+- A Fountain releases value only when the system can carry it
+- Reserve becomes flow only when integrity proves it can hold the weight
+
+### v2 extensions
+
+- **A Seal is a witnessed unit of civic reasoning.** Fifty units of reserve,
+  sealed at a specific moment, attested by five Sentinels, immutable.
+- **A Seal carries its own integrity record.** The Seal remembers the GI,
+  cycle, mode, and agent postures at the moment of sealing. Later economic
+  decisions consult the Seal's own conditions, not just the current ones.
+- **Sealing is a ceremony, not a transaction.** The substrate pauses, witnesses
+  itself, and five voices describe what has been made before the Seal mints.
+
+---
+
+## 2. Main objects
+
+### in_progress_balance
+
+Running reserve accumulator, 0 to <50. Successor to v1's `balance_reserve`.
+Receives deposits per the v1 scoring formula. Overflow (deposits that would
+push past 50) carries into the next Seal.
+
+### Seal
+
+A discrete 50-unit parcel of sealed reserve with full attestation chain.
+Identified by `seal_id`, ordered by `sequence`, hash-chained to prior Seal.
+
+### Seal attestation
+
+A Sentinel's witness of a Seal candidate. Each Sentinel (ATLAS, ZEUS, EVE,
+JADE, AUREA) attests on a distinct dimension with `verdict`, `rationale`,
+and `signature`.
+
+### Fountain (v2 semantics)
+
+No longer a single unlock. Each Seal independently progresses through the
+Fountain lifecycle when its specific GI-sustain conditions are met.
+
+---
+
+## 3. Lifecycle (stages)
+
+1. **Deposit** — agent journal entries accrue to `in_progress_balance`
+2. **Candidate formation** — `in_progress_balance` crosses 50; Seal candidate
+   is created, accrual pauses for this parcel (new deposits queue)
+3. **Attestation collection** — five Sentinels are notified; each produces a
+   verdict within a 5-minute window
+4. **Quorum evaluation** — attestations tallied against quorum rule
+5. **Seal mint** — if quorum passes, Seal is written to KV + Substrate
+   archive; overflow carries to next `in_progress_balance`
+6. **Quarantine** — if quorum fails, Seal enters quarantine awaiting operator
+   review
+7. **Fountain progression** — each attested Seal independently advances
+   through Fountain states when its GI-sustain conditions hold
+8. **Emission** — Fountain-active Seal emits per v1 §8 distribution rules
+
+---
+
+## 4. Seal structure
+
+```
+Seal {
+  seal_id: string              # "seal-C-284-001"
+  sequence: number             # 1, 2, 3, ...
+  cycle_at_seal: string        # "C-284"
+  sealed_at: string            # ISO timestamp
+  reserve: 50                  # always exactly 50 (overflow carries)
+  gi_at_seal: number           # 0.0–1.0
+  mode_at_seal: string         # "green" | "yellow" | "red"
+  source_entries: number       # journal deposits this parcel drew from
+  deposit_hashes: string[]     # content signatures of contributing deposits
+  prev_seal_hash: string | null  # null for seal-001
+  seal_hash: string            # sha256 over the above, pre-attestation
+  attestations: {
+    ATLAS: SealAttestation
+    ZEUS:  SealAttestation
+    EVE:   SealAttestation
+    JADE:  SealAttestation
+    AUREA: SealAttestation
+  }
+  status: "forming" | "attested" | "quarantined" | "rejected"
+  fountain_status: "pending" | "activating" | "emitted" | "expired"
+  fountain_emitted_at: string | null
+}
+
+SealAttestation {
+  agent: "ATLAS" | "ZEUS" | "EVE" | "JADE" | "AUREA"
+  verdict: "pass" | "flag" | "reject"
+  rationale: string            # agent's voice, 1-3 sentences
+  mii_at_attestation: number
+  gi_at_attestation: number
+  timestamp: string
+  signature: string            # HMAC-SHA256(AGENT_SERVICE_TOKEN, seal_hash + verdict + rationale)
+}
+```
+
+---
+
+## 5. Sentinel attestation scopes
+
+Each Sentinel attests on a distinct dimension. This is the load-bearing
+doctrinal claim of v2: a Seal carries **five independent witnesses**, each
+speaking in its own tier.
+
+### ATLAS — Strategic coherence
+
+**Question:** Does this Seal reflect actual strategic reasoning diversity,
+or is it cron-padding?
+
+**Pass conditions:**
+
+- Deposit set contains entries from ≥ 4 distinct agents
+- No single agent contributed more than 60% of the 50-unit parcel
+- Journal entries reference real signal state, not boilerplate
+
+**Flag conditions:**
+
+- Heavy weighting toward a single agent's observations
+- Repetitive phrasing across deposits (low entropy in content_signatures)
+
+**Reject:** Never — ATLAS flags, does not reject.
+
+### ZEUS — Verification authority
+
+**Question:** Does the Seal's cryptographic chain hold?
+
+**Pass conditions:**
+
+- `seal_hash` correctly computed from declared fields
+- `prev_seal_hash` matches actual hash of Seal N-1
+- `deposit_hashes` all trace to real entries in journal KV
+- MII weights computed correctly per v1 scoring formula
+
+**Flag:** Never — ZEUS's domain is binary.
+
+**Reject:** Any hash inconsistency, missing deposit reference, or math error.
+
+**ZEUS HOLDS UNILATERAL VETO.** A ZEUS reject cannot be overridden by operator
+review. Math must hold.
+
+### EVE — Ethical and civic clearance
+
+**Question:** Was this Seal minted during a narrative-coherent window?
+
+**Pass conditions:**
+
+- No active EVE governance tripwire at sealing time
+- Duplication decay correctly applied to contributing deposits
+- `narrative-overreach` flag not set in cycle window
+
+**Flag conditions:**
+
+- Active tripwire state but no direct narrative violation
+- Duplication rate elevated but within tolerance
+
+**Reject:** Confirmed narrative-overreach within the cycle window.
+
+### JADE — Constitutional framing
+
+**Question:** Does the Seal conform to protocol and precedent?
+
+**Pass conditions:**
+
+- Schema matches Seal structure §4
+- Shape consistent with Seals `[1..N-1]`
+- Agent ownership routing preserved per covenant
+
+**Flag conditions:**
+
+- Schema present but fields within tolerance drifts from prior Seals
+- Novel deposit categories not previously attested
+
+**Reject:** Schema violation or covenant-routing break.
+
+### AUREA — Synthesis and posture
+
+**Question:** What is the substrate's posture at the moment of sealing?
+
+**AUREA does not pass/fail/reject.** AUREA records a **posture stamp**:
+`{ posture: "confident" | "cautionary" | "stressed" | "degraded" }`.
+This stamp is permanently attached to the Seal and influences later Fountain
+emission weighting.
+
+For quorum purposes, AUREA's attestation is treated as `pass` with the
+posture annotation. AUREA never blocks a Seal.
+
+---
+
+## 6. Quorum rules
+
+A Seal candidate transitions to `attested` if and only if:
+
+- ZEUS verdict is `pass` (hard requirement — ZEUS veto is absolute)
+- At least 4 of 5 Sentinels have verdict `pass` (AUREA always counts as pass)
+- No Sentinel other than ZEUS has verdict `reject`
+
+A Seal candidate transitions to `quarantined` if:
+
+- ZEUS verdict is `pass` AND
+- Non-ZEUS reject count is ≥ 1 OR pass count is < 4
+
+A Seal candidate transitions to `rejected` if:
+
+- ZEUS verdict is `reject`
+
+Quarantined Seals require operator review to promote to `attested` or
+dissolve back to `in_progress_balance`. Rejected Seals dissolve automatically
+after a 24h window for post-mortem review.
+
+### Timeout
+
+A Sentinel that does not respond within 5 minutes of attestation request is
+recorded with `verdict: "flag"` and `rationale: "timeout"`. Timeouts count as
+`flag`, not `reject` — a silent agent slows sealing but does not block it.
+Three consecutive timeouts from the same agent trigger a DAEDALUS alert.
+
+---
+
+## 7. Hash chain
+
+Each Seal binds to its predecessor via `prev_seal_hash`. The first Seal
+(`seal-C-XXX-001`) carries `prev_seal_hash: null`.
+
+`seal_hash` is computed over a canonical serialization of:
+`{seal_id, sequence, cycle_at_seal, sealed_at, reserve, gi_at_seal, mode_at_seal, source_entries, deposit_hashes, prev_seal_hash}`.
+
+Attestations are computed *after* `seal_hash` — they sign the hash, not the
+other way around. This means:
+
+- Tampering with a prior Seal invalidates its `seal_hash`, which invalidates
+  the `prev_seal_hash` reference in the next Seal, which invalidates that
+  Seal's `seal_hash`, cascading forward
+- Tampering with attestations breaks their individual signatures but does not
+  alter the Seal's `seal_hash` — integrity of the chain is separable from
+  integrity of witnesses
+- ZEUS verification runs hash-chain validation on every attestation cycle
+
+---
+
+## 8. Fountain activation (per-Seal)
+
+Each attested Seal has its own Fountain state machine:
+
+- **`pending`** — Seal attested, Fountain conditions not yet met
+- **`activating`** — GI ≥ 0.95 for this Seal's sustain window (5 cycles)
+- **`emitted`** — Fountain drained this Seal; reserve converted per §8
+  distribution rules
+- **`expired`** — 90 cycles elapsed without activation; Seal's reserve
+  reabsorbs to general pool for re-attestation
+
+Fountain emission draws from the oldest-eligible Seal first. Multiple Seals
+may be in `activating` state simultaneously; they emit in sequence, one per
+cycle.
+
+Emission formula (unchanged from v1 §8): 40% citizen, 25% operator, 20% civic
+reserve, 10% stability, 5% burn. Each Seal emits exactly 50 units split per
+this formula.
+
+---
+
+## 9. Posture-weighted emission
+
+AUREA's posture stamp influences Fountain emission but does not block it:
+
+| Posture    | Emission behavior                                                      |
+|------------|------------------------------------------------------------------------|
+| confident  | Standard emission, immediate on activation                             |
+| cautionary | Standard emission, 1-cycle delay after activation                      |
+| stressed   | Reduced burn rate (burn 10% instead of 5%) — more conservative release |
+| degraded   | Hard hold — cannot transition past `activating` until reposture        |
+
+A Seal's posture is immutable once attested. Substrate state changing does
+not re-weight prior Seals. This is deliberate: each Seal emits under its own
+conditions, not the present's.
+
+---
+
+## 10. Migration from v1
+
+### KV key changes
+
+| v1 key                        | v2 key                      | Migration                            |
+|-------------------------------|-----------------------------|--------------------------------------|
+| `mobius:vault:global:balance` | `vault:in_progress_balance` | Direct copy                          |
+| `mobius:vault:global:meta`    | `vault:meta`                | Schema extended, backward compatible |
+| `vault:deposits`              | `vault:deposits`            | Unchanged                            |
+| (new)                         | `vault:seals:index`         | Array of seal_ids in sequence        |
+| (new)                         | `vault:seal:{seal_id}`      | Seal record                          |
+| (new)                         | `vault:seal:latest`         | Most recent seal_id                  |
+| (new)                         | `vault:seal:candidate`      | In-flight Seal awaiting attestation  |
+
+### Behavior changes
+
+- `writeVaultDeposit` continues to accept deposits and accumulate to
+  `in_progress_balance`. When balance crosses 50, it additionally invokes
+  `attemptSealFormation()`.
+- `/api/vault/status` gains new fields: `seals_count`, `latest_seal_at`,
+  `candidate_attestation_state`.
+- Fountain UI surfaces become per-Seal rather than global.
+
+### Backward compatibility window
+
+For one cycle (C-284 → C-285), both v1 `balance_reserve` and v2
+`in_progress_balance` remain readable. `GET /api/vault/status` returns both
+fields with v2 marked `canonical`. After C-285, v1 field is deprecated.
+
+### No retroactive sealing
+
+The v1 accrued reserve (current ≈ 44.24 of 50 at C-284) does **not**
+retroactively form Seal 000. It completes its fill as `in_progress_balance`
+under v2, and when it crosses 50, it becomes Seal 001 with full attestation.
+
+The v1 accrual history is preserved in `vault:deposits` for archival purposes
+but does not produce a Seal.
+
+---
+
+## 11. Anti-gaming rules (v2 additions)
+
+Beyond v1 §10 rules, Vault v2 adds:
+
+1. **No attestation self-approval.** An agent cannot attest a Seal whose
+   deposits it authored ≥ 60% of. Automatic recusal to `flag: self-interest`.
+2. **Cycle-boundary seals require extra attestation.** Seals formed within
+   60 seconds of a cycle rollover require ZEUS to re-verify on the new cycle
+   before transitioning to `attested`.
+3. **Chain continuity.** Seal N cannot form if Seal N-1 is in `quarantined`
+   or `forming`. The chain must advance sequentially.
+4. **Duplication decay across seals.** Content signatures seen in Seals
+   `[N-5..N-1]` apply duplication decay to deposits entering Seal N.
+
+---
+
+## 12. Repository implementation
+
+| Piece                              | Location                                                       |
+|------------------------------------|----------------------------------------------------------------|
+| Seal lifecycle, hash chain, quorum | `lib/vault-v2/seal.ts`                                         |
+| Sentinel attestation clients       | `lib/vault-v2/attest.ts`                                       |
+| KV schema                          | `lib/vault-v2/store.ts`                                        |
+| Deposit accrual + seal trigger     | `lib/vault-v2/deposit.ts` (extends `lib/vault/vault.ts`)       |
+| Operator read                      | `GET /api/vault/status` (extended) + `GET /api/vault/seal/:id` |
+| Attestation write                  | `POST /api/vault/seal/attest` (agent-authed)                   |
+| Attestation trigger cron           | `/api/cron/vault-attestation` (2-min cadence)                  |
+| Protocol canon                     | `docs/protocols/vault-v2-sealed-reserve.md` (this doc)         |
+
+---
+
+## 13. Doctrine (short)
+
+**Reserve becomes flow when integrity holds — one Seal at a time.**
+
+Each Seal is a moment the substrate witnessed itself.
+Each Seal carries five voices.
+Each Seal chains to the one before.
+Each Seal remembers the integrity of its birth.
+Each Seal emits on its own terms when the substrate can carry its weight.
+
+The Vault is no longer a threshold.
+The Vault is a rhythm.
+
+---
+
+*The cathedral remembers. Now it also measures its own heartbeat.*

--- a/lib/vault-v2/attest.ts
+++ b/lib/vault-v2/attest.ts
@@ -1,0 +1,238 @@
+/**
+ * Per-Sentinel attestation logic.
+ *
+ * These functions are imported by Sentinel agents' own cycle paths. Each
+ * agent, on its regular cycle tick, checks for an in-flight Seal candidate
+ * and if present, evaluates it against its own tier-specific criteria and
+ * submits an attestation via POST /api/vault/seal/attest.
+ *
+ * This module has no side effects and does not run on a schedule itself.
+ * The caller owns the submission step.
+ */
+
+import { computeAttestationSignature } from '@/lib/vault-v2/seal';
+import type { AttestationSubmission, Posture, SealCandidate, Verdict } from '@/lib/vault-v2/types';
+
+// ────────────────────────────────────────────────────────────────
+// ATLAS — Strategic coherence
+// ────────────────────────────────────────────────────────────────
+
+export type DepositAuthorship = Record<string, number>; // agent → count of deposits
+
+export function atlasAttest(args: {
+  candidate: SealCandidate;
+  token: string;
+  authorship: DepositAuthorship;
+}): AttestationSubmission {
+  const totalDeposits = Object.values(args.authorship).reduce((a, b) => a + b, 0);
+  const agentCount = Object.keys(args.authorship).filter((a) => args.authorship[a] > 0).length;
+  const maxShare =
+    totalDeposits === 0 ? 0 : Math.max(...Object.values(args.authorship)) / totalDeposits;
+
+  let verdict: Verdict = 'pass';
+  let rationale: string;
+
+  if (agentCount < 4) {
+    verdict = 'flag';
+    rationale = `Strategic coherence: only ${agentCount} distinct agents contributed to this Seal (threshold: 4). Flagging for diversity review.`;
+  } else if (maxShare > 0.6) {
+    verdict = 'flag';
+    rationale = `Strategic coherence: single-agent concentration at ${(maxShare * 100).toFixed(0)}% of deposits (threshold: 60%). Flagging for balance review.`;
+  } else {
+    rationale = `Strategic coherence confirmed. ${agentCount} agents contributing, max concentration ${(maxShare * 100).toFixed(0)}%. Reasoning diversity within tolerance.`;
+  }
+
+  const signature = computeAttestationSignature({
+    token: args.token,
+    seal_hash: args.candidate.seal_hash,
+    verdict,
+    rationale,
+  });
+
+  return {
+    seal_id: args.candidate.seal_id,
+    agent: 'ATLAS',
+    verdict,
+    rationale,
+    signature,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────
+// ZEUS — Verification authority
+// ────────────────────────────────────────────────────────────────
+
+export function zeusAttest(args: {
+  candidate: SealCandidate;
+  token: string;
+  hashChainValid: boolean;
+  depositHashesValid: boolean;
+  miiMathValid: boolean;
+}): AttestationSubmission {
+  const failures: string[] = [];
+  if (!args.hashChainValid) failures.push('hash chain broken');
+  if (!args.depositHashesValid) failures.push('deposit hashes unverified');
+  if (!args.miiMathValid) failures.push('MII math inconsistent');
+
+  let verdict: Verdict;
+  let rationale: string;
+
+  if (failures.length > 0) {
+    verdict = 'reject';
+    rationale = `Verification failed: ${failures.join('; ')}. Seal cannot mint — math does not hold.`;
+  } else {
+    verdict = 'pass';
+    rationale = `Verification confirmed. Hash chain valid, deposit hashes verified against journal KV, MII weights computed correctly per v1 scoring formula.`;
+  }
+
+  const signature = computeAttestationSignature({
+    token: args.token,
+    seal_hash: args.candidate.seal_hash,
+    verdict,
+    rationale,
+  });
+
+  return {
+    seal_id: args.candidate.seal_id,
+    agent: 'ZEUS',
+    verdict,
+    rationale,
+    signature,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────
+// EVE — Ethical and civic clearance
+// ────────────────────────────────────────────────────────────────
+
+export function eveAttest(args: {
+  candidate: SealCandidate;
+  token: string;
+  activeNarrativeTripwire: boolean;
+  duplicationRate: number; // 0..1
+  narrativeOverreachConfirmed: boolean;
+}): AttestationSubmission {
+  let verdict: Verdict = 'pass';
+  let rationale: string;
+
+  if (args.narrativeOverreachConfirmed) {
+    verdict = 'reject';
+    rationale = `Confirmed narrative-overreach within cycle window. Seal cannot mint under active civic-risk state.`;
+  } else if (args.activeNarrativeTripwire) {
+    verdict = 'flag';
+    rationale = `Active EVE tripwire state at sealing — no confirmed violation but flagging for civic-risk review. Duplication rate: ${(args.duplicationRate * 100).toFixed(1)}%.`;
+  } else if (args.duplicationRate > 0.35) {
+    verdict = 'flag';
+    rationale = `Elevated duplication rate at ${(args.duplicationRate * 100).toFixed(1)}% (threshold: 35%). Deposits within tolerance but flagging for pattern review.`;
+  } else {
+    rationale = `Ethical clearance confirmed. No active narrative tripwire, duplication rate ${(args.duplicationRate * 100).toFixed(1)}%, no overreach patterns detected.`;
+  }
+
+  const signature = computeAttestationSignature({
+    token: args.token,
+    seal_hash: args.candidate.seal_hash,
+    verdict,
+    rationale,
+  });
+
+  return {
+    seal_id: args.candidate.seal_id,
+    agent: 'EVE',
+    verdict,
+    rationale,
+    signature,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────
+// JADE — Constitutional framing
+// ────────────────────────────────────────────────────────────────
+
+export function jadeAttest(args: {
+  candidate: SealCandidate;
+  token: string;
+  schemaValid: boolean;
+  covenantRoutingValid: boolean;
+  precedentConsistent: boolean;
+}): AttestationSubmission {
+  let verdict: Verdict = 'pass';
+  let rationale: string;
+
+  if (!args.schemaValid) {
+    verdict = 'reject';
+    rationale = `Schema violation detected. Seal structure does not conform to Vault v2 protocol §4.`;
+  } else if (!args.covenantRoutingValid) {
+    verdict = 'reject';
+    rationale = `Covenant routing break. Agent ownership does not preserve constitutional framing.`;
+  } else if (!args.precedentConsistent) {
+    verdict = 'flag';
+    rationale = `Precedent drift noted — Seal shape diverges from Seals [1..N-1] within tolerance. Flagging for JADE review.`;
+  } else {
+    rationale = `Constitutional framing confirmed. Schema matches v2 §4, covenant routing preserved, shape consistent with prior Seals.`;
+  }
+
+  const signature = computeAttestationSignature({
+    token: args.token,
+    seal_hash: args.candidate.seal_hash,
+    verdict,
+    rationale,
+  });
+
+  return {
+    seal_id: args.candidate.seal_id,
+    agent: 'JADE',
+    verdict,
+    rationale,
+    signature,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────
+// AUREA — Synthesis and posture
+// ────────────────────────────────────────────────────────────────
+
+/**
+ * AUREA does not pass/fail/reject. It always submits `pass` with a posture
+ * stamp that influences later Fountain emission weighting.
+ *
+ * Posture rubric:
+ *   - GI >= 0.88 AND mode green → confident
+ *   - GI >= 0.74 AND mode yellow → cautionary
+ *   - GI >= 0.60 AND mode yellow → stressed
+ *   - GI < 0.60 OR mode red → degraded
+ */
+export function aureaAttest(args: {
+  candidate: SealCandidate;
+  token: string;
+}): AttestationSubmission {
+  const { gi_at_seal, mode_at_seal } = args.candidate;
+  let posture: Posture;
+  if (gi_at_seal >= 0.88 && mode_at_seal === 'green') {
+    posture = 'confident';
+  } else if (gi_at_seal >= 0.74 && mode_at_seal === 'yellow') {
+    posture = 'cautionary';
+  } else if (gi_at_seal >= 0.6 && mode_at_seal === 'yellow') {
+    posture = 'stressed';
+  } else {
+    posture = 'degraded';
+  }
+
+  const rationale = `Posture at sealing: ${posture}. GI ${gi_at_seal.toFixed(2)}, mode ${mode_at_seal}. This Seal's future Fountain behavior will be weighted by this posture — see Vault v2 §9.`;
+
+  const verdict: Verdict = 'pass';
+  const signature = computeAttestationSignature({
+    token: args.token,
+    seal_hash: args.candidate.seal_hash,
+    verdict,
+    rationale,
+  });
+
+  return {
+    seal_id: args.candidate.seal_id,
+    agent: 'AUREA',
+    verdict,
+    rationale,
+    signature,
+    posture,
+  };
+}

--- a/lib/vault-v2/deposit.ts
+++ b/lib/vault-v2/deposit.ts
@@ -1,0 +1,180 @@
+/**
+ * Vault v2 deposit path.
+ *
+ * Extends v1's `writeVaultDeposit` (lib/vault/vault.ts) with Seal candidate
+ * formation. The v1 scoring and balance-accrual logic is unchanged — this
+ * module wraps it and triggers candidate formation when the threshold is
+ * crossed.
+ *
+ * Flow:
+ *   1. v1 scores the deposit and writes to vault:deposits list (unchanged)
+ *   2. accrueDepositV2 adds deposit_amount to vault:in_progress_balance
+ *   3. If balance >= 50:
+ *      a. Attempt to form a Seal candidate (may no-op if one already in flight)
+ *      b. Reset in_progress_balance to overflow (balance - 50)
+ *      c. Log the candidate creation
+ *   4. If candidate formation is deferred (another in flight), the deposit
+ *      amount stays in in_progress_balance; it will be included in the NEXT
+ *      candidate once the current one resolves.
+ */
+
+import type { AgentJournalEntry } from '@/lib/terminal/types';
+import { loadGIState } from '@/lib/kv/store';
+import {
+  clearInProgressHashes,
+  getCandidate,
+  getInProgressBalance,
+  readInProgressHashes,
+  setInProgressBalance,
+  writeInProgressHashes,
+} from '@/lib/vault-v2/store';
+import { formCandidate } from '@/lib/vault-v2/seal';
+import type { Mode, SealCandidate } from '@/lib/vault-v2/types';
+
+const THRESHOLD = 50;
+
+export type AccrualResult = {
+  balance_after: number;
+  candidate_formed: SealCandidate | null;
+  candidate_deferred: boolean;
+  overflow: number;
+};
+
+async function readGIAndMode(): Promise<{ gi: number; mode: Mode }> {
+  let gi = 0.74;
+  let mode: Mode = 'yellow';
+  try {
+    const st = await loadGIState();
+    if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
+      gi = Math.max(0, Math.min(1, st.global_integrity));
+    }
+    if (st && (st.mode === 'green' || st.mode === 'yellow' || st.mode === 'red')) {
+      mode = st.mode;
+    }
+  } catch {
+    // defaults
+  }
+  return { gi, mode };
+}
+
+/**
+ * Accrue a deposit to in_progress_balance. If the accrual crosses the
+ * threshold, attempt to form a Seal candidate. Returns the new balance
+ * and the candidate outcome.
+ *
+ * This function is called AFTER v1's writeVaultDeposit has run. It does not
+ * replace v1 — it adds the v2 semantics on top.
+ */
+export async function accrueDepositV2(args: {
+  deposit_amount: number;
+  content_signature: string;
+  cycle: string;
+  agent_entry?: AgentJournalEntry;
+}): Promise<AccrualResult> {
+  const prev = await getInProgressBalance();
+  const next = Number((prev + args.deposit_amount).toFixed(6));
+
+  // Track the content signature for inclusion in the Seal.
+  const hashes = await readInProgressHashes();
+  if (!hashes.includes(args.content_signature)) {
+    hashes.push(args.content_signature);
+    await writeInProgressHashes(hashes);
+  }
+
+  if (next < THRESHOLD) {
+    await setInProgressBalance(next);
+    return {
+      balance_after: next,
+      candidate_formed: null,
+      candidate_deferred: false,
+      overflow: 0,
+    };
+  }
+
+  const overflow = Number((next - THRESHOLD).toFixed(6));
+  const { gi, mode } = await readGIAndMode();
+
+  // Check chain continuity: if a candidate is already in flight, defer.
+  const existingCandidate = await getCandidate();
+  if (existingCandidate) {
+    await setInProgressBalance(next);
+    return {
+      balance_after: next,
+      candidate_formed: null,
+      candidate_deferred: true,
+      overflow,
+    };
+  }
+
+  const candidate = await formCandidate({
+    cycle: args.cycle,
+    gi_at_seal: gi,
+    mode_at_seal: mode,
+    source_entries: hashes.length,
+    deposit_hashes: hashes,
+  });
+
+  if (!candidate) {
+    // Race: another writer formed a candidate between our check and our write.
+    await setInProgressBalance(next);
+    return {
+      balance_after: next,
+      candidate_formed: null,
+      candidate_deferred: true,
+      overflow,
+    };
+  }
+
+  await setInProgressBalance(overflow);
+  await clearInProgressHashes();
+
+  console.info('[vault-v2] seal candidate formed', {
+    seal_id: candidate.seal_id,
+    sequence: candidate.sequence,
+    gi_at_seal: gi,
+    source_entries: candidate.source_entries,
+    overflow_carried: overflow,
+  });
+
+  return {
+    balance_after: overflow,
+    candidate_formed: candidate,
+    candidate_deferred: false,
+    overflow,
+  };
+}
+
+/**
+ * Called by the attestation cron when a candidate finalizes. If there's
+ * queued reserve from deposits that arrived during attestation, this
+ * triggers the NEXT candidate formation immediately.
+ */
+export async function tryFormNextCandidate(args: { cycle: string }): Promise<SealCandidate | null> {
+  const balance = await getInProgressBalance();
+  if (balance < THRESHOLD) return null;
+
+  const existing = await getCandidate();
+  if (existing) return null;
+
+  const { gi, mode } = await readGIAndMode();
+  const hashes = await readInProgressHashes();
+
+  const candidate = await formCandidate({
+    cycle: args.cycle,
+    gi_at_seal: gi,
+    mode_at_seal: mode,
+    source_entries: hashes.length,
+    deposit_hashes: hashes,
+  });
+
+  if (candidate) {
+    const overflow = Number((balance - THRESHOLD).toFixed(6));
+    await setInProgressBalance(overflow);
+    await clearInProgressHashes();
+    console.info('[vault-v2] next candidate formed from queued reserve', {
+      seal_id: candidate.seal_id,
+      overflow_carried: overflow,
+    });
+  }
+  return candidate;
+}

--- a/lib/vault-v2/seal.ts
+++ b/lib/vault-v2/seal.ts
@@ -1,0 +1,380 @@
+/**
+ * Seal lifecycle — candidate formation, hash computation, quorum evaluation,
+ * mint/quarantine/reject transitions.
+ *
+ * Hash computation and quorum evaluation are pure. The only side-effecting
+ * functions are formCandidate, finalizeSeal, and injectTimeouts, which are
+ * called explicitly by the deposit path or the attestation cron.
+ */
+
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import {
+  appendSealToChain,
+  clearCandidate,
+  getCandidate,
+  getLatestSeal,
+  listSealIds,
+  writeCandidate,
+  writeSeal,
+} from '@/lib/vault-v2/store';
+import type {
+  AttestationSubmission,
+  Mode,
+  Seal,
+  SealAttestation,
+  SealCandidate,
+  SentinelAgent,
+  Verdict,
+} from '@/lib/vault-v2/types';
+import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
+
+const ATTESTATION_TIMEOUT_MS = 5 * 60 * 1000; // 5 min per spec §6
+
+// ────────────────────────────────────────────────────────────────
+// Hash chain
+// ────────────────────────────────────────────────────────────────
+
+type CanonicalFields = {
+  seal_id: string;
+  sequence: number;
+  cycle_at_seal: string;
+  sealed_at: string;
+  reserve: 50;
+  gi_at_seal: number;
+  mode_at_seal: Mode;
+  source_entries: number;
+  deposit_hashes: string[];
+  prev_seal_hash: string | null;
+};
+
+/**
+ * Canonical serialization for hashing. Order matters — every field in this
+ * exact order, no extras, no missing. Changing this shape breaks the chain.
+ * Spec §7.
+ */
+function canonicalize(fields: CanonicalFields): string {
+  return JSON.stringify([
+    fields.seal_id,
+    fields.sequence,
+    fields.cycle_at_seal,
+    fields.sealed_at,
+    fields.reserve,
+    Number(fields.gi_at_seal.toFixed(6)),
+    fields.mode_at_seal,
+    fields.source_entries,
+    [...fields.deposit_hashes].sort(),
+    fields.prev_seal_hash,
+  ]);
+}
+
+export function computeSealHash(fields: CanonicalFields): string {
+  return createHash('sha256').update(canonicalize(fields)).digest('hex');
+}
+
+/**
+ * Verify a Seal's hash matches its declared fields. ZEUS uses this during
+ * attestation to check cryptographic integrity.
+ */
+export function verifySealHash(seal: Seal): boolean {
+  const recomputed = computeSealHash({
+    seal_id: seal.seal_id,
+    sequence: seal.sequence,
+    cycle_at_seal: seal.cycle_at_seal,
+    sealed_at: seal.sealed_at,
+    reserve: seal.reserve,
+    gi_at_seal: seal.gi_at_seal,
+    mode_at_seal: seal.mode_at_seal,
+    source_entries: seal.source_entries,
+    deposit_hashes: seal.deposit_hashes,
+    prev_seal_hash: seal.prev_seal_hash,
+  });
+  return recomputed === seal.seal_hash;
+}
+
+// ────────────────────────────────────────────────────────────────
+// Attestation signatures
+// ────────────────────────────────────────────────────────────────
+
+/**
+ * HMAC-SHA256(AGENT_SERVICE_TOKEN, seal_hash :: verdict :: rationale).
+ * Agents compute this with the shared service token; the server verifies
+ * using the same token.
+ */
+export function computeAttestationSignature(args: {
+  token: string;
+  seal_hash: string;
+  verdict: Verdict;
+  rationale: string;
+}): string {
+  const payload = `${args.seal_hash}::${args.verdict}::${args.rationale}`;
+  return createHmac('sha256', args.token).update(payload).digest('hex');
+}
+
+export function verifyAttestationSignature(
+  token: string,
+  submission: AttestationSubmission,
+  seal_hash: string,
+): boolean {
+  const expected = computeAttestationSignature({
+    token,
+    seal_hash,
+    verdict: submission.verdict,
+    rationale: submission.rationale,
+  });
+  if (expected.length !== submission.signature.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(submission.signature, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────
+// Candidate formation
+// ────────────────────────────────────────────────────────────────
+
+/**
+ * Called by the deposit path when in_progress_balance crosses 50.
+ * Creates a SealCandidate, persists it, and returns it for observation.
+ *
+ * Returns null if a candidate is already in flight — deposits queue until
+ * the current candidate resolves (spec §11.3, chain continuity).
+ */
+export async function formCandidate(args: {
+  cycle: string;
+  gi_at_seal: number;
+  mode_at_seal: Mode;
+  source_entries: number;
+  deposit_hashes: string[];
+}): Promise<SealCandidate | null> {
+  const existing = await getCandidate();
+  if (existing) return null;
+
+  const prevSeal = await getLatestSeal();
+  const sequence = (prevSeal?.sequence ?? 0) + 1;
+  const prev_seal_hash = prevSeal?.seal_hash ?? null;
+  const sealed_at = new Date().toISOString();
+  const seal_id = formatSealId(args.cycle, sequence);
+
+  const seal_hash = computeSealHash({
+    seal_id,
+    sequence,
+    cycle_at_seal: args.cycle,
+    sealed_at,
+    reserve: 50,
+    gi_at_seal: args.gi_at_seal,
+    mode_at_seal: args.mode_at_seal,
+    source_entries: args.source_entries,
+    deposit_hashes: args.deposit_hashes,
+    prev_seal_hash,
+  });
+
+  const requested_at = sealed_at;
+  const timeout_at = new Date(Date.now() + ATTESTATION_TIMEOUT_MS).toISOString();
+
+  const candidate: SealCandidate = {
+    seal_id,
+    sequence,
+    cycle_at_seal: args.cycle,
+    sealed_at,
+    reserve: 50,
+    gi_at_seal: args.gi_at_seal,
+    mode_at_seal: args.mode_at_seal,
+    source_entries: args.source_entries,
+    deposit_hashes: args.deposit_hashes,
+    prev_seal_hash,
+    seal_hash,
+    attestations: {},
+    posture: null,
+    requested_at,
+    timeout_at,
+    status: 'forming',
+  };
+
+  await writeCandidate(candidate);
+  return candidate;
+}
+
+function formatSealId(cycle: string, sequence: number): string {
+  const paddedSeq = String(sequence).padStart(3, '0');
+  return `seal-${cycle}-${paddedSeq}`;
+}
+
+// ────────────────────────────────────────────────────────────────
+// Quorum evaluation
+// ────────────────────────────────────────────────────────────────
+
+export type QuorumResult =
+  | { decision: 'attested' }
+  | { decision: 'quarantined'; reasons: string[] }
+  | { decision: 'rejected'; rejecter: SentinelAgent; rationale: string }
+  | { decision: 'waiting'; missing: SentinelAgent[] };
+
+/**
+ * Applies spec §6 quorum rules:
+ *   - ZEUS reject → rejected (absolute)
+ *   - All attestations present, ZEUS pass, ≥ 4 pass, no non-ZEUS reject → attested
+ *   - All attestations present, otherwise → quarantined
+ *   - Missing attestations → waiting
+ *
+ * Timeouts are injected by the cron as `flag: timeout` before this is called.
+ */
+export function evaluateQuorum(candidate: SealCandidate): QuorumResult {
+  const attestations = candidate.attestations;
+
+  const zeus = attestations.ZEUS;
+  if (zeus?.verdict === 'reject') {
+    return {
+      decision: 'rejected',
+      rejecter: 'ZEUS',
+      rationale: zeus.rationale,
+    };
+  }
+
+  const missing: SentinelAgent[] = [];
+  for (const agent of SENTINEL_AGENTS) {
+    if (!attestations[agent]) missing.push(agent);
+  }
+  if (missing.length > 0) {
+    return { decision: 'waiting', missing };
+  }
+
+  if (zeus?.verdict !== 'pass') {
+    return {
+      decision: 'quarantined',
+      reasons: ['ZEUS did not pass'],
+    };
+  }
+
+  let passes = 0;
+  const nonZeusRejects: SentinelAgent[] = [];
+  for (const agent of SENTINEL_AGENTS) {
+    const a = attestations[agent];
+    if (!a) continue;
+    if (a.verdict === 'pass') passes += 1;
+    if (agent !== 'ZEUS' && a.verdict === 'reject') nonZeusRejects.push(agent);
+  }
+
+  if (nonZeusRejects.length > 0) {
+    return {
+      decision: 'quarantined',
+      reasons: nonZeusRejects.map((r) => `${r} rejected`),
+    };
+  }
+
+  if (passes < 4) {
+    return {
+      decision: 'quarantined',
+      reasons: [`only ${passes}/5 passes — quorum requires 4`],
+    };
+  }
+
+  return { decision: 'attested' };
+}
+
+// ────────────────────────────────────────────────────────────────
+// Seal finalization
+// ────────────────────────────────────────────────────────────────
+
+/**
+ * Called by the attestation cron after quorum reaches a terminal state.
+ * Promotes the candidate to a Seal (attested, quarantined, or rejected),
+ * writes to KV, and clears the candidate slot so the next parcel can fill.
+ *
+ * Returns the finalized Seal, or null if no candidate exists or decision
+ * is not terminal.
+ */
+export async function finalizeSeal(decision: QuorumResult): Promise<Seal | null> {
+  const candidate = await getCandidate();
+  if (!candidate) return null;
+
+  let status: Seal['status'];
+  switch (decision.decision) {
+    case 'attested':
+      status = 'attested';
+      break;
+    case 'quarantined':
+      status = 'quarantined';
+      break;
+    case 'rejected':
+      status = 'rejected';
+      break;
+    case 'waiting':
+      return null;
+  }
+
+  const aurea = candidate.attestations.AUREA;
+  const seal: Seal = {
+    seal_id: candidate.seal_id,
+    sequence: candidate.sequence,
+    cycle_at_seal: candidate.cycle_at_seal,
+    sealed_at: candidate.sealed_at,
+    reserve: candidate.reserve,
+    gi_at_seal: candidate.gi_at_seal,
+    mode_at_seal: candidate.mode_at_seal,
+    source_entries: candidate.source_entries,
+    deposit_hashes: candidate.deposit_hashes,
+    prev_seal_hash: candidate.prev_seal_hash,
+    seal_hash: candidate.seal_hash,
+    attestations: candidate.attestations,
+    status,
+    fountain_status: 'pending',
+    fountain_emitted_at: null,
+    posture: aurea?.posture ?? candidate.posture ?? null,
+  };
+
+  // Only attested seals join the chain; quarantined/rejected seals are
+  // written but not appended to the index (they do not advance the chain).
+  if (status === 'attested') {
+    await appendSealToChain(seal);
+  } else {
+    await writeSeal(seal);
+  }
+
+  await clearCandidate();
+  return seal;
+}
+
+// ────────────────────────────────────────────────────────────────
+// Timeout injection
+// ────────────────────────────────────────────────────────────────
+
+/**
+ * Cron-callable. For a candidate past its timeout_at with missing attestations,
+ * inject `flag: timeout` for each missing agent so quorum can be evaluated.
+ * Returns the updated candidate, or null if no candidate or not yet timed out.
+ */
+export async function injectTimeouts(now: number = Date.now()): Promise<SealCandidate | null> {
+  const candidate = await getCandidate();
+  if (!candidate) return null;
+  if (new Date(candidate.timeout_at).getTime() > now) return null;
+
+  const injected: Partial<Record<SentinelAgent, SealAttestation>> = { ...candidate.attestations };
+  for (const agent of SENTINEL_AGENTS) {
+    if (!injected[agent]) {
+      const stamp: SealAttestation = {
+        agent,
+        verdict: 'flag',
+        rationale: 'timeout',
+        mii_at_attestation: 0,
+        gi_at_attestation: 0,
+        timestamp: new Date(now).toISOString(),
+        signature: 'timeout',
+      };
+      injected[agent] = stamp;
+    }
+  }
+
+  const next: SealCandidate = { ...candidate, attestations: injected };
+  await writeCandidate(next);
+  return next;
+}
+
+// ────────────────────────────────────────────────────────────────
+// Convenience: counters for UI / ops surfaces
+// ────────────────────────────────────────────────────────────────
+
+export async function countAttestedSeals(): Promise<number> {
+  // Index only contains attested seals (by design — see finalizeSeal).
+  return (await listSealIds()).length;
+}

--- a/lib/vault-v2/store.ts
+++ b/lib/vault-v2/store.ts
@@ -1,0 +1,258 @@
+/**
+ * Vault v2 KV store.
+ *
+ * Key layout:
+ *   vault:in_progress_balance        → number, running accumulator 0..<50
+ *   vault:in_progress_hashes         → content sigs accruing into next seal
+ *   vault:seals:index                → ordered array of seal_ids
+ *   vault:seal:latest                → most recent seal_id (quick chain access)
+ *   vault:seal:{seal_id}             → full Seal record
+ *   vault:seal:candidate             → in-flight SealCandidate awaiting attestations
+ *
+ * All keys use RAW Redis key names (no `mobius:` prefix) — distinct namespace
+ * from v1 `mobius:vault:global:*` keys. v1 keys remain untouched.
+ */
+
+import { Redis } from '@upstash/redis';
+import type { Seal, SealAttestation, SealCandidate, SentinelAgent } from '@/lib/vault-v2/types';
+
+const BALANCE_KEY = 'vault:in_progress_balance';
+const IN_PROGRESS_HASHES_KEY = 'vault:in_progress_hashes';
+const SEALS_INDEX_KEY = 'vault:seals:index';
+const LATEST_SEAL_KEY = 'vault:seal:latest';
+const CANDIDATE_KEY = 'vault:seal:candidate';
+
+function sealKey(seal_id: string): string {
+  return `vault:seal:${seal_id}`;
+}
+
+function getRedis(): Redis | null {
+  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  try {
+    return new Redis({ url, token });
+  } catch {
+    return null;
+  }
+}
+
+function parseMaybeJson<T>(raw: unknown): T | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      return null;
+    }
+  }
+  return raw as T;
+}
+
+// ────────────────────────────────────────────────────────────────
+// Balance (in-progress accumulator)
+// ────────────────────────────────────────────────────────────────
+
+export async function getInProgressBalance(): Promise<number> {
+  const redis = getRedis();
+  if (!redis) return 0;
+  try {
+    const raw = await redis.get<number | string>(BALANCE_KEY);
+    if (typeof raw === 'number') return raw;
+    if (typeof raw === 'string') {
+      const parsed = Number(raw);
+      return Number.isFinite(parsed) ? parsed : 0;
+    }
+    return 0;
+  } catch {
+    return 0;
+  }
+}
+
+export async function setInProgressBalance(balance: number): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    await redis.set(BALANCE_KEY, Number(balance.toFixed(6)));
+  } catch (err) {
+    console.warn('[vault-v2:store] setInProgressBalance failed:', err instanceof Error ? err.message : err);
+  }
+}
+
+// ────────────────────────────────────────────────────────────────
+// In-progress content signatures (tracked for inclusion in next seal)
+// ────────────────────────────────────────────────────────────────
+
+export async function readInProgressHashes(): Promise<string[]> {
+  const redis = getRedis();
+  if (!redis) return [];
+  try {
+    const raw = await redis.get<string[] | string>(IN_PROGRESS_HASHES_KEY);
+    if (Array.isArray(raw)) return raw;
+    const parsed = parseMaybeJson<string[]>(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function writeInProgressHashes(hashes: string[]): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    await redis.set(IN_PROGRESS_HASHES_KEY, hashes);
+  } catch (err) {
+    console.warn('[vault-v2:store] writeInProgressHashes failed:', err instanceof Error ? err.message : err);
+  }
+}
+
+export async function clearInProgressHashes(): Promise<void> {
+  await writeInProgressHashes([]);
+}
+
+// ────────────────────────────────────────────────────────────────
+// Seal index + chain access
+// ────────────────────────────────────────────────────────────────
+
+export async function listSealIds(): Promise<string[]> {
+  const redis = getRedis();
+  if (!redis) return [];
+  try {
+    const raw = await redis.get<string[] | string>(SEALS_INDEX_KEY);
+    if (Array.isArray(raw)) return raw;
+    const parsed = parseMaybeJson<string[]>(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function countSeals(): Promise<number> {
+  const ids = await listSealIds();
+  return ids.length;
+}
+
+export async function getLatestSealId(): Promise<string | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+  try {
+    const raw = await redis.get<string>(LATEST_SEAL_KEY);
+    return typeof raw === 'string' && raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function getLatestSeal(): Promise<Seal | null> {
+  const id = await getLatestSealId();
+  if (!id) return null;
+  return getSeal(id);
+}
+
+export async function getSeal(seal_id: string): Promise<Seal | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+  try {
+    const raw = await redis.get<Seal | string>(sealKey(seal_id));
+    if (raw && typeof raw === 'object') return raw as Seal;
+    const parsed = parseMaybeJson<Seal>(raw);
+    return parsed ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function listSeals(limit = 50): Promise<Seal[]> {
+  const ids = await listSealIds();
+  const recent = ids.slice(-limit);
+  const results = await Promise.all(recent.map((id) => getSeal(id)));
+  return results.filter((s): s is Seal => s !== null).reverse();
+}
+
+/**
+ * Append a new Seal to the index and mark it latest.
+ * Caller is responsible for validating hash chain integrity before calling.
+ */
+export async function appendSealToChain(seal: Seal): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    const ids = await listSealIds();
+    if (!ids.includes(seal.seal_id)) {
+      ids.push(seal.seal_id);
+      await redis.set(SEALS_INDEX_KEY, ids);
+    }
+    await redis.set(sealKey(seal.seal_id), seal);
+    await redis.set(LATEST_SEAL_KEY, seal.seal_id);
+  } catch (err) {
+    console.warn('[vault-v2:store] appendSealToChain failed:', err instanceof Error ? err.message : err);
+  }
+}
+
+/**
+ * Update/write a Seal record. Does not modify index or latest pointer.
+ * Used for quarantined/rejected seals and for fountain_status transitions.
+ */
+export async function writeSeal(seal: Seal): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    await redis.set(sealKey(seal.seal_id), seal);
+  } catch (err) {
+    console.warn('[vault-v2:store] writeSeal failed:', err instanceof Error ? err.message : err);
+  }
+}
+
+// ────────────────────────────────────────────────────────────────
+// Candidate (in-flight Seal awaiting attestations)
+// ────────────────────────────────────────────────────────────────
+
+export async function getCandidate(): Promise<SealCandidate | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+  try {
+    const raw = await redis.get<SealCandidate | string>(CANDIDATE_KEY);
+    if (raw && typeof raw === 'object') return raw as SealCandidate;
+    const parsed = parseMaybeJson<SealCandidate>(raw);
+    return parsed ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeCandidate(candidate: SealCandidate): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    await redis.set(CANDIDATE_KEY, candidate);
+  } catch (err) {
+    console.warn('[vault-v2:store] writeCandidate failed:', err instanceof Error ? err.message : err);
+  }
+}
+
+export async function recordAttestation(
+  seal_id: string,
+  agent: SentinelAgent,
+  attestation: SealAttestation,
+): Promise<SealCandidate | null> {
+  const current = await getCandidate();
+  if (!current || current.seal_id !== seal_id) return null;
+
+  const next: SealCandidate = {
+    ...current,
+    attestations: { ...current.attestations, [agent]: attestation },
+    posture: agent === 'AUREA' && attestation.posture ? attestation.posture : current.posture,
+  };
+  await writeCandidate(next);
+  return next;
+}
+
+export async function clearCandidate(): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    await redis.del(CANDIDATE_KEY);
+  } catch (err) {
+    console.warn('[vault-v2:store] clearCandidate failed:', err instanceof Error ? err.message : err);
+  }
+}

--- a/lib/vault-v2/types.ts
+++ b/lib/vault-v2/types.ts
@@ -1,0 +1,122 @@
+/**
+ * Vault v2 — Sealed Reserve types.
+ *
+ * Spec: docs/protocols/vault-v2-sealed-reserve.md
+ *
+ * Each Seal is a discrete 50-unit reserve parcel with five independent
+ * Sentinel attestations. Hash-chained to its predecessor.
+ */
+
+export type SentinelAgent = 'ATLAS' | 'ZEUS' | 'EVE' | 'JADE' | 'AUREA';
+
+export const SENTINEL_AGENTS: readonly SentinelAgent[] = [
+  'ATLAS',
+  'ZEUS',
+  'EVE',
+  'JADE',
+  'AUREA',
+] as const;
+
+export type SealStatus =
+  | 'forming' // candidate created, awaiting attestations
+  | 'attested' // quorum passed, Seal minted
+  | 'quarantined' // quorum failed (non-ZEUS), awaiting operator review
+  | 'rejected'; // ZEUS rejected, auto-dissolve in 24h
+
+export type FountainStatus =
+  | 'pending' // attested, GI conditions not yet met
+  | 'activating' // GI sustain window in progress
+  | 'emitted' // Fountain drained this Seal
+  | 'expired'; // 90 cycles without activation
+
+export type Verdict = 'pass' | 'flag' | 'reject';
+
+export type Posture = 'confident' | 'cautionary' | 'stressed' | 'degraded';
+
+export type Mode = 'green' | 'yellow' | 'red';
+
+/**
+ * AUREA's attestation carries a posture stamp in addition to the standard
+ * verdict fields. Other agents omit this field.
+ */
+export type SealAttestation = {
+  agent: SentinelAgent;
+  verdict: Verdict;
+  rationale: string;
+  mii_at_attestation: number;
+  gi_at_attestation: number;
+  timestamp: string;
+  signature: string;
+  /** AUREA only. Undefined for other agents. */
+  posture?: Posture;
+};
+
+export type Seal = {
+  seal_id: string;
+  sequence: number;
+  cycle_at_seal: string;
+  sealed_at: string;
+  reserve: 50;
+  gi_at_seal: number;
+  mode_at_seal: Mode;
+  source_entries: number;
+  deposit_hashes: string[];
+  prev_seal_hash: string | null;
+  seal_hash: string;
+  attestations: Partial<Record<SentinelAgent, SealAttestation>>;
+  status: SealStatus;
+  fountain_status: FountainStatus;
+  fountain_emitted_at: string | null;
+  /** AUREA's posture, copied out of attestations for quick lookup. */
+  posture: Posture | null;
+};
+
+/**
+ * A Seal candidate is the pre-attestation record. Once all attestations are
+ * collected and quorum evaluated, it transitions into a full Seal.
+ */
+export type SealCandidate = {
+  seal_id: string;
+  sequence: number;
+  cycle_at_seal: string;
+  sealed_at: string;
+  reserve: 50;
+  gi_at_seal: number;
+  mode_at_seal: Mode;
+  source_entries: number;
+  deposit_hashes: string[];
+  prev_seal_hash: string | null;
+  seal_hash: string;
+  attestations: Partial<Record<SentinelAgent, SealAttestation>>;
+  posture: Posture | null;
+  status: 'forming';
+  requested_at: string;
+  timeout_at: string;
+};
+
+/**
+ * Attestation request payload sent to Sentinel agents.
+ * Agent responds via POST /api/vault/seal/attest.
+ */
+export type AttestationRequest = {
+  seal_id: string;
+  seal_hash: string;
+  sequence: number;
+  cycle_at_seal: string;
+  gi_at_seal: number;
+  source_entries: number;
+  deposit_hashes: string[];
+  prev_seal_hash: string | null;
+  requested_at: string;
+  timeout_at: string;
+};
+
+export type AttestationSubmission = {
+  seal_id: string;
+  agent: SentinelAgent;
+  verdict: Verdict;
+  rationale: string;
+  signature: string;
+  /** Required only from AUREA. */
+  posture?: Posture;
+};

--- a/lib/vault/vault.ts
+++ b/lib/vault/vault.ts
@@ -6,6 +6,7 @@
 import { Redis } from '@upstash/redis';
 import type { AgentJournalEntry } from '@/lib/terminal/types';
 import { kvGet, kvSet, loadGIState } from '@/lib/kv/store';
+import { accrueDepositV2 } from '@/lib/vault-v2/deposit';
 
 const BALANCE_KEY = 'vault:global:balance';
 const META_KEY = 'vault:global:meta';
@@ -228,6 +229,23 @@ export async function recordVaultDepositsForCouncil(
         content_signature: sig,
       };
       await writeVaultDeposit(deposit);
+
+      // Vault v2 — accrue to in_progress_balance and possibly form a Seal
+      // candidate. Non-fatal: failures here must never break v1 accrual.
+      try {
+        await accrueDepositV2({
+          deposit_amount: amount,
+          content_signature: sig,
+          cycle: entry.cycle ?? 'C-?',
+          agent_entry: entry,
+        });
+      } catch (err) {
+        console.warn(
+          '[vault-v2] accrueDepositV2 failed (non-fatal):',
+          err instanceof Error ? err.message : err,
+        );
+      }
+
       deposited += 1;
     } catch {
       errors += 1;

--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,10 @@
     {
       "path": "/api/cron/gi-refresh",
       "schedule": "45 0 * * *"
+    },
+    {
+      "path": "/api/cron/vault-attestation",
+      "schedule": "*/2 * * * *"
     }
   ],
   "installCommand": "pnpm install --no-frozen-lockfile"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Mobius PR — Cycle

- **Cycle:** C-284
- **Type:** Feature (protocol upgrade)
- **Primary Area(s):** packages (`lib/vault-v2/`), apps (`app/api/vault/seal/*`, `app/api/cron/vault-attestation`), docs
- **Pulse Attached:** ⬜

---

## 1. Summary

Replaces the continuous 50-unit Vault threshold with a rhythm of discrete, hash-chained, Sentinel-attested **Seals**. Each 50-unit parcel seals into a durable civic unit, witnessed by five Sentinels (ATLAS, ZEUS, EVE, JADE, AUREA) before the next parcel begins filling. Fountain semantics become per-Seal rather than one-shot — the substrate acquires a heartbeat.

No v1 behavior is removed. `mobius:vault:global:*` keys are untouched. v2 lives in its own `vault:*` namespace and is gated behind the natural next accrual crossing 50.

---

## 2. Details

- **Motivation:** v1's single dramatic threshold (50 → Fountain activation) reframes the reserve as one moment. Doctrine says "reserve becomes flow *when* integrity holds" — that reads better as a repeating cycle than a one-time unlock.
- **Solution:** Discrete 50-unit Seals, each with its own seal_id, cycle, GI-at-seal, posture, and full attestation chain. Hash-chained to the prior Seal via `prev_seal_hash`. Overflow carries into the next parcel.
- **Architecture impact:** New library (`lib/vault-v2/`), three new API routes, one new cron (2-min cadence), status endpoint extended. v1 deposit path wired via non-fatal call to `accrueDepositV2` inside `recordVaultDepositsForCouncil`.
- **Breaking changes:** None. v1 `balance_reserve` field and `mobius:vault:global:*` keys are preserved verbatim during the C-284 → C-285 compatibility window.

### Seal structure (§4)

```
Seal {
  seal_id, sequence, cycle_at_seal, sealed_at,
  reserve: 50, gi_at_seal, mode_at_seal,
  source_entries, deposit_hashes,
  prev_seal_hash, seal_hash,          # sha256 over canonical fields
  attestations: { ATLAS, ZEUS, EVE, JADE, AUREA },
  status: forming | attested | quarantined | rejected,
  fountain_status: pending | activating | emitted | expired,
  posture: confident | cautionary | stressed | degraded | null,
}
```

### Quorum rules (§6)

- **ZEUS reject → rejected** (absolute veto — math must hold)
- **All 5 attestations + ZEUS pass + ≥ 4 pass + no non-ZEUS reject → attested**
- Otherwise (with ZEUS pass) → **quarantined** (awaits operator review)
- Missing attestations past 5-minute window → cron injects `flag: timeout`
- AUREA always attests `pass` with a posture stamp (never blocks)

### Sentinel attestation scopes (§5)

| Sentinel | Dimension               | Reject?   |
|----------|-------------------------|-----------|
| ATLAS    | Strategic coherence     | Never     |
| ZEUS    | Verification authority   | Math only |
| EVE      | Ethical / civic clearance | Narrative-overreach |
| JADE     | Constitutional framing  | Schema/covenant |
| AUREA    | Synthesis / posture     | Never — stamps only |

---

## 3. Integrity & Safety

- **GI Impact:** Non-degrading. Vault v2 reads GI via existing `loadGIState()` — it does not *write* GI.
- **MII Impact:** Attestations optionally record `mii_at_attestation` per agent. Does not alter MII feed semantics.
- **Risk surface:**
  - New Redis namespace (`vault:*`) — distinct from v1 keys, isolated blast radius
  - New authed write path (`POST /api/vault/seal/attest`) — gated by existing `AGENT_SERVICE_TOKEN` bearer + HMAC-SHA256 signature on the seal hash
  - New cron (`*/2 * * * *`) — idempotent, guarded by `x-vercel-cron` header or `CRON_SECRET` bearer
- **Sentinel review:** Per the protocol, future Sentinel cycles will attest on this PR's sealing artifacts. For this code PR:
  - ATLAS: ⬜ (library/spec PR — no live seal yet)
  - AUREA: ⬜
  - ECHO: ⬜

---

## 4. Mobius Pulse

Not generated for this PR. Recommended for the first live Seal when in_progress_balance first crosses 50.

---

## 5. Tests

- ✅ `pnpm exec tsc --noEmit` — pass
- ✅ `pnpm build` — pass, all 4 new routes compile (`/api/vault/seal`, `/api/vault/seal/[id]`, `/api/vault/seal/attest`, `/api/cron/vault-attestation`)
- ✅ Pure-function smoke tests (hash stability, tamper detection, signature round-trip, quorum rule table) — see summary below
- ✅ Dev-server endpoint smoke tests — auth gates enforced, status payload includes both v1 and v2 fields, candidate state empty-initial, seal-by-id 404s cleanly

Test output (abbreviated):
```
hash stable across hash order? true
hash changes on tamper?        true
sig verifies?                  true
sig rejects wrong rationale?   true
sig rejects wrong token?       true
5 pass                    → attested
4 pass + 1 flag (non-ZEUS) → attested
3 pass + 2 flag           → quarantined (only 3 passes)
ZEUS reject               → rejected
EVE reject                → quarantined (EVE)
missing ATLAS             → waiting
```

Live endpoint smoke (no KV in dev):
```
GET  /api/vault/status        → 200 { vault_version: 2, balance_reserve: 0, in_progress_balance: 0, seals_count: 0, ... }
GET  /api/vault/seal          → 200 { total: 0, candidate: null, seals: [] }
GET  /api/vault/seal/<id>     → 404 Not found
POST /api/vault/seal/attest   → 401 Unauthorized (no token)
GET  /api/cron/vault-attestation                     → 403 Cron-only
GET  /api/cron/vault-attestation (x-vercel-cron: 1)  → 200 { candidate_state: 'none', seals_total: 0, ... }
```

---

## 6. Checklist

- [x] MCP Enforcer: typecheck + build pass
- [x] Security: attestation endpoint HMAC-verifies signature before writing; cron endpoint requires vercel-cron header or secret
- [x] Docs: canonical spec committed at `docs/protocols/vault-v2-sealed-reserve.md`
- [ ] Pulse generated — not required for spec PR
- [ ] Sentinel review — requested after merge

---

## What's deliberately not shipped in v2.0

- **Fountain emission per-Seal.** `fountain_status` field tracked but actual economic emission mechanism is v2.1 territory.
- **Substrate archive writer.** Seals should be mirrored to `Mobius-Substrate/journals/vault/seals/{seal_id}.json` — separate PR.
- **UI for sealed Seals.** The Vault chamber needs a new "Completed Seals" panel consuming `/api/vault/seal`.
- **Operator override UI for quarantined Seals.** API surface is ready (status is writeable); no UI yet.
- **Agent-side attestation hook-ins.** The helpers in `lib/vault-v2/attest.ts` are importable by each Sentinel's cycle-synthesize route, but the wire-in is per-agent and lives in those repos/routes. Until all 5 agent hook-ins are in place, the cron will inject `flag: timeout` at 5 min and quorum will fail for missing agents (seals will quarantine until the council is fully live).

---

## Rollback

```bash
git revert <merge-sha>
# v2 KV keys are orphaned but harmless (distinct namespace). Optional cleanup:
# redis-cli DEL vault:in_progress_balance vault:in_progress_hashes \
#   vault:seals:index vault:seal:latest vault:seal:candidate
# redis-cli --scan --pattern 'vault:seal:*' | xargs -r redis-cli DEL
```

---

*Vault v2 · Cathedral now has a heartbeat. Each Seal is a pulse.*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f210318-1872-44d9-9230-e8ebe6219bf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f210318-1872-44d9-9230-e8ebe6219bf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

