### PR TITLE
docs(mic): MIC Issuance Protocol v1 + runtime reference (Terminal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ The terminal visualizes the current state of eight Mobius agents:
 
 The system tracks a **Global Integrity Score (GI)** that measures information health across source reliability, institutional trust, consensus stability, and narrative divergence. The goal is not to suppress information but to expose reliability levels transparently.
 
+### Mobius Integrity Credits (MIC)
+
+**MIC** is an integrity-linked credit: **spendable or wallet-visible MIC is not the same thing as Vault reserve units.** Journals accrue **reserve** toward sealed tranches; **Fountain** release stays **GI- and sustain-gated** (see Vault chamber and `/api/vault/status`). Broader economics or cathedral-scale tokenomics for MIC may live in **Mobius-Substrate**; the **runtime-canonical** description for this stack is:
+
+- [`docs/protocols/mic/mic_issuance_protocol.md`](docs/protocols/mic/mic_issuance_protocol.md) — issuance layers and mint vs reserve  
+- [`docs/protocols/mic/mic_runtime_reference.md`](docs/protocols/mic/mic_runtime_reference.md) — routes and libraries in **this** repo
+
 ### Ecosystem Integration
 
 **From [Mobius-Substrate](https://github.com/kaizencycle/Mobius-Substrate):**

--- a/docs/backlog/mobius-substrate.md
+++ b/docs/backlog/mobius-substrate.md
@@ -8,3 +8,8 @@ Structured reasoning memory for the civic stack lives in the **Mobius Substrate*
 | Source repository | https://github.com/kaizencycle/Mobius-Substrate |
 
 When filing Terminal-side tasks that depend on Substrate, link both URLs in the issue or PR description so operators can jump to docs and code.
+
+## MIC documentation split
+
+- **Terminal (this repo):** [`docs/protocols/mic/`](../protocols/mic/README.md) — Vault, Fountain, seal attestation, `/api/mic/*` as deployed here.  
+- **Substrate:** economics cathedral, `tokenomics-engine`, `configs/tokenomics.yaml` — keep **reward accounting** and **macro research** clearly labeled; align canonical **mint / Fountain** language with the Terminal MIC docs to avoid “two MICs” confusion.

--- a/docs/protocols/mic/README.md
+++ b/docs/protocols/mic/README.md
@@ -1,0 +1,18 @@
+# MIC — runtime documentation (this repo)
+
+**Status:** Canonical for **Mobius Civic AI Terminal** + linked protocol docs.  
+**Not in scope here:** full **Mobius-Substrate** economics cathedral, tokenomics engine source, or `docs/04-TECHNICAL-ARCHITECTURE/` tree (that layout lives in the Substrate repo if used).
+
+| Document | Role |
+|----------|------|
+| [mic_issuance_protocol.md](./mic_issuance_protocol.md) | MIC as integrity-gated issuance; layers; mint vs reserve |
+| [mic_reserve_model.md](./mic_reserve_model.md) | Vault reserve units, tranches, Fountain vs spendable MIC |
+| [mic_quorum_attestation.md](./mic_quorum_attestation.md) | Seal council (Vault v2) vs future mint authorization |
+| [mic_genesis_block.md](./mic_genesis_block.md) | Proposed genesis / first Fountain-class mint ceremony (not implemented) |
+| [mic_runtime_reference.md](./mic_runtime_reference.md) | Ground-truth map to routes and libraries **in this repository** |
+
+**Related protocol (reserve → Fountain):** [../vault-to-fountain-protocol.md](../vault-to-fountain-protocol.md)  
+**Seal I doctrine:** [../vault-seal-i.md](../vault-seal-i.md)  
+**Vault v3 north-star (phased implementation):** [../vault-v3-setup.md](../vault-v3-setup.md)
+
+**One-line canon:** MIC is not emitted merely because activity happened; **circulating MIC is tied to integrity, attestation, and release gates**—not to speculative macro narratives alone.

--- a/docs/protocols/mic/mic_genesis_block.md
+++ b/docs/protocols/mic/mic_genesis_block.md
@@ -1,0 +1,48 @@
+# MIC — Genesis block (proposed)
+
+**Status:** **Not implemented** in `mobius-civic-ai-terminal` as an on-chain or automatic ceremony.  
+**Purpose:** Freeze a **target shape** for the first **Fountain-class** or “genesis” release so economics docs and runtime can converge later.
+
+---
+
+## Block name (working)
+
+`MIC Genesis Block — Fountain Unlock` (or **Seal I + Fountain** milestone name once policy fixes the ordinal).
+
+---
+
+## Preconditions (proposal)
+
+| Gate | Target |
+|------|--------|
+| GI | **≥ 0.95** at cycle close used for mint decision |
+| Sustain | **≥ 5** consecutive cycles at or above GI threshold |
+| Reserve | In-progress + sealed semantics satisfy policy (e.g. first **50**-unit tranche **sealed** and attestations **complete**) |
+| Replay / novelty | Within configured ceilings; no tripwire halt |
+| Quorum | Mint-specific attestors signed; Vault seal council may be **necessary but not sufficient** |
+
+---
+
+## Example allocation (illustrative only)
+
+**Total example: 95.00 MIC** (numbers from your draft; **not** committed product):
+
+| Bucket | Amount |
+|--------|--------:|
+| Reserve | 38.00 |
+| Operator | 19.00 |
+| Sentinel pool | 19.00 |
+| Civic test | 9.50 |
+| Burn / locked | 9.50 |
+
+Actual splits require **ledger schema**, **MIC wallet service**, and **operator approval**.
+
+---
+
+## Implementation note
+
+When implemented, the genesis event should be:
+
+1. **Logged** as a ledger / vault event (see MIC issuance protocol event vocabulary in Substrate or ledger repo).  
+2. **Linked** to `latest_seal_id` / `seal_hash` for traceability.  
+3. **Never** retroactively implied by UI without a real attestation payload.

--- a/docs/protocols/mic/mic_issuance_protocol.md
+++ b/docs/protocols/mic/mic_issuance_protocol.md
@@ -1,0 +1,109 @@
+# MIC Issuance Protocol v1
+
+**Status:** Proposed canonical **runtime-facing** spec for the civic stack.  
+**Repo:** `mobius-civic-ai-terminal` (Terminal + protocol docs); ledger/MIC wallet services may live on Render or in **Mobius-Substrate**.  
+**Cycle:** C-285 draft
+
+---
+
+## Purpose
+
+Define **MIC (Mobius Integrity Credits)** as a **runtime protocol concern**: measured integrity, reserve accumulation, attested seals, and **Fountain-gated** release—distinct from cathedral-scale economic storytelling or premature “global currency” claims.
+
+---
+
+## Canonical definition
+
+**MIC (Mobius Integrity Credits) are issued or released as spendable value only when system integrity satisfies constitutional thresholds and the path is attested in the civic ledger (or equivalent attested rail)—not merely when agents produce activity.**
+
+*Reward accounting* (scores, multipliers, provisional credits) may run continuously; **mint authorization** and **public release** are stricter.
+
+---
+
+## Layer separation (end state)
+
+| Layer | Contents | Canonical for |
+|-------|----------|----------------|
+| **L1 — Runtime truth** | GI, sustain, Vault deposits, tranche seals, Fountain, quorum, ledger attestations | **Implementation & Terminal** |
+| **L2 — Economic model** | Supply caps, allocation buckets, treasury design | Policy, after L1 is stable |
+| **L3 — Macro / research** | Central banks, IMF-style framing, long-horizon adoption | **Non-runtime**; archive or research docs only |
+
+Older docs that treat L3 as if it were L1 **weaken credibility**. Keep them as labeled research, not as the definition of “how MIC works today.”
+
+---
+
+## Relationship to Mobius-Substrate
+
+If **Mobius-Substrate** contains `packages/tokenomics-engine`, `configs/tokenomics.yaml`, and economics cathedral markdown:
+
+- Treat that engine as **reward scoring / accounting** unless and until it is explicitly wired to **Vault + Fountain + sustain** as the only path to **authorized mint**.
+- This Terminal repo documents **what the operator UI and `/api/vault/*` surfaces implement today**; Substrate should add a parallel `mic_issuance_protocol.md` (or `docs/04-TECHNICAL-ARCHITECTURE/mic/`) that **cross-links** here and aligns YAML to the same gates.
+
+---
+
+## State model (conceptual)
+
+1. **Activity** — journals, verifications, EPICON flow.  
+2. **Reward accounting (optional / engine)** — provisional MIC-weighted or score-like value.  
+3. **Reserve accumulation** — **Vault reserve units** from scored journal deposits (`vault:deposits`); not spendable MIC.  
+4. **Tranche seal** — when in-progress reserve crosses the tranche threshold, a **seal candidate** and **sentinel attestation** path applies (Vault v2).  
+5. **Fountain unlock** — **integrity-gated** (GI + sustain + healthy lanes); **not** the same as “reserve crossed 50.”  
+6. **Ledger commit** — mint, burn, or settlement events recorded on the **civic ledger** / MIC service with attestation.
+
+**One-line reserve doctrine:** *Seal the tranche, not the history* — see [vault-seal-i.md](../vault-seal-i.md).
+
+---
+
+## Constitutional mint rule (target)
+
+These numbers match existing protocol docs in this repo (`vault-to-fountain-protocol.md`, Vault status routes); **sustain in KV** may still be partial until Phase 1 Vault v3 wiring lands.
+
+### Hard orientation
+
+- **Fountain / spendable release:** GI gate **≥ 0.95** (with sustain window **N** cycles, commonly **5** in status payloads).  
+- **Reserve tranche seal:** may occur when **in-progress reserve ≥ tranche size (50)** without implying Fountain unlock.
+
+### Freeze bands (policy target — align engines before enforcing)
+
+| GI band | Intended posture |
+|---------|-------------------|
+| **≥ 0.95** (sustained) | Eligible for Fountain / standard issuance policy (subject to sustain + attestations). |
+| **0.90 – 0.95** | Reserve accrual may continue; **mint / Fountain locked** or preview-only. |
+| **0.80 – 0.90** | Repair mode; reduced or zero issuance; elevated verification. |
+| **&lt; 0.80** | Constitutional lockdown; no mint narrative. |
+
+Exact numeric enforcement belongs in **GI computation** + **tokenomics config**; this doc is the **contract** those implementations should converge on.
+
+---
+
+## Replay / novelty
+
+Mint or Fountain unlock must be **denied** when replay/novelty signals show synthetic farming. Operational signals include:
+
+- **content_signature** repetition in `vault:deposits` (duplication decay in scoring);  
+- journal lane deduplication and ZEUS verification posture;  
+- tripwire / integrity lanes.
+
+---
+
+## Tokenomics compatibility
+
+- Existing **multiplier / reward** math (where it lives) = **provisional scoring layer**.  
+- **Vault + Seal + Fountain + sustain** = **issuance / release layer**.  
+Do not describe multipliers alone as “how MIC mints” without the issuance layer.
+
+---
+
+## API direction (illustrative)
+
+Not all routes exist on every deployment. Prefer namespaced evolution:
+
+- `GET /api/vault/status` — canonical reserve + Fountain semantics (today).  
+- `GET /api/vault/contributions` — contributor legibility (today).  
+- Future: `GET /api/mic/mint-preview`, `POST /api/mic/mint/authorize` — **only** after ledger + policy agree.
+
+---
+
+## One-line canon
+
+**MIC is not emitted because activity happened; MIC is issued or released because integrity was proven and attested under the reserve and Fountain gates.**

--- a/docs/protocols/mic/mic_quorum_attestation.md
+++ b/docs/protocols/mic/mic_quorum_attestation.md
@@ -1,0 +1,38 @@
+# MIC — Quorum & attestation
+
+**Status:** Runtime reference for **this** codebase; mint ceremony details may extend on ledger/MIC services.
+
+---
+
+## Vault Seal council (live in Terminal)
+
+Vault v2 **seal attestation** uses a fixed sentinel union (see `lib/vault-v2/types.ts`):
+
+- **ATLAS, ZEUS, EVE, JADE, AUREA**
+
+Per-agent secrets: `VAULT_*_SECRET_TOKEN` (legacy fallback: `AGENT_SERVICE_TOKEN`).  
+Attestation route: `POST /api/vault/seal/attest`.  
+Cron: `app/api/cron/vault-attestation/route.ts`.
+
+This quorum is **for sealing reserve tranches**, not automatically for **MIC wallet mint**—but it is the **integrity witness pattern** MIC issuance should reuse or extend.
+
+---
+
+## Future: MIC mint authorization quorum (proposed)
+
+A **separate** mint-authorization ceremony might require:
+
+- **ZEUS** — verification / ledger consistency  
+- **ATLAS** — strategic continuity  
+- **JADE** — constitutional / civic-risk framing  
+- **HERMES** — lane separation / narrative integrity  
+
+Optional stabilizers (e.g. **EVE**, **AUREA**) — policy choice; must be written in spec before enforcement.
+
+**Pass condition** must be defined in code + docs together (counts, timeouts, veto).
+
+---
+
+## Principle
+
+**Quorum proves witness; GI + sustain proves system health; Fountain proves release.** None replaces the others.

--- a/docs/protocols/mic/mic_reserve_model.md
+++ b/docs/protocols/mic/mic_reserve_model.md
@@ -1,0 +1,42 @@
+# MIC — Reserve model (Vault ↔ MIC)
+
+**Status:** Runtime reference; aligns with Vault v2 and [vault-to-fountain-protocol.md](../vault-to-fountain-protocol.md).
+
+---
+
+## Objects
+
+| Object | Meaning |
+|--------|---------|
+| **Journal** | Structured agent output; **not** money. |
+| **Vault reserve units** | Accumulated from scored journal deposits; **non-spendable** proof-bearing reserve (`vault:deposits`, `balance_reserve` v1 compat, `in_progress_balance` v2). |
+| **Tranche** | Default size **50** reserve units (`VAULT_RESERVE_PARCEL_UNITS` in code); eligible for **seal**, not automatically MIC. |
+| **Seal** | Attested frozen tranche record (Vault v2 seal chain + audit index). |
+| **Fountain** | **Release** gate for spendable flow; requires **GI + sustain** and related integrity conditions—not only reserve size. |
+| **MIC (spendable)** | Wallet / ledger balance users or operators see when services are healthy; must not be conflated with raw reserve counters. |
+
+---
+
+## Flow (short)
+
+```
+Journal (claim) → Vault deposit (reserve units) → Tranche seal (attested) → … → Fountain unlock (integrity) → Controlled MIC / settlement flow
+```
+
+**Reserve can seal before the Fountain unseals.** That is constitutional: see [vault-seal-i.md](../vault-seal-i.md).
+
+---
+
+## Implementation pointers (this repo)
+
+- `lib/vault/vault.ts` — deposits, `writeVaultDeposit`, `recordVaultDepositsForCouncil`.  
+- `lib/vault-v2/deposit.ts`, `lib/vault-v2/seal.ts`, `lib/vault-v2/store.ts` — in-progress balance, candidates, seals.  
+- `app/api/vault/status` — operator-facing `sealed_reserve_total`, `fountain_status`, `in_progress_balance`, etc.  
+- `app/api/vault/contributions` — per-agent / per-cycle reserve from deposits.
+
+---
+
+## What not to claim in docs
+
+- Do not equate **“reserve ≥ 50”** with **“MIC unlocked.”**  
+- Do not describe **central bank integration** or **ROI** as current runtime truth for issuance.

--- a/docs/protocols/mic/mic_runtime_reference.md
+++ b/docs/protocols/mic/mic_runtime_reference.md
@@ -1,0 +1,57 @@
+# MIC — Runtime reference (mobius-civic-ai-terminal)
+
+**Purpose:** Map **MIC-related behavior and reserve/Fountain truth** to files and routes **in this repository**.  
+**Out of repo:** Mobius-Substrate `tokenomics-engine`, `configs/tokenomics.yaml`, economics cathedral trees—document there and link here.
+
+---
+
+## Operator & API
+
+| Surface | Path |
+|---------|------|
+| Vault status (reserve, tranche, Fountain, seals) | `GET /api/vault/status` — `app/api/vault/status/route.ts` |
+| Seal list / audit scope | `GET /api/vault/seal` — `app/api/vault/seal/route.ts` |
+| Contributions | `GET /api/vault/contributions` — `app/api/vault/contributions/route.ts` |
+| Seal attestation (sentinels) | `POST /api/vault/seal/attest` — `app/api/vault/seal/attest/route.ts` |
+| Vault attestation cron | `app/api/cron/vault-attestation/route.ts` |
+| MIC account (wallet proxy / degraded) | `GET /api/mic/account` — `app/api/mic/account/route.ts` |
+| MIC settle (EPICON claim) | `POST /api/mic/settle` — `app/api/mic/settle/route.ts` |
+
+---
+
+## Libraries
+
+| Concern | Location |
+|---------|----------|
+| Vault v1 deposits, journal scoring, `writeVaultDeposit` + v2 hook | `lib/vault/vault.ts` |
+| Vault v2 accrual, seal candidate | `lib/vault-v2/deposit.ts`, `lib/vault-v2/seal.ts` |
+| KV seals, in-progress balance, indexes | `lib/vault-v2/store.ts` |
+| Per-agent Vault bearer/HMAC | `lib/vault-v2/auth.ts` |
+| Fountain vs reserve lane copy | `lib/vault/lane-status.ts` |
+| GI load for status | `lib/kv/store.ts` (`loadGIState`), `lib/gi/compute.ts` (formula — **LOCKED** per `AGENTS.md` / `CURRENT_CYCLE.md`) |
+| MIC settle helper | `lib/mic/settle.ts` |
+| Identity / MIC account cache | `lib/identity/identityStore.ts` |
+
+---
+
+## Protocol docs (this repo)
+
+| Doc | Topic |
+|-----|--------|
+| [vault-to-fountain-protocol.md](../vault-to-fountain-protocol.md) | Reserve → Fountain doctrine |
+| [vault-seal-i.md](../vault-seal-i.md) | First tranche seal semantics |
+| [vault-v2-sealed-reserve.md](../vault-v2-sealed-reserve.md) | Sentinel-attested reserve framework |
+
+---
+
+## Environment (illustrative)
+
+- `RENDER_MIC_URL` / `NEXT_PUBLIC_MIC_URL` — MIC wallet service.  
+- `VAULT_*_SECRET_TOKEN`, `AGENT_SERVICE_TOKEN` (legacy) — see `.env.example`.  
+- KV / backup Redis — vault persistence; not MIC-specific.
+
+---
+
+## Substrate backlog
+
+Cross-repo work: [Mobius-Substrate](https://github.com/kaizencycle/Mobius-Substrate) — see also `docs/backlog/mobius-substrate.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **runtime-canonical MIC documentation** under `docs/protocols/mic/` so the Terminal repo states clearly: **reserve ≠ spendable MIC**, **Vault / Seal vs Fountain**, and **integrity-gated issuance**—without claiming Substrate paths (`packages/tokenomics-engine`, `docs/04-…`) that live in **Mobius-Substrate**.

## New files

| File | Purpose |
|------|---------|
| `docs/protocols/mic/README.md` | Index + links to Vault protocols + `vault-v3-setup.md` |
| `mic_issuance_protocol.md` | MIC Issuance Protocol v1 (layers, mint vs reserve, GI bands, Substrate cross-note) |
| `mic_reserve_model.md` | Vault ↔ MIC reserve model |
| `mic_quorum_attestation.md` | Vault v2 seal council + future mint quorum sketch |
| `mic_genesis_block.md` | Proposed genesis / Fountain-class block (**not implemented**) |
| `mic_runtime_reference.md` | Maps to `app/api/vault/*`, `app/api/mic/*`, `lib/vault*`, `lib/mic/*` |

## Also

- `README.md` — short **MIC** subsection under Integrity Metrics with links to the protocol docs.
- `docs/backlog/mobius-substrate.md` — **MIC documentation split** (Terminal vs Substrate) to reduce “two MICs” confusion.

## Out of scope (Substrate repo)

File moves under `docs/04-TECHNICAL-ARCHITECTURE/mic/`, README there, tokenomics YAML, and engine renames should be a **separate PR** on `kaizencycle/Mobius-Substrate` with cross-links to these Terminal paths.

## Verification

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- Lint — not configured
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

