### PR TITLE
Vault v2 — per-sentinel attestation secrets for Seal Council

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,15 @@ NEXT_PUBLIC_LAB7_URL=https://lab7-proof.onrender.com
 RENDER_IDENTITY_URL=https://mobius-identity-service.onrender.com
 RENDER_MIC_URL=https://mobius-mic-wallet-service.onrender.com
 RENDER_LEDGER_URL=https://civic-protocol-core-ledger.onrender.com
-# Identity JWT for ledger attest + /ledger/events + MIC earn (falls back to RENDER_API_KEY)
+# Vault v2 per-sentinel attestation secrets (preferred for Seal Council HMAC + bearer)
+VAULT_ATLAS_SECRET_TOKEN=
+VAULT_ZEUS_SECRET_TOKEN=
+VAULT_EVE_SECRET_TOKEN=
+VAULT_JADE_SECRET_TOKEN=
+VAULT_AUREA_SECRET_TOKEN=
+
+# Legacy shared token: ledger attest + /ledger/events + MIC earn (falls back to RENDER_API_KEY);
+# also used as Vault v2 migration fallback when per-sentinel Vault secrets are unset
 AGENT_SERVICE_TOKEN=
 MIC_WALLET_URL=https://mobius-mic-wallet-service.onrender.com
 IDENTITY_SERVICE_URL=https://mobius-identity-service.onrender.com

--- a/app/api/vault/seal/attest/route.ts
+++ b/app/api/vault/seal/attest/route.ts
@@ -2,7 +2,8 @@
  * POST /api/vault/seal/attest
  *
  * Agent endpoint. A Sentinel submits its attestation for the current in-flight
- * Seal candidate. Authed with AGENT_SERVICE_TOKEN (bearer).
+ * Seal candidate. Bearer auth uses that sentinel's Vault secret (see
+ * `getVaultAttestationToken`), with legacy fallback to AGENT_SERVICE_TOKEN.
  *
  * Body:
  *   {
@@ -24,6 +25,7 @@
 
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { bearerMatchesToken, getVaultAttestationToken } from '@/lib/vault-v2/auth';
 import { getCandidate, recordAttestation } from '@/lib/vault-v2/store';
 import { verifyAttestationSignature } from '@/lib/vault-v2/seal';
 import type {
@@ -36,20 +38,6 @@ import type {
 import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
 
 export const dynamic = 'force-dynamic';
-
-const AGENT_TOKEN = process.env.AGENT_SERVICE_TOKEN || '';
-
-function authed(req: NextRequest): boolean {
-  if (!AGENT_TOKEN) return false;
-  const header = req.headers.get('authorization') || '';
-  const bearer = header.startsWith('Bearer ') ? header.slice(7) : '';
-  if (bearer.length !== AGENT_TOKEN.length) return false;
-  let diff = 0;
-  for (let i = 0; i < bearer.length; i++) {
-    diff |= bearer.charCodeAt(i) ^ AGENT_TOKEN.charCodeAt(i);
-  }
-  return diff === 0;
-}
 
 function validate(raw: unknown): AttestationSubmission | string {
   if (!raw || typeof raw !== 'object') return 'body must be an object';
@@ -95,10 +83,6 @@ function validate(raw: unknown): AttestationSubmission | string {
 }
 
 export async function POST(req: NextRequest) {
-  if (!authed(req)) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
   let body: unknown;
   try {
     body = await req.json();
@@ -109,6 +93,18 @@ export async function POST(req: NextRequest) {
   const submission = validate(body);
   if (typeof submission === 'string') {
     return NextResponse.json({ error: submission }, { status: 400 });
+  }
+
+  const agentToken = getVaultAttestationToken(submission.agent);
+  if (!agentToken) {
+    return NextResponse.json(
+      { error: `No Vault attestation secret configured for ${submission.agent}` },
+      { status: 503 },
+    );
+  }
+
+  if (!bearerMatchesToken(req.headers.get('authorization'), agentToken)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   const candidate = await getCandidate();
@@ -131,7 +127,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  if (!verifyAttestationSignature(AGENT_TOKEN, submission, candidate.seal_hash)) {
+  if (!verifyAttestationSignature(agentToken, submission, candidate.seal_hash)) {
     return NextResponse.json({ error: 'Signature verification failed' }, { status: 401 });
   }
 

--- a/docs/protocols/vault-v2-sealed-reserve.md
+++ b/docs/protocols/vault-v2-sealed-reserve.md
@@ -131,7 +131,7 @@ SealAttestation {
   mii_at_attestation: number
   gi_at_attestation: number
   timestamp: string
-  signature: string            # HMAC-SHA256(AGENT_SERVICE_TOKEN, seal_hash + verdict + rationale)
+  signature: string            # HMAC-SHA256(VAULT_<AGENT>_SECRET_TOKEN or legacy AGENT_SERVICE_TOKEN, seal_hash + verdict + rationale)
 }
 ```
 

--- a/lib/vault-v2/attest.ts
+++ b/lib/vault-v2/attest.ts
@@ -4,7 +4,9 @@
  * These functions are imported by Sentinel agents' own cycle paths. Each
  * agent, on its regular cycle tick, checks for an in-flight Seal candidate
  * and if present, evaluates it against its own tier-specific criteria and
- * submits an attestation via POST /api/vault/seal/attest.
+ * submits an attestation via POST /api/vault/seal/attest. Pass the same
+ * sentinel-specific Vault secret for `token` as used in the request's
+ * `Authorization: Bearer` header (`getVaultAttestationToken(agent)`).
  *
  * This module has no side effects and does not run on a schedule itself.
  * The caller owns the submission step.

--- a/lib/vault-v2/auth.ts
+++ b/lib/vault-v2/auth.ts
@@ -1,0 +1,35 @@
+import { timingSafeEqual } from 'node:crypto';
+import type { SentinelAgent } from '@/lib/vault-v2/types';
+
+const VAULT_AGENT_ENV: Record<SentinelAgent, string> = {
+  ATLAS: 'VAULT_ATLAS_SECRET_TOKEN',
+  ZEUS: 'VAULT_ZEUS_SECRET_TOKEN',
+  EVE: 'VAULT_EVE_SECRET_TOKEN',
+  JADE: 'VAULT_JADE_SECRET_TOKEN',
+  AUREA: 'VAULT_AUREA_SECRET_TOKEN',
+};
+
+/**
+ * Resolves the HMAC/bearer secret for Vault v2 Seal attestations for a given
+ * sentinel. Prefers `VAULT_*_SECRET_TOKEN`; falls back to `AGENT_SERVICE_TOKEN`
+ * during migration when a per-sentinel secret is unset.
+ */
+export function getVaultAttestationToken(agent: SentinelAgent): string {
+  const specificKey = VAULT_AGENT_ENV[agent];
+  const specificToken = process.env[specificKey];
+  if (typeof specificToken === 'string' && specificToken.length > 0) {
+    return specificToken;
+  }
+  return process.env.AGENT_SERVICE_TOKEN ?? '';
+}
+
+export function bearerMatchesToken(authHeader: string | null, token: string): boolean {
+  if (!token) return false;
+  const bearer = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : '';
+  if (!bearer || bearer.length !== token.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(bearer, 'utf8'), Buffer.from(token, 'utf8'));
+  } catch {
+    return false;
+  }
+}

--- a/lib/vault-v2/seal.ts
+++ b/lib/vault-v2/seal.ts
@@ -96,9 +96,17 @@ export function verifySealHash(seal: Seal): boolean {
 // ────────────────────────────────────────────────────────────────
 
 /**
- * HMAC-SHA256(AGENT_SERVICE_TOKEN, seal_hash :: verdict :: rationale).
- * Agents compute this with the shared service token; the server verifies
- * using the same token.
+ * HMAC-SHA256(agent-specific Vault secret, seal_hash :: verdict :: rationale).
+ *
+ * Preferred envs:
+ *   - VAULT_ATLAS_SECRET_TOKEN
+ *   - VAULT_ZEUS_SECRET_TOKEN
+ *   - VAULT_EVE_SECRET_TOKEN
+ *   - VAULT_JADE_SECRET_TOKEN
+ *   - VAULT_AUREA_SECRET_TOKEN
+ *
+ * Legacy fallback (when a per-sentinel secret is unset):
+ *   - AGENT_SERVICE_TOKEN
  */
 export function computeAttestationSignature(args: {
   token: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens Vault v2 Seal Council attestations by binding bearer auth and HMAC verification to **per-sentinel Vault secrets** (`VAULT_ATLAS_SECRET_TOKEN`, …, `VAULT_AUREA_SECRET_TOKEN`), with a **legacy fallback** to `AGENT_SERVICE_TOKEN` when a sentinel-specific secret is unset so existing deployments keep working during rollout.

## Changes

- New `lib/vault-v2/auth.ts`: `getVaultAttestationToken(agent)`, `bearerMatchesToken` (constant-time compare).
- `POST /api/vault/seal/attest`: parse body first, resolve token from `submission.agent`, require non-empty secret (503 if missing), verify Bearer then HMAC with the same key.
- `lib/vault-v2/seal.ts`: comment updated for agent-specific secrets + legacy fallback.
- `.env.example`: documents the five `VAULT_*_SECRET_TOKEN` vars; clarifies `AGENT_SERVICE_TOKEN` dual role.
- Protocol doc + `attest.ts` module comment aligned with the new signing model.

## Non-goals

- No Ed25519 migration (future).
- No change to quorum, chain append rules, overflow provenance, or rejected/quarantine indexing (separate follow-ups from PR 313 review).

## Rollout

1. Merge with fallback OK.
2. Set per-sentinel secrets in the deployment environment.
3. Update each sentinel caller to use its own secret for both HMAC and `Authorization: Bearer`.
4. Optionally remove reliance on shared `AGENT_SERVICE_TOKEN` for Vault once all lanes are migrated.

## Tests

- `pnpm exec tsc --noEmit`
- `pnpm build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

