### PR TITLE
C-284 — Vault v2 overflow provenance, dual seal indexes, attest MII

### DIFF
--- a/app/api/cron/vault-attestation/route.ts
+++ b/app/api/cron/vault-attestation/route.ts
@@ -22,10 +22,11 @@
 
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { getCandidate, listSeals } from '@/lib/vault-v2/store';
+import type { Seal } from '@/lib/vault-v2/types';
+import { countAllSeals, countSeals, getCandidate, listSeals } from '@/lib/vault-v2/store';
 import { evaluateQuorum, finalizeSeal, injectTimeouts } from '@/lib/vault-v2/seal';
 import { tryFormNextCandidate } from '@/lib/vault-v2/deposit';
-import { loadGIState } from '@/lib/kv/store';
+import { loadEchoState, loadTripwireState } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
 
@@ -46,6 +47,8 @@ type Report = {
   attestations_received: number;
   next_candidate_formed: string | null;
   seals_total: number;
+  seals_attested_total: number;
+  seals_audit_total: number;
   fountain_pending_count: number;
   errors: string[];
 };
@@ -64,9 +67,11 @@ export async function GET(req: NextRequest) {
 
   let currentCycle = 'C-284';
   try {
-    const st = await loadGIState();
-    if (st && typeof (st as unknown as { cycle?: string }).cycle === 'string') {
-      currentCycle = (st as unknown as { cycle: string }).cycle;
+    const [echo, trip] = await Promise.all([loadEchoState(), loadTripwireState()]);
+    if (echo?.cycleId) {
+      currentCycle = echo.cycleId;
+    } else if (trip?.cycleId) {
+      currentCycle = trip.cycleId;
     }
   } catch (e) {
     errors.push(`cycle load failed: ${e instanceof Error ? e.message : String(e)}`);
@@ -148,11 +153,19 @@ export async function GET(req: NextRequest) {
   // ── Step 3: fountain pending count (informational) ─────────────
   let fountain_pending_count = 0;
   let seals_total = 0;
+  let seals_attested_total = 0;
+  let seals_audit_total = 0;
   try {
-    const seals = await listSeals(200);
+    const [seals, attestedCount, auditCount] = await Promise.all([
+      listSeals(200),
+      countSeals(),
+      countAllSeals(),
+    ]);
     seals_total = seals.length;
+    seals_attested_total = attestedCount;
+    seals_audit_total = auditCount;
     fountain_pending_count = seals.filter(
-      (s) => s.status === 'attested' && s.fountain_status === 'pending',
+      (s: Seal) => s.status === 'attested' && s.fountain_status === 'pending',
     ).length;
   } catch (e) {
     errors.push(`seals list: ${e instanceof Error ? e.message : String(e)}`);
@@ -167,6 +180,8 @@ export async function GET(req: NextRequest) {
     attestations_received,
     next_candidate_formed,
     seals_total,
+    seals_attested_total,
+    seals_audit_total,
     fountain_pending_count,
     errors,
   };

--- a/app/api/vault/seal/attest/route.ts
+++ b/app/api/vault/seal/attest/route.ts
@@ -36,6 +36,7 @@ import type {
   Verdict,
 } from '@/lib/vault-v2/types';
 import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
+import { SENTINEL_ATTESTATION_COUNT } from '@/lib/vault-v2/constants';
 
 export const dynamic = 'force-dynamic';
 
@@ -58,6 +59,13 @@ function validate(raw: unknown): AttestationSubmission | string {
   if (typeof r.signature !== 'string' || r.signature.length === 0) {
     return 'signature required';
   }
+  let mii_at_attestation: number | undefined;
+  if (r.mii_at_attestation !== undefined) {
+    if (typeof r.mii_at_attestation !== 'number' || !Number.isFinite(r.mii_at_attestation)) {
+      return 'mii_at_attestation must be a finite number when provided';
+    }
+    mii_at_attestation = r.mii_at_attestation;
+  }
   if (r.agent === 'AUREA') {
     const posture = r.posture;
     if (
@@ -78,6 +86,7 @@ function validate(raw: unknown): AttestationSubmission | string {
     verdict: r.verdict as Verdict,
     rationale: (r.rationale as string).trim().slice(0, 2000),
     signature: r.signature as string,
+    ...(mii_at_attestation !== undefined ? { mii_at_attestation } : {}),
     posture: r.agent === 'AUREA' ? (r.posture as Posture) : undefined,
   };
 }
@@ -135,7 +144,9 @@ export async function POST(req: NextRequest) {
     agent: submission.agent,
     verdict: submission.verdict,
     rationale: submission.rationale,
-    mii_at_attestation: 0,
+    ...(submission.mii_at_attestation !== undefined
+      ? { mii_at_attestation: submission.mii_at_attestation }
+      : {}),
     gi_at_attestation: candidate.gi_at_seal,
     timestamp: new Date().toISOString(),
     signature: submission.signature,
@@ -155,6 +166,6 @@ export async function POST(req: NextRequest) {
     agent: submission.agent,
     verdict: submission.verdict,
     attestations_received: attestationsReceived,
-    attestations_needed: 5 - attestationsReceived,
+    attestations_needed: SENTINEL_ATTESTATION_COUNT - attestationsReceived,
   });
 }

--- a/app/api/vault/seal/route.ts
+++ b/app/api/vault/seal/route.ts
@@ -8,7 +8,8 @@
 
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { countSeals, getCandidate, getLatestSeal, listSeals } from '@/lib/vault-v2/store';
+import { SENTINEL_ATTESTATION_COUNT } from '@/lib/vault-v2/constants';
+import { countAllSeals, countSeals, getCandidate, getLatestSeal, listAllSeals, listSeals } from '@/lib/vault-v2/store';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,10 +18,12 @@ export async function GET(req: NextRequest) {
   const limit = Number.isFinite(limitParam)
     ? Math.max(1, Math.min(200, Math.floor(limitParam)))
     : 50;
+  const scope = req.nextUrl.searchParams.get('scope')?.toLowerCase();
+  const includeAllHistory = scope === 'all' || scope === 'audit';
 
   const [seals, total, latest, candidate] = await Promise.all([
-    listSeals(limit),
-    countSeals(),
+    includeAllHistory ? listAllSeals(limit) : listSeals(limit),
+    includeAllHistory ? countAllSeals() : countSeals(),
     getLatestSeal(),
     getCandidate(),
   ]);
@@ -28,6 +31,7 @@ export async function GET(req: NextRequest) {
   return NextResponse.json(
     {
       ok: true,
+      scope: includeAllHistory ? 'audit' : 'attested',
       total,
       returned: seals.length,
       latest_seal_id: latest?.seal_id ?? null,
@@ -42,7 +46,8 @@ export async function GET(req: NextRequest) {
               requested_at: candidate.requested_at,
               timeout_at: candidate.timeout_at,
               attestations_received: Object.keys(candidate.attestations).length,
-              attestations_needed: 5 - Object.keys(candidate.attestations).length,
+              attestations_needed:
+                SENTINEL_ATTESTATION_COUNT - Object.keys(candidate.attestations).length,
               attesting_agents: Object.keys(candidate.attestations),
             },
       seals,

--- a/app/api/vault/status/route.ts
+++ b/app/api/vault/status/route.ts
@@ -16,11 +16,13 @@ import { NextResponse } from 'next/server';
 import { loadGIState } from '@/lib/kv/store';
 import { getVaultStatusPayload } from '@/lib/vault/vault';
 import {
+  countAllSeals,
   countSeals,
   getCandidate,
   getInProgressBalance,
   getLatestSeal,
 } from '@/lib/vault-v2/store';
+import { SENTINEL_ATTESTATION_COUNT } from '@/lib/vault-v2/constants';
 
 export const dynamic = 'force-dynamic';
 
@@ -37,9 +39,10 @@ export async function GET() {
 
   const v1 = await getVaultStatusPayload(gi);
 
-  const [inProgressBalance, sealsCount, latestSeal, candidate] = await Promise.all([
+  const [inProgressBalance, sealsCount, sealsAuditCount, latestSeal, candidate] = await Promise.all([
     getInProgressBalance(),
     countSeals(),
+    countAllSeals(),
     getLatestSeal(),
     getCandidate(),
   ]);
@@ -48,6 +51,7 @@ export async function GET() {
     ...v1,
     in_progress_balance: inProgressBalance,
     seals_count: sealsCount,
+    seals_audit_count: sealsAuditCount,
     latest_seal_id: latestSeal?.seal_id ?? null,
     latest_seal_at: latestSeal?.sealed_at ?? null,
     latest_seal_hash: latestSeal?.seal_hash ?? null,
@@ -59,7 +63,8 @@ export async function GET() {
           requested_at: candidate.requested_at,
           timeout_at: candidate.timeout_at,
           attestations_received: Object.keys(candidate.attestations).length,
-          attestations_needed: 5 - Object.keys(candidate.attestations).length,
+          attestations_needed:
+            SENTINEL_ATTESTATION_COUNT - Object.keys(candidate.attestations).length,
         }
       : {
           in_flight: false,

--- a/docs/protocols/vault-v2-sealed-reserve.md
+++ b/docs/protocols/vault-v2-sealed-reserve.md
@@ -110,6 +110,7 @@ Seal {
   mode_at_seal: string         # "green" | "yellow" | "red"
   source_entries: number       # journal deposits this parcel drew from
   deposit_hashes: string[]     # content signatures of contributing deposits
+  carried_forward_deposit_hashes?: string[]  # optional; hashes whose value spilled into the next parcel
   prev_seal_hash: string | null  # null for seal-001
   seal_hash: string            # sha256 over the above, pre-attestation
   attestations: {
@@ -128,7 +129,7 @@ SealAttestation {
   agent: "ATLAS" | "ZEUS" | "EVE" | "JADE" | "AUREA"
   verdict: "pass" | "flag" | "reject"
   rationale: string            # agent's voice, 1-3 sentences
-  mii_at_attestation: number
+  mii_at_attestation?: number | null  # optional; omit when agent did not supply MII
   gi_at_attestation: number
   timestamp: string
   signature: string            # HMAC-SHA256(VAULT_<AGENT>_SECRET_TOKEN or legacy AGENT_SERVICE_TOKEN, seal_hash + verdict + rationale)
@@ -325,7 +326,9 @@ conditions, not the present's.
 | `mobius:vault:global:balance` | `vault:in_progress_balance` | Direct copy                          |
 | `mobius:vault:global:meta`    | `vault:meta`                | Schema extended, backward compatible |
 | `vault:deposits`              | `vault:deposits`            | Unchanged                            |
-| (new)                         | `vault:seals:index`         | Array of seal_ids in sequence        |
+| (new)                         | `vault:seals:index:attested` | Attested seal_ids only (canonical chain) |
+| (new)                         | `vault:seals:index:all`      | All finalized seal_ids (audit trail)     |
+| (legacy compat)               | `vault:seals:index`          | Mirrored to attested index for old readers |
 | (new)                         | `vault:seal:{seal_id}`      | Seal record                          |
 | (new)                         | `vault:seal:latest`         | Most recent seal_id                  |
 | (new)                         | `vault:seal:candidate`      | In-flight Seal awaiting attestation  |
@@ -335,8 +338,10 @@ conditions, not the present's.
 - `writeVaultDeposit` continues to accept deposits and accumulate to
   `in_progress_balance`. When balance crosses 50, it additionally invokes
   `attemptSealFormation()`.
-- `/api/vault/status` gains new fields: `seals_count`, `latest_seal_at`,
-  `candidate_attestation_state`.
+- `/api/vault/status` gains new fields: `seals_count`, `seals_audit_count`,
+  `latest_seal_at`, `candidate_attestation_state`.
+- `GET /api/vault/seal?scope=audit` returns the full audit list (attested +
+  quarantined + rejected); default scope remains attested-only.
 - Fountain UI surfaces become per-Seal rather than global.
 
 ### Backward compatibility window

--- a/lib/vault-v2/constants.ts
+++ b/lib/vault-v2/constants.ts
@@ -1,0 +1,7 @@
+import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
+
+/** Units per sealed reserve parcel (Vault v2). */
+export const VAULT_RESERVE_PARCEL_UNITS = 50;
+
+/** Sentinel council size for attestation quorum UI. */
+export const SENTINEL_ATTESTATION_COUNT = SENTINEL_AGENTS.length;

--- a/lib/vault-v2/deposit.ts
+++ b/lib/vault-v2/deposit.ts
@@ -12,7 +12,10 @@
  *   3. If balance >= 50:
  *      a. Attempt to form a Seal candidate (may no-op if one already in flight)
  *      b. Reset in_progress_balance to overflow (balance - 50)
- *      c. Log the candidate creation
+ *      c. Preserve overflow provenance: crossing-deposit hash is recorded on the
+ *         candidate/seal as `carried_forward_deposit_hashes` and re-seeded into
+ *         `vault:in_progress_hashes` for the next parcel
+ *      d. Log the candidate creation
  *   4. If candidate formation is deferred (another in flight), the deposit
  *      amount stays in in_progress_balance; it will be included in the NEXT
  *      candidate once the current one resolves.
@@ -21,17 +24,17 @@
 import type { AgentJournalEntry } from '@/lib/terminal/types';
 import { loadGIState } from '@/lib/kv/store';
 import {
-  clearInProgressHashes,
   getCandidate,
   getInProgressBalance,
   readInProgressHashes,
   setInProgressBalance,
   writeInProgressHashes,
 } from '@/lib/vault-v2/store';
+import { VAULT_RESERVE_PARCEL_UNITS } from '@/lib/vault-v2/constants';
 import { formCandidate } from '@/lib/vault-v2/seal';
 import type { Mode, SealCandidate } from '@/lib/vault-v2/types';
 
-const THRESHOLD = 50;
+const THRESHOLD = VAULT_RESERVE_PARCEL_UNITS;
 
 export type AccrualResult = {
   balance_after: number;
@@ -106,12 +109,18 @@ export async function accrueDepositV2(args: {
     };
   }
 
+  const carried_forward =
+    overflow > 0 && hashes.includes(args.content_signature)
+      ? [args.content_signature]
+      : undefined;
+
   const candidate = await formCandidate({
     cycle: args.cycle,
     gi_at_seal: gi,
     mode_at_seal: mode,
     source_entries: hashes.length,
     deposit_hashes: hashes,
+    ...(carried_forward ? { carried_forward_deposit_hashes: carried_forward } : {}),
   });
 
   if (!candidate) {
@@ -126,7 +135,7 @@ export async function accrueDepositV2(args: {
   }
 
   await setInProgressBalance(overflow);
-  await clearInProgressHashes();
+  await writeInProgressHashes(carried_forward ?? []);
 
   console.info('[vault-v2] seal candidate formed', {
     seal_id: candidate.seal_id,
@@ -159,18 +168,23 @@ export async function tryFormNextCandidate(args: { cycle: string }): Promise<Sea
   const { gi, mode } = await readGIAndMode();
   const hashes = await readInProgressHashes();
 
+  const overflow = Number((balance - THRESHOLD).toFixed(6));
+  const lastHash = hashes.length > 0 ? hashes[hashes.length - 1] : null;
+  const carried_forward =
+    overflow > 0 && lastHash ? [lastHash] : undefined;
+
   const candidate = await formCandidate({
     cycle: args.cycle,
     gi_at_seal: gi,
     mode_at_seal: mode,
     source_entries: hashes.length,
     deposit_hashes: hashes,
+    ...(carried_forward ? { carried_forward_deposit_hashes: carried_forward } : {}),
   });
 
   if (candidate) {
-    const overflow = Number((balance - THRESHOLD).toFixed(6));
     await setInProgressBalance(overflow);
-    await clearInProgressHashes();
+    await writeInProgressHashes(carried_forward ?? []);
     console.info('[vault-v2] next candidate formed from queued reserve', {
       seal_id: candidate.seal_id,
       overflow_carried: overflow,

--- a/lib/vault-v2/seal.ts
+++ b/lib/vault-v2/seal.ts
@@ -9,6 +9,7 @@
 
 import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 import {
+  appendSealToAuditChain,
   appendSealToChain,
   clearCandidate,
   getCandidate,
@@ -27,6 +28,7 @@ import type {
   Verdict,
 } from '@/lib/vault-v2/types';
 import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
+import { VAULT_RESERVE_PARCEL_UNITS } from '@/lib/vault-v2/constants';
 
 const ATTESTATION_TIMEOUT_MS = 5 * 60 * 1000; // 5 min per spec §6
 
@@ -39,7 +41,7 @@ type CanonicalFields = {
   sequence: number;
   cycle_at_seal: string;
   sealed_at: string;
-  reserve: 50;
+  reserve: typeof VAULT_RESERVE_PARCEL_UNITS;
   gi_at_seal: number;
   mode_at_seal: Mode;
   source_entries: number;
@@ -154,6 +156,7 @@ export async function formCandidate(args: {
   mode_at_seal: Mode;
   source_entries: number;
   deposit_hashes: string[];
+  carried_forward_deposit_hashes?: string[];
 }): Promise<SealCandidate | null> {
   const existing = await getCandidate();
   if (existing) return null;
@@ -169,7 +172,7 @@ export async function formCandidate(args: {
     sequence,
     cycle_at_seal: args.cycle,
     sealed_at,
-    reserve: 50,
+    reserve: VAULT_RESERVE_PARCEL_UNITS,
     gi_at_seal: args.gi_at_seal,
     mode_at_seal: args.mode_at_seal,
     source_entries: args.source_entries,
@@ -185,11 +188,14 @@ export async function formCandidate(args: {
     sequence,
     cycle_at_seal: args.cycle,
     sealed_at,
-    reserve: 50,
+    reserve: VAULT_RESERVE_PARCEL_UNITS,
     gi_at_seal: args.gi_at_seal,
     mode_at_seal: args.mode_at_seal,
     source_entries: args.source_entries,
     deposit_hashes: args.deposit_hashes,
+    ...(args.carried_forward_deposit_hashes?.length
+      ? { carried_forward_deposit_hashes: [...args.carried_forward_deposit_hashes] }
+      : {}),
     prev_seal_hash,
     seal_hash,
     attestations: {},
@@ -322,6 +328,9 @@ export async function finalizeSeal(decision: QuorumResult): Promise<Seal | null>
     mode_at_seal: candidate.mode_at_seal,
     source_entries: candidate.source_entries,
     deposit_hashes: candidate.deposit_hashes,
+    ...(candidate.carried_forward_deposit_hashes?.length
+      ? { carried_forward_deposit_hashes: [...candidate.carried_forward_deposit_hashes] }
+      : {}),
     prev_seal_hash: candidate.prev_seal_hash,
     seal_hash: candidate.seal_hash,
     attestations: candidate.attestations,
@@ -331,12 +340,13 @@ export async function finalizeSeal(decision: QuorumResult): Promise<Seal | null>
     posture: aurea?.posture ?? candidate.posture ?? null,
   };
 
-  // Only attested seals join the chain; quarantined/rejected seals are
-  // written but not appended to the index (they do not advance the chain).
+  // Attested seals advance the proof chain; all outcomes append to the full
+  // audit index so quarantined/rejected history remains visible.
   if (status === 'attested') {
     await appendSealToChain(seal);
   } else {
     await writeSeal(seal);
+    await appendSealToAuditChain(seal);
   }
 
   await clearCandidate();
@@ -364,8 +374,7 @@ export async function injectTimeouts(now: number = Date.now()): Promise<SealCand
         agent,
         verdict: 'flag',
         rationale: 'timeout',
-        mii_at_attestation: 0,
-        gi_at_attestation: 0,
+        gi_at_attestation: candidate.gi_at_seal,
         timestamp: new Date(now).toISOString(),
         signature: 'timeout',
       };

--- a/lib/vault-v2/store.ts
+++ b/lib/vault-v2/store.ts
@@ -4,7 +4,9 @@
  * Key layout:
  *   vault:in_progress_balance        → number, running accumulator 0..<50
  *   vault:in_progress_hashes         → content sigs accruing into next seal
- *   vault:seals:index                → ordered array of seal_ids
+ *   vault:seals:index                → legacy attested index (kept in sync with :attested)
+ *   vault:seals:index:attested       → attested seals only (canonical chain)
+ *   vault:seals:index:all            → all finalized seals (attested + quarantined + rejected)
  *   vault:seal:latest                → most recent seal_id (quick chain access)
  *   vault:seal:{seal_id}             → full Seal record
  *   vault:seal:candidate             → in-flight SealCandidate awaiting attestations
@@ -18,7 +20,12 @@ import type { Seal, SealAttestation, SealCandidate, SentinelAgent } from '@/lib/
 
 const BALANCE_KEY = 'vault:in_progress_balance';
 const IN_PROGRESS_HASHES_KEY = 'vault:in_progress_hashes';
-const SEALS_INDEX_KEY = 'vault:seals:index';
+/** Legacy key — same sequence as attested index after migration. */
+const SEALS_INDEX_LEGACY_KEY = 'vault:seals:index';
+/** Attested seals only (canonical chain head / latest). */
+const SEALS_INDEX_ATTESTED_KEY = 'vault:seals:index:attested';
+/** Every finalized seal (attested, quarantined, rejected) for full audit history. */
+const SEALS_INDEX_ALL_KEY = 'vault:seals:index:all';
 const LATEST_SEAL_KEY = 'vault:seal:latest';
 const CANDIDATE_KEY = 'vault:seal:candidate';
 
@@ -114,11 +121,9 @@ export async function clearInProgressHashes(): Promise<void> {
 // Seal index + chain access
 // ────────────────────────────────────────────────────────────────
 
-export async function listSealIds(): Promise<string[]> {
-  const redis = getRedis();
-  if (!redis) return [];
+async function readStringArrayKey(redis: Redis, key: string): Promise<string[]> {
   try {
-    const raw = await redis.get<string[] | string>(SEALS_INDEX_KEY);
+    const raw = await redis.get<string[] | string>(key);
     if (Array.isArray(raw)) return raw;
     const parsed = parseMaybeJson<string[]>(raw);
     return Array.isArray(parsed) ? parsed : [];
@@ -127,8 +132,54 @@ export async function listSealIds(): Promise<string[]> {
   }
 }
 
+/**
+ * Attested-seal index (advances the proof chain). Migrates from legacy
+ * `vault:seals:index` once if the new key is empty.
+ */
+export async function listSealIds(): Promise<string[]> {
+  const redis = getRedis();
+  if (!redis) return [];
+  try {
+    let ids = await readStringArrayKey(redis, SEALS_INDEX_ATTESTED_KEY);
+    if (ids.length === 0) {
+      const legacy = await readStringArrayKey(redis, SEALS_INDEX_LEGACY_KEY);
+      if (legacy.length > 0) {
+        ids = legacy;
+        await redis.set(SEALS_INDEX_ATTESTED_KEY, ids);
+      }
+    }
+    return ids;
+  } catch {
+    return [];
+  }
+}
+
+/** Full audit trail: every finalized seal id in order (attested + quarantined + rejected). */
+export async function listAllSealIds(): Promise<string[]> {
+  const redis = getRedis();
+  if (!redis) return [];
+  try {
+    let ids = await readStringArrayKey(redis, SEALS_INDEX_ALL_KEY);
+    if (ids.length === 0) {
+      const attested = await listSealIds();
+      if (attested.length > 0) {
+        ids = [...attested];
+        await redis.set(SEALS_INDEX_ALL_KEY, ids);
+      }
+    }
+    return ids;
+  } catch {
+    return [];
+  }
+}
+
 export async function countSeals(): Promise<number> {
   const ids = await listSealIds();
+  return ids.length;
+}
+
+export async function countAllSeals(): Promise<number> {
+  const ids = await listAllSealIds();
   return ids.length;
 }
 
@@ -164,26 +215,71 @@ export async function getSeal(seal_id: string): Promise<Seal | null> {
 
 export async function listSeals(limit = 50): Promise<Seal[]> {
   const ids = await listSealIds();
+  if (ids.length === 0) return [];
   const recent = ids.slice(-limit);
   const results = await Promise.all(recent.map((id) => getSeal(id)));
   return results.filter((s): s is Seal => s !== null).reverse();
 }
 
+/** Newest-first list from the full audit index (includes quarantined/rejected). */
+export async function listAllSeals(limit = 50): Promise<Seal[]> {
+  const ids = await listAllSealIds();
+  if (ids.length === 0) return [];
+  const recent = ids.slice(-limit);
+  const results = await Promise.all(recent.map((id) => getSeal(id)));
+  return results.filter((s): s is Seal => s !== null).reverse();
+}
+
+async function appendSealIdToIndex(redis: Redis, key: string, seal_id: string): Promise<string[]> {
+  const ids = await readStringArrayKey(redis, key);
+  if (!ids.includes(seal_id)) {
+    ids.push(seal_id);
+    await redis.set(key, ids);
+  }
+  return ids;
+}
+
 /**
- * Append a new Seal to the index and mark it latest.
- * Caller is responsible for validating hash chain integrity before calling.
+ * Append a finalized seal id to the full-history index (all outcomes).
+ * Caller must persist the seal body separately (e.g. `writeSeal`).
+ */
+export async function appendSealToAuditChain(seal: Seal): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    await appendSealIdToIndex(redis, SEALS_INDEX_ALL_KEY, seal.seal_id);
+  } catch (err) {
+    console.warn('[vault-v2:store] appendSealToAuditChain failed:', err instanceof Error ? err.message : err);
+  }
+}
+
+/**
+ * Append a new attested Seal to the attested index and mark it latest.
+ * Also appends to the full audit index. Caller validates hash chain integrity.
  */
 export async function appendSealToChain(seal: Seal): Promise<void> {
   const redis = getRedis();
   if (!redis) return;
   try {
-    const ids = await listSealIds();
-    if (!ids.includes(seal.seal_id)) {
-      ids.push(seal.seal_id);
-      await redis.set(SEALS_INDEX_KEY, ids);
-    }
-    await redis.set(sealKey(seal.seal_id), seal);
-    await redis.set(LATEST_SEAL_KEY, seal.seal_id);
+    const [attested, legacy, all] = await Promise.all([
+      readStringArrayKey(redis, SEALS_INDEX_ATTESTED_KEY),
+      readStringArrayKey(redis, SEALS_INDEX_LEGACY_KEY),
+      readStringArrayKey(redis, SEALS_INDEX_ALL_KEY),
+    ]);
+    const pushIfMissing = (ids: string[]) => {
+      if (!ids.includes(seal.seal_id)) ids.push(seal.seal_id);
+      return ids;
+    };
+    const nextAttested = pushIfMissing([...attested]);
+    const nextLegacy = pushIfMissing([...legacy]);
+    const nextAll = pushIfMissing([...all]);
+    await Promise.all([
+      redis.set(SEALS_INDEX_ATTESTED_KEY, nextAttested),
+      redis.set(SEALS_INDEX_LEGACY_KEY, nextLegacy),
+      redis.set(SEALS_INDEX_ALL_KEY, nextAll),
+      redis.set(sealKey(seal.seal_id), seal),
+      redis.set(LATEST_SEAL_KEY, seal.seal_id),
+    ]);
   } catch (err) {
     console.warn('[vault-v2:store] appendSealToChain failed:', err instanceof Error ? err.message : err);
   }

--- a/lib/vault-v2/types.ts
+++ b/lib/vault-v2/types.ts
@@ -43,7 +43,8 @@ export type SealAttestation = {
   agent: SentinelAgent;
   verdict: Verdict;
   rationale: string;
-  mii_at_attestation: number;
+  /** Present when the agent supplied MII at seal time; omitted when unknown. */
+  mii_at_attestation?: number | null;
   gi_at_attestation: number;
   timestamp: string;
   signature: string;
@@ -61,6 +62,12 @@ export type Seal = {
   mode_at_seal: Mode;
   source_entries: number;
   deposit_hashes: string[];
+  /**
+   * Deposit content hashes that contributed to the *next* forming parcel after
+   * this seal closed (numeric overflow from the crossing deposit). Preserves
+   * provenance across the 50-unit boundary.
+   */
+  carried_forward_deposit_hashes?: string[];
   prev_seal_hash: string | null;
   seal_hash: string;
   attestations: Partial<Record<SentinelAgent, SealAttestation>>;
@@ -85,6 +92,11 @@ export type SealCandidate = {
   mode_at_seal: Mode;
   source_entries: number;
   deposit_hashes: string[];
+  /**
+   * Set when this candidate is formed with overflow into the next parcel;
+   * copied onto the finalized Seal for audit.
+   */
+  carried_forward_deposit_hashes?: string[];
   prev_seal_hash: string | null;
   seal_hash: string;
   attestations: Partial<Record<SentinelAgent, SealAttestation>>;
@@ -117,6 +129,8 @@ export type AttestationSubmission = {
   verdict: Verdict;
   rationale: string;
   signature: string;
+  /** Optional; when set must be a finite number (MII snapshot at attestation). */
+  mii_at_attestation?: number;
   /** Required only from AUREA. */
   posture?: Posture;
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cycle **C-284** hardening for Vault v2: fixes overflow provenance at the 50-unit seal boundary, adds a full **audit** seal index (quarantined/rejected visible in history), makes **MII at attestation** optional instead of storing a misleading `0`, and bundles several small protocol/ops improvements.

## Fixes

1. **Overflow provenance** — When a deposit crosses the threshold, the triggering content hash is stored on the candidate/seal as `carried_forward_deposit_hashes` and re-seeded into `vault:in_progress_hashes` for the next parcel (instead of wiping all hashes).
2. **Audit visibility** — New `vault:seals:index:all`; quarantined/rejected seals append there. Attested chain remains `vault:seals:index:attested` with legacy `vault:seals:index` kept in sync.
3. **`mii_at_attestation`** — Optional on submissions and stored attestations; no fake zero for real agents.

## API / ops

- `GET /api/vault/seal?scope=audit` (or `all`) — full history list + `total` from audit index; default remains attested-only.
- `GET /api/vault/status` — adds `seals_audit_count`.
- `GET /api/cron/vault-attestation` — `seals_attested_total`, `seals_audit_total`; cycle id from ECHO/tripwire KV (parallel load) instead of a non-existent GI `cycle` field.

## Other optimizations

- Shared constants: `VAULT_RESERVE_PARCEL_UNITS`, `SENTINEL_ATTESTATION_COUNT`.
- `appendSealToChain` batches index reads/writes in one round-trip where possible.
- Timeout injection uses `gi_at_attestation: candidate.gi_at_seal` instead of `0`.
- `listSeals` early-return when index empty.

## Docs

- `docs/protocols/vault-v2-sealed-reserve.md` updated for keys, fields, and API.

## Tests

- `pnpm exec tsc --noEmit`
- `pnpm build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

