### PR TITLE
feat(terminal/mic): MIC runtime surface — readiness, Vault, Seal, Fountain, quorum UI

### DIFF
--- a/app/api/mic/attestations/route.ts
+++ b/app/api/mic/attestations/route.ts
@@ -1,0 +1,39 @@
+/**
+ * GET /api/mic/attestations
+ *
+ * MIC_REWARD_V2-shaped summaries derived from recent `vault:deposits` rows.
+ * Not ledger node attestations — placeholder until substrate exposes `/mic/attestations`.
+ */
+
+import { NextResponse } from 'next/server';
+import type { MicRewardAttestationSummary } from '@/lib/mic/types';
+import { listVaultDeposits } from '@/lib/vault/vault';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const limitParam = 40;
+  const deposits = await listVaultDeposits(limitParam);
+
+  const rows: MicRewardAttestationSummary[] = deposits.map((d) => {
+    const j = d.journal_score;
+    const wg = j > 0 && Number.isFinite(j) ? Number((d.deposit_amount / j).toFixed(4)) : undefined;
+    return {
+      nodeId: `${d.agent}:${d.journal_id}`,
+      mic: d.deposit_amount,
+      timestamp: d.timestamp,
+      source: 'vault_deposit_summary' as const,
+      breakdown: {
+        integrity: d.journal_score,
+        multipliers: {
+          giMultiplier: wg,
+        },
+      },
+    };
+  });
+
+  return NextResponse.json(
+    { ok: true, schema: 'MIC_REWARD_V2_SUMMARY', rows },
+    { headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'mic-attestations-deposit-proxy' } },
+  );
+}

--- a/app/api/mic/readiness/route.ts
+++ b/app/api/mic/readiness/route.ts
@@ -1,0 +1,113 @@
+/**
+ * GET /api/mic/readiness
+ *
+ * MIC_READINESS_V1 — assembled server-side from Vault status + deposit sample.
+ * Terminal displays this payload; it does not re-derive policy.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
+import { buildMicReadinessV1, type VaultStatusJson } from '@/lib/mic/runtime-readiness';
+import { loadGIState } from '@/lib/kv/store';
+import { computeVaultSealLaneSemantics } from '@/lib/vault/lane-status';
+import { getVaultStatusPayload } from '@/lib/vault/vault';
+import { countSeals, getCandidate, getInProgressBalance, getLatestSeal } from '@/lib/vault-v2/store';
+import { SENTINEL_ATTESTATION_COUNT } from '@/lib/vault-v2/constants';
+import { listVaultDeposits } from '@/lib/vault/vault';
+
+export const dynamic = 'force-dynamic';
+
+async function getVaultStatusShape(): Promise<VaultStatusJson> {
+  let gi: number | null = null;
+  try {
+    const st = await loadGIState();
+    if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
+      gi = Math.max(0, Math.min(1, st.global_integrity));
+    }
+  } catch {
+    gi = null;
+  }
+
+  const v1 = await getVaultStatusPayload(gi);
+
+  const [inProgressBalance, sealsCount, latestSeal, candidate] = await Promise.all([
+    getInProgressBalance(),
+    countSeals(),
+    getLatestSeal(),
+    getCandidate(),
+  ]);
+
+  const seal_lane = computeVaultSealLaneSemantics({
+    inProgressBalance,
+    sealsCountAttested: sealsCount,
+    giCurrent: gi,
+    giThreshold: v1.gi_threshold,
+    sustainCyclesRequired: v1.sustain_cycles_required,
+    v1Status: v1.status,
+    candidateInFlight: Boolean(candidate),
+  });
+
+  const candidate_attestation_state = candidate
+    ? {
+        in_flight: true,
+        seal_id: candidate.seal_id,
+        sequence: candidate.sequence,
+        requested_at: candidate.requested_at,
+        timeout_at: candidate.timeout_at,
+        attestations_received: Object.keys(candidate.attestations).length,
+        attestations_needed: SENTINEL_ATTESTATION_COUNT - Object.keys(candidate.attestations).length,
+      }
+    : {
+        in_flight: false,
+        seal_id: null,
+        attestations_received: 0,
+        timeout_at: null,
+      };
+
+  return {
+    ...v1,
+    gi_current: gi,
+    in_progress_balance: inProgressBalance,
+    sealed_reserve_total: seal_lane.sealed_reserve_total,
+    current_tranche_balance: seal_lane.current_tranche_balance,
+    carry_forward_in_tranche: seal_lane.carry_forward_in_tranche,
+    reserve_threshold_met: seal_lane.reserve_threshold_met,
+    gi_threshold_met: seal_lane.gi_threshold_met,
+    sustain_cycles_met: seal_lane.sustain_met,
+    fountain_status: seal_lane.fountain_lane,
+    reserve_lane: seal_lane.reserve_lane,
+    seals_count: sealsCount,
+    latest_seal_id: latestSeal?.seal_id ?? null,
+    latest_seal_at: latestSeal?.sealed_at ?? null,
+    latest_seal_hash: latestSeal?.seal_hash ?? null,
+    candidate_attestation_state,
+  };
+}
+
+export async function GET(req: NextRequest) {
+  const cycleParam = req.nextUrl.searchParams.get('cycle')?.trim();
+  let cycle = cycleParam ?? '';
+  if (!cycle) {
+    try {
+      cycle = (await resolveOperatorCycleId()) ?? '';
+    } catch {
+      cycle = '';
+    }
+  }
+
+  const vaultStatus = await getVaultStatusShape();
+  const deposits = await listVaultDeposits(120);
+  const readiness = buildMicReadinessV1({
+    vaultStatus,
+    depositsSample: deposits,
+    cycle: cycle || undefined,
+  });
+
+  return NextResponse.json(readiness, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Mobius-Source': 'mic-readiness-v1',
+    },
+  });
+}

--- a/app/terminal/mic/MicPageClient.tsx
+++ b/app/terminal/mic/MicPageClient.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { MicStatusCard } from '@/components/mic/MicStatusCard';
 import ChamberSkeleton from '@/components/terminal/ChamberSkeleton';
+import { fetchMicAttestations } from '@/lib/mic/fetchMicAttestations';
+import { fetchMicReadiness } from '@/lib/mic/fetchMicReadiness';
+import type { MicReadinessResponse, MicRewardAttestationSummary } from '@/lib/mic/types';
 import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
 
 type Identity = { user?: { username?: string; mic_balance?: number; tier?: string } };
@@ -9,6 +13,9 @@ type Identity = { user?: { username?: string; mic_balance?: number; tier?: strin
 export default function MicPageClient() {
   const { snapshot, loading } = useTerminalSnapshot();
   const [identity, setIdentity] = useState<Identity | null>(null);
+  const [readiness, setReadiness] = useState<MicReadinessResponse | null>(null);
+  const [attestations, setAttestations] = useState<MicRewardAttestationSummary[]>([]);
+  const [readinessErr, setReadinessErr] = useState<string | null>(null);
 
   useEffect(() => {
     fetch('/api/identity/session', { cache: 'no-store' })
@@ -17,13 +24,44 @@ export default function MicPageClient() {
       .catch(() => setIdentity({}));
   }, []);
 
+  useEffect(() => {
+    void (async () => {
+      try {
+        const [r, a] = await Promise.all([fetchMicReadiness(), fetchMicAttestations()]);
+        if (!r) {
+          setReadinessErr('MIC readiness unavailable');
+          setReadiness(null);
+        } else {
+          setReadinessErr(null);
+          setReadiness(r);
+        }
+        setAttestations(a);
+      } catch {
+        setReadinessErr('MIC readiness fetch failed');
+        setReadiness(null);
+      }
+    })();
+  }, []);
+
   if (loading && !snapshot) return <ChamberSkeleton blocks={5} />;
 
   const integrity = (snapshot?.integrity?.data ?? {}) as { totalMicMinted?: number; mic_supply?: number };
 
   return (
     <div className="h-full overflow-y-auto p-4">
-      <h1 className="mb-3 text-lg font-semibold">MIC wallet</h1>
+      <h1 className="mb-3 text-lg font-semibold text-slate-100">MIC · operator surface</h1>
+
+      {readinessErr || !readiness ? (
+        <div className="mb-4 rounded border border-amber-500/35 bg-amber-950/25 px-3 py-2 font-mono text-xs text-amber-100">
+          {readinessErr ?? 'Loading MIC readiness…'}
+        </div>
+      ) : (
+        <div className="mb-4">
+          <MicStatusCard readiness={readiness} attestations={attestations} />
+        </div>
+      )}
+
+      <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">Wallet / snapshot</h2>
       {identity?.user ? (
         <div className="mb-3 rounded border border-slate-800 bg-slate-900/60 p-3 text-sm">
           {identity.user.username} · balance {identity.user.mic_balance ?? 0} · tier {identity.user.tier ?? 'Observer'}
@@ -32,7 +70,9 @@ export default function MicPageClient() {
         <div className="mb-3 text-sm text-slate-400">Login required to view operator wallet details.</div>
       )}
       <div className="grid gap-3 md:grid-cols-2">
-        <div className="rounded border border-slate-800 bg-slate-900/60 p-3 text-sm">totalMicMinted: {integrity.totalMicMinted ?? '—'}</div>
+        <div className="rounded border border-slate-800 bg-slate-900/60 p-3 text-sm">
+          totalMicMinted: {integrity.totalMicMinted ?? '—'}
+        </div>
         <div className="rounded border border-slate-800 bg-slate-900/60 p-3 text-sm">mic_supply: {integrity.mic_supply ?? '—'}</div>
       </div>
     </div>

--- a/components/mic/FountainStatusCard.tsx
+++ b/components/mic/FountainStatusCard.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import type { MicReadinessResponse } from '@/lib/mic/types';
+
+export function FountainStatusCard({ fountain }: { fountain: MicReadinessResponse['fountain'] }) {
+  return (
+    <div className="rounded-xl border border-slate-700/80 bg-slate-950/70 p-3">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Fountain</h3>
+      <div className="mt-2 space-y-1 font-mono text-[11px] text-slate-300">
+        <div>Lane: {fountain.lane}</div>
+        <div>Locked: {String(fountain.locked)}</div>
+        <div>Eligible: {String(fountain.eligible)}</div>
+        <div>Unlocked: {String(fountain.unlocked)}</div>
+      </div>
+    </div>
+  );
+}

--- a/components/mic/MicAttestationTable.tsx
+++ b/components/mic/MicAttestationTable.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import type { MicRewardAttestationSummary } from '@/lib/mic/types';
+
+export function MicAttestationTable({ rows }: { rows: MicRewardAttestationSummary[] }) {
+  return (
+    <div className="rounded-xl border border-slate-700/80 bg-slate-950/70 p-3">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Recent reserve deposits</h3>
+      <p className="mt-1 text-[10px] text-slate-600">
+        Proxy for MIC_REWARD_V2 summaries from <span className="font-mono">vault:deposits</span> until ledger attestations are wired.
+      </p>
+      <div className="mt-2 max-h-48 overflow-y-auto">
+        <table className="w-full text-left font-mono text-[10px] text-slate-300">
+          <thead className="sticky top-0 bg-slate-950 text-slate-500">
+            <tr>
+              <th className="pb-1 pr-2">Source</th>
+              <th className="pb-1 pr-2">Reserve Δ</th>
+              <th className="pb-1">Time</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={3} className="py-2 text-slate-600">
+                  No rows.
+                </td>
+              </tr>
+            ) : (
+              rows.map((row) => (
+                <tr key={`${row.nodeId}-${row.timestamp}`} className="border-t border-slate-800/80">
+                  <td className="py-1 pr-2 align-top text-slate-400">{row.nodeId}</td>
+                  <td className="py-1 pr-2 align-top text-cyan-100">{row.mic.toFixed(4)}</td>
+                  <td className="py-1 align-top text-slate-500">{row.timestamp}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/components/mic/MicStatusCard.tsx
+++ b/components/mic/MicStatusCard.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import type { MicReadinessResponse, MicRewardAttestationSummary } from '@/lib/mic/types';
+import { FountainStatusCard } from '@/components/mic/FountainStatusCard';
+import { MicAttestationTable } from '@/components/mic/MicAttestationTable';
+import { MintReadinessBadge } from '@/components/mic/MintReadinessBadge';
+import { QuorumStatusCard } from '@/components/mic/QuorumStatusCard';
+import { SealStatusCard } from '@/components/mic/SealStatusCard';
+import { VaultStatusCard } from '@/components/mic/VaultStatusCard';
+
+export function MicStatusCard({
+  readiness,
+  attestations,
+}: {
+  readiness: MicReadinessResponse;
+  attestations: MicRewardAttestationSummary[];
+}) {
+  const giLine =
+    readiness.gi != null && Number.isFinite(readiness.gi)
+      ? `${readiness.gi.toFixed(2)} / ${readiness.mintThresholdGi.toFixed(2)} threshold`
+      : `— / ${readiness.mintThresholdGi.toFixed(2)} threshold`;
+
+  return (
+    <div className="rounded-2xl border border-violet-500/25 bg-slate-950/80 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-violet-200">MIC runtime surface</h2>
+          <p className="mt-1 font-mono text-[11px] text-slate-400">
+            Cycle {readiness.cycle} · GI {giLine}
+          </p>
+          <p className="mt-0.5 font-mono text-[10px] text-slate-600">Schema {readiness.schema}</p>
+        </div>
+        <MintReadinessBadge mintReadiness={readiness.mintReadiness} />
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <VaultStatusCard reserve={readiness.reserve} />
+        <SealStatusCard sustain={readiness.sustain} replay={readiness.replay} novelty={readiness.novelty} />
+        <QuorumStatusCard quorum={readiness.quorum} />
+        <FountainStatusCard fountain={readiness.fountain} />
+      </div>
+
+      <div className="mt-4">
+        <MicAttestationTable rows={attestations} />
+      </div>
+
+      <p className="mt-3 text-[10px] leading-relaxed text-slate-600">
+        Display-only: readiness is assembled on the server from Vault + GI + deposit sample. Policy and mint authorization
+        remain in substrate / ledger services — not recomputed in the browser.
+      </p>
+    </div>
+  );
+}

--- a/components/mic/MintReadinessBadge.tsx
+++ b/components/mic/MintReadinessBadge.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import type { MicMintReadiness } from '@/lib/mic/types';
+
+const LABEL_MAP: Record<MicMintReadiness, string> = {
+  not_eligible: 'Not Eligible',
+  reserve_only: 'Reserve Only',
+  seal_ready: 'Seal Ready',
+  quorum_pending: 'Quorum Pending',
+  fountain_ready: 'Fountain Ready',
+};
+
+export function MintReadinessBadge({ mintReadiness }: { mintReadiness: MicMintReadiness }) {
+  return (
+    <div className="rounded-md border border-violet-500/40 bg-violet-500/10 px-3 py-1.5 text-xs font-medium text-violet-100">
+      Mint readiness: {LABEL_MAP[mintReadiness]}
+    </div>
+  );
+}

--- a/components/mic/QuorumStatusCard.tsx
+++ b/components/mic/QuorumStatusCard.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import type { MicReadinessResponse } from '@/lib/mic/types';
+
+export function QuorumStatusCard({ quorum }: { quorum: MicReadinessResponse['quorum'] }) {
+  return (
+    <div className="rounded-xl border border-slate-700/80 bg-slate-950/70 p-3">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Seal quorum</h3>
+      <div className="mt-2 space-y-1 font-mono text-[11px] text-slate-300">
+        <div>Required: {quorum.required.join(', ')}</div>
+        <div>
+          Attestations received: {quorum.attestations_received} · remaining slots: {quorum.attestations_needed}
+        </div>
+        <div>Status: {quorum.status}</div>
+        <div>Candidate in flight: {String(quorum.seal_candidate_in_flight)}</div>
+        {quorum.attested.length > 0 ? <div>Attested agents: {quorum.attested.join(', ')}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/components/mic/SealStatusCard.tsx
+++ b/components/mic/SealStatusCard.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import type { MicReadinessResponse } from '@/lib/mic/types';
+
+export function SealStatusCard({
+  sustain,
+  replay,
+  novelty,
+}: {
+  sustain: MicReadinessResponse['sustain'];
+  replay: MicReadinessResponse['replay'];
+  novelty: MicReadinessResponse['novelty'];
+}) {
+  return (
+    <div className="rounded-xl border border-slate-700/80 bg-slate-950/70 p-3">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Seal / integrity window</h3>
+      <div className="mt-2 space-y-1 font-mono text-[11px] text-slate-300">
+        <div>
+          Sustain: {sustain.consecutiveEligibleCycles} / {sustain.requiredCycles}{' '}
+          <span className="text-slate-500">({sustain.status})</span>
+        </div>
+        {sustain.sustain_tracking_placeholder ? (
+          <div className="text-amber-200/80">Sustain: not tracked in KV yet (placeholder)</div>
+        ) : null}
+        <div>
+          Replay: <span className="text-slate-200">{replay.status}</span> · pressure {replay.replayPressure.toFixed(3)}
+        </div>
+        <div>
+          Novelty: <span className="text-slate-200">{novelty.status}</span> · score {novelty.noveltyScore.toFixed(3)}{' '}
+          <span className="text-slate-600">(avg journal_score window)</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/mic/VaultStatusCard.tsx
+++ b/components/mic/VaultStatusCard.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import type { MicReadinessResponse } from '@/lib/mic/types';
+
+export function VaultStatusCard({ reserve }: { reserve: MicReadinessResponse['reserve'] }) {
+  return (
+    <div className="rounded-xl border border-slate-700/80 bg-slate-950/70 p-3">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Vault / reserve</h3>
+      <div className="mt-2 space-y-1 font-mono text-[11px] text-slate-300">
+        <div>
+          In progress: <span className="text-cyan-200">{reserve.inProgressBalance.toFixed(4)}</span>
+        </div>
+        <div>Tranche target: {reserve.trancheTarget.toFixed(2)}</div>
+        <div>Sealed total: {reserve.sealedReserveTotal.toFixed(2)}</div>
+        <div className="text-slate-500">v1 cumulative (compat): {reserve.balanceReserveV1.toFixed(4)}</div>
+        <div>
+          Tranche status: <span className="text-amber-200/90">{reserve.trancheStatus}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/protocols/mic/mic_runtime_reference.md
+++ b/docs/protocols/mic/mic_runtime_reference.md
@@ -16,6 +16,8 @@
 | Vault attestation cron | `app/api/cron/vault-attestation/route.ts` |
 | MIC account (wallet proxy / degraded) | `GET /api/mic/account` — `app/api/mic/account/route.ts` |
 | MIC settle (EPICON claim) | `POST /api/mic/settle` — `app/api/mic/settle/route.ts` |
+| MIC readiness (MIC_READINESS_V1) | `GET /api/mic/readiness` — `app/api/mic/readiness/route.ts` |
+| MIC attestation summaries (deposit proxy) | `GET /api/mic/attestations` — `app/api/mic/attestations/route.ts` |
 
 ---
 

--- a/lib/mic/fetchMicAttestations.ts
+++ b/lib/mic/fetchMicAttestations.ts
@@ -1,0 +1,16 @@
+import type { MicRewardAttestationSummary } from '@/lib/mic/types';
+
+type AttestationsEnvelope = { ok?: boolean; rows?: MicRewardAttestationSummary[] };
+
+export async function fetchMicAttestations(): Promise<MicRewardAttestationSummary[]> {
+  try {
+    const response = await fetch('/api/mic/attestations', { cache: 'no-store' });
+    if (!response.ok) throw new Error(`Failed attestation fetch: ${response.status}`);
+    const body = (await response.json()) as AttestationsEnvelope | MicRewardAttestationSummary[];
+    if (Array.isArray(body)) return body;
+    return body.rows ?? [];
+  } catch (error) {
+    console.warn('[mic] attestation fetch failed', error);
+    return [];
+  }
+}

--- a/lib/mic/fetchMicQuorum.ts
+++ b/lib/mic/fetchMicQuorum.ts
@@ -1,0 +1,8 @@
+import type { MicReadinessResponse } from '@/lib/mic/types';
+
+export async function fetchMicQuorum(): Promise<MicReadinessResponse['quorum'] | null> {
+  const response = await fetch('/api/mic/readiness', { cache: 'no-store' });
+  if (!response.ok) throw new Error(`Failed quorum fetch: ${response.status}`);
+  const data = (await response.json()) as MicReadinessResponse;
+  return data.quorum;
+}

--- a/lib/mic/fetchMicReadiness.ts
+++ b/lib/mic/fetchMicReadiness.ts
@@ -1,0 +1,12 @@
+import type { MicReadinessResponse } from '@/lib/mic/types';
+
+export async function fetchMicReadiness(): Promise<MicReadinessResponse | null> {
+  try {
+    const response = await fetch('/api/mic/readiness', { cache: 'no-store' });
+    if (!response.ok) throw new Error(`Failed readiness fetch: ${response.status}`);
+    return (await response.json()) as MicReadinessResponse;
+  } catch (error) {
+    console.warn('[mic] readiness fetch failed', error);
+    return null;
+  }
+}

--- a/lib/mic/fetchMicReserve.ts
+++ b/lib/mic/fetchMicReserve.ts
@@ -1,0 +1,8 @@
+import type { MicReadinessResponse } from '@/lib/mic/types';
+
+export async function fetchMicReserve(): Promise<MicReadinessResponse['reserve'] | null> {
+  const response = await fetch('/api/mic/readiness', { cache: 'no-store' });
+  if (!response.ok) throw new Error(`Failed reserve fetch: ${response.status}`);
+  const data = (await response.json()) as MicReadinessResponse;
+  return data.reserve;
+}

--- a/lib/mic/runtime-readiness.ts
+++ b/lib/mic/runtime-readiness.ts
@@ -1,0 +1,185 @@
+/**
+ * Assembles MIC_READINESS_V1 from existing Vault + GI payloads (server-side only).
+ */
+
+import { currentCycleId } from '@/lib/eve/cycle-engine';
+import { VAULT_RESERVE_PARCEL_UNITS } from '@/lib/vault-v2/constants';
+import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
+import type { MicReadinessResponse, MicMintReadiness, MicNoveltyStatus, MicQuorumStatus, MicReplayStatus } from '@/lib/mic/types';
+
+export type VaultStatusJson = {
+  balance_reserve?: number;
+  in_progress_balance?: number;
+  sealed_reserve_total?: number;
+  current_tranche_balance?: number;
+  carry_forward_in_tranche?: number;
+  activation_threshold?: number;
+  gi_threshold?: number;
+  gi_current?: number | null;
+  sustain_cycles_required?: number;
+  sustain_cycles_met?: boolean;
+  gi_threshold_met?: boolean;
+  reserve_threshold_met?: boolean;
+  fountain_status?: string;
+  reserve_lane?: string;
+  seals_count?: number;
+  latest_seal_id?: string | null;
+  latest_seal_at?: string | null;
+  latest_seal_hash?: string | null;
+  candidate_attestation_state?: {
+    in_flight?: boolean;
+    attestations_received?: number;
+    attestations_needed?: number;
+    seal_id?: string | null;
+    sequence?: number;
+    requested_at?: string;
+    timeout_at?: string | null;
+  };
+};
+
+function fountainTriplet(lane: string | undefined): { locked: boolean; eligible: boolean; unlocked: boolean } {
+  const s = (lane ?? 'locked').toLowerCase();
+  if (s === 'active' || s === 'unsealed') {
+    return { locked: false, eligible: true, unlocked: true };
+  }
+  if (s === 'tracking' || s === 'preview') {
+    return { locked: true, eligible: true, unlocked: false };
+  }
+  return { locked: true, eligible: false, unlocked: false };
+}
+
+function trancheStatus(v: VaultStatusJson): MicReadinessResponse['reserve']['trancheStatus'] {
+  const inP = v.in_progress_balance ?? 0;
+  const cap = v.activation_threshold ?? VAULT_RESERVE_PARCEL_UNITS;
+  const lane = v.reserve_lane;
+  const eligible =
+    Boolean(v.reserve_threshold_met) || inP >= cap || lane === 'tranche_ready' || lane === 'sealing';
+  if (eligible) return 'eligible_for_seal';
+  const sealed = v.sealed_reserve_total ?? 0;
+  const cand = Boolean(v.candidate_attestation_state?.in_flight);
+  if (sealed > 0 && inP < 1e-6 && !cand) return 'sealed';
+  return 'in_progress';
+}
+
+/** Deposits are newest-first (Redis LPUSH); repeats = rows whose signature already appeared earlier in the list. */
+function replayFromDeposits(deposits: { content_signature: string }[]): { pressure: number; status: MicReplayStatus } {
+  if (deposits.length === 0) return { pressure: 0, status: 'clear' };
+  const seen = new Set<string>();
+  let repeats = 0;
+  for (const d of deposits) {
+    if (seen.has(d.content_signature)) repeats += 1;
+    seen.add(d.content_signature);
+  }
+  const pressure = Number((repeats / deposits.length).toFixed(4));
+  if (pressure >= 0.35) return { pressure, status: 'blocked' };
+  if (pressure >= 0.15) return { pressure, status: 'elevated' };
+  return { pressure, status: 'clear' };
+}
+
+function noveltyFromDeposits(deposits: { journal_score?: number }[]): { score: number; status: MicNoveltyStatus } {
+  const scores = deposits.map((d) => d.journal_score).filter((n): n is number => typeof n === 'number' && Number.isFinite(n));
+  if (scores.length === 0) return { score: 0, status: 'acceptable' };
+  const avg = scores.reduce((a, b) => a + b, 0) / scores.length;
+  const score = Number(avg.toFixed(4));
+  if (avg >= 0.72) return { score, status: 'strong' };
+  if (avg >= 0.45) return { score, status: 'acceptable' };
+  return { score, status: 'weak' };
+}
+
+function quorumFromVault(v: VaultStatusJson): MicReadinessResponse['quorum'] {
+  const required = [...SENTINEL_AGENTS];
+  const cand = v.candidate_attestation_state;
+  const inFlight = Boolean(cand?.in_flight);
+  const received = typeof cand?.attestations_received === 'number' ? cand.attestations_received : 0;
+  const needed = typeof cand?.attestations_needed === 'number' ? cand.attestations_needed : required.length;
+
+  let status: MicQuorumStatus = 'pending';
+  if (inFlight) {
+    if (received >= required.length) status = 'satisfied';
+    else if (received > 0) status = 'partial';
+    else status = 'pending';
+  } else {
+    status = 'pending';
+  }
+
+  const attested: string[] = [];
+  // We only have counts from status payload, not per-agent list, until seal detail is wired.
+  return {
+    required,
+    attested,
+    status,
+    attestations_received: received,
+    attestations_needed: Math.max(0, needed),
+    seal_candidate_in_flight: inFlight,
+  };
+}
+
+function deriveMintReadiness(v: VaultStatusJson, fountain: MicReadinessResponse['fountain'], quorum: MicReadinessResponse['quorum']): MicMintReadiness {
+  if (fountain.unlocked) return 'fountain_ready';
+  if (quorum.seal_candidate_in_flight && quorum.status !== 'satisfied') return 'quorum_pending';
+  const tr = trancheStatus(v);
+  if (tr === 'eligible_for_seal' && !quorum.seal_candidate_in_flight) return 'seal_ready';
+  const hasReserve =
+    (v.balance_reserve ?? 0) > 0 || (v.in_progress_balance ?? 0) > 0 || (v.sealed_reserve_total ?? 0) > 0;
+  if (hasReserve) return 'reserve_only';
+  return 'not_eligible';
+}
+
+export function buildMicReadinessV1(args: {
+  vaultStatus: VaultStatusJson;
+  depositsSample: { content_signature: string; journal_score?: number }[];
+  cycle?: string;
+}): MicReadinessResponse {
+  const v = args.vaultStatus;
+  const cycle = args.cycle?.trim() || currentCycleId();
+  const gi = typeof v.gi_current === 'number' && Number.isFinite(v.gi_current) ? v.gi_current : null;
+  const mintThresholdGi = v.gi_threshold ?? 0.95;
+  const trancheTarget = v.activation_threshold ?? VAULT_RESERVE_PARCEL_UNITS;
+  const inProgress = v.in_progress_balance ?? 0;
+  const sealed = v.sealed_reserve_total ?? 0;
+  const sustainPlaceholder = true;
+  const sustainMet = Boolean(v.sustain_cycles_met);
+  const requiredSustain = v.sustain_cycles_required ?? 5;
+  const sustain: MicReadinessResponse['sustain'] = {
+    consecutiveEligibleCycles: sustainPlaceholder ? 0 : sustainMet ? requiredSustain : 0,
+    requiredCycles: requiredSustain,
+    status: sustainPlaceholder ? 'not_started' : sustainMet ? 'satisfied' : 'in_progress',
+    sustain_tracking_placeholder: sustainPlaceholder,
+  };
+
+  const { pressure, status: replayStatus } = replayFromDeposits(args.depositsSample);
+  const { score: noveltyScore, status: noveltyStatus } = noveltyFromDeposits(args.depositsSample);
+  const fountainLane = v.fountain_status ?? 'locked';
+  const fountain = { ...fountainTriplet(fountainLane), lane: fountainLane };
+  const quorum = quorumFromVault(v);
+  const mintReadiness = deriveMintReadiness(v, fountain, quorum);
+
+  return {
+    schema: 'MIC_READINESS_V1',
+    cycle,
+    gi,
+    mintThresholdGi,
+    reserve: {
+      inProgressBalance: inProgress,
+      trancheTarget,
+      sealedReserveTotal: sealed,
+      trancheStatus: trancheStatus(v),
+      balanceReserveV1: v.balance_reserve ?? 0,
+    },
+    sustain,
+    replay: { replayPressure: pressure, status: replayStatus },
+    novelty: { noveltyScore, status: noveltyStatus },
+    quorum,
+    fountain,
+    mintReadiness,
+    vault: {
+      reserve_lane: v.reserve_lane ?? null,
+      fountain_status: v.fountain_status ?? null,
+      gi_threshold_met: v.gi_threshold_met ?? null,
+      sustain_cycles_met: v.sustain_cycles_met ?? null,
+      reserve_threshold_met: v.reserve_threshold_met ?? null,
+      candidate_attestation_state: v.candidate_attestation_state ?? null,
+    },
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/lib/mic/types.ts
+++ b/lib/mic/types.ts
@@ -1,0 +1,118 @@
+/**
+ * MIC runtime surface — UI / API contract (MIC_READINESS_V1).
+ * Values are assembled server-side; the Terminal displays them without policy logic.
+ */
+
+export type MicTrancheStatus = 'in_progress' | 'eligible_for_seal' | 'sealed';
+
+export type MicSustainStatus = 'not_started' | 'in_progress' | 'satisfied';
+
+export type MicReplayStatus = 'clear' | 'elevated' | 'blocked';
+
+export type MicNoveltyStatus = 'weak' | 'acceptable' | 'strong';
+
+export type MicQuorumStatus = 'pending' | 'partial' | 'satisfied';
+
+export type MicMintReadiness =
+  | 'not_eligible'
+  | 'reserve_only'
+  | 'seal_ready'
+  | 'quorum_pending'
+  | 'fountain_ready';
+
+export interface MicReadinessResponse {
+  schema: 'MIC_READINESS_V1';
+  cycle: string;
+  gi: number | null;
+  mintThresholdGi: number;
+
+  reserve: {
+    inProgressBalance: number;
+    trancheTarget: number;
+    sealedReserveTotal: number;
+    trancheStatus: MicTrancheStatus;
+    /** v1 cumulative compat (same as balance_reserve on vault status). */
+    balanceReserveV1: number;
+  };
+
+  sustain: {
+    consecutiveEligibleCycles: number;
+    requiredCycles: number;
+    status: MicSustainStatus;
+    /** True when KV sustain is not wired; UI should show "not tracked" not fake numbers. */
+    sustain_tracking_placeholder: boolean;
+  };
+
+  replay: {
+    replayPressure: number;
+    status: MicReplayStatus;
+  };
+
+  novelty: {
+    noveltyScore: number;
+    status: MicNoveltyStatus;
+  };
+
+  quorum: {
+    required: string[];
+    attested: string[];
+    status: MicQuorumStatus;
+    attestations_received: number;
+    attestations_needed: number;
+    seal_candidate_in_flight: boolean;
+  };
+
+  fountain: {
+    locked: boolean;
+    eligible: boolean;
+    unlocked: boolean;
+    /** Raw lane from vault status (locked | preview | tracking | unsealed | active). */
+    lane: string;
+  };
+
+  mintReadiness: MicMintReadiness;
+
+  /** Echo fields from vault status for operator cross-check (not recomputed in UI). */
+  vault: {
+    reserve_lane: string | null;
+    fountain_status: string | null;
+    gi_threshold_met: boolean | null;
+    sustain_cycles_met: boolean | null;
+    reserve_threshold_met: boolean | null;
+    candidate_attestation_state: unknown;
+  };
+
+  updatedAt: string;
+}
+
+export interface MicRewardAttestationSummary {
+  nodeId: string;
+  mic: number;
+  timestamp: string;
+  source: 'vault_deposit_summary' | 'ledger';
+  breakdown?: {
+    integrity?: number;
+    humanIntent?: number;
+    coordination?: number;
+    resilience?: number;
+    multipliers?: {
+      giMultiplier?: number;
+      consensusMultiplier?: number;
+      noveltyMultiplier?: number;
+      antiDriftMultiplier?: number;
+    };
+  };
+}
+
+export interface MicGenesisBlockSummary {
+  cycle: string;
+  mint: number;
+  timestamp: string;
+  allocation?: {
+    reserve?: number;
+    operator?: number;
+    sentinel?: number;
+    civic?: number;
+    burn?: number;
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## C-285 — MIC Runtime Surface (Terminal)

### Summary

Adds an operator-facing **MIC runtime surface** on `/terminal/mic`: server-assembled **MIC_READINESS_V1**, client fetch helpers, and display-only cards for **Vault / reserve**, **Seal / sustain / replay / novelty (windowed)**, **Seal quorum counts**, **Fountain**, **mint readiness badge**, and a **deposit-proxy** attestation table.

**Rule:** Terminal **displays** assembled truth; it does **not** own mint policy. Readiness is built in `lib/mic/runtime-readiness.ts` + `GET /api/mic/readiness` from existing Vault/GI/deposit data (no self-HTTP to `/api/vault/status`).

### New API

- `GET /api/mic/readiness` — `MicReadinessResponse` (`schema: MIC_READINESS_V1`)
- `GET /api/mic/attestations` — `{ ok, schema, rows }` from recent `vault:deposits` (placeholder until ledger `/mic/attestations` exists)

### New files

- `lib/mic/types.ts`, `lib/mic/runtime-readiness.ts`, `lib/mic/fetchMic*.ts`
- `components/mic/*` — `MicStatusCard`, `VaultStatusCard`, `SealStatusCard`, `FountainStatusCard`, `QuorumStatusCard`, `MintReadinessBadge`, `MicAttestationTable`
- `app/api/mic/readiness/route.ts`, `app/api/mic/attestations/route.ts`

### Modified

- `app/terminal/mic/MicPageClient.tsx` — loads readiness + attestations, renders `MicStatusCard` above wallet/snapshot
- `docs/protocols/mic/mic_runtime_reference.md` — documents new routes

### Notes / caveats

- **Sustain:** `sustain_tracking_placeholder: true` until KV sustain is wired; UI shows explicit placeholder (not fake cycle counts).
- **Quorum `attested`:** empty until per-agent list is exposed on status; counts come from `candidate_attestation_state`.
- **Replay / novelty:** derived from **recent deposit list window** for operator signal only — not a full protocol replay engine.
- **Repo layout:** uses `lib/` and `components/` (not `src/`) per this codebase.

### Verification

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- Lint — not configured
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

