### PR TITLE
feat(vault): Phase 2 contribution breakdown (agent + cycle) and Vault UI

### DIFF
--- a/app/api/vault/contributions/route.ts
+++ b/app/api/vault/contributions/route.ts
@@ -2,16 +2,22 @@
  * GET /api/vault/contributions
  *
  * Reads `vault:deposits` (newest-first LPUSH list) and aggregates reserve
- * contributed by agent. Source is journal-scored deposits, not wallets.
+ * contributed from journal-scored deposits (not wallets).
  *
  * Query:
- *   group_by=agent  (default; only supported value today)
- *   limit=200       (max rows scanned from the list tail; default 200)
+ *   group_by=agent | cycle  (default agent)
+ *   cycle=C-285     optional filter: only deposits whose journal_id parses to this cycle
+ *   limit=200       max rows scanned (default 200, max 200)
  */
 
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { handbookCorsHeaders } from '@/lib/http/handbook-cors';
+import {
+  aggregateByAgent,
+  aggregateByCycle,
+  buildDepositReplayMetrics,
+} from '@/lib/vault/contributions';
 import { listVaultDeposits } from '@/lib/vault/vault';
 
 export const dynamic = 'force-dynamic';
@@ -22,20 +28,12 @@ export async function OPTIONS(req: NextRequest) {
   return new NextResponse(null, { status: 204, headers: cors });
 }
 
-type AgentContribution = {
-  agent: string;
-  total_reserve_contributed: number;
-  deposit_count: number;
-  last_deposit_at: string | null;
-  last_journal_id: string | null;
-};
-
 export async function GET(req: NextRequest) {
   const cors = handbookCorsHeaders(req.headers.get('origin'));
   const groupBy = (req.nextUrl.searchParams.get('group_by') ?? 'agent').toLowerCase();
-  if (groupBy !== 'agent') {
+  if (groupBy !== 'agent' && groupBy !== 'cycle') {
     return NextResponse.json(
-      { error: 'Unsupported group_by; use group_by=agent' },
+      { error: 'Unsupported group_by; use group_by=agent or group_by=cycle' },
       { status: 400, headers: { ...(cors ?? {}) } },
     );
   }
@@ -45,53 +43,70 @@ export async function GET(req: NextRequest) {
     ? Math.max(1, Math.min(200, Math.floor(limitParam)))
     : 200;
 
+  const cycleFilter = req.nextUrl.searchParams.get('cycle')?.trim() || null;
+
   const deposits = await listVaultDeposits(limit);
+  const replay = buildDepositReplayMetrics(deposits);
 
-  const byAgent = new Map<string, AgentContribution>();
+  const base = {
+    ok: true,
+    source: 'vault:deposits',
+    description:
+      'Reserve units accrued from scored agent journal entries (not MIC wallet stakes).',
+    rows_scanned: deposits.length,
+    limit,
+    cycle_filter: cycleFilter,
+    timestamp: new Date().toISOString(),
+  };
 
-  for (const d of deposits) {
-    const agent = d.agent;
-    const prev = byAgent.get(agent);
-    const amt = d.deposit_amount;
-    if (!prev) {
-      byAgent.set(agent, {
-        agent,
-        total_reserve_contributed: amt,
-        deposit_count: 1,
-        last_deposit_at: d.timestamp,
-        last_journal_id: d.journal_id,
-      });
-    } else {
-      prev.total_reserve_contributed = Number((prev.total_reserve_contributed + amt).toFixed(6));
-      prev.deposit_count += 1;
-      // Deposits are newest-first; first row seen per agent is the latest deposit.
-      if (!prev.last_deposit_at || d.timestamp > prev.last_deposit_at) {
-        prev.last_deposit_at = d.timestamp;
-        prev.last_journal_id = d.journal_id;
-      }
-    }
+  if (groupBy === 'agent') {
+    const { agents, aggregates } = aggregateByAgent(deposits, replay, cycleFilter);
+    const total_reserve = Number(
+      agents.reduce((s, a) => s + a.total_reserve_contributed, 0).toFixed(6),
+    );
+
+    return NextResponse.json(
+      {
+        ...base,
+        group_by: 'agent',
+        total_reserve_contributed: total_reserve,
+        agents,
+        aggregates: {
+          ...aggregates,
+          duplication_note:
+            aggregates.deposits_after_first_signature_repeat > 0
+              ? `${aggregates.deposits_after_first_signature_repeat} deposit(s) in this window follow a repeated content_signature (novelty/decay replay).`
+              : 'No repeated content_signature within this scan window.',
+        },
+      },
+      {
+        headers: {
+          ...(cors ?? {}),
+          'Cache-Control': 'no-store',
+          'X-Mobius-Source': 'vault-contributions',
+        },
+      },
+    );
   }
 
-  const agents = [...byAgent.values()].sort((a, b) =>
-    a.agent.localeCompare(b.agent, undefined, { sensitivity: 'base' }),
-  );
-
+  const { cycles, aggregates } = aggregateByCycle(deposits, replay, cycleFilter);
   const total_reserve = Number(
-    agents.reduce((s, a) => s + a.total_reserve_contributed, 0).toFixed(6),
+    cycles.reduce((s, c) => s + c.total_reserve_contributed, 0).toFixed(6),
   );
 
   return NextResponse.json(
     {
-      ok: true,
-      group_by: 'agent',
-      source: 'vault:deposits',
-      description:
-        'Reserve units accrued from scored agent journal entries (not MIC wallet stakes).',
-      rows_scanned: deposits.length,
-      limit,
+      ...base,
+      group_by: 'cycle',
       total_reserve_contributed: total_reserve,
-      agents,
-      timestamp: new Date().toISOString(),
+      cycles,
+      aggregates: {
+        ...aggregates,
+        duplication_note:
+          aggregates.deposits_after_first_signature_repeat > 0
+            ? `${aggregates.deposits_after_first_signature_repeat} deposit(s) in this window follow a repeated content_signature (novelty/decay replay).`
+            : 'No repeated content_signature within this scan window.',
+      },
     },
     {
       headers: {

--- a/app/terminal/vault/page.tsx
+++ b/app/terminal/vault/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
 
 type VaultPayload = {
   ok?: boolean;
@@ -32,9 +33,36 @@ type VaultPayload = {
   timestamp?: string;
 };
 
+type ContributionAgentRow = {
+  agent: string;
+  total_reserve_contributed: number;
+  deposit_count: number;
+  avg_deposit_per_entry: number;
+};
+
+type ContributionsPayload = {
+  ok?: boolean;
+  group_by?: string;
+  cycle_filter?: string | null;
+  rows_scanned?: number;
+  total_reserve_contributed?: number;
+  agents?: ContributionAgentRow[];
+  aggregates?: {
+    avg_journal_score?: number | null;
+    avg_gi_weight_factor?: number | null;
+    avg_novelty_factor?: number | null;
+    avg_duplication_decay?: number | null;
+    deposits_after_first_signature_repeat?: number;
+    duplication_note?: string;
+  };
+};
+
 export default function VaultPage() {
   const [data, setData] = useState<VaultPayload | null>(null);
+  const [contrib, setContrib] = useState<ContributionsPayload | null>(null);
+  const [contribErr, setContribErr] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const focusCycle = currentCycleId();
 
   useEffect(() => {
     void fetch('/api/vault/status', { cache: 'no-store' })
@@ -42,6 +70,29 @@ export default function VaultPage() {
       .then((j: VaultPayload) => setData(j))
       .catch(() => setErr('Unable to load vault status'));
   }, []);
+
+  useEffect(() => {
+    const q = new URLSearchParams({
+      group_by: 'agent',
+      cycle: focusCycle,
+      limit: '200',
+    });
+    void fetch(`/api/vault/contributions?${q.toString()}`, { cache: 'no-store' })
+      .then(async (r) => {
+        const j = (await r.json()) as ContributionsPayload & { error?: string };
+        if (!r.ok) {
+          setContribErr(j.error ?? `HTTP ${r.status}`);
+          setContrib(null);
+          return;
+        }
+        setContribErr(null);
+        setContrib(j);
+      })
+      .catch(() => {
+        setContribErr('Unable to load contributions');
+        setContrib(null);
+      });
+  }, [focusCycle]);
 
   if (err) {
     return <div className="p-4 text-sm text-rose-300">{err}</div>;
@@ -184,6 +235,79 @@ export default function VaultPage() {
             </div>
           );
         })()}
+      </div>
+
+      <div className="mt-4 rounded border border-cyan-900/40 bg-slate-950/70 p-4 font-mono text-xs">
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-2 text-[11px] uppercase tracking-[0.18em] text-cyan-300/85">
+          <span>Contributions · {focusCycle}</span>
+          <span className="text-[10px] font-normal normal-case tracking-normal text-slate-500">
+            GET /api/vault/contributions?group_by=agent&amp;cycle=
+            {focusCycle}
+          </span>
+        </div>
+        {contribErr ? (
+          <p className="text-[11px] text-amber-200/90">{contribErr}</p>
+        ) : !contrib?.ok ? (
+          <p className="text-slate-500">Loading contributions…</p>
+        ) : (
+          <>
+            <div className="mb-3 grid gap-2 text-[10px] text-slate-400 sm:grid-cols-2">
+              <div>
+                Reserve in window:{' '}
+                <span className="text-cyan-100">{(contrib.total_reserve_contributed ?? 0).toFixed(4)}</span> · rows{' '}
+                {contrib.rows_scanned ?? 0}
+              </div>
+              {contrib.aggregates ? (
+                <div className="space-y-0.5">
+                  <div>
+                    Avg journal_score:{' '}
+                    {contrib.aggregates.avg_journal_score != null
+                      ? contrib.aggregates.avg_journal_score.toFixed(3)
+                      : '—'}
+                    {' · '}Avg Wg (dep/J):{' '}
+                    {contrib.aggregates.avg_gi_weight_factor != null
+                      ? contrib.aggregates.avg_gi_weight_factor.toFixed(3)
+                      : '—'}
+                  </div>
+                  <div>
+                    Replay N / D:{' '}
+                    {contrib.aggregates.avg_novelty_factor != null
+                      ? contrib.aggregates.avg_novelty_factor.toFixed(3)
+                      : '—'}{' '}
+                    /{' '}
+                    {contrib.aggregates.avg_duplication_decay != null
+                      ? contrib.aggregates.avg_duplication_decay.toFixed(3)
+                      : '—'}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+            {contrib.aggregates?.duplication_note ? (
+              <p className="mb-3 text-[10px] leading-relaxed text-slate-500">{contrib.aggregates.duplication_note}</p>
+            ) : null}
+            <div className="text-[10px] uppercase tracking-wide text-slate-500">Top agents (this cycle)</div>
+            <ul className="mt-1 space-y-1.5">
+              {(contrib.agents ?? []).slice(0, 8).map((a) => (
+                <li
+                  key={a.agent}
+                  className="flex flex-wrap items-baseline justify-between gap-2 border-b border-slate-800/80 py-1 last:border-0"
+                >
+                  <span className="text-slate-300">{a.agent}</span>
+                  <span className="text-right text-slate-400">
+                    <span className="text-cyan-100">{a.total_reserve_contributed.toFixed(4)}</span>
+                    <span className="text-slate-600"> · </span>
+                    {a.deposit_count} dep
+                    <span className="text-slate-600"> · avg </span>
+                    {a.avg_deposit_per_entry.toFixed(4)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            {(contrib.agents ?? []).length === 0 ? (
+              <p className="mt-2 text-[10px] text-slate-600">No deposits parsed for this cycle in the current window.</p>
+            ) : null}
+          </>
+        )}
       </div>
     </div>
   );

--- a/lib/vault/contributions.ts
+++ b/lib/vault/contributions.ts
@@ -1,0 +1,213 @@
+import type { VaultDeposit } from '@/lib/vault/vault';
+
+/** Extract cycle id from common journal id shapes (e.g. `journal-ATLAS-C-285-abc`, `ZEUS-C-285-123`). */
+export function parseCycleFromJournalId(journalId: string): string | null {
+  const m = journalId.match(/(C-\d+)/i);
+  if (!m) return null;
+  const raw = m[1];
+  if (/^c-/i.test(raw) && raw.length > 2) return `C-${raw.slice(2)}`;
+  return raw;
+}
+
+export type AgentContributionRow = {
+  agent: string;
+  total_reserve_contributed: number;
+  deposit_count: number;
+  avg_deposit_per_entry: number;
+  last_deposit_at: string | null;
+  last_journal_id: string | null;
+};
+
+export type CycleContributionRow = {
+  cycle: string;
+  total_reserve_contributed: number;
+  deposit_count: number;
+  avg_deposit_per_entry: number;
+  last_deposit_at: string | null;
+};
+
+export type ContributionAggregates = {
+  rows_scanned: number;
+  /** Mean journal_score over deposits that had a finite score. */
+  avg_journal_score: number | null;
+  /** Mean Wg = deposit / journal_score where journal_score > 0. */
+  avg_gi_weight_factor: number | null;
+  /** Mean N over deposits with replay-derived N,D (see buildDepositReplayMetrics). */
+  avg_novelty_factor: number | null;
+  /** Mean D factor. */
+  avg_duplication_decay: number | null;
+  /** Deposits where content_signature matched a prior deposit in this scan window (newest-first order). */
+  deposits_after_first_signature_repeat: number;
+};
+
+export type DepositReplayRow = VaultDeposit & {
+  /** Novelty factor N from v1 scoring (dup count in prior tail). */
+  novelty_n: number;
+  /** Duplication decay D. */
+  duplication_d: number;
+};
+
+/**
+ * Recompute N and D for each deposit as if deposits were applied oldest-first within the list
+ * (list is newest-first from Redis; we walk from end to start).
+ */
+export function buildDepositReplayMetrics(deposits: VaultDeposit[]): DepositReplayRow[] {
+  const chronological = [...deposits].reverse();
+  const sigCounts = new Map<string, number>();
+  const out: DepositReplayRow[] = [];
+
+  for (const d of chronological) {
+    const sig = d.content_signature;
+    const dupCount = sigCounts.get(sig) ?? 0;
+    sigCounts.set(sig, dupCount + 1);
+
+    const N = dupCount === 0 ? 0.85 : Math.max(0, Math.min(1, 0.85 / (1 + dupCount * 1.4)));
+    const D = dupCount === 0 ? 1.0 : Math.max(0, Math.min(1, 1 / (1 + dupCount * 0.5)));
+
+    out.push({
+      ...d,
+      novelty_n: N,
+      duplication_d: D,
+    });
+  }
+
+  // Map back to newest-first order to align with deposits array index
+  return out.reverse();
+}
+
+function meanFinite(values: number[]): number | null {
+  const xs = values.filter((n) => Number.isFinite(n));
+  if (xs.length === 0) return null;
+  return Number((xs.reduce((a, b) => a + b, 0) / xs.length).toFixed(6));
+}
+
+export function computeContributionAggregates(
+  deposits: VaultDeposit[],
+  replay: DepositReplayRow[],
+): ContributionAggregates {
+  const journalScores = deposits.map((d) => d.journal_score).filter((n) => typeof n === 'number' && Number.isFinite(n));
+  const wg = deposits
+    .map((d) => (d.journal_score > 0 ? d.deposit_amount / d.journal_score : NaN))
+    .filter((n) => Number.isFinite(n));
+
+  let repeats = 0;
+  const seen = new Set<string>();
+  for (const d of deposits) {
+    if (seen.has(d.content_signature)) repeats += 1;
+    else seen.add(d.content_signature);
+  }
+
+  return {
+    rows_scanned: deposits.length,
+    avg_journal_score: meanFinite(journalScores),
+    avg_gi_weight_factor: meanFinite(wg),
+    avg_novelty_factor: meanFinite(replay.map((r) => r.novelty_n)),
+    avg_duplication_decay: meanFinite(replay.map((r) => r.duplication_d)),
+    deposits_after_first_signature_repeat: repeats,
+  };
+}
+
+export function aggregateByAgent(
+  deposits: VaultDeposit[],
+  replay: DepositReplayRow[],
+  filterCycle: string | null,
+): { agents: AgentContributionRow[]; aggregates: ContributionAggregates } {
+  const byAgent = new Map<string, AgentContributionRow>();
+  const filtered: VaultDeposit[] = [];
+  const filteredReplay: DepositReplayRow[] = [];
+
+  for (let i = 0; i < deposits.length; i++) {
+    const d = deposits[i];
+    const cyc = parseCycleFromJournalId(d.journal_id);
+    if (filterCycle && cyc !== filterCycle.trim()) continue;
+    filtered.push(d);
+    filteredReplay.push(replay[i]);
+  }
+
+  for (let i = 0; i < filtered.length; i++) {
+    const d = filtered[i];
+    const agent = d.agent;
+    const prev = byAgent.get(agent);
+    const amt = d.deposit_amount;
+    if (!prev) {
+      byAgent.set(agent, {
+        agent,
+        total_reserve_contributed: amt,
+        deposit_count: 1,
+        avg_deposit_per_entry: amt,
+        last_deposit_at: d.timestamp,
+        last_journal_id: d.journal_id,
+      });
+    } else {
+      prev.total_reserve_contributed = Number((prev.total_reserve_contributed + amt).toFixed(6));
+      prev.deposit_count += 1;
+      prev.avg_deposit_per_entry = Number((prev.total_reserve_contributed / prev.deposit_count).toFixed(6));
+      if (!prev.last_deposit_at || d.timestamp > prev.last_deposit_at) {
+        prev.last_deposit_at = d.timestamp;
+        prev.last_journal_id = d.journal_id;
+      }
+    }
+  }
+
+  const agents = [...byAgent.values()].sort((a, b) =>
+    b.total_reserve_contributed - a.total_reserve_contributed || a.agent.localeCompare(b.agent, undefined, { sensitivity: 'base' }),
+  );
+
+  return {
+    agents,
+    aggregates: computeContributionAggregates(filtered, filteredReplay),
+  };
+}
+
+export function aggregateByCycle(
+  deposits: VaultDeposit[],
+  replay: DepositReplayRow[],
+  filterCycle: string | null,
+): { cycles: CycleContributionRow[]; aggregates: ContributionAggregates } {
+  const byCycle = new Map<string, CycleContributionRow>();
+  const filtered: VaultDeposit[] = [];
+  const filteredReplay: DepositReplayRow[] = [];
+
+  for (let i = 0; i < deposits.length; i++) {
+    const d = deposits[i];
+    const cyc = parseCycleFromJournalId(d.journal_id) ?? 'unknown';
+    if (filterCycle && cyc !== filterCycle.trim()) continue;
+    filtered.push(d);
+    filteredReplay.push(replay[i]);
+  }
+
+  for (let i = 0; i < filtered.length; i++) {
+    const d = filtered[i];
+    const cycle = parseCycleFromJournalId(d.journal_id) ?? 'unknown';
+    const prev = byCycle.get(cycle);
+    const amt = d.deposit_amount;
+    if (!prev) {
+      byCycle.set(cycle, {
+        cycle,
+        total_reserve_contributed: amt,
+        deposit_count: 1,
+        avg_deposit_per_entry: amt,
+        last_deposit_at: d.timestamp,
+      });
+    } else {
+      prev.total_reserve_contributed = Number((prev.total_reserve_contributed + amt).toFixed(6));
+      prev.deposit_count += 1;
+      prev.avg_deposit_per_entry = Number((prev.total_reserve_contributed / prev.deposit_count).toFixed(6));
+      if (!prev.last_deposit_at || d.timestamp > prev.last_deposit_at) {
+        prev.last_deposit_at = d.timestamp;
+      }
+    }
+  }
+
+  const cycles = [...byCycle.values()].sort((a, b) => {
+    const na = parseInt(a.cycle.replace(/\D/g, ''), 10);
+    const nb = parseInt(b.cycle.replace(/\D/g, ''), 10);
+    if (Number.isFinite(na) && Number.isFinite(nb) && na !== nb) return nb - na;
+    return b.cycle.localeCompare(a.cycle);
+  });
+
+  return {
+    cycles,
+    aggregates: computeContributionAggregates(filtered, filteredReplay),
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (Vault v3 — Phase 2)

Implements **contribution visibility** from `docs/protocols/vault-v3-setup.md` §6 / §14 Phase 2: extend `/api/vault/contributions`, add aggregation helpers, and surface a **Contributions** panel on `/terminal/vault`.

### API: `GET /api/vault/contributions`

- **`group_by=cycle`** — rollup per cycle (parsed from `journal_id` via `C-\d+`).
- **`group_by=agent`** (default) — unchanged contract plus **`avg_deposit_per_entry`** per agent.
- **`cycle=C-285`** (optional) — filter deposits to entries whose journal id contains that cycle (both group modes).
- **`limit`** — unchanged (1–200, default 200).
- **`aggregates`** on both responses:
  - `avg_journal_score`, `avg_gi_weight_factor` (mean `deposit_amount / journal_score` where score &gt; 0)
  - `avg_novelty_factor`, `avg_duplication_decay` (replay of v1 N/D over the scanned window, oldest→newest)
  - `deposits_after_first_signature_repeat`, `duplication_note` (human-readable)

CORS / OPTIONS unchanged (`handbookCorsHeaders`).

### Library

- `lib/vault/contributions.ts` — parsing, replay metrics, `aggregateByAgent`, `aggregateByCycle`.

### Terminal

- `app/terminal/vault/page.tsx` — loads `?group_by=agent&cycle={currentCycleId()}` and shows top 8 agents, window total, aggregate stats, duplication note.

### Notes

- Cycle attribution is **best-effort** from `journal_id` text; entries without `C-nnn` fall into **`unknown`** for `group_by=cycle` only.
- Journal scoring at write time is unchanged; N/D replay approximates **decay effect over the list window**, not full historical KV.

## Verification

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- ESLint — not configured in repo

## Risk

**Tier 2** — journal deposit list read path extended (no KV key schema change, no LPUSH/LTRIM changes). Response shape is **additive** (`avg_deposit_per_entry`, `aggregates`, `cycle_filter`; `group_by=cycle` adds `cycles` instead of `agents`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

