### PR TITLE
feat(terminal/mic): MIC runtime + proof surface (readiness, hashes, panels)

### DIFF
--- a/app/api/mic/attestations/route.ts
+++ b/app/api/mic/attestations/route.ts
@@ -1,12 +1,13 @@
 /**
  * GET /api/mic/attestations
  *
- * MIC_REWARD_V2-shaped summaries derived from recent `vault:deposits` rows.
- * Not ledger node attestations — placeholder until substrate exposes `/mic/attestations`.
+ * MIC_REWARD_V2-shaped rows with server-side SHA-256 over canonical JSON.
+ * Deposit-proxy until ledger returns signed rows.
  */
 
 import { NextResponse } from 'next/server';
 import type { MicRewardAttestationSummary } from '@/lib/mic/types';
+import { withHash } from '@/lib/mic/hash';
 import { listVaultDeposits } from '@/lib/vault/vault';
 
 export const dynamic = 'force-dynamic';
@@ -18,7 +19,8 @@ export async function GET() {
   const rows: MicRewardAttestationSummary[] = deposits.map((d) => {
     const j = d.journal_score;
     const wg = j > 0 && Number.isFinite(j) ? Number((d.deposit_amount / j).toFixed(4)) : undefined;
-    return {
+    const base = {
+      type: 'MIC_REWARD_V2' as const,
       nodeId: `${d.agent}:${d.journal_id}`,
       mic: d.deposit_amount,
       timestamp: d.timestamp,
@@ -29,6 +31,13 @@ export async function GET() {
           giMultiplier: wg,
         },
       },
+    };
+    const { payload, hash } = withHash(base);
+    return {
+      ...payload,
+      hash,
+      hash_algorithm: 'sha256' as const,
+      previous_hash: null as string | null,
     };
   });
 

--- a/app/api/mic/blocks/latest/route.ts
+++ b/app/api/mic/blocks/latest/route.ts
@@ -1,0 +1,62 @@
+/**
+ * GET /api/mic/blocks/latest
+ *
+ * MIC_GENESIS_BLOCK-shaped payload when ledger has not written one yet:
+ * returns `ok: false` with reason, or a stub only if env provides values.
+ */
+
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const cycle = process.env.MIC_GENESIS_STUB_CYCLE?.trim();
+  const mintRaw = process.env.MIC_GENESIS_STUB_MINT;
+  const giRaw = process.env.MIC_GENESIS_STUB_GI;
+
+  if (!cycle || !mintRaw || !giRaw) {
+    return NextResponse.json(
+      {
+        ok: false,
+        reason: 'no_genesis_block',
+        message:
+          'No genesis block on ledger yet. Set MIC_GENESIS_STUB_* env vars for operator preview, or wire ledger /mic/blocks/latest.',
+      },
+      { status: 404, headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'mic-blocks-latest' } },
+    );
+  }
+
+  const mint = Number(mintRaw);
+  const gi = Number(giRaw);
+  if (!Number.isFinite(mint) || !Number.isFinite(gi)) {
+    return NextResponse.json(
+      { ok: false, reason: 'invalid_stub_env' },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+
+  const timestamp = new Date().toISOString();
+  return NextResponse.json(
+    {
+      ok: true,
+      stub: true,
+      type: 'MIC_GENESIS_BLOCK',
+      cycle,
+      gi,
+      mint,
+      timestamp,
+      allocation: {
+        reserve: Number(process.env.MIC_GENESIS_STUB_RESERVE ?? '0') || undefined,
+        operator: Number(process.env.MIC_GENESIS_STUB_OPERATOR ?? '0') || undefined,
+        sentinel: Number(process.env.MIC_GENESIS_STUB_SENTINEL ?? '0') || undefined,
+        civic: Number(process.env.MIC_GENESIS_STUB_CIVIC ?? '0') || undefined,
+        burn: Number(process.env.MIC_GENESIS_STUB_BURN ?? '0') || undefined,
+      },
+      previous_hash: null,
+      hash: null,
+      hash_algorithm: 'sha256',
+      message: 'Stub preview only — hash populated when monorepo commits block to ledger.',
+    },
+    { headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'mic-blocks-latest-stub' } },
+  );
+}

--- a/app/api/mic/seals/latest/route.ts
+++ b/app/api/mic/seals/latest/route.ts
@@ -1,21 +1,20 @@
 /**
- * GET /api/mic/readiness
+ * GET /api/mic/seals/latest
  *
- * MIC_READINESS_V1 — assembled server-side from Vault status + deposit sample.
- * Terminal displays this payload; it does not re-derive policy.
+ * MIC_SEAL_V1 snapshot + hash (from current readiness assembly).
  */
 
-import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
 import { buildMicReadinessV1, type VaultStatusJson } from '@/lib/mic/runtime-readiness';
+import { buildMicSealSnapshotBody } from '@/lib/mic/proof-payloads';
+import { withHash } from '@/lib/mic/hash';
 import { loadGIState } from '@/lib/kv/store';
 import { computeVaultSealLaneSemantics } from '@/lib/vault/lane-status';
 import { getVaultStatusPayload } from '@/lib/vault/vault';
 import { countSeals, getCandidate, getInProgressBalance, getLatestSeal } from '@/lib/vault-v2/store';
 import { SENTINEL_ATTESTATION_COUNT } from '@/lib/vault-v2/constants';
 import { listVaultDeposits } from '@/lib/vault/vault';
-import { withHash } from '@/lib/mic/hash';
 
 export const dynamic = 'force-dynamic';
 
@@ -31,7 +30,6 @@ async function getVaultStatusShape(): Promise<VaultStatusJson> {
   }
 
   const v1 = await getVaultStatusPayload(gi);
-
   const [inProgressBalance, sealsCount, latestSeal, candidate] = await Promise.all([
     getInProgressBalance(),
     countSeals(),
@@ -86,15 +84,12 @@ async function getVaultStatusShape(): Promise<VaultStatusJson> {
   };
 }
 
-export async function GET(req: NextRequest) {
-  const cycleParam = req.nextUrl.searchParams.get('cycle')?.trim();
-  let cycle = cycleParam ?? '';
-  if (!cycle) {
-    try {
-      cycle = (await resolveOperatorCycleId()) ?? '';
-    } catch {
-      cycle = '';
-    }
+export async function GET() {
+  let cycle = '';
+  try {
+    cycle = (await resolveOperatorCycleId()) ?? '';
+  } catch {
+    cycle = '';
   }
 
   const vaultStatus = await getVaultStatusShape();
@@ -105,20 +100,16 @@ export async function GET(req: NextRequest) {
     cycle: cycle || undefined,
   });
 
-  const proof = withHash(readiness);
+  const body = buildMicSealSnapshotBody(readiness);
+  const { payload, hash } = withHash(body);
 
   return NextResponse.json(
     {
-      ...readiness,
-      readiness_proof: {
-        hash: proof.hash,
-        hash_algorithm: 'sha256' as const,
-      },
+      ...payload,
+      hash,
+      hash_algorithm: 'sha256',
+      previous_hash: (vaultStatus.latest_seal_hash as string | null) ?? null,
     },
-    {
-    headers: {
-      'Cache-Control': 'no-store',
-      'X-Mobius-Source': 'mic-readiness-v1',
-    },
-  });
+    { headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'mic-seal-latest' } },
+  );
 }

--- a/app/terminal/mic/MicPageClient.tsx
+++ b/app/terminal/mic/MicPageClient.tsx
@@ -1,11 +1,16 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { AttestationProofPanel } from '@/components/mic/AttestationProofPanel';
+import { GenesisBlockViewer } from '@/components/mic/GenesisBlockViewer';
 import { MicStatusCard } from '@/components/mic/MicStatusCard';
+import { SealProofPanel } from '@/components/mic/SealProofPanel';
 import ChamberSkeleton from '@/components/terminal/ChamberSkeleton';
 import { fetchMicAttestations } from '@/lib/mic/fetchMicAttestations';
+import { fetchMicGenesisBlock } from '@/lib/mic/fetchMicGenesisBlock';
 import { fetchMicReadiness } from '@/lib/mic/fetchMicReadiness';
-import type { MicReadinessResponse, MicRewardAttestationSummary } from '@/lib/mic/types';
+import { fetchMicSeal } from '@/lib/mic/fetchMicSeal';
+import type { MicGenesisBlockSummary, MicReadinessResponse, MicRewardAttestationSummary, MicSealSnapshot } from '@/lib/mic/types';
 import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
 
 type Identity = { user?: { username?: string; mic_balance?: number; tier?: string } };
@@ -15,6 +20,8 @@ export default function MicPageClient() {
   const [identity, setIdentity] = useState<Identity | null>(null);
   const [readiness, setReadiness] = useState<MicReadinessResponse | null>(null);
   const [attestations, setAttestations] = useState<MicRewardAttestationSummary[]>([]);
+  const [seal, setSeal] = useState<MicSealSnapshot | null>(null);
+  const [genesis, setGenesis] = useState<MicGenesisBlockSummary | null>(null);
   const [readinessErr, setReadinessErr] = useState<string | null>(null);
 
   useEffect(() => {
@@ -27,7 +34,12 @@ export default function MicPageClient() {
   useEffect(() => {
     void (async () => {
       try {
-        const [r, a] = await Promise.all([fetchMicReadiness(), fetchMicAttestations()]);
+        const [r, a, s, g] = await Promise.all([
+          fetchMicReadiness(),
+          fetchMicAttestations(),
+          fetchMicSeal(),
+          fetchMicGenesisBlock(),
+        ]);
         if (!r) {
           setReadinessErr('MIC readiness unavailable');
           setReadiness(null);
@@ -36,6 +48,8 @@ export default function MicPageClient() {
           setReadiness(r);
         }
         setAttestations(a);
+        setSeal(s);
+        setGenesis(g);
       } catch {
         setReadinessErr('MIC readiness fetch failed');
         setReadiness(null);
@@ -56,8 +70,11 @@ export default function MicPageClient() {
           {readinessErr ?? 'Loading MIC readiness…'}
         </div>
       ) : (
-        <div className="mb-4">
+        <div className="mb-4 space-y-4">
           <MicStatusCard readiness={readiness} attestations={attestations} />
+          {seal ? <SealProofPanel seal={seal} /> : null}
+          {genesis ? <GenesisBlockViewer block={genesis} /> : null}
+          {attestations.length > 0 ? <AttestationProofPanel attestation={attestations[0]} /> : null}
         </div>
       )}
 

--- a/components/mic/AttestationProofPanel.tsx
+++ b/components/mic/AttestationProofPanel.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import type { MicRewardAttestationSummary } from '@/lib/mic/types';
+import { ChainIntegrityCard } from '@/components/mic/ChainIntegrityCard';
+
+export function AttestationProofPanel({ attestation }: { attestation: MicRewardAttestationSummary }) {
+  return (
+    <div className="rounded-xl border border-emerald-900/35 bg-slate-950/70 p-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-[11px] font-semibold uppercase tracking-wide text-emerald-400/90">Attestation proof</h3>
+          <p className="mt-1 font-mono text-[11px] text-slate-300">
+            {attestation.nodeId} · {attestation.mic.toFixed(4)} reserve units
+          </p>
+        </div>
+        <div className="text-[10px] text-slate-500">{attestation.timestamp}</div>
+      </div>
+
+      <div className="mt-3 grid gap-3 md:grid-cols-2">
+        <div className="space-y-1 font-mono text-[11px] text-slate-300">
+          <div>Type: {attestation.type ?? 'MIC_REWARD_V2'}</div>
+          <div>Source: {attestation.source ?? '—'}</div>
+          <div>GI multiplier (dep/J): {attestation.breakdown?.multipliers?.giMultiplier ?? '—'}</div>
+          <div>Consensus: {attestation.breakdown?.multipliers?.consensusMultiplier ?? '—'}</div>
+          <div>Novelty: {attestation.breakdown?.multipliers?.noveltyMultiplier ?? '—'}</div>
+          <div>Anti-drift: {attestation.breakdown?.multipliers?.antiDriftMultiplier ?? '—'}</div>
+        </div>
+        <ChainIntegrityCard
+          hash={attestation.hash}
+          previousHash={attestation.previous_hash}
+          algorithm={attestation.hash_algorithm ?? 'sha256'}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/mic/ChainIntegrityCard.tsx
+++ b/components/mic/ChainIntegrityCard.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { HashBadge } from '@/components/mic/HashBadge';
+
+export function ChainIntegrityCard({
+  hash,
+  previousHash,
+  algorithm = 'sha256',
+}: {
+  hash?: string | null;
+  previousHash?: string | null;
+  algorithm?: string;
+}) {
+  const status = hash ? 'Present' : 'Missing';
+
+  return (
+    <div className="rounded-xl border border-slate-700/80 bg-slate-950/70 p-3">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Chain integrity</h3>
+      <div className="mt-2 space-y-2 font-mono text-[11px] text-slate-300">
+        <div>Algorithm: {algorithm}</div>
+        <div>Status: {status}</div>
+        <HashBadge label="Hash" hash={hash} />
+        <HashBadge label="Previous" hash={previousHash} />
+      </div>
+    </div>
+  );
+}

--- a/components/mic/GenesisBlockViewer.tsx
+++ b/components/mic/GenesisBlockViewer.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import type { MicGenesisBlockSummary } from '@/lib/mic/types';
+import { ChainIntegrityCard } from '@/components/mic/ChainIntegrityCard';
+
+export function GenesisBlockViewer({ block }: { block: MicGenesisBlockSummary }) {
+  return (
+    <div className="rounded-2xl border border-violet-900/35 bg-slate-950/75 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-violet-300/90">Genesis block</h2>
+          <p className="mt-0.5 font-mono text-[11px] text-slate-400">
+            {block.type ?? 'MIC_GENESIS_BLOCK'} · {block.cycle}
+          </p>
+        </div>
+        <div className="text-[10px] text-slate-500">{block.timestamp}</div>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        <div className="space-y-1 font-mono text-[11px] text-slate-300">
+          <div>GI: {block.gi}</div>
+          <div>Mint: {block.mint} MIC</div>
+          <div className="pt-1 font-medium text-slate-500">Allocation</div>
+          <div>Reserve: {block.allocation?.reserve ?? '—'}</div>
+          <div>Operator: {block.allocation?.operator ?? '—'}</div>
+          <div>Sentinel: {block.allocation?.sentinel ?? '—'}</div>
+          <div>Civic: {block.allocation?.civic ?? '—'}</div>
+          <div>Burn: {block.allocation?.burn ?? '—'}</div>
+        </div>
+        <ChainIntegrityCard
+          hash={block.hash}
+          previousHash={block.previous_hash}
+          algorithm={block.hash_algorithm ?? 'sha256'}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/mic/HashBadge.tsx
+++ b/components/mic/HashBadge.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+import { shortHash } from '@/lib/mic/formatHash';
+
+export function HashBadge({ label, hash }: { label: string; hash?: string | null }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copyHash() {
+    if (!hash) return;
+    try {
+      await navigator.clipboard.writeText(hash);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-md border border-slate-700 bg-slate-900/50 px-2 py-1.5 font-mono text-[11px] text-slate-300">
+      <span className="font-medium text-slate-400">{label}:</span>
+      <code className="break-all text-slate-200" title={hash ?? undefined}>
+        {shortHash(hash)}
+      </code>
+      {hash ? (
+        <button
+          type="button"
+          onClick={() => void copyHash()}
+          className="ml-auto rounded border border-slate-600 px-2 py-0.5 text-[10px] text-slate-400 hover:border-slate-500 hover:text-slate-200"
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/components/mic/MicStatusCard.tsx
+++ b/components/mic/MicStatusCard.tsx
@@ -7,6 +7,7 @@ import { MintReadinessBadge } from '@/components/mic/MintReadinessBadge';
 import { QuorumStatusCard } from '@/components/mic/QuorumStatusCard';
 import { SealStatusCard } from '@/components/mic/SealStatusCard';
 import { VaultStatusCard } from '@/components/mic/VaultStatusCard';
+import { ChainIntegrityCard } from '@/components/mic/ChainIntegrityCard';
 
 export function MicStatusCard({
   readiness,
@@ -43,6 +44,17 @@ export function MicStatusCard({
       <div className="mt-4">
         <MicAttestationTable rows={attestations} />
       </div>
+
+      {readiness.readiness_proof?.hash ? (
+        <div className="mt-4">
+          <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-slate-500">Readiness snapshot hash</div>
+          <ChainIntegrityCard
+            hash={readiness.readiness_proof.hash}
+            previousHash={null}
+            algorithm={readiness.readiness_proof.hash_algorithm ?? 'sha256'}
+          />
+        </div>
+      ) : null}
 
       <p className="mt-3 text-[10px] leading-relaxed text-slate-600">
         Display-only: readiness is assembled on the server from Vault + GI + deposit sample. Policy and mint authorization

--- a/components/mic/SealProofPanel.tsx
+++ b/components/mic/SealProofPanel.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import type { MicSealSnapshot } from '@/lib/mic/types';
+import { ChainIntegrityCard } from '@/components/mic/ChainIntegrityCard';
+
+export function SealProofPanel({ seal }: { seal: MicSealSnapshot }) {
+  return (
+    <div className="rounded-2xl border border-cyan-900/35 bg-slate-950/75 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-cyan-300/90">Seal snapshot</h2>
+          <p className="mt-0.5 font-mono text-[11px] text-slate-400">
+            {seal.type ?? 'MIC_SEAL_V1'} · {seal.cycle}
+          </p>
+        </div>
+        <div className="text-[10px] text-slate-500">{seal.timestamp}</div>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        <div className="space-y-1 font-mono text-[11px] text-slate-300">
+          <div>GI: {seal.gi.toFixed(4)}</div>
+          <div>
+            Reserve: {seal.reserve.inProgressBalance.toFixed(4)} / {seal.reserve.trancheTarget.toFixed(2)}
+          </div>
+          <div>Sealed total: {seal.reserve.sealedReserveTotal.toFixed(2)}</div>
+          <div>Tranche: {seal.reserve.trancheStatus}</div>
+          <div>
+            Sustain: {seal.sustain.consecutiveEligibleCycles} / {seal.sustain.requiredCycles} ({seal.sustain.status})
+          </div>
+          <div>Replay: {seal.replay.status}</div>
+          <div>Novelty: {seal.novelty.status}</div>
+          <div>Quorum: {seal.quorum.status}</div>
+        </div>
+        <ChainIntegrityCard
+          hash={seal.hash}
+          previousHash={seal.previous_hash}
+          algorithm={seal.hash_algorithm ?? 'sha256'}
+        />
+      </div>
+    </div>
+  );
+}

--- a/docs/protocols/mic/mic_runtime_reference.md
+++ b/docs/protocols/mic/mic_runtime_reference.md
@@ -17,7 +17,10 @@
 | MIC account (wallet proxy / degraded) | `GET /api/mic/account` — `app/api/mic/account/route.ts` |
 | MIC settle (EPICON claim) | `POST /api/mic/settle` — `app/api/mic/settle/route.ts` |
 | MIC readiness (MIC_READINESS_V1) | `GET /api/mic/readiness` — `app/api/mic/readiness/route.ts` |
-| MIC attestation summaries (deposit proxy) | `GET /api/mic/attestations` — `app/api/mic/attestations/route.ts` |
+| MIC attestation summaries (deposit proxy, hashed) | `GET /api/mic/attestations` — `app/api/mic/attestations/route.ts` |
+| MIC seal snapshot (latest, hashed) | `GET /api/mic/seals/latest` — `app/api/mic/seals/latest/route.ts` |
+| MIC genesis block (stub or future ledger) | `GET /api/mic/blocks/latest` — `app/api/mic/blocks/latest/route.ts` |
+| Canonical JSON + SHA-256 helpers (parity with monorepo) | `lib/mic/canonicalJson.ts`, `lib/mic/hash.ts`, `lib/mic/chainHash.ts` |
 
 ---
 

--- a/lib/mic/canonicalJson.ts
+++ b/lib/mic/canonicalJson.ts
@@ -1,0 +1,57 @@
+/**
+ * Canonical JSON serializer for stable hashing (Terminal-side display / parity with monorepo).
+ *
+ * Rules:
+ * - object keys sorted lexicographically
+ * - arrays preserve order
+ * - undefined omitted
+ * - Date → ISO string
+ * - NaN / Infinity rejected
+ */
+
+type JsonLike =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonLike[]
+  | { [key: string]: JsonLike };
+
+function normalize(value: unknown): JsonLike {
+  if (value === null) return null;
+  if (typeof value === 'string' || typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error('canonicalJson: non-finite number encountered');
+    }
+    return value;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (Array.isArray(value)) {
+    return value.map(normalize);
+  }
+  if (typeof value === 'object') {
+    const input = value as Record<string, unknown>;
+    const keys = Object.keys(input).sort();
+    const output: Record<string, JsonLike> = {};
+    for (const key of keys) {
+      const v = input[key];
+      if (v === undefined) continue;
+      output[key] = normalize(v);
+    }
+    return output;
+  }
+  throw new Error(`canonicalJson: unsupported type "${typeof value}"`);
+}
+
+export function canonicalize(value: unknown): JsonLike {
+  return normalize(value);
+}
+
+export function canonicalStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}

--- a/lib/mic/chainHash.ts
+++ b/lib/mic/chainHash.ts
@@ -1,0 +1,29 @@
+import { hashPayload } from '@/lib/mic/hash';
+
+export interface ChainableRecord {
+  previous_hash: string | null;
+  [key: string]: unknown;
+}
+
+export interface ChainedRecord<T extends object> {
+  payload: T & { previous_hash: string | null };
+  hash: string;
+}
+
+export function chainRecord<T extends object>(payload: T, previousHash: string | null): ChainedRecord<T> {
+  const chainedPayload = {
+    ...payload,
+    previous_hash: previousHash,
+  };
+  return {
+    payload: chainedPayload,
+    hash: hashPayload(chainedPayload),
+  };
+}
+
+export function verifyChainLink<T extends object>(
+  payload: T & { previous_hash: string | null },
+  expectedHash: string,
+): boolean {
+  return hashPayload(payload) === expectedHash;
+}

--- a/lib/mic/fetchMicGenesisBlock.ts
+++ b/lib/mic/fetchMicGenesisBlock.ts
@@ -1,0 +1,24 @@
+import type { MicGenesisBlockSummary } from '@/lib/mic/types';
+
+type GenesisEnvelope =
+  | (MicGenesisBlockSummary & { ok?: boolean; stub?: boolean; message?: string })
+  | { ok: false; reason?: string };
+
+export async function fetchMicGenesisBlock(): Promise<MicGenesisBlockSummary | null> {
+  try {
+    const response = await fetch('/api/mic/blocks/latest', { cache: 'no-store' });
+    const data = (await response.json()) as GenesisEnvelope;
+    if (!response.ok || ('ok' in data && data.ok === false)) {
+      return null;
+    }
+    const { ok: _o, stub: _s, message: _m, ...rest } = data as MicGenesisBlockSummary & {
+      ok?: boolean;
+      stub?: boolean;
+      message?: string;
+    };
+    return rest as MicGenesisBlockSummary;
+  } catch (error) {
+    console.warn('[mic] genesis block fetch failed', error);
+    return null;
+  }
+}

--- a/lib/mic/fetchMicSeal.ts
+++ b/lib/mic/fetchMicSeal.ts
@@ -1,0 +1,12 @@
+import type { MicSealSnapshot } from '@/lib/mic/types';
+
+export async function fetchMicSeal(): Promise<MicSealSnapshot | null> {
+  try {
+    const response = await fetch('/api/mic/seals/latest', { cache: 'no-store' });
+    if (!response.ok) throw new Error(`Failed seal fetch: ${response.status}`);
+    return (await response.json()) as MicSealSnapshot;
+  } catch (error) {
+    console.warn('[mic] seal fetch failed', error);
+    return null;
+  }
+}

--- a/lib/mic/formatHash.ts
+++ b/lib/mic/formatHash.ts
@@ -1,0 +1,5 @@
+export function shortHash(hash?: string | null, size = 10): string {
+  if (!hash) return '—';
+  if (hash.length <= size * 2) return hash;
+  return `${hash.slice(0, size)}…${hash.slice(-size)}`;
+}

--- a/lib/mic/hash.ts
+++ b/lib/mic/hash.ts
@@ -1,0 +1,26 @@
+import { createHash } from 'node:crypto';
+import { canonicalStringify } from '@/lib/mic/canonicalJson';
+
+export interface HashEnvelope<T = unknown> {
+  payload: T;
+  hash: string;
+}
+
+export function sha256Hex(input: string): string {
+  return createHash('sha256').update(input, 'utf8').digest('hex');
+}
+
+export function hashPayload<T>(payload: T): string {
+  return sha256Hex(canonicalStringify(payload));
+}
+
+export function withHash<T>(payload: T): HashEnvelope<T> {
+  return {
+    payload,
+    hash: hashPayload(payload),
+  };
+}
+
+export function verifyPayloadHash<T>(payload: T, expectedHash: string): boolean {
+  return hashPayload(payload) === expectedHash;
+}

--- a/lib/mic/proof-payloads.ts
+++ b/lib/mic/proof-payloads.ts
@@ -1,0 +1,31 @@
+import type { MicReadinessResponse } from '@/lib/mic/types';
+import type { MicSealSnapshot } from '@/lib/mic/types';
+
+/** Build MIC_SEAL_V1 body (pre-hash) from readiness for operator proof display. */
+export function buildMicSealSnapshotBody(readiness: MicReadinessResponse): Omit<MicSealSnapshot, 'hash' | 'hash_algorithm' | 'previous_hash'> {
+  const gi = readiness.gi != null && Number.isFinite(readiness.gi) ? readiness.gi : 0;
+  return {
+    type: 'MIC_SEAL_V1',
+    cycle: readiness.cycle,
+    gi,
+    timestamp: readiness.updatedAt,
+    reserve: {
+      inProgressBalance: readiness.reserve.inProgressBalance,
+      trancheTarget: readiness.reserve.trancheTarget,
+      sealedReserveTotal: readiness.reserve.sealedReserveTotal,
+      trancheStatus: readiness.reserve.trancheStatus,
+    },
+    sustain: {
+      consecutiveEligibleCycles: readiness.sustain.consecutiveEligibleCycles,
+      requiredCycles: readiness.sustain.requiredCycles,
+      status: readiness.sustain.status,
+    },
+    replay: { ...readiness.replay },
+    novelty: { ...readiness.novelty },
+    quorum: {
+      required: readiness.quorum.required,
+      attested: readiness.quorum.attested,
+      status: readiness.quorum.status,
+    },
+  };
+}

--- a/lib/mic/types.ts
+++ b/lib/mic/types.ts
@@ -1,7 +1,14 @@
 /**
- * MIC runtime surface — UI / API contract (MIC_READINESS_V1).
- * Values are assembled server-side; the Terminal displays them without policy logic.
+ * MIC runtime + proof surface — UI / API contract.
+ * Canonical hash creation for attestations / seals may also run server-side here
+ * for degraded/standalone Terminal; monorepo remains source for ledger writes.
  */
+
+export interface MicHashMeta {
+  hash?: string;
+  hash_algorithm?: 'sha256';
+  previous_hash?: string | null;
+}
 
 export type MicTrancheStatus = 'in_progress' | 'eligible_for_seal' | 'sealed';
 
@@ -39,7 +46,6 @@ export interface MicReadinessResponse {
     consecutiveEligibleCycles: number;
     requiredCycles: number;
     status: MicSustainStatus;
-    /** True when KV sustain is not wired; UI should show "not tracked" not fake numbers. */
     sustain_tracking_placeholder: boolean;
   };
 
@@ -66,13 +72,11 @@ export interface MicReadinessResponse {
     locked: boolean;
     eligible: boolean;
     unlocked: boolean;
-    /** Raw lane from vault status (locked | preview | tracking | unsealed | active). */
     lane: string;
   };
 
   mintReadiness: MicMintReadiness;
 
-  /** Echo fields from vault status for operator cross-check (not recomputed in UI). */
   vault: {
     reserve_lane: string | null;
     fountain_status: string | null;
@@ -83,13 +87,17 @@ export interface MicReadinessResponse {
   };
 
   updatedAt: string;
+
+  /** Optional: hash of readiness payload for audit (server-assembled proof). */
+  readiness_proof?: MicHashMeta;
 }
 
-export interface MicRewardAttestationSummary {
+export interface MicRewardAttestationSummary extends MicHashMeta {
+  type?: 'MIC_REWARD_V2';
   nodeId: string;
   mic: number;
   timestamp: string;
-  source: 'vault_deposit_summary' | 'ledger';
+  source?: 'vault_deposit_summary' | 'ledger';
   breakdown?: {
     integrity?: number;
     humanIntent?: number;
@@ -104,8 +112,41 @@ export interface MicRewardAttestationSummary {
   };
 }
 
-export interface MicGenesisBlockSummary {
+export interface MicSealSnapshot extends MicHashMeta {
+  type?: 'MIC_SEAL_V1';
   cycle: string;
+  gi: number;
+  timestamp: string;
+  reserve: {
+    inProgressBalance: number;
+    trancheTarget: number;
+    sealedReserveTotal: number;
+    trancheStatus: MicTrancheStatus;
+  };
+  sustain: {
+    consecutiveEligibleCycles: number;
+    requiredCycles: number;
+    status: MicSustainStatus;
+  };
+  replay: {
+    replayPressure: number;
+    status: MicReplayStatus;
+  };
+  novelty: {
+    noveltyScore: number;
+    status: MicNoveltyStatus;
+  };
+  quorum: {
+    required: string[];
+    attested: string[];
+    status: MicQuorumStatus;
+  };
+}
+
+export interface MicGenesisBlockSummary extends MicHashMeta {
+  type?: 'MIC_GENESIS_BLOCK';
+  cycle: string;
+  gi: number;
   mint: number;
   timestamp: string;
   allocation?: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**MIC runtime surface** (readiness, Vault/Seal/Fountain/quorum cards, deposit-proxy table) **plus MIC proof UI** (hash badges, chain integrity, attestation/seal/genesis panels, canonical JSON + SHA-256 on server routes).

## Key routes

| Route | Role |
|-------|------|
| `GET /api/mic/readiness` | MIC_READINESS_V1 + `readiness_proof` hash |
| `GET /api/mic/attestations` | MIC_REWARD_V2 rows with `hash` (deposit proxy) |
| `GET /api/mic/seals/latest` | MIC_SEAL_V1 + hash, `previous_hash` from latest Vault seal |
| `GET /api/mic/blocks/latest` | 404 until ledger; optional `MIC_GENESIS_STUB_*` stub |

## Libraries

- `lib/mic/canonicalJson.ts`, `hash.ts`, `chainHash.ts` — parity with monorepo hashing approach
- `lib/mic/proof-payloads.ts`, `formatHash.ts`, `fetchMicSeal.ts`, `fetchMicGenesisBlock.ts`

## UI

- `components/mic/*` — runtime cards + `HashBadge`, `ChainIntegrityCard`, proof panels
- `app/terminal/mic/MicPageClient.tsx` — combined surface

## Notes

- Terminal **displays** assembled/hashed payloads; monorepo remains canonical for ledger writes.
- Genesis stub: set `MIC_GENESIS_STUB_CYCLE`, `MIC_GENESIS_STUB_MINT`, `MIC_GENESIS_STUB_GI` (+ optional allocation envs) to preview `GenesisBlockViewer`.

## Verification

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

