### PR TITLE
feat(vault): Seal I operator semantics — tranche vs Fountain, no history wipe

### DIFF
--- a/app/api/vault/status/route.ts
+++ b/app/api/vault/status/route.ts
@@ -14,6 +14,7 @@
 
 import { NextResponse } from 'next/server';
 import { loadGIState } from '@/lib/kv/store';
+import { computeVaultSealLaneSemantics } from '@/lib/vault/lane-status';
 import { getVaultStatusPayload } from '@/lib/vault/vault';
 import {
   countAllSeals,
@@ -47,9 +48,33 @@ export async function GET() {
     getCandidate(),
   ]);
 
+  const seal_lane = computeVaultSealLaneSemantics({
+    inProgressBalance: inProgressBalance,
+    sealsCountAttested: sealsCount,
+    giCurrent: gi,
+    giThreshold: v1.gi_threshold,
+    sustainCyclesRequired: v1.sustain_cycles_required,
+    v1Status: v1.status,
+    candidateInFlight: Boolean(candidate),
+  });
+
   const body = {
     ...v1,
     in_progress_balance: inProgressBalance,
+    sealed_reserve_total: seal_lane.sealed_reserve_total,
+    current_tranche_balance: seal_lane.current_tranche_balance,
+    carry_forward_in_tranche: seal_lane.carry_forward_in_tranche,
+    reserve_threshold_met: seal_lane.reserve_threshold_met,
+    gi_threshold_met: seal_lane.gi_threshold_met,
+    sustain_cycles_met: seal_lane.sustain_met,
+    fountain_status: seal_lane.fountain_lane,
+    reserve_lane: seal_lane.reserve_lane,
+    vault_headline: seal_lane.headline,
+    vault_canon: seal_lane.canon,
+    unseal_requirements_remaining: {
+      gi_sustain: !seal_lane.gi_threshold_met || !seal_lane.sustain_met,
+      fountain: seal_lane.fountain_lane !== 'active' && seal_lane.fountain_lane !== 'unsealed',
+    },
     seals_count: sealsCount,
     seals_audit_count: sealsAuditCount,
     latest_seal_id: latestSeal?.seal_id ?? null,

--- a/app/terminal/vault/page.tsx
+++ b/app/terminal/vault/page.tsx
@@ -7,6 +7,11 @@ type VaultPayload = {
   ok?: boolean;
   vault_id?: string;
   balance_reserve?: number;
+  in_progress_balance?: number;
+  sealed_reserve_total?: number;
+  current_tranche_balance?: number;
+  carry_forward_in_tranche?: number;
+  seals_count?: number;
   activation_threshold?: number;
   gi_threshold?: number;
   sustain_cycles_required?: number;
@@ -15,6 +20,15 @@ type VaultPayload = {
   source_entries?: number;
   last_deposit?: string | null;
   gi_current?: number | null;
+  gi_threshold_met?: boolean;
+  reserve_threshold_met?: boolean;
+  sustain_cycles_met?: boolean;
+  fountain_status?: string;
+  reserve_lane?: string;
+  vault_headline?: string;
+  vault_canon?: string;
+  latest_seal_id?: string | null;
+  latest_seal_at?: string | null;
   timestamp?: string;
 };
 
@@ -36,13 +50,17 @@ export default function VaultPage() {
     return <div className="p-4 text-sm text-slate-400">Loading vault…</div>;
   }
 
-  const bal = data.balance_reserve ?? 0;
+  const v1Bal = data.balance_reserve ?? 0;
   const cap = data.activation_threshold ?? 50;
-  const pct = cap > 0 ? Math.min(100, (bal / cap) * 100) : 0;
-  const filled = Math.round(pct / 10);
-  const bar = '▓'.repeat(filled) + '░'.repeat(Math.max(0, 10 - filled));
+  const inProg = data.in_progress_balance ?? data.current_tranche_balance ?? 0;
+  const sealedTotal = data.sealed_reserve_total ?? 0;
+  const tranchePct = cap > 0 ? Math.min(100, (inProg / cap) * 100) : 0;
+  const trancheFilled = Math.round(tranchePct / 10);
+  const trancheBar = '▓'.repeat(trancheFilled) + '░'.repeat(Math.max(0, 10 - trancheFilled));
   const giCur = data.gi_current;
-  const status = (data.status ?? 'sealed').toUpperCase();
+  const v1Status = (data.status ?? 'sealed').toUpperCase();
+  const fountain = (data.fountain_status ?? 'locked').toUpperCase();
+  const headline = data.vault_headline ?? 'Vault reserve';
 
   return (
     <div className="h-full overflow-y-auto p-4 text-slate-200">
@@ -52,40 +70,72 @@ export default function VaultPage() {
           ← Sentinel
         </Link>
       </div>
+
+      <div className="mb-3 rounded border border-emerald-500/25 bg-slate-950/90 p-3 font-mono text-[11px] text-emerald-100/95">
+        <div className="text-[10px] uppercase tracking-[0.18em] text-emerald-400/90">Reserve seal</div>
+        <p className="mt-1 leading-relaxed text-emerald-50/90">{headline}</p>
+        {data.vault_canon ? (
+          <p className="mt-1 text-[10px] italic text-slate-500">{data.vault_canon}</p>
+        ) : null}
+      </div>
+
       <div className="rounded border border-violet-500/30 bg-slate-950/80 p-4 font-mono text-xs">
-        <div className="text-[11px] uppercase tracking-[0.2em] text-violet-300/90">VAULT · {status}</div>
+        <div className="text-[11px] uppercase tracking-[0.2em] text-violet-300/90">Fountain / v1 gate · {v1Status}</div>
         <div className="mt-2 text-[10px] text-slate-400">
-          {bar} {bal.toFixed(2)} / {cap.toFixed(2)} reserve units
+          v1 cumulative (compat): {v1Bal.toFixed(2)} units — not reset when tranches seal
         </div>
         <div className="mt-3 space-y-1 text-slate-400">
           <div>
+            Sealed reserve total: <span className="text-violet-200">{sealedTotal.toFixed(2)}</span> (attested
+            tranches)
+          </div>
+          <div>
+            Current tranche:{' '}
+            <span className="text-violet-200">
+              {trancheBar} {inProg.toFixed(2)} / {cap.toFixed(2)}
+            </span>
+          </div>
+          <div>
+            Fountain: <span className="text-amber-200/90">{fountain}</span>
+            {data.reserve_lane ? <span className="text-slate-500"> · reserve_lane: {data.reserve_lane}</span> : null}
+          </div>
+          <div>
             GI threshold: {data.gi_threshold ?? 0.95} · Current:{' '}
             {giCur != null && Number.isFinite(giCur) ? giCur.toFixed(2) : '—'}
+            {data.gi_threshold_met ? ' · GI gate met' : ''}
           </div>
-          <div>Sustain cycles required: {data.sustain_cycles_required ?? 5}</div>
           <div>
-            preview_active: {data.preview_active ? 'true' : 'false'} (preview band at GI ≥ 0.88)
+            Sustain cycles required: {data.sustain_cycles_required ?? 5}
+            {data.sustain_cycles_met ? ' · sustain met' : ' · sustain: not tracked in KV yet'}
+          </div>
+          <div>
+            preview_active: {data.preview_active ? 'true' : 'false'} (GI preview band)
           </div>
           <div>source_entries: {data.source_entries ?? 0}</div>
           <div>last_deposit: {data.last_deposit ?? 'null'}</div>
+          {(data.latest_seal_id || data.latest_seal_at) && (
+            <div className="pt-1 text-slate-500">
+              Latest seal: {data.latest_seal_id ?? '—'} @ {data.latest_seal_at ?? '—'}
+            </div>
+          )}
         </div>
       </div>
 
       <div className="mt-4 rounded border border-slate-700/50 bg-slate-950/60 p-4 font-mono text-xs">
-        <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-violet-300/80">Path to unsealing</div>
+        <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-violet-300/80">Path to Fountain (integrity)</div>
         {(() => {
           const giThresh = data.gi_threshold ?? 0.95;
           const giGap = giCur != null ? Math.max(0, giThresh - giCur) : giThresh;
           const sustain = data.sustain_cycles_required ?? 5;
-          const reserveGap = Math.max(0, cap - bal);
-          const giReady = giCur != null && giCur >= giThresh;
-          const reserveReady = bal >= cap;
+          const reserveGap = Math.max(0, cap - inProg);
+          const giReady = data.gi_threshold_met ?? (giCur != null && giCur >= giThresh);
+          const reserveReady = data.reserve_threshold_met ?? inProg >= cap;
 
           return (
             <div className="space-y-2.5">
               <div>
                 <div className="mb-1 flex items-center justify-between text-[10px]">
-                  <span className="text-slate-400">GI ≥ {giThresh.toFixed(2)}</span>
+                  <span className="text-slate-400">GI ≥ {giThresh.toFixed(2)} (Fountain)</span>
                   <span className={giReady ? 'text-emerald-400' : 'text-amber-400'}>
                     {giReady ? 'MET' : `gap: ${giGap.toFixed(2)}`}
                   </span>
@@ -99,14 +149,11 @@ export default function VaultPage() {
                     }}
                   />
                 </div>
-                <div className="mt-0.5 text-[9px] text-slate-600">
-                  Primary blockers: freshness ({((data as Record<string, unknown>).signals as Record<string, number> | undefined)?.freshness?.toFixed(2) ?? '?'}), information quality
-                </div>
               </div>
 
               <div>
                 <div className="mb-1 flex items-center justify-between text-[10px]">
-                  <span className="text-slate-400">Reserve ≥ {cap.toFixed(0)} units</span>
+                  <span className="text-slate-400">Next tranche ≥ {cap.toFixed(0)} (in progress)</span>
                   <span className={reserveReady ? 'text-emerald-400' : 'text-amber-400'}>
                     {reserveReady ? 'MET' : `need: ${reserveGap.toFixed(2)} more`}
                   </span>
@@ -115,7 +162,7 @@ export default function VaultPage() {
                   <div
                     className="h-full rounded transition-all duration-500"
                     style={{
-                      width: `${pct}%`,
+                      width: `${tranchePct}%`,
                       background: reserveReady ? '#10b981' : '#a78bfa',
                     }}
                   />
@@ -125,12 +172,14 @@ export default function VaultPage() {
               <div>
                 <div className="flex items-center justify-between text-[10px]">
                   <span className="text-slate-400">Sustain GI ≥ {giThresh} for {sustain} cycles</span>
-                  <span className="text-slate-500">tracking</span>
+                  <span className="text-slate-500">tracking (when wired)</span>
                 </div>
               </div>
 
               <p className="mt-1 text-[9px] leading-relaxed text-slate-600">
-                The vault unseals when GI sustains above {giThresh} for {sustain} consecutive cycles and reserve exceeds {cap} units. Fountain activation converts reserve to spendable MIC.
+                A <strong className="text-slate-500">reserve tranche</strong> can seal at 50 units without Fountain
+                unlock. Fountain unlock still requires GI sustain and the v1 activating path — do not conflate
+                &quot;Seal achieved&quot; with &quot;Vault unsealed&quot; for payouts.
               </p>
             </div>
           );

--- a/docs/protocols/vault-seal-i.md
+++ b/docs/protocols/vault-seal-i.md
@@ -1,0 +1,38 @@
+# Vault Seal I — Protocol (C-284 draft)
+
+**Canon:** Reserve can be sealed before integrity unseals the Fountain.
+
+**Rule:** Seal the tranche, not the history.
+
+## Intent
+
+Seal completed **50.00** reserve-unit tranches into immutable Vault v2 seal history. This does **not** imply Fountain activation, MIC payout, or erasing deposit history (`vault:deposits`, `balance_reserve`).
+
+## Preconditions (reserve seal)
+
+- `in_progress_balance >= 50` (v2) and no conflicting candidate, **or** deposit path forms candidate per v2.
+- **Does not require** `GI >= 0.95` or sustain cycles — those gate **Fountain**, not the reserve tranche seal.
+
+## State operators care about
+
+| Field | Meaning |
+|-------|--------|
+| `sealed_reserve_total` | `seals_count` (attested) × 50 — frozen tranches only |
+| `in_progress_balance` / `current_tranche_balance` | Forming next tranche (includes carry-forward) |
+| `balance_reserve` | v1 cumulative (compatibility; not reset on seal) |
+| `fountain_status` | `locked` until GI + sustain unseal path (lane model in API) |
+
+## UI language
+
+**Use:** Seal I achieved · Reserve tranche sealed · Fountain locked · Carry-forward to next tranche.
+
+**Avoid:** “Vault unsealed” (ambiguous) · “Activated” for reserve alone · “Reserve reset”.
+
+## Implementation notes
+
+- Seal records and hashing: see `docs/protocols/vault-v2-sealed-reserve.md`.
+- Operator-facing lane labels: `GET /api/vault/status` exposes `vault_headline`, `fountain_status`, `reserve_lane`, `sealed_reserve_total`, etc.
+
+---
+
+*We heal as we walk.*

--- a/lib/terminal/snapshotLanes.ts
+++ b/lib/terminal/snapshotLanes.ts
@@ -692,10 +692,25 @@ function normalizeVaultLane(leaf: SnapshotLeaf): SnapshotLaneState {
     };
   }
   const balance = typeof row.balance_reserve === 'number' ? row.balance_reserve : 0;
+  const sealedTotal =
+    typeof (row as Record<string, unknown>).sealed_reserve_total === 'number'
+      ? ((row as Record<string, unknown>).sealed_reserve_total as number)
+      : 0;
+  const inProg =
+    typeof (row as Record<string, unknown>).in_progress_balance === 'number'
+      ? ((row as Record<string, unknown>).in_progress_balance as number)
+      : null;
   const status = typeof row.status === 'string' ? row.status : 'sealed';
   const preview = row.preview_active === true;
+  const fountain = (row as Record<string, unknown>).fountain_status;
   const b = balance.toFixed(2);
-  const message = `Vault · ${b} reserve units · ${status}${preview ? ' · preview' : ''}`;
+  const tranche =
+    inProg !== null
+      ? ` · sealed ${sealedTotal.toFixed(0)} · tranche ${inProg.toFixed(2)}/50`
+      : '';
+  const fountainBit =
+    typeof fountain === 'string' ? ` · fountain ${fountain}` : '';
+  const message = `Vault · ${b} reserve (v1)${tranche}${fountainBit} · ${status}${preview ? ' · preview' : ''}`;
   return {
     key: 'vault',
     ok: true,

--- a/lib/vault/lane-status.ts
+++ b/lib/vault/lane-status.ts
@@ -1,0 +1,102 @@
+/**
+ * Operator-facing Vault lane labels: reserve tranche sealing vs Fountain / integrity.
+ * See docs/protocols/vault-seal-i.md (Seal the tranche, not the history).
+ */
+
+import { VAULT_RESERVE_PARCEL_UNITS } from '@/lib/vault-v2/constants';
+
+export type VaultFountainLaneStatus = 'locked' | 'preview' | 'tracking' | 'unsealed' | 'active';
+
+export type VaultReserveLaneStatus = 'accumulating' | 'tranche_ready' | 'sealing' | 'sealed_tranches';
+
+export type VaultSealOneSemantics = {
+  /** Sum of completed v2 attested reserve parcels (50-unit tranches). */
+  sealed_reserve_total: number;
+  /** Canonical forming tranche progress (v2 in_progress_balance). */
+  current_tranche_balance: number;
+  /** Same as current_tranche_balance for spec wording. */
+  carry_forward_in_tranche: number;
+  reserve_threshold: number;
+  reserve_threshold_met: boolean;
+  gi_threshold: number;
+  gi_threshold_met: boolean;
+  sustain_cycles_required: number;
+  /** Placeholder until sustain is tracked in KV; always false for now. */
+  sustain_met: boolean;
+  /** v1 payload status: sealed | preview | activating */
+  vault_status: 'sealed' | 'preview' | 'activating';
+  /** Reserve tranche lifecycle for UI. */
+  reserve_lane: VaultReserveLaneStatus;
+  /** Fountain / integrity gate for UI — not the same as reserve seal. */
+  fountain_lane: VaultFountainLaneStatus;
+  /** Human-readable headline (e.g. Seal I achieved). */
+  headline: string;
+  /** Short operator line. */
+  canon: string;
+};
+
+export function computeVaultSealLaneSemantics(args: {
+  inProgressBalance: number;
+  sealsCountAttested: number;
+  giCurrent: number | null;
+  giThreshold: number;
+  sustainCyclesRequired: number;
+  v1Status: 'sealed' | 'preview' | 'activating';
+  candidateInFlight: boolean;
+}): VaultSealOneSemantics {
+  const reserve_threshold = VAULT_RESERVE_PARCEL_UNITS;
+  const sealed_reserve_total = args.sealsCountAttested * reserve_threshold;
+  const current_tranche_balance = args.inProgressBalance;
+  const carry_forward_in_tranche = current_tranche_balance;
+
+  const gi = args.giCurrent;
+  const gi_threshold_met = gi !== null && Number.isFinite(gi) && gi >= args.giThreshold;
+  const reserve_threshold_met = current_tranche_balance >= reserve_threshold;
+
+  let fountain_lane: VaultFountainLaneStatus = 'locked';
+  if (args.v1Status === 'activating') fountain_lane = 'active';
+  else if (args.v1Status === 'preview') fountain_lane = 'preview';
+  else if (gi_threshold_met) fountain_lane = 'tracking';
+
+  let reserve_lane: VaultReserveLaneStatus = 'accumulating';
+  if (args.candidateInFlight) {
+    reserve_lane = 'sealing';
+  } else if (reserve_threshold_met) {
+    reserve_lane = 'tranche_ready';
+  } else if (args.sealsCountAttested > 0) {
+    reserve_lane = 'sealed_tranches';
+  }
+
+  const sealOrdinal = args.sealsCountAttested;
+  const headline = (() => {
+    if (args.candidateInFlight) {
+      return 'Reserve tranche sealing in progress (council attestation)';
+    }
+    if (sealOrdinal >= 1) {
+      return sealOrdinal === 1
+        ? 'Seal I achieved — reserve tranche sealed'
+        : `Seal ${sealOrdinal} achieved — reserve tranche sealed`;
+    }
+    if (reserve_threshold_met) {
+      return 'Reserve tranche ready to seal (50 units)';
+    }
+    return 'Reserve accumulating toward first tranche';
+  })();
+
+  return {
+    sealed_reserve_total: Number(sealed_reserve_total.toFixed(2)),
+    current_tranche_balance: Number(current_tranche_balance.toFixed(6)),
+    carry_forward_in_tranche: Number(carry_forward_in_tranche.toFixed(6)),
+    reserve_threshold,
+    reserve_threshold_met,
+    gi_threshold: args.giThreshold,
+    gi_threshold_met,
+    sustain_cycles_required: args.sustainCyclesRequired,
+    sustain_met: false,
+    vault_status: args.v1Status,
+    reserve_lane,
+    fountain_lane,
+    headline,
+    canon: 'Reserve can be sealed before integrity unseals the Fountain.',
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Seal the tranche, not the history** at the API and Vault chamber UI layer: explicit **sealed reserve total** (from attested v2 seal count × 50), **current tranche** (`in_progress_balance`), **Fountain lane** vs **reserve seal** wording, and a committed **Vault Seal I** protocol note. Does **not** reset `balance_reserve` or deposit history.

## API (`GET /api/vault/status`)

New fields (additive):

- `sealed_reserve_total`, `current_tranche_balance`, `carry_forward_in_tranche`
- `reserve_threshold_met`, `gi_threshold_met`, `sustain_cycles_met` (sustain still false until tracked in KV)
- `fountain_status`: `locked` | `preview` | `tracking` | `unsealed` | `active` (derived from v1 status + GI)
- `reserve_lane`, `vault_headline`, `vault_canon`, `unseal_requirements_remaining`

## UI

- `/terminal/vault` — headline + sealed total + tranche bar + Fountain label; clarifies v1 cumulative is compat-only.

## Snapshot

- Vault lane message includes sealed total + in-progress tranche + fountain lane when present.

## Docs

- `docs/protocols/vault-seal-i.md` — C-284 draft canon.

## Tests

- `pnpm exec tsc --noEmit`
- `pnpm build`

## Non-goals (this PR)

- No manual “seal now” operator route (v2 deposit path + council already form seals).
- No sustain-cycle KV tracking yet (`sustain_cycles_met` stays false).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

