### PR TITLE
C-285: profession lens matrix doc + Pulse Phase 1 legibility

### DIFF
--- a/CURRENT_CYCLE.md
+++ b/CURRENT_CYCLE.md
@@ -89,6 +89,12 @@ C-285 begins in a **stressed but functioning** state. EVE has issued **critical 
 
 ---
 
+## Profession lens (C-285 bundle)
+
+Multi-audience legibility matrix and phased PR bundle: [`docs/protocols/c-285-profession-lens-matrix.md`](docs/protocols/c-285-profession-lens-matrix.md). Pulse chamber implements Phase 1 slices (system story, why-this-matters, freshness language, provenance badges, VERIFY rollup).
+
+---
+
 ## PR CHECKLIST REFERENCE
 
 1. Read `AGENTS.md`, `BUILD.md`, and this file.  

--- a/app/terminal/pulse/PulsePageClient.tsx
+++ b/app/terminal/pulse/PulsePageClient.tsx
@@ -103,6 +103,28 @@ function relTime(ts?: string): string {
   return `${Math.floor(h / 24)}d ago`;
 }
 
+/** Human-readable data freshness for synthesis / operator trust (C-285 legibility). */
+function synthesisFreshness(ts?: string): { tier: 'live' | 'fresh' | 'delayed' | 'stale' | 'unknown'; line: string } {
+  if (!ts) {
+    return { tier: 'unknown', line: 'No synthesis timestamp — treat governance text as unverified for recency.' };
+  }
+  const ms = Date.now() - new Date(ts).getTime();
+  if (!Number.isFinite(ms) || ms < 0) {
+    return { tier: 'unknown', line: 'Timestamp not parseable.' };
+  }
+  const min = ms / 60000;
+  if (min < 5) {
+    return { tier: 'live', line: 'Synthesis is live: updated within the last few minutes.' };
+  }
+  if (min < 30) {
+    return { tier: 'fresh', line: 'Synthesis is fresh: still within a normal operator sweep window.' };
+  }
+  if (min < 120) {
+    return { tier: 'delayed', line: 'Delayed: journal synthesis is older than usual — confirm nothing is stuck upstream.' };
+  }
+  return { tier: 'stale', line: 'Stale: synthesis may not reflect the current cycle — prefer live lanes before acting.' };
+}
+
 type ResolvedPulseState = {
   gi: number | null;
   posture: 'NOMINAL' | 'WATCH' | 'DEGRADED' | 'STALE' | 'UNRESOLVED';
@@ -115,6 +137,52 @@ type ResolvedPulseState = {
   vaultBalance: number | null;
   source: string;
 };
+
+function whyThisMatters(state: ResolvedPulseState, degradedLanes: number): string {
+  if (state.posture === 'DEGRADED' || state.tripwireActive) {
+    return 'Why this matters: elevated civic or integrity signals mean broad promotion and unattended automation carry higher reputational and audit risk until review catches up.';
+  }
+  if (state.posture === 'WATCH') {
+    return 'Why this matters: the system is under watch — meaning is still reliable, but operator judgment should gate irreversible actions.';
+  }
+  if (degradedLanes >= 2) {
+    return 'Why this matters: multiple degraded lanes reduce confidence that the snapshot is complete — verify critical paths before external commitments.';
+  }
+  return 'Why this matters: legible state helps policy, compliance, and operators align on the same risk picture without surveillance of individuals.';
+}
+
+function systemStory(state: ResolvedPulseState, degradedLanes: number, giDelta: number | null): string {
+  const gi = state.gi != null ? `GI ${state.gi.toFixed(2)}` : 'GI unknown';
+  const tw = state.tripwireActive ? 'Tripwire context active.' : 'No active tripwire tag on latest synthesis.';
+  const lanes = degradedLanes > 0 ? `${degradedLanes} lane(s) degraded/offline.` : 'Core lanes nominal.';
+  const delta =
+    giDelta != null
+      ? giDelta < 0
+        ? `GI slipped ${Math.abs(giDelta).toFixed(2)} vs prior cycle snapshot.`
+        : `GI held or improved vs prior cycle snapshot.`
+      : '';
+  const response =
+    state.posture === 'DEGRADED' || state.tripwireActive
+      ? 'Sentinels should bias to verification and tighter promotion gates.'
+      : state.posture === 'WATCH'
+        ? 'Sentinels are tightening review; continue monitoring before broad promotion.'
+        : 'Continue normal operator cadence.';
+  return `${state.cycle}: ${gi}. ${tw} ${lanes} ${delta} ${response}`.replace(/\s+/g, ' ').trim();
+}
+
+function suggestedActions(state: ResolvedPulseState): string[] {
+  const out: string[] = ['Continue monitoring'];
+  if (state.posture === 'DEGRADED' || state.tripwireActive) {
+    out.unshift('Hold broad promotion until GI and tripwire posture improve');
+    out.push('Escalate contested EPICONs for explicit ATLAS review');
+  } else if (state.posture === 'WATCH') {
+    out.unshift('Prefer watch-only on automated promotion paths');
+  }
+  if (state.gi != null && state.gi < 0.85) {
+    out.push('Tighten promotion gates until GI stabilizes');
+  }
+  return [...new Set(out)];
+}
 
 function resolvePosture(lanes: LaneState[], integrity: IntegrityData | null, latestSynthesis: JournalEntry | null): ResolvedPulseState['posture'] {
   const sevText = (latestSynthesis?.severity ?? '').toLowerCase();
@@ -187,7 +255,6 @@ export default function PulsePageClient() {
   );
   const giDelta = currentGi != null && prevGi != null ? currentGi - prevGi : null;
   const lanes = useMemo(() => ((snapshot as { lanes?: LaneState[] } | null)?.lanes ?? []) as LaneState[], [snapshot]);
-  const vault = (snapshot?.mii?.data ?? null) as unknown;
   const vaultData = useMemo(() => {
     const raw = ((snapshot as Record<string, unknown> | null)?.vault as { data?: VaultData } | undefined)?.data;
     return raw ?? null;
@@ -226,6 +293,37 @@ export default function PulsePageClient() {
   const degradedLaneCount = useMemo(() => {
     return lanes.filter((lane) => lane.state === 'degraded' || lane.state === 'offline').length;
   }, [lanes]);
+  const synthesisFresh = useMemo(
+    () => synthesisFreshness(latestSynthesis?.timestamp),
+    [latestSynthesis?.timestamp],
+  );
+  const whyMatters = useMemo(
+    () => whyThisMatters(resolvedState, degradedLaneCount),
+    [resolvedState, degradedLaneCount],
+  );
+  const systemStoryLine = useMemo(
+    () => systemStory(resolvedState, degradedLaneCount, giDelta),
+    [resolvedState, degradedLaneCount, giDelta],
+  );
+  const actionItems = useMemo(() => suggestedActions(resolvedState), [resolvedState]);
+
+  const rolledEventRows = useMemo(() => {
+    type Row = { kind: 'single'; item: PulseItem } | { kind: 'verify_rollup'; items: PulseItem[] };
+    if (selected !== 'ALL') {
+      return filtered.map((item): Row => ({ kind: 'single', item }));
+    }
+    const verifyItems = filtered.filter((i) => mapEventType(i) === 'VERIFY');
+    const other = filtered.filter((i) => mapEventType(i) !== 'VERIFY');
+    const rows: Row[] = [];
+    if (verifyItems.length >= 3) {
+      rows.push({ kind: 'verify_rollup', items: verifyItems });
+    } else {
+      verifyItems.forEach((item) => rows.push({ kind: 'single', item }));
+    }
+    other.forEach((item) => rows.push({ kind: 'single', item }));
+    return rows;
+  }, [filtered, selected]);
+
   const promotionCounters = ((snapshot?.promotion?.data ?? {}) as { counters?: { pending_promotable_count?: number; promoted_this_cycle_count?: number } }).counters;
   const epiconSources = ((snapshot?.epicon?.data ?? {}) as {
     sources?: { github?: number; kv?: number; ledgerApi?: number; memory?: number; memoryLedger?: number };
@@ -266,6 +364,22 @@ export default function PulsePageClient() {
           <span className="text-slate-400">{filtered.length} entries</span>
         </div>
       </div>
+
+      <section className="mb-3 space-y-2 rounded border border-slate-700/80 bg-slate-950/70 p-3 text-[11px] leading-relaxed text-slate-300">
+        <div>
+          <div className="mb-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-violet-300/90">System story</div>
+          <p className="text-slate-200">{systemStoryLine}</p>
+        </div>
+        <p className="border-t border-slate-800 pt-2 text-slate-400">{whyMatters}</p>
+        <div className="border-t border-slate-800 pt-2">
+          <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-500">Suggested actions</div>
+          <ul className="list-inside list-disc space-y-0.5 text-slate-400">
+            {actionItems.map((a) => (
+              <li key={a}>{a}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
 
       {/* Agent filter tabs — scrollable, never clipped */}
       <div className="mb-4 flex gap-1.5 overflow-x-auto pb-1 scrollbar-none">
@@ -313,6 +427,26 @@ export default function PulsePageClient() {
         {latestSynthesis ? (
           <div>
             <div className="mb-1.5 flex flex-wrap items-center gap-1.5 text-[10px]">
+              <span
+                className="cursor-help rounded border border-slate-600 px-1 py-0.5 font-mono text-slate-400"
+                title="Global Integrity — composite operator signal (0–1). Not a citizen score."
+              >
+                GI?
+              </span>
+              <span
+                className={`rounded border px-1.5 py-0.5 font-mono uppercase ${
+                  synthesisFresh.tier === 'live' || synthesisFresh.tier === 'fresh'
+                    ? 'border-emerald-600/50 text-emerald-200'
+                    : synthesisFresh.tier === 'delayed'
+                      ? 'border-amber-600/50 text-amber-200'
+                      : synthesisFresh.tier === 'stale'
+                        ? 'border-rose-600/50 text-rose-200'
+                        : 'border-slate-600 text-slate-500'
+                }`}
+                title={synthesisFresh.line}
+              >
+                data: {synthesisFresh.tier}
+              </span>
               <span className="rounded border border-cyan-600/50 bg-cyan-500/10 px-1.5 py-0.5 font-mono text-cyan-100">{latestSynthesis.agent}</span>
               <span className="text-slate-500">{relTime(latestSynthesis.timestamp)}</span>
               <span className={`rounded border px-1.5 py-0.5 ${sevStyle(latestSynthesis.severity ?? 'nominal')}`}>
@@ -329,13 +463,34 @@ export default function PulsePageClient() {
                 </span>
               ) : null}
             </div>
+            <p className="mb-1.5 text-[10px] text-slate-500">{synthesisFresh.line}</p>
             <div className="space-y-1.5 text-[11px] leading-snug">
-              <p className="text-slate-200"><span className="font-semibold text-slate-400">Obs:</span> {latestSynthesis.observation}</p>
-              <p className="text-slate-200"><span className="font-semibold text-cyan-400/80">Inf:</span> {latestSynthesis.inference}</p>
+              <p className="text-slate-200">
+                <span className="mr-1 rounded border border-slate-600 bg-slate-900/80 px-1 py-0.5 text-[9px] font-mono text-slate-400" title="From agent journal — not ledger-attested fact">
+                  OBSERVED
+                </span>
+                {latestSynthesis.observation}
+              </p>
+              <p className="text-slate-200">
+                <span className="mr-1 rounded border border-cyan-700/50 bg-cyan-950/40 px-1 py-0.5 text-[9px] font-mono text-cyan-300/90" title="Agent reasoning — verify before treating as settled">
+                  INFERRED
+                </span>
+                {latestSynthesis.inference}
+              </p>
               {latestSynthesis.recommendation !== latestSynthesis.inference ? (
-                <p className="text-slate-200"><span className="font-semibold text-emerald-400/80">Rec:</span> {latestSynthesis.recommendation}</p>
+                <p className="text-slate-200">
+                  <span className="mr-1 rounded border border-emerald-700/50 bg-emerald-950/30 px-1 py-0.5 text-[9px] font-mono text-emerald-300/90" title="Suggested operator response — not automatic execution">
+                    RECOMMENDED
+                  </span>
+                  {latestSynthesis.recommendation}
+                </p>
               ) : (
-                <p className="text-slate-300"><span className="font-semibold text-emerald-400/80">Rec:</span> Verify current posture against live signal surface; defer promotion until next synthesis confirms stability.</p>
+                <p className="text-slate-300">
+                  <span className="mr-1 rounded border border-emerald-700/50 bg-emerald-950/30 px-1 py-0.5 text-[9px] font-mono text-emerald-300/90" title="Suggested operator response — not automatic execution">
+                    RECOMMENDED
+                  </span>
+                  Verify current posture against live signal surface; defer promotion until next synthesis confirms stability.
+                </p>
               )}
             </div>
           </div>
@@ -359,37 +514,69 @@ export default function PulsePageClient() {
 
       {/* Event list */}
       <div className="space-y-2">
-        {filtered.map((item) => (
-          <article key={item.id} className="rounded border border-slate-800 bg-slate-900/60 p-2.5 md:p-3">
-            <div className="mb-1 flex flex-wrap items-center gap-1.5 text-[10px] md:text-xs">
-              <span className="rounded border border-cyan-600/40 bg-cyan-500/10 px-1.5 py-0.5 font-mono text-cyan-100">
-                {mapEventType(item)}
-              </span>
-              <span className="rounded border border-slate-700 px-1.5 py-0.5 font-mono text-slate-400">{item.agent ?? 'SYSTEM'}</span>
-              <span className="text-slate-500">{item.status ?? 'active'}</span>
-            </div>
-            <div className="text-sm font-semibold leading-snug text-slate-100">
-              {item.title ?? 'Untitled EPICON event'}
-            </div>
-            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-slate-400">
-              <span>{item.timestamp ?? '—'}</span>
-              <span>{relTime(item.timestamp)}</span>
-              <span>sev {item.severity ?? 'unknown'}</span>
-              <span>MII {item.mii_score ?? '—'}</span>
-            </div>
-            <details className="mt-1.5 text-[10px] text-slate-500">
-              <summary className="cursor-pointer list-none text-slate-500 underline decoration-dotted underline-offset-2">
-                More details
+        {rolledEventRows.map((row, idx) =>
+          row.kind === 'verify_rollup' ? (
+            <details
+              key={`verify-rollup-${idx}`}
+              className="rounded border border-amber-700/40 bg-amber-950/20 p-2.5 md:p-3"
+            >
+              <summary className="cursor-pointer list-none text-[11px] text-amber-100/95">
+                <span className="rounded border border-amber-600/50 bg-amber-500/15 px-1.5 py-0.5 font-mono text-[10px] uppercase">
+                  VERIFY ×{row.items.length}
+                </span>
+                <span className="ml-2 text-slate-400">Repeated verification events — expand for list</span>
               </summary>
-              <div className="mt-1 space-y-0.5">
-                <div>source {item.source ?? '—'} · id {item.id}</div>
-                {item.category ? <div>category {item.category}</div> : null}
-                {item.cycle ? <div>cycle {item.cycle}</div> : null}
-                {item.tags?.length ? <div>tags {item.tags.join(', ')}</div> : null}
+              <div className="mt-2 space-y-2 border-t border-amber-900/40 pt-2">
+                {row.items.map((item) => (
+                  <article key={item.id} className="rounded border border-slate-800 bg-slate-900/60 p-2">
+                    <div className="text-xs font-medium text-slate-200">{item.title ?? item.id}</div>
+                    <div className="mt-0.5 text-[10px] text-slate-500">
+                      {item.agent ?? 'SYSTEM'} · {relTime(item.timestamp)}
+                    </div>
+                  </article>
+                ))}
               </div>
             </details>
-          </article>
-        ))}
+          ) : (
+            <article key={row.item.id} className="rounded border border-slate-800 bg-slate-900/60 p-2.5 md:p-3">
+              <div className="mb-1 flex flex-wrap items-center gap-1.5 text-[10px] md:text-xs">
+                <span className="rounded border border-cyan-600/40 bg-cyan-500/10 px-1.5 py-0.5 font-mono text-cyan-100">
+                  {mapEventType(row.item)}
+                </span>
+                {mapEventType(row.item) === 'VERIFY' ? (
+                  <span
+                    className="rounded border border-sky-700/50 bg-sky-950/40 px-1 py-0.5 text-[9px] font-mono text-sky-200/90"
+                    title="Lane verification — not ledger attestation"
+                  >
+                    VERIFIED
+                  </span>
+                ) : null}
+                <span className="rounded border border-slate-700 px-1.5 py-0.5 font-mono text-slate-400">{row.item.agent ?? 'SYSTEM'}</span>
+                <span className="text-slate-500">{row.item.status ?? 'active'}</span>
+              </div>
+              <div className="text-sm font-semibold leading-snug text-slate-100">
+                {row.item.title ?? 'Untitled EPICON event'}
+              </div>
+              <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-slate-400">
+                <span>{row.item.timestamp ?? '—'}</span>
+                <span>{relTime(row.item.timestamp)}</span>
+                <span>sev {row.item.severity ?? 'unknown'}</span>
+                <span>MII {row.item.mii_score ?? '—'}</span>
+              </div>
+              <details className="mt-1.5 text-[10px] text-slate-500">
+                <summary className="cursor-pointer list-none text-slate-500 underline decoration-dotted underline-offset-2">
+                  More details
+                </summary>
+                <div className="mt-1 space-y-0.5">
+                  <div>source {row.item.source ?? '—'} · id {row.item.id}</div>
+                  {row.item.category ? <div>category {row.item.category}</div> : null}
+                  {row.item.cycle ? <div>cycle {row.item.cycle}</div> : null}
+                  {row.item.tags?.length ? <div>tags {row.item.tags.join(', ')}</div> : null}
+                </div>
+              </details>
+            </article>
+          ),
+        )}
       </div>
     </div>
   );

--- a/docs/protocols/c-285-profession-lens-matrix.md
+++ b/docs/protocols/c-285-profession-lens-matrix.md
@@ -1,0 +1,130 @@
+# Mobius Terminal — 10 Profession Lens Matrix + PR Optimization Bundle
+
+## C-285 Draft
+
+**Purpose:** Translate Mobius Terminal through the eyes of 10 different professions, then convert those perspectives into concrete Terminal optimizations that improve clarity, trust, and product fit.
+
+---
+
+## Part I — How Mobius appears to 10 different professions
+
+### 1. Politician / Policy Leader
+
+**What they see:** civic accountability substrate; institutional AI legibility; public-trust layer; anti–black-box governance potential.
+
+**Main question:** Does this increase accountability without becoming surveillance?
+
+**What matters:** auditability; transparency of systems not citizens; explainable escalations; policy compatibility; public legitimacy.
+
+### 2. Engineer
+
+**What they see:** control-plane / observability; state machine with integrity thresholds; distributed coordination; trust boundaries.
+
+**Main question:** What are the invariants, failure modes, and trust boundaries?
+
+**What matters:** data freshness; state transitions; failure handling; replayability; health under degradation.
+
+### 3. Developer
+
+**What they see:** APIs, ledgers, routes, schemas, auth, agent surfaces.
+
+**Main question:** What do I build first, and how do I plug into it?
+
+**What matters:** endpoints; payload shape; auth; env; docs.
+
+### 4. Healthcare Worker
+
+**What they see:** triage and continuity; safer handoff / escalation memory.
+
+**Main question:** Does this reduce harm and make escalation easier to understand?
+
+**What matters:** alert clarity; actionability; handoff history; human override.
+
+### 5. Robotics Operator
+
+**What they see:** mission control; fleet health; safety and telemetry; shared human–bot state.
+
+**Main question:** What is the robot doing, is it safe, what next?
+
+**What matters:** posture; fault state; tripwires; intervention timing.
+
+### 6. Security / Cyber Operator
+
+**What they see:** tamper-evident events; anomaly chronology; verification lane.
+
+**Main question:** Silent drift, unauthorized action, unverifiable state?
+
+**What matters:** provenance; attestation; tripwire severity; audit trails.
+
+### 7. Founder / Executive
+
+**What they see:** multi-vertical platform; trust moat; category story.
+
+**Main question:** What is the wedge; how do we sell it legibly?
+
+**What matters:** value clarity; adoption path; coherence.
+
+### 8. Researcher / Academic
+
+**What they see:** living experiment; measurable integrity behavior.
+
+**Main question:** What can be measured, reproduced, falsified?
+
+**What matters:** metrics; methodology; archives; defined terms.
+
+### 9. Compliance / Risk / Legal
+
+**What they see:** record of why promotions happened; defensible review.
+
+**Main question:** Who decided what, on what basis, under what authority?
+
+**What matters:** authority provenance; record integrity; approval paths; retention.
+
+### 10. Everyday User / Citizen
+
+**What they see:** serious system with memory and order; dense dashboard.
+
+**Main question:** What for me today; why trust?
+
+**What matters:** clarity; obvious status; human language over jargon.
+
+---
+
+## Part II — Synthesis
+
+All ten professions see the same pattern through different lenses. **Conclusion:** the Terminal should be a **multi-audience legibility surface** — deep constitutionally, easier to interpret without diluting truth.
+
+---
+
+## Part III — PR optimization bundle (10 items)
+
+1. **“Why this matters” strip** on critical / elevated cards — plain-language consequence.
+2. **Provenance badges** — OBSERVED / INFERRED / RECOMMENDED / VERIFIED / ATTESTED where applicable.
+3. **Audience view presets** (Operator / Executive / Research / Civic / Robotics) — presentation only.
+4. **System Story** summary block — posture, blocker, active response, next decision.
+5. **Severity compression / dedupe rollups** — repeated VERIFY (or similar) collapsed with expand.
+6. **Authority path callouts** — who may act; human review required.
+7. **Freshness in human language** — live / fresh / delayed / stale with one-line meaning.
+8. **Profession-linked explainer microcopy** — hover/help for GI, EPICON, Journal, Vault, Seal, Tripwire, Promotion.
+9. **Action lane** — Hold promotion / Escalate / Watch / Safe-stop (distinct from narrative).
+10. **Cycle close / seal widget** — latest seal, carryover, unresolved into next cycle.
+
+### Implementation phases
+
+- **Phase 1:** items 1, 2, 5, 7 (Pulse chamber initial slice in Terminal repo).
+- **Phase 2:** 3, 4, 8.
+- **Phase 3:** 6, 9, 10.
+
+### Risk
+
+Low–medium UX / IA only; no GI formula, MIC, Vault economics, or permission changes in this bundle.
+
+---
+
+## One-line takeaway
+
+**Mobius Terminal should remain constitutionally deep, but become professionally legible.**
+
+---
+
+*We heal as we walk.*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Commits the **10 profession lens matrix + PR optimization bundle** as an in-repo protocol (`docs/protocols/c-285-profession-lens-matrix.md`) and implements **Phase 1** legibility on the **Pulse** chamber: system story, why-this-matters, human synthesis freshness, provenance badges on latest synthesis, VERIFY event rollup (ALL filter), and a suggested **actions** list. `CURRENT_CYCLE.md` links to the doc.

## Pulse UI (Phase 1)

- **System story** — one paragraph from posture, GI, tripwire tag, lane health, GI delta, sentinel bias text.
- **Why this matters** — consequence framing for degraded / watch / multi-lane failure.
- **Suggested actions** — operator-oriented bullets (hold promotion, ATLAS on contested EPICONs, etc.) derived from state (not new backend authority).
- **Synthesis freshness** — `live` | `fresh` | `delayed` | `stale` + human sentence + `GI?` tooltip.
- **Badges** — OBSERVED / INFERRED / RECOMMENDED on journal lines; VERIFIED on VERIFY EPICON rows (tooltip: lane verification ≠ ledger attestation).
- **Dedupe** — When filter is ALL and ≥3 VERIFY events, collapses into expandable **VERIFY ×N** rollup.

## Non-goals (this PR)

- No audience presets, global explainer drawer, authority path schema, or seal widget (Phases 2–3 per doc).
- No GI formula, promotion rules, or MIC changes.

## Tests

- `pnpm exec tsc --noEmit`
- `pnpm build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

