### PR TITLE
Expose per-agent Vault contributions via GET /api/vault/contributions

### DIFF
--- a/app/api/vault/contributions/route.ts
+++ b/app/api/vault/contributions/route.ts
@@ -1,0 +1,90 @@
+/**
+ * GET /api/vault/contributions
+ *
+ * Reads `vault:deposits` (newest-first LPUSH list) and aggregates reserve
+ * contributed by agent. Source is journal-scored deposits, not wallets.
+ *
+ * Query:
+ *   group_by=agent  (default; only supported value today)
+ *   limit=200       (max rows scanned from the list tail; default 200)
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { listVaultDeposits } from '@/lib/vault/vault';
+
+export const dynamic = 'force-dynamic';
+
+type AgentContribution = {
+  agent: string;
+  total_reserve_contributed: number;
+  deposit_count: number;
+  last_deposit_at: string | null;
+  last_journal_id: string | null;
+};
+
+export async function GET(req: NextRequest) {
+  const groupBy = (req.nextUrl.searchParams.get('group_by') ?? 'agent').toLowerCase();
+  if (groupBy !== 'agent') {
+    return NextResponse.json(
+      { error: 'Unsupported group_by; use group_by=agent' },
+      { status: 400 },
+    );
+  }
+
+  const limitParam = Number(req.nextUrl.searchParams.get('limit') ?? '200');
+  const limit = Number.isFinite(limitParam)
+    ? Math.max(1, Math.min(200, Math.floor(limitParam)))
+    : 200;
+
+  const deposits = await listVaultDeposits(limit);
+
+  const byAgent = new Map<string, AgentContribution>();
+
+  for (const d of deposits) {
+    const agent = d.agent;
+    const prev = byAgent.get(agent);
+    const amt = d.deposit_amount;
+    if (!prev) {
+      byAgent.set(agent, {
+        agent,
+        total_reserve_contributed: amt,
+        deposit_count: 1,
+        last_deposit_at: d.timestamp,
+        last_journal_id: d.journal_id,
+      });
+    } else {
+      prev.total_reserve_contributed = Number((prev.total_reserve_contributed + amt).toFixed(6));
+      prev.deposit_count += 1;
+    }
+  }
+
+  const agents = [...byAgent.values()].sort((a, b) =>
+    a.agent.localeCompare(b.agent, undefined, { sensitivity: 'base' }),
+  );
+
+  const total_reserve = Number(
+    agents.reduce((s, a) => s + a.total_reserve_contributed, 0).toFixed(6),
+  );
+
+  return NextResponse.json(
+    {
+      ok: true,
+      group_by: 'agent',
+      source: 'vault:deposits',
+      description:
+        'Reserve units accrued from scored agent journal entries (not MIC wallet stakes).',
+      rows_scanned: deposits.length,
+      limit,
+      total_reserve_contributed: total_reserve,
+      agents,
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'no-store',
+        'X-Mobius-Source': 'vault-contributions',
+      },
+    },
+  );
+}

--- a/lib/vault/vault.ts
+++ b/lib/vault/vault.ts
@@ -98,6 +98,46 @@ export function computeVaultDeposit(entry: AgentJournalEntry, gi: number, recent
   return Number(amount.toFixed(6));
 }
 
+function parseDepositRow(raw: string | unknown): VaultDeposit | null {
+  try {
+    const o = typeof raw === 'string' ? (JSON.parse(raw) as VaultDeposit) : (raw as unknown as VaultDeposit);
+    if (!o || o.event_type !== 'vault_deposit') return null;
+    if (
+      typeof o.agent !== 'string' ||
+      typeof o.journal_id !== 'string' ||
+      typeof o.timestamp !== 'string' ||
+      typeof o.deposit_amount !== 'number'
+    ) {
+      return null;
+    }
+    if (!Number.isFinite(o.deposit_amount)) return null;
+    return o;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Newest-first raw deposit rows from `vault:deposits` (same list as LPUSH in
+ * `writeVaultDeposit`, capped at DEPOSITS_MAX).
+ */
+export async function listVaultDeposits(limit = DEPOSITS_MAX): Promise<VaultDeposit[]> {
+  const redis = getRedis();
+  if (!redis) return [];
+  try {
+    const cap = Math.max(1, Math.min(DEPOSITS_MAX, Math.floor(limit)));
+    const raw = await redis.lrange<string>(DEPOSITS_LIST_KEY, 0, cap - 1);
+    const out: VaultDeposit[] = [];
+    for (const row of raw) {
+      const d = parseDepositRow(row);
+      if (d) out.push(d);
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
 export async function getRecentContentSignatures(limit: number): Promise<string[]> {
   const redis = getRedis();
   if (!redis) return [];
@@ -105,13 +145,9 @@ export async function getRecentContentSignatures(limit: number): Promise<string[
     const raw = await redis.lrange<string>(DEPOSITS_LIST_KEY, 0, limit - 1);
     const sigs: string[] = [];
     for (const row of raw) {
-      try {
-        const o = typeof row === 'string' ? (JSON.parse(row) as VaultDeposit) : (row as unknown as VaultDeposit);
-        if (o && typeof o.content_signature === 'string') {
-          sigs.push(o.content_signature);
-        }
-      } catch {
-        // skip
+      const o = parseDepositRow(row);
+      if (o && typeof o.content_signature === 'string') {
+        sigs.push(o.content_signature);
       }
     }
     return sigs;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **`GET /api/vault/contributions?group_by=agent`** so operators can see per-agent reserve totals derived from **`vault:deposits`** (journal-scored deposits), matching the existing accrual model in `lib/vault/vault.ts`.

## Implementation

- **`listVaultDeposits(limit)`** in `lib/vault/vault.ts` — LRANGE newest-first, validates rows via shared `parseDepositRow`.
- **`parseDepositRow`** — reused by `getRecentContentSignatures` to avoid duplicate JSON parsing logic.
- **Route** — aggregates `total_reserve_contributed`, `deposit_count`, `last_deposit_at`, `last_journal_id` per agent (last = newest in list for that agent). Response includes `rows_scanned`, `limit`, `total_reserve_contributed`, and a short `description` that this is journal-based, not MIC wallet stakes.

## Query params

- `group_by=agent` (default; other values return 400)
- `limit` — max 200, caps scan depth (list is already trimmed to 200 in writers)

## Tests

- `pnpm exec tsc --noEmit`
- `pnpm build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

