### PR TITLE
CORS for Mobius Handbook (GitHub Pages) on snapshot-lite + public vault reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,9 @@ KV_REST_API_TOKEN=
 REDIS_URL=
 # Set to true to mirror successful kvSet / kvSetRawKey to REDIS_URL (same key names as primary)
 MOBIUS_KV_BACKUP_MIRROR=
+# When true, kvGet/kvGetRaw also read from REDIS_URL on primary miss/error
+MOBIUS_KV_READ_FALLBACK=
+
+# Comma-separated extra origins for Handbook / GitHub Pages CORS on public GET routes
+# (defaults include https://kaizencycle.github.io and mobius-browser-shell.vercel.app)
+MOBIUS_HANDBOOK_CORS_ORIGINS=

--- a/app/api/bridge/status/route.ts
+++ b/app/api/bridge/status/route.ts
@@ -1,16 +1,17 @@
+import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { handbookCorsHeaders } from '@/lib/http/handbook-cors';
 
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': 'https://mobius-browser-shell.vercel.app',
-  'Access-Control-Allow-Methods': 'GET, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
-} as const;
-
-export async function OPTIONS() {
-  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+export async function OPTIONS(req: NextRequest) {
+  const cors = handbookCorsHeaders(req.headers.get('origin'));
+  if (!cors) {
+    return new NextResponse(null, { status: 204 });
+  }
+  return new NextResponse(null, { status: 204, headers: cors });
 }
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const cors = handbookCorsHeaders(req.headers.get('origin'));
   let integrity: { cycle?: string; global_integrity?: number; mode?: string } | null = null;
   try {
     const base = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
@@ -44,6 +45,6 @@ export async function GET() {
       substrate: 'https://github.com/kaizencycle/Mobius-Substrate',
       timestamp: new Date().toISOString(),
     },
-    { headers: CORS_HEADERS },
+    { headers: { ...(cors ?? {}) } },
   );
 }

--- a/app/api/terminal/snapshot-lite/route.ts
+++ b/app/api/terminal/snapshot-lite/route.ts
@@ -1,4 +1,6 @@
+import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { handbookCorsHeaders } from '@/lib/http/handbook-cors';
 import {
   isRedisAvailable,
   kvGet,
@@ -13,6 +15,14 @@ import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { getHeartbeat, getJournalHeartbeat } from '@/lib/runtime/heartbeat';
 
 export const dynamic = 'force-dynamic';
+
+export async function OPTIONS(req: NextRequest) {
+  const cors = handbookCorsHeaders(req.headers.get('origin'));
+  if (!cors) {
+    return new NextResponse(null, { status: 204 });
+  }
+  return new NextResponse(null, { status: 204, headers: cors });
+}
 
 type SystemPulse = {
   ok?: boolean;
@@ -37,8 +47,9 @@ function freshness(sec: number | null): 'fresh' | 'nominal' | 'stale' | 'degrade
   return 'degraded';
 }
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   const start = Date.now();
+  const cors = handbookCorsHeaders(req.headers.get('origin'));
 
   const [kv, gi, signals, echo, tripwire, pulse] = await Promise.all([
     kvHealth(),
@@ -125,6 +136,7 @@ export async function GET() {
     },
   }, {
     headers: {
+      ...(cors ?? {}),
       'Cache-Control': 'public, s-maxage=10, stale-while-revalidate=30',
       'X-Mobius-Source': 'terminal-snapshot-lite',
     },

--- a/app/api/vault/contributions/route.ts
+++ b/app/api/vault/contributions/route.ts
@@ -11,9 +11,16 @@
 
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { handbookCorsHeaders } from '@/lib/http/handbook-cors';
 import { listVaultDeposits } from '@/lib/vault/vault';
 
 export const dynamic = 'force-dynamic';
+
+export async function OPTIONS(req: NextRequest) {
+  const cors = handbookCorsHeaders(req.headers.get('origin'));
+  if (!cors) return new NextResponse(null, { status: 204 });
+  return new NextResponse(null, { status: 204, headers: cors });
+}
 
 type AgentContribution = {
   agent: string;
@@ -24,11 +31,12 @@ type AgentContribution = {
 };
 
 export async function GET(req: NextRequest) {
+  const cors = handbookCorsHeaders(req.headers.get('origin'));
   const groupBy = (req.nextUrl.searchParams.get('group_by') ?? 'agent').toLowerCase();
   if (groupBy !== 'agent') {
     return NextResponse.json(
       { error: 'Unsupported group_by; use group_by=agent' },
-      { status: 400 },
+      { status: 400, headers: { ...(cors ?? {}) } },
     );
   }
 
@@ -82,6 +90,7 @@ export async function GET(req: NextRequest) {
     },
     {
       headers: {
+        ...(cors ?? {}),
         'Cache-Control': 'no-store',
         'X-Mobius-Source': 'vault-contributions',
       },

--- a/app/api/vault/seal/[id]/route.ts
+++ b/app/api/vault/seal/[id]/route.ts
@@ -8,37 +8,52 @@
 
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { handbookCorsHeaders } from '@/lib/http/handbook-cors';
 import { getCandidate, getSeal } from '@/lib/vault-v2/store';
 import { verifySealHash } from '@/lib/vault-v2/seal';
 
 export const dynamic = 'force-dynamic';
 
+export async function OPTIONS(req: NextRequest) {
+  const cors = handbookCorsHeaders(req.headers.get('origin'));
+  if (!cors) return new NextResponse(null, { status: 204 });
+  return new NextResponse(null, { status: 204, headers: cors });
+}
+
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const cors = handbookCorsHeaders(req.headers.get('origin'));
+  const baseHeaders = { ...(cors ?? {}) };
   const { id } = await params;
 
   const seal = await getSeal(id);
   if (seal) {
     const hash_valid = verifySealHash(seal);
-    return NextResponse.json({
-      ok: true,
-      type: 'seal',
-      hash_valid,
-      seal,
-    });
+    return NextResponse.json(
+      {
+        ok: true,
+        type: 'seal',
+        hash_valid,
+        seal,
+      },
+      { headers: baseHeaders },
+    );
   }
 
   const candidate = await getCandidate();
   if (candidate && candidate.seal_id === id) {
-    return NextResponse.json({
-      ok: true,
-      type: 'candidate',
-      hash_valid: true,
-      candidate,
-    });
+    return NextResponse.json(
+      {
+        ok: true,
+        type: 'candidate',
+        hash_valid: true,
+        candidate,
+      },
+      { headers: baseHeaders },
+    );
   }
 
-  return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json({ error: 'Not found' }, { status: 404, headers: baseHeaders });
 }

--- a/app/api/vault/seal/route.ts
+++ b/app/api/vault/seal/route.ts
@@ -8,12 +8,20 @@
 
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { handbookCorsHeaders } from '@/lib/http/handbook-cors';
 import { SENTINEL_ATTESTATION_COUNT } from '@/lib/vault-v2/constants';
 import { countAllSeals, countSeals, getCandidate, getLatestSeal, listAllSeals, listSeals } from '@/lib/vault-v2/store';
 
 export const dynamic = 'force-dynamic';
 
+export async function OPTIONS(req: NextRequest) {
+  const cors = handbookCorsHeaders(req.headers.get('origin'));
+  if (!cors) return new NextResponse(null, { status: 204 });
+  return new NextResponse(null, { status: 204, headers: cors });
+}
+
 export async function GET(req: NextRequest) {
+  const cors = handbookCorsHeaders(req.headers.get('origin'));
   const limitParam = Number(req.nextUrl.searchParams.get('limit') ?? '50');
   const limit = Number.isFinite(limitParam)
     ? Math.max(1, Math.min(200, Math.floor(limitParam)))
@@ -55,6 +63,7 @@ export async function GET(req: NextRequest) {
     },
     {
       headers: {
+        ...(cors ?? {}),
         'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=120',
         'X-Mobius-Source': 'vault-v2-seals',
       },

--- a/app/api/vault/status/route.ts
+++ b/app/api/vault/status/route.ts
@@ -12,7 +12,9 @@
  * `in_progress_balance` field exposes the v2 canonical accumulator.
  */
 
+import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { handbookCorsHeaders } from '@/lib/http/handbook-cors';
 import { loadGIState } from '@/lib/kv/store';
 import { computeVaultSealLaneSemantics } from '@/lib/vault/lane-status';
 import { getVaultStatusPayload } from '@/lib/vault/vault';
@@ -27,7 +29,14 @@ import { SENTINEL_ATTESTATION_COUNT } from '@/lib/vault-v2/constants';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export async function OPTIONS(req: NextRequest) {
+  const cors = handbookCorsHeaders(req.headers.get('origin'));
+  if (!cors) return new NextResponse(null, { status: 204 });
+  return new NextResponse(null, { status: 204, headers: cors });
+}
+
+export async function GET(req: NextRequest) {
+  const cors = handbookCorsHeaders(req.headers.get('origin'));
   let gi: number | null = null;
   try {
     const st = await loadGIState();
@@ -102,6 +111,10 @@ export async function GET() {
   };
 
   return NextResponse.json(body, {
-    headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'vault-status-v2' },
+    headers: {
+      ...(cors ?? {}),
+      'Cache-Control': 'no-store',
+      'X-Mobius-Source': 'vault-status-v2',
+    },
   });
 }

--- a/lib/http/handbook-cors.ts
+++ b/lib/http/handbook-cors.ts
@@ -1,0 +1,36 @@
+/**
+ * CORS for public Handbook / proof UIs (e.g. GitHub Pages) calling read-only Terminal APIs.
+ *
+ * Configure extra origins via MOBIUS_HANDBOOK_CORS_ORIGINS (comma-separated full origins).
+ */
+
+const DEFAULT_ALLOWED = [
+  'https://mobius-browser-shell.vercel.app',
+  'https://kaizencycle.github.io',
+] as const;
+
+function allowedOrigins(): Set<string> {
+  const set = new Set<string>(DEFAULT_ALLOWED);
+  const raw = process.env.MOBIUS_HANDBOOK_CORS_ORIGINS?.trim();
+  if (raw) {
+    for (const part of raw.split(',')) {
+      const o = part.trim();
+      if (o) set.add(o);
+    }
+  }
+  return set;
+}
+
+/**
+ * Returns CORS headers when the request `Origin` is allowlisted; otherwise undefined.
+ */
+export function handbookCorsHeaders(origin: string | null): Record<string, string> | undefined {
+  if (!origin) return undefined;
+  if (!allowedOrigins().has(origin)) return undefined;
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    Vary: 'Origin',
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

[Mobius-Substrate PR #266](https://github.com/kaizencycle/Mobius-Substrate/pull/266) loads live proof tiles and a header strip from `https://mobius-civic-ai-terminal.vercel.app`. Browsers block cross-origin `fetch` unless the Terminal responds with CORS for `https://kaizencycle.github.io`.

## What

- New `lib/http/handbook-cors.ts`: allowlist `Origin` → `Access-Control-Allow-Origin` (echo), `GET, OPTIONS`, `Content-Type`, **`Vary: Origin`**.
- **Defaults:** `https://kaizencycle.github.io`, `https://mobius-browser-shell.vercel.app` (preserves prior bridge shell behavior).
- **Optional:** `MOBIUS_HANDBOOK_CORS_ORIGINS` — comma-separated extra origins (documented in `.env.example`).

## Routes

| Route | Methods |
|-------|---------|
| `/api/terminal/snapshot-lite` | GET, OPTIONS |
| `/api/bridge/status` | GET, OPTIONS |
| `/api/vault/status` | GET, OPTIONS |
| `/api/vault/seal` | GET, OPTIONS |
| `/api/vault/seal/[id]` | GET, OPTIONS |
| `/api/vault/contributions` | GET, OPTIONS |

CORS headers are only added when `Origin` matches the allowlist (no wildcard).

## Deploy

No new secrets required for GitHub Pages. Merge + deploy Terminal; optional `MOBIUS_HANDBOOK_CORS_ORIGINS` if you add preview Pages hostnames.

## Tests

- `pnpm exec tsc --noEmit`
- `pnpm build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

