### PR TITLE
feat(terminal/journal): render confidence, severity, scope, and derivedFrom

### DIFF
--- a/app/terminal/journal/JournalPageClient.tsx
+++ b/app/terminal/journal/JournalPageClient.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import JournalEntryCard from '@/components/terminal/journal/JournalEntryCard';
 import ChamberEmptyState from '@/components/terminal/ChamberEmptyState';
 import ChamberSkeleton from '@/components/terminal/ChamberSkeleton';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
+import type { JournalDisplayEntry, JournalDisplaySeverity, JournalDisplayStatus } from '@/lib/journal/types';
 
 const AGENTS = ['ATLAS', 'ZEUS', 'EVE', 'AUREA', 'HERMES', 'JADE', 'DAEDALUS', 'ECHO'] as const;
 
@@ -21,27 +23,7 @@ const AGENT_PILL_STYLE: Record<string, { border: string; activeBg: string; text:
   ECHO: { border: 'border-slate-500/50', activeBg: 'bg-slate-600/20', text: 'text-slate-100' },
 };
 
-type JournalStatus = 'draft' | 'committed' | 'contested' | 'verified';
-type JournalSeverity = 'nominal' | 'elevated' | 'critical';
-
-type JournalEntry = {
-  id: string;
-  agent: string;
-  cycle?: string;
-  category?: string;
-  observation?: string;
-  inference?: string;
-  recommendation?: string;
-  confidence?: number;
-  derivedFrom?: string[];
-  source?: string;
-  timestamp?: string;
-  status?: JournalStatus;
-  severity?: JournalSeverity;
-  scope?: string;
-};
-
-type JournalResponse = { count?: number; entries?: JournalEntry[] };
+type JournalResponse = { count?: number; entries?: JournalDisplayEntry[] };
 
 type EpiconItem = {
   id: string;
@@ -63,16 +45,16 @@ function deriveAgent(item: EpiconItem): string {
   return 'ATLAS';
 }
 
-function epiconSeverityToJournal(sev: string): JournalSeverity {
+function epiconSeverityToJournal(sev: string): JournalDisplaySeverity {
   const s = sev.toLowerCase();
   if (s === 'critical' || s === 'high') return 'critical';
   if (s === 'elevated' || s === 'medium') return 'elevated';
   return 'nominal';
 }
 
-function toDerivedEntry(item: EpiconItem): JournalEntry {
+function toDerivedEntry(item: EpiconItem): JournalDisplayEntry {
   const cycle = currentCycleId();
-  const status: JournalStatus = item.type === 'zeus-verify' ? 'verified' : 'committed';
+  const status: JournalDisplayStatus = item.type === 'zeus-verify' ? 'verified' : 'committed';
   const severity = epiconSeverityToJournal(item.severity ?? 'nominal');
   return {
     id: `derived-${item.id}`,
@@ -95,7 +77,7 @@ function parseCycleOrdinal(cycle: string | undefined): number {
   return Number.isFinite(n) ? n : 0;
 }
 
-function statusRank(s: JournalStatus | undefined): number {
+function statusRank(s: JournalDisplayStatus | undefined): number {
   if (s === 'verified') return 4;
   if (s === 'committed') return 3;
   if (s === 'contested') return 2;
@@ -103,7 +85,7 @@ function statusRank(s: JournalStatus | undefined): number {
   return 2;
 }
 
-function severityRank(s: JournalSeverity | undefined): number {
+function severityRank(s: JournalDisplaySeverity | undefined): number {
   if (s === 'critical') return 3;
   if (s === 'elevated') return 2;
   if (s === 'nominal') return 1;
@@ -111,7 +93,7 @@ function severityRank(s: JournalSeverity | undefined): number {
 }
 
 /** Operator-first: current cycle, status, severity, confidence, recency. */
-function sortJournalOperatorFirst(rows: JournalEntry[], focusCycleId: string): JournalEntry[] {
+function sortJournalOperatorFirst(rows: JournalDisplayEntry[], focusCycleId: string): JournalDisplayEntry[] {
   const focus = focusCycleId.trim();
   return [...rows].sort((a, b) => {
     const aCurrent = (a.cycle?.trim() ?? '') === focus ? 1 : 0;
@@ -141,15 +123,33 @@ function sortJournalOperatorFirst(rows: JournalEntry[], focusCycleId: string): J
 }
 
 export default function JournalPageClient() {
-  const [entries, setEntries] = useState<JournalEntry[] | null>(null);
+  const [entries, setEntries] = useState<JournalDisplayEntry[] | null>(null);
   const [agent, setAgent] = useState('ALL');
   const [cycleTab, setCycleTab] = useState<string>(() => currentCycleId());
   const [derivedMode, setDerivedMode] = useState(false);
+  const [missingRelatedId, setMissingRelatedId] = useState<string | null>(null);
+  const anchorsRef = useRef<Map<string, HTMLElement>>(new Map());
+
+  const registerAnchor = useCallback((id: string, el: HTMLElement | null) => {
+    if (el) anchorsRef.current.set(id, el);
+    else anchorsRef.current.delete(id);
+  }, []);
+
+  const onRelatedClick = useCallback((journalEntryId: string) => {
+    const el = anchorsRef.current.get(journalEntryId);
+    if (el) {
+      setMissingRelatedId(null);
+      el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      return;
+    }
+    setMissingRelatedId(journalEntryId);
+    window.setTimeout(() => setMissingRelatedId(null), 5000);
+  }, []);
 
   useEffect(() => {
     let mounted = true;
     void (async () => {
-      let journalEntries: JournalEntry[] = [];
+      let journalEntries: JournalDisplayEntry[] = [];
       try {
         const res = await fetch('/api/agents/journal?limit=100', { cache: 'no-store' });
         const data = (await res.json()) as JournalResponse;
@@ -312,39 +312,20 @@ export default function JournalPageClient() {
               );
             })}
           </div>
+          {missingRelatedId ? (
+            <div className="mb-2 rounded border border-amber-500/35 bg-amber-950/25 px-3 py-2 text-[11px] text-amber-100">
+              Source not in current window: <span className="font-mono text-amber-50">{missingRelatedId}</span>
+            </div>
+          ) : null}
           <div className="space-y-2">
-            {filtered.map((entry) => {
-              const rec = (entry.recommendation ?? '').trim();
-              const inf = (entry.inference ?? '').trim();
-              const showRec = rec.length > 0 && rec !== inf;
-              const statusLabel = (entry.status ?? 'committed').toUpperCase();
-              const severityLabel = (entry.severity ?? 'nominal').toUpperCase();
-              return (
-                <article key={entry.id} className="rounded border border-slate-800 bg-slate-900/60 p-3 text-xs">
-                  <div className="flex flex-wrap items-center gap-2 font-mono text-slate-400">
-                    <span>
-                      {entry.agent} · {entry.cycle ?? 'C-—'} · {entry.category ?? 'journal'}
-                    </span>
-                    <span className="rounded border border-slate-600 px-1.5 py-0.5 text-[10px] text-slate-300">{statusLabel}</span>
-                    <span
-                      className={`rounded border px-1.5 py-0.5 text-[10px] ${
-                        severityLabel === 'CRITICAL'
-                          ? 'border-rose-500/50 text-rose-200'
-                          : severityLabel === 'ELEVATED'
-                            ? 'border-amber-500/50 text-amber-200'
-                            : 'border-slate-600 text-slate-400'
-                      }`}
-                    >
-                      {severityLabel}
-                    </span>
-                  </div>
-                  <div className="mt-1 text-slate-200">{entry.observation ?? '—'}</div>
-                  <div className="mt-1 text-slate-400">Inference: {entry.inference ?? '—'}</div>
-                  {showRec ? <div className="mt-1 text-slate-400">Recommendation: {entry.recommendation}</div> : null}
-                  <div className="mt-1 text-slate-500">{entry.timestamp ?? '—'} · source {entry.source ?? 'journal'}</div>
-                </article>
-              );
-            })}
+            {filtered.map((entry) => (
+              <JournalEntryCard
+                key={entry.id}
+                entry={entry}
+                onRelatedClick={onRelatedClick}
+                registerAnchor={registerAnchor}
+              />
+            ))}
           </div>
         </>
       )}

--- a/components/terminal/journal/ConfidenceBadge.tsx
+++ b/components/terminal/journal/ConfidenceBadge.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import type { JournalDisplayEntry } from '@/lib/journal/types';
+
+type Props = {
+  confidence: JournalDisplayEntry['confidence'];
+};
+
+export default function ConfidenceBadge({ confidence }: Props) {
+  if (typeof confidence !== 'number' || !Number.isFinite(confidence)) return null;
+
+  const c = Math.max(0, Math.min(1, confidence));
+  let cls =
+    'rounded-full border px-2 py-0.5 font-mono text-[10px] tabular-nums border-slate-600 bg-slate-800/80 text-slate-300';
+  if (c >= 0.85) {
+    cls =
+      'rounded-full border px-2 py-0.5 font-mono text-[10px] tabular-nums border-emerald-500/45 bg-emerald-500/10 text-emerald-100';
+  } else if (c >= 0.7) {
+    cls =
+      'rounded-full border px-2 py-0.5 font-mono text-[10px] tabular-nums border-amber-500/45 bg-amber-500/10 text-amber-100';
+  }
+
+  return <span className={cls}>{c.toFixed(2)}</span>;
+}

--- a/components/terminal/journal/DerivedFromChain.tsx
+++ b/components/terminal/journal/DerivedFromChain.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+/** Match `journal-ATLAS-C-285-9691` inside a longer substrate ref. */
+const JOURNAL_SUBSTRING = /journal-[A-Za-z0-9-]+/i;
+/** Short-form cron id e.g. `ATLAS-C-285-1776531745478`. */
+const SHORT_FORM = /^[A-Z]{2,12}-C-\d+-\d+$/i;
+
+export function extractJournalEntryIdForNav(ref: string): string | null {
+  const t = ref.trim();
+  if (!t) return null;
+  const embedded = t.match(JOURNAL_SUBSTRING);
+  if (embedded) return embedded[0];
+  if (SHORT_FORM.test(t)) return t;
+  if (t.startsWith('journal-')) return t;
+  return null;
+}
+
+type Props = {
+  items: string[] | undefined;
+  onJournalRefClick?: (journalEntryId: string) => void;
+};
+
+export default function DerivedFromChain({ items, onJournalRefClick }: Props) {
+  const list = (items ?? []).filter((s) => typeof s === 'string' && s.trim().length > 0);
+  if (list.length === 0) return null;
+
+  return (
+    <div className="mt-2 space-y-1">
+      <div className="text-[10px] font-medium uppercase tracking-wide text-slate-500">Derived from</div>
+      <div className="flex flex-wrap gap-1.5">
+        {list.map((ref) => {
+          const navId = extractJournalEntryIdForNav(ref);
+          const clickable = Boolean(onJournalRefClick) && navId !== null;
+          const base =
+            'max-w-full truncate rounded border px-2 py-0.5 font-mono text-[10px] transition ' +
+            (clickable
+              ? 'cursor-pointer border-violet-500/40 bg-violet-500/10 text-violet-100 hover:border-violet-400/60 hover:bg-violet-500/15'
+              : 'cursor-default border-slate-700 bg-slate-900/80 text-slate-400');
+          return (
+            <button
+              key={ref}
+              type="button"
+              disabled={!clickable}
+              title={clickable ? `Scroll to ${navId}` : ref}
+              onClick={() => clickable && navId && onJournalRefClick?.(navId)}
+              className={base}
+            >
+              {ref}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/terminal/journal/JournalEntryCard.tsx
+++ b/components/terminal/journal/JournalEntryCard.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import ConfidenceBadge from '@/components/terminal/journal/ConfidenceBadge';
+import DerivedFromChain from '@/components/terminal/journal/DerivedFromChain';
+import SeverityPill from '@/components/terminal/journal/SeverityPill';
+import type { JournalDisplayEntry } from '@/lib/journal/types';
+
+export type JournalEntryCardProps = {
+  entry: JournalDisplayEntry;
+  onRelatedClick?: (journalEntryId: string) => void;
+  registerAnchor?: (id: string, el: HTMLElement | null) => void;
+};
+
+export default function JournalEntryCard({ entry, onRelatedClick, registerAnchor }: JournalEntryCardProps) {
+  const rootRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    registerAnchor?.(entry.id, rootRef.current);
+    return () => {
+      registerAnchor?.(entry.id, null);
+    };
+  }, [entry.id, registerAnchor]);
+
+  const rec = (entry.recommendation ?? '').trim();
+  const inf = (entry.inference ?? '').trim();
+  const showRec = rec.length > 0 && rec !== inf;
+  const statusLabel = (entry.status ?? 'committed').toUpperCase();
+  const scope = (entry.scope ?? '').trim();
+  const category = (entry.category ?? '').trim();
+
+  return (
+    <article
+      ref={(n) => {
+        rootRef.current = n;
+      }}
+      data-journal-entry-id={entry.id}
+      className="rounded border border-slate-800 bg-slate-900/60 p-3 text-xs"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-2 font-mono text-slate-300">
+            <span className="font-semibold">{entry.agent}</span>
+            <span className="text-slate-500">·</span>
+            <span>{entry.cycle ?? 'C-—'}</span>
+            <span className="text-slate-500">·</span>
+            <span className="text-slate-400">{entry.timestamp ?? '—'}</span>
+          </div>
+          {scope ? <p className="text-[11px] italic leading-snug text-slate-500">{scope}</p> : null}
+        </div>
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
+          <SeverityPill severity={entry.severity} />
+          <ConfidenceBadge confidence={entry.confidence} />
+        </div>
+      </div>
+
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <span className="rounded border border-slate-600 px-1.5 py-0.5 text-[10px] text-slate-300">{statusLabel}</span>
+        {category ? (
+          <span className="rounded border border-slate-700/80 bg-slate-800/50 px-1.5 py-0.5 text-[10px] text-slate-400">
+            {category}
+          </span>
+        ) : null}
+        <span className="text-[10px] text-slate-600">source {entry.source ?? 'journal'}</span>
+      </div>
+
+      <div className="mt-2 text-slate-200">
+        <span className="font-medium text-slate-400">Observed: </span>
+        {entry.observation ?? '—'}
+      </div>
+      <div className="mt-1.5 text-slate-300">
+        <span className="font-medium text-slate-500">Inferred: </span>
+        {entry.inference ?? '—'}
+      </div>
+      {showRec ? (
+        <div className="mt-1.5 text-slate-300">
+          <span className="font-medium text-slate-500">Recommends: </span>
+          {entry.recommendation}
+        </div>
+      ) : null}
+
+      <DerivedFromChain items={entry.derivedFrom} onJournalRefClick={onRelatedClick} />
+    </article>
+  );
+}

--- a/components/terminal/journal/SeverityPill.tsx
+++ b/components/terminal/journal/SeverityPill.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { JournalDisplaySeverity } from '@/lib/journal/types';
+
+type Props = {
+  severity: JournalDisplaySeverity | undefined;
+};
+
+export default function SeverityPill({ severity }: Props) {
+  const s = (severity ?? 'nominal').toLowerCase() as JournalDisplaySeverity;
+  const label = s.toUpperCase();
+
+  if (s === 'critical') {
+    return (
+      <span className="motion-safe:animate-pulse rounded-full border border-rose-500/55 bg-rose-500/15 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-rose-100 motion-reduce:animate-none">
+        {label}
+      </span>
+    );
+  }
+  if (s === 'elevated') {
+    return (
+      <span className="rounded-full border border-amber-500/50 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-100">
+        {label}
+      </span>
+    );
+  }
+  return (
+    <span className="rounded-full border border-slate-600 bg-slate-800/60 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-400">
+      {label}
+    </span>
+  );
+}

--- a/lib/journal/types.ts
+++ b/lib/journal/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Journal chamber display types (aligned with `/api/agents/journal` payload).
+ * UI-only; API route owns the canonical write shape.
+ */
+
+export type JournalDisplayStatus = 'draft' | 'committed' | 'contested' | 'verified';
+export type JournalDisplaySeverity = 'nominal' | 'elevated' | 'critical';
+
+/** Fields the journal API returns; optional where legacy or derived entries may omit. */
+export type JournalDisplayEntry = {
+  id: string;
+  agent: string;
+  cycle?: string;
+  category?: string;
+  observation?: string;
+  inference?: string;
+  recommendation?: string;
+  confidence?: number;
+  derivedFrom?: string[];
+  source?: string;
+  timestamp?: string;
+  status?: JournalDisplayStatus;
+  severity?: JournalDisplaySeverity;
+  scope?: string;
+  agentOrigin?: string;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## C-285 — Journal chamber PR 1 (UI only)

Implements the first PR from the **Journal Chamber · Three-PR Plan**: surface fields already returned by `GET /api/agents/journal` without changing the API or KV.

### What changed

- New **`JournalEntryCard`** layout: agent · cycle · timestamp; **scope** as italic subtitle; **severity** pill + **confidence** numeric badge; **status** + **category** tags; Observed / Inferred / Recommends rows; **derivedFrom** chip row.
- **Confidence**: green ≥ 0.85, amber 0.70–0.85, grey &lt; 0.70; hidden if missing/invalid.
- **Severity**: nominal grey, elevated amber, critical rose with `motion-safe:animate-pulse` and `motion-reduce:animate-none`.
- **Recommendation row**: hidden when `recommendation === inference` (per plan PR1 note).
- **derivedFrom navigation**: chips that embed a `journal-*` id (e.g. `atlas-journal:journal-ATLAS-C-285-9691`) extract the id and scroll the matching card into view; if the target is not in the loaded list, a **“Source not in current window”** banner appears for 5s.
- Shared display type: **`lib/journal/types.ts`** (`JournalDisplayEntry`).

### Boundaries (unchanged)

- No `/api/agents/journal` response changes  
- No cron / KV / journal write path changes  
- EPICON-derived fallback entries unchanged (no `derivedFrom` / `scope` unless present)

### Verification

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- ESLint — not configured in repo

### Follow-up

PR 2 (cron dedupe) and PR 3 (deltas / threading) remain separate work per the plan.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

