### PR TITLE
feat(C-285): deposit hashing, MIC readiness ingest, provisional MIC rename

### DIFF
--- a/app/api/eve/cycle-advance/route.ts
+++ b/app/api/eve/cycle-advance/route.ts
@@ -92,6 +92,7 @@ export async function POST() {
         eventCount: 1,
         avgMii: 0,
         totalGiDelta: 0,
+        totalMicProvisional: 0,
         totalMicMinted: 0,
         agentAverages: {},
         ratings: [],

--- a/app/api/integrity-status/route.ts
+++ b/app/api/integrity-status/route.ts
@@ -1,7 +1,19 @@
 import { NextResponse } from 'next/server';
 import { computeIntegrityPayload } from '@/lib/integrity/buildStatus';
+import { getEchoIntegrity } from '@/lib/echo/store';
 
 export const dynamic = 'force-dynamic';
+
+function echoMicProvisional(): { totalMicProvisional: number; totalMicMinted: number } {
+  const i = getEchoIntegrity();
+  const v =
+    i && typeof i.totalMicProvisional === 'number'
+      ? i.totalMicProvisional
+      : i && typeof i.totalMicMinted === 'number'
+        ? i.totalMicMinted
+        : 0;
+  return { totalMicProvisional: v, totalMicMinted: v };
+}
 
 function buildAuthority(payload: Awaited<ReturnType<typeof computeIntegrityPayload>>, renderEnabled: boolean, renderUsed: boolean) {
   const signalAuthority =
@@ -36,10 +48,12 @@ export async function GET() {
   const renderGicUrl = process.env.RENDER_GIC_URL;
 
   if (!renderGicUrl) {
+    const mic = echoMicProvisional();
     return NextResponse.json({
       ok: true as const,
       degraded: true,
       ...payload,
+      ...mic,
       authority: buildAuthority(payload, false, false),
     });
   }
@@ -61,10 +75,12 @@ export async function GET() {
 
     if (!response.ok) {
       console.error(`[render:gic] ${response.status} ${response.statusText}`);
+      const mic = echoMicProvisional();
       return NextResponse.json({
         ok: true as const,
         degraded: true,
         ...payload,
+        ...mic,
         authority: buildAuthority(payload, true, false),
       });
     }
@@ -83,9 +99,11 @@ export async function GET() {
           ? remote.gi
           : payload.global_integrity;
 
+    const mic = echoMicProvisional();
     return NextResponse.json({
       ok: true as const,
       ...payload,
+      ...mic,
       global_integrity: computedGi,
       mode: remote.mode ?? payload.mode,
       summary: remote.summary ?? payload.summary,
@@ -95,10 +113,12 @@ export async function GET() {
     });
   } catch (error) {
     console.error('[render:gic] request failed', error);
+    const mic = echoMicProvisional();
     return NextResponse.json({
       ok: true as const,
       degraded: true,
       ...payload,
+      ...mic,
       authority: buildAuthority(payload, true, false),
     });
   }

--- a/app/api/mic/readiness/route.ts
+++ b/app/api/mic/readiness/route.ts
@@ -1,124 +1,79 @@
 /**
- * GET /api/mic/readiness
- *
- * MIC_READINESS_V1 — assembled server-side from Vault status + deposit sample.
- * Terminal displays this payload; it does not re-derive policy.
+ * GET /api/mic/readiness — MIC_READINESS_V1 (local + optional upstream KV merge) + readiness_proof hash
+ * POST /api/mic/readiness — accept MIC_READINESS_V1 from tokenomics-engine; store in KV
  */
 
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
-import { buildMicReadinessV1, type VaultStatusJson } from '@/lib/mic/runtime-readiness';
-import { loadGIState } from '@/lib/kv/store';
-import { computeVaultSealLaneSemantics } from '@/lib/vault/lane-status';
-import { getVaultStatusPayload } from '@/lib/vault/vault';
-import { countSeals, getCandidate, getInProgressBalance, getLatestSeal } from '@/lib/vault-v2/store';
-import { SENTINEL_ATTESTATION_COUNT } from '@/lib/vault-v2/constants';
-import { listVaultDeposits } from '@/lib/vault/vault';
-import { withHash } from '@/lib/mic/hash';
+import { bearerMatchesToken } from '@/lib/vault-v2/auth';
+import { assembleLocalMicReadiness, getMergedMicReadiness, resolveReadinessCycle } from '@/lib/mic/assembleMicReadiness';
+import { mergeMicReadinessFromUpstream } from '@/lib/mic/readinessMerge';
+import type { MicReadinessResponse } from '@/lib/mic/types';
+import { kvSet, kvLpushCapped, KV_KEYS } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
 
-async function getVaultStatusShape(): Promise<VaultStatusJson> {
-  let gi: number | null = null;
-  try {
-    const st = await loadGIState();
-    if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
-      gi = Math.max(0, Math.min(1, st.global_integrity));
-    }
-  } catch {
-    gi = null;
-  }
-
-  const v1 = await getVaultStatusPayload(gi);
-
-  const [inProgressBalance, sealsCount, latestSeal, candidate] = await Promise.all([
-    getInProgressBalance(),
-    countSeals(),
-    getLatestSeal(),
-    getCandidate(),
-  ]);
-
-  const seal_lane = computeVaultSealLaneSemantics({
-    inProgressBalance,
-    sealsCountAttested: sealsCount,
-    giCurrent: gi,
-    giThreshold: v1.gi_threshold,
-    sustainCyclesRequired: v1.sustain_cycles_required,
-    v1Status: v1.status,
-    candidateInFlight: Boolean(candidate),
-  });
-
-  const candidate_attestation_state = candidate
-    ? {
-        in_flight: true,
-        seal_id: candidate.seal_id,
-        sequence: candidate.sequence,
-        requested_at: candidate.requested_at,
-        timeout_at: candidate.timeout_at,
-        attestations_received: Object.keys(candidate.attestations).length,
-        attestations_needed: SENTINEL_ATTESTATION_COUNT - Object.keys(candidate.attestations).length,
-      }
-    : {
-        in_flight: false,
-        seal_id: null,
-        attestations_received: 0,
-        timeout_at: null,
-      };
-
-  return {
-    ...v1,
-    gi_current: gi,
-    in_progress_balance: inProgressBalance,
-    sealed_reserve_total: seal_lane.sealed_reserve_total,
-    current_tranche_balance: seal_lane.current_tranche_balance,
-    carry_forward_in_tranche: seal_lane.carry_forward_in_tranche,
-    reserve_threshold_met: seal_lane.reserve_threshold_met,
-    gi_threshold_met: seal_lane.gi_threshold_met,
-    sustain_cycles_met: seal_lane.sustain_met,
-    fountain_status: seal_lane.fountain_lane,
-    reserve_lane: seal_lane.reserve_lane,
-    seals_count: sealsCount,
-    latest_seal_id: latestSeal?.seal_id ?? null,
-    latest_seal_at: latestSeal?.sealed_at ?? null,
-    latest_seal_hash: latestSeal?.seal_hash ?? null,
-    candidate_attestation_state,
-  };
+function micReadinessPostAuth(req: NextRequest): boolean {
+  const agents = process.env.AGENT_SERVICE_TOKEN ?? '';
+  const cron = process.env.CRON_SECRET ?? '';
+  const mobius = process.env.MOBIUS_SERVICE_SECRET ?? '';
+  const h = req.headers.get('authorization');
+  if (agents && bearerMatchesToken(h, agents)) return true;
+  if (cron && bearerMatchesToken(h, cron)) return true;
+  if (mobius && bearerMatchesToken(h, mobius)) return true;
+  return false;
 }
 
 export async function GET(req: NextRequest) {
   const cycleParam = req.nextUrl.searchParams.get('cycle')?.trim();
-  let cycle = cycleParam ?? '';
-  if (!cycle) {
-    try {
-      cycle = (await resolveOperatorCycleId()) ?? '';
-    } catch {
-      cycle = '';
-    }
-  }
+  const readiness = await getMergedMicReadiness(cycleParam);
 
-  const vaultStatus = await getVaultStatusShape();
-  const deposits = await listVaultDeposits(120);
-  const readiness = buildMicReadinessV1({
-    vaultStatus,
-    depositsSample: deposits,
-    cycle: cycle || undefined,
-  });
-
-  const proof = withHash(readiness);
-
-  return NextResponse.json(
-    {
-      ...readiness,
-      readiness_proof: {
-        hash: proof.hash,
-        hash_algorithm: 'sha256' as const,
-      },
-    },
-    {
+  return NextResponse.json(readiness, {
     headers: {
       'Cache-Control': 'no-store',
       'X-Mobius-Source': 'mic-readiness-v1',
     },
   });
+}
+
+export async function POST(req: NextRequest) {
+  if (!micReadinessPostAuth(req)) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: 'invalid_json' }, { status: 400 });
+  }
+
+  const b = body as Record<string, unknown>;
+  const nested = b.snapshot && typeof b.snapshot === 'object' ? (b.snapshot as Record<string, unknown>) : null;
+  const type = typeof b.type === 'string' ? b.type : nested && typeof nested.type === 'string' ? nested.type : '';
+  if (type !== '' && type !== 'MIC_READINESS_V1') {
+    return NextResponse.json({ ok: false, error: 'invalid_type' }, { status: 400 });
+  }
+
+  const cycle = await resolveReadinessCycle(
+    typeof b.cycle === 'string' ? b.cycle : nested && typeof nested.cycle === 'string' ? nested.cycle : null,
+  );
+  const local = await assembleLocalMicReadiness(cycle || undefined);
+  const stripMeta = (o: Record<string, unknown>) => {
+    const { type: _t, received_at: _r, source: _s, snapshot: _sn, ...rest } = o;
+    return rest;
+  };
+  const incoming = nested ? stripMeta(nested) : stripMeta(b);
+  const merged = mergeMicReadinessFromUpstream(local, incoming as Partial<MicReadinessResponse>);
+
+  const snapshot = {
+    snapshot: merged,
+    received_at: new Date().toISOString(),
+    source: 'tokenomics-engine',
+  };
+
+  await kvSet(KV_KEYS.MIC_READINESS_SNAPSHOT, JSON.stringify(snapshot), 7200);
+  await kvLpushCapped(KV_KEYS.MIC_READINESS_FEED, JSON.stringify(snapshot), 100);
+
+  return NextResponse.json({ ok: true, received_at: snapshot.received_at });
 }

--- a/app/api/mic/seals/latest/route.ts
+++ b/app/api/mic/seals/latest/route.ts
@@ -1,104 +1,21 @@
 /**
  * GET /api/mic/seals/latest
  *
- * MIC_SEAL_V1 snapshot + hash (from current readiness assembly).
+ * MIC_SEAL_V1 snapshot + hash (from merged MIC readiness).
  */
 
 import { NextResponse } from 'next/server';
-import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
-import { buildMicReadinessV1, type VaultStatusJson } from '@/lib/mic/runtime-readiness';
 import { buildMicSealSnapshotBody } from '@/lib/mic/proof-payloads';
 import { withHash } from '@/lib/mic/hash';
-import { loadGIState } from '@/lib/kv/store';
-import { computeVaultSealLaneSemantics } from '@/lib/vault/lane-status';
-import { getVaultStatusPayload } from '@/lib/vault/vault';
-import { countSeals, getCandidate, getInProgressBalance, getLatestSeal } from '@/lib/vault-v2/store';
-import { SENTINEL_ATTESTATION_COUNT } from '@/lib/vault-v2/constants';
-import { listVaultDeposits } from '@/lib/vault/vault';
+import { getMergedMicReadiness } from '@/lib/mic/assembleMicReadiness';
+import { getLatestSeal } from '@/lib/vault-v2/store';
 
 export const dynamic = 'force-dynamic';
 
-async function getVaultStatusShape(): Promise<VaultStatusJson> {
-  let gi: number | null = null;
-  try {
-    const st = await loadGIState();
-    if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
-      gi = Math.max(0, Math.min(1, st.global_integrity));
-    }
-  } catch {
-    gi = null;
-  }
-
-  const v1 = await getVaultStatusPayload(gi);
-  const [inProgressBalance, sealsCount, latestSeal, candidate] = await Promise.all([
-    getInProgressBalance(),
-    countSeals(),
-    getLatestSeal(),
-    getCandidate(),
-  ]);
-
-  const seal_lane = computeVaultSealLaneSemantics({
-    inProgressBalance,
-    sealsCountAttested: sealsCount,
-    giCurrent: gi,
-    giThreshold: v1.gi_threshold,
-    sustainCyclesRequired: v1.sustain_cycles_required,
-    v1Status: v1.status,
-    candidateInFlight: Boolean(candidate),
-  });
-
-  const candidate_attestation_state = candidate
-    ? {
-        in_flight: true,
-        seal_id: candidate.seal_id,
-        sequence: candidate.sequence,
-        requested_at: candidate.requested_at,
-        timeout_at: candidate.timeout_at,
-        attestations_received: Object.keys(candidate.attestations).length,
-        attestations_needed: SENTINEL_ATTESTATION_COUNT - Object.keys(candidate.attestations).length,
-      }
-    : {
-        in_flight: false,
-        seal_id: null,
-        attestations_received: 0,
-        timeout_at: null,
-      };
-
-  return {
-    ...v1,
-    gi_current: gi,
-    in_progress_balance: inProgressBalance,
-    sealed_reserve_total: seal_lane.sealed_reserve_total,
-    current_tranche_balance: seal_lane.current_tranche_balance,
-    carry_forward_in_tranche: seal_lane.carry_forward_in_tranche,
-    reserve_threshold_met: seal_lane.reserve_threshold_met,
-    gi_threshold_met: seal_lane.gi_threshold_met,
-    sustain_cycles_met: seal_lane.sustain_met,
-    fountain_status: seal_lane.fountain_lane,
-    reserve_lane: seal_lane.reserve_lane,
-    seals_count: sealsCount,
-    latest_seal_id: latestSeal?.seal_id ?? null,
-    latest_seal_at: latestSeal?.sealed_at ?? null,
-    latest_seal_hash: latestSeal?.seal_hash ?? null,
-    candidate_attestation_state,
-  };
-}
-
 export async function GET() {
-  let cycle = '';
-  try {
-    cycle = (await resolveOperatorCycleId()) ?? '';
-  } catch {
-    cycle = '';
-  }
-
-  const vaultStatus = await getVaultStatusShape();
-  const deposits = await listVaultDeposits(120);
-  const readiness = buildMicReadinessV1({
-    vaultStatus,
-    depositsSample: deposits,
-    cycle: cycle || undefined,
-  });
+  const full = await getMergedMicReadiness();
+  const { readiness_proof: _rp, ...readiness } = full;
+  const latestSeal = await getLatestSeal();
 
   const body = buildMicSealSnapshotBody(readiness);
   const { payload, hash } = withHash(body);
@@ -108,7 +25,7 @@ export async function GET() {
       ...payload,
       hash,
       hash_algorithm: 'sha256',
-      previous_hash: (vaultStatus.latest_seal_hash as string | null) ?? null,
+      previous_hash: latestSeal?.seal_hash ?? null,
     },
     { headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'mic-seal-latest' } },
   );

--- a/app/api/terminal/snapshot/route.ts
+++ b/app/api/terminal/snapshot/route.ts
@@ -11,6 +11,7 @@ import { GET as getPromotion } from '@/app/api/epicon/promotion-status/route';
 import { GET as getEve } from '@/app/api/eve/cycle-advance/route';
 import { GET as getMii } from '@/app/api/mii/feed/route';
 import { GET as getVault } from '@/app/api/vault/status/route';
+import { GET as getMicReadiness } from '@/app/api/mic/readiness/route';
 import { loadSignalSnapshot, isRedisAvailable } from '@/lib/kv/store';
 import {
   normalizeAllSnapshotLanes,
@@ -84,6 +85,7 @@ export async function GET(request: NextRequest) {
     timedHandler(makeRequest(baseUrl, '/api/eve/cycle-advance'), getEve),
     timedHandler(makeRequest(baseUrl, '/api/mii/feed'), getMii),
     timedHandler(makeRequest(baseUrl, '/api/vault/status'), getVault),
+    timedHandler(makeRequest(baseUrl, '/api/mic/readiness'), getMicReadiness),
   ]);
 
   const [cached, results] = await Promise.all([cachedPromise, lanesPromise]);
@@ -100,7 +102,8 @@ export async function GET(request: NextRequest) {
     signalsDuration = Date.now() - signalsStart;
   }
 
-  const [integrity, kvHealth, agents, epicon, echo, journal, sentiment, runtime, promotion, eve, mii, vault] = results;
+  const [integrity, kvHealth, agents, epicon, echo, journal, sentiment, runtime, promotion, eve, mii, vault, micReadiness] =
+    results;
 
   const timings: Record<string, number> = {
     signals: signalsDuration,
@@ -116,6 +119,7 @@ export async function GET(request: NextRequest) {
     eve: eve.duration_ms,
     mii: mii.duration_ms,
     vault: vault.duration_ms,
+    micReadiness: micReadiness.duration_ms,
   };
 
   type SubstrateAgentRow = { agent: string; lastEntry: SubstrateJournalEntry | null; entryCount: number };
@@ -151,6 +155,7 @@ export async function GET(request: NextRequest) {
     integrity: integrity.leaf, signals, kvHealth: kvHealth.leaf, agents: agents.leaf,
     epicon: epicon.leaf, echo: echo.leaf, journal: journal.leaf, sentiment: sentiment.leaf,
     runtime: runtime.leaf, promotion: promotion.leaf, eve: eve.leaf, mii: mii.leaf, vault: vault.leaf,
+    micReadiness: micReadiness.leaf,
   };
 
   const lanes: SnapshotLaneState[] = normalizeAllSnapshotLanes(leaves);
@@ -192,6 +197,7 @@ export async function GET(request: NextRequest) {
     integrity: integrity.leaf, signals, kvHealth: kvHealth.leaf, agents: agents.leaf,
     epicon: epicon.leaf, echo: echo.leaf, journal: journal.leaf, sentiment: sentiment.leaf,
     runtime: runtime.leaf, promotion: promotion.leaf, eve: eve.leaf, mii: mii.leaf, vault: vault.leaf,
+    micReadiness: micReadiness.leaf,
     substrate,
   }, {
     headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'terminal-snapshot' },

--- a/app/api/vault/status/route.ts
+++ b/app/api/vault/status/route.ts
@@ -17,7 +17,7 @@ import { NextResponse } from 'next/server';
 import { handbookCorsHeaders } from '@/lib/http/handbook-cors';
 import { loadGIState } from '@/lib/kv/store';
 import { computeVaultSealLaneSemantics } from '@/lib/vault/lane-status';
-import { getVaultStatusPayload } from '@/lib/vault/vault';
+import { getVaultDepositHashCoverage, getVaultStatusPayload } from '@/lib/vault/vault';
 import {
   countAllSeals,
   countSeals,
@@ -67,6 +67,8 @@ export async function GET(req: NextRequest) {
     candidateInFlight: Boolean(candidate),
   });
 
+  const hashCoverage = await getVaultDepositHashCoverage(200);
+
   const body = {
     ...v1,
     in_progress_balance: inProgressBalance,
@@ -108,6 +110,12 @@ export async function GET(req: NextRequest) {
         },
     vault_version: 2,
     canonical: 'in_progress_balance',
+    hashed_deposits_count: hashCoverage.hashed_deposits_count,
+    legacy_deposits_count: hashCoverage.legacy_deposits_count,
+    hash_coverage_pct: hashCoverage.hash_coverage_pct,
+    hash_coverage_rows_scanned: hashCoverage.rows_scanned,
+    _balance_reserve_deprecated:
+      'balance_reserve is v1 cumulative compat. Prefer in_progress_balance + sealed_reserve_total for tranche truth. Removed in a later cycle.',
   };
 
   return NextResponse.json(body, {
@@ -115,6 +123,7 @@ export async function GET(req: NextRequest) {
       ...(cors ?? {}),
       'Cache-Control': 'no-store',
       'X-Mobius-Source': 'vault-status-v2',
+      Deprecation: 'true',
     },
   });
 }

--- a/app/terminal/mic/MicPageClient.tsx
+++ b/app/terminal/mic/MicPageClient.tsx
@@ -59,7 +59,11 @@ export default function MicPageClient() {
 
   if (loading && !snapshot) return <ChamberSkeleton blocks={5} />;
 
-  const integrity = (snapshot?.integrity?.data ?? {}) as { totalMicMinted?: number; mic_supply?: number };
+  const integrity = (snapshot?.integrity?.data ?? {}) as {
+    totalMicProvisional?: number;
+    totalMicMinted?: number;
+    mic_supply?: number;
+  };
 
   return (
     <div className="h-full overflow-y-auto p-4">
@@ -88,7 +92,7 @@ export default function MicPageClient() {
       )}
       <div className="grid gap-3 md:grid-cols-2">
         <div className="rounded border border-slate-800 bg-slate-900/60 p-3 text-sm">
-          totalMicMinted: {integrity.totalMicMinted ?? '—'}
+          totalMicProvisional: {integrity.totalMicProvisional ?? integrity.totalMicMinted ?? '—'}
         </div>
         <div className="rounded border border-slate-800 bg-slate-900/60 p-3 text-sm">mic_supply: {integrity.mic_supply ?? '—'}</div>
       </div>

--- a/components/terminal/IntegrityRatingPanel.tsx
+++ b/components/terminal/IntegrityRatingPanel.tsx
@@ -201,10 +201,10 @@ export default function IntegrityRatingPanel({
         </div>
         <div className="text-center">
           <div className="text-2xl font-mono font-semibold text-sky-300">
-            {integrity.totalMicMinted.toFixed(4)}
+            {(integrity.totalMicProvisional ?? integrity.totalMicMinted).toFixed(4)}
           </div>
           <div className="text-[10px] font-mono uppercase tracking-[0.15em] text-slate-500">
-            MIC Minted
+            MIC provisional
           </div>
         </div>
         <div className="text-center">

--- a/components/terminal/MICWalletPanel.tsx
+++ b/components/terminal/MICWalletPanel.tsx
@@ -136,7 +136,7 @@ export default function MICWalletPanel({
           <div className="flex items-center justify-between text-xs mb-3">
             <span className="text-slate-400">Cycle MIC</span>
             <span className="font-mono text-emerald-400">
-              +{(integrity?.totalMicMinted ?? 0).toFixed(4)}
+              +{((integrity?.totalMicProvisional ?? integrity?.totalMicMinted) ?? 0).toFixed(4)}
             </span>
           </div>
           <div className="p-2 bg-slate-800/60 rounded-lg border border-slate-700/50">

--- a/docs/protocols/mic/mic_runtime_reference.md
+++ b/docs/protocols/mic/mic_runtime_reference.md
@@ -16,7 +16,8 @@
 | Vault attestation cron | `app/api/cron/vault-attestation/route.ts` |
 | MIC account (wallet proxy / degraded) | `GET /api/mic/account` — `app/api/mic/account/route.ts` |
 | MIC settle (EPICON claim) | `POST /api/mic/settle` — `app/api/mic/settle/route.ts` |
-| MIC readiness (MIC_READINESS_V1) | `GET /api/mic/readiness` — `app/api/mic/readiness/route.ts` |
+| MIC readiness (MIC_READINESS_V1) | `GET /api/mic/readiness` — merged local Vault assembly + optional KV snapshot from `POST` |
+| MIC readiness ingest (Substrate / tokenomics-engine) | `POST /api/mic/readiness` — Bearer `AGENT_SERVICE_TOKEN`, `CRON_SECRET`, or `MOBIUS_SERVICE_SECRET`; writes `mobius:mic:readiness:snapshot` + feed |
 | MIC attestation summaries (deposit proxy, hashed) | `GET /api/mic/attestations` — `app/api/mic/attestations/route.ts` |
 | MIC seal snapshot (latest, hashed) | `GET /api/mic/seals/latest` — `app/api/mic/seals/latest/route.ts` |
 | MIC genesis block (stub or future ledger) | `GET /api/mic/blocks/latest` — `app/api/mic/blocks/latest/route.ts` |

--- a/hooks/useTerminalData.ts
+++ b/hooks/useTerminalData.ts
@@ -277,11 +277,12 @@ export function useTerminalData(selectedNav: NavKey, initialData?: TerminalBoots
 
   useEffect(() => {
     if (!echoIntegrity) return;
-    if (echoIntegrity.totalMicMinted <= 0) return;
+    const micProv = echoIntegrity.totalMicProvisional ?? echoIntegrity.totalMicMinted;
+    if (micProv <= 0) return;
     if (lastMintedCycleRef.current === echoIntegrity.cycleId) return;
 
     lastMintedCycleRef.current = echoIntegrity.cycleId;
-    earnMIC('echo_integrity_mint', echoIntegrity.totalMicMinted, {
+    earnMIC('echo_integrity_mint', micProv, {
       cycleId: echoIntegrity.cycleId,
       avgMii: echoIntegrity.avgMii,
       eventCount: echoIntegrity.eventCount,

--- a/lib/echo/integrity-engine.ts
+++ b/lib/echo/integrity-engine.ts
@@ -82,6 +82,11 @@ export type CycleIntegritySummary = {
   eventCount: number;
   avgMii: number;
   totalGiDelta: number;
+  /** Sum of provisional MIC from integrity ratings (MIC_REWARD_V2 class); not circulation mint. */
+  totalMicProvisional: number;
+  /**
+   * @deprecated C-285 — use `totalMicProvisional`. Same numeric value; removed in a later cycle.
+   */
   totalMicMinted: number;
   agentAverages: Record<string, number>;
   ratings: IntegrityRating[];
@@ -326,7 +331,7 @@ export function rateBatch(
     ? ratings.reduce((sum, r) => sum + r.mii, 0) / eventCount
     : 0;
   const totalGiDelta = ratings.reduce((sum, r) => sum + r.integrityDelta, 0);
-  const totalMicMinted = ratings.reduce((sum, r) => sum + r.micMinted, 0);
+  const totalMicProvisional = ratings.reduce((sum, r) => sum + r.micMinted, 0);
 
   // Agent averages
   const agentSums: Record<string, { total: number; count: number }> = {};
@@ -348,7 +353,8 @@ export function rateBatch(
     eventCount,
     avgMii,
     totalGiDelta: Number(totalGiDelta.toFixed(4)),
-    totalMicMinted: Number(totalMicMinted.toFixed(6)),
+    totalMicProvisional: Number(totalMicProvisional.toFixed(6)),
+    totalMicMinted: Number(totalMicProvisional.toFixed(6)),
     agentAverages,
     ratings,
   };

--- a/lib/kv/store.ts
+++ b/lib/kv/store.ts
@@ -198,12 +198,32 @@ export async function kvExists(key: string): Promise<boolean> {
   }
 }
 
+/** LPUSH + LTRIM on a prefixed list (e.g. readiness feed). Returns false if Redis unavailable. */
+export async function kvLpushCapped(key: string, value: string, maxLen: number): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  const cap = Math.max(1, Math.floor(maxLen));
+  try {
+    const fullKey = prefixKey(key);
+    await redis.lpush(fullKey, value);
+    await redis.ltrim(fullKey, 0, cap - 1);
+    return true;
+  } catch (err) {
+    console.warn(`[mobius-kv] LPUSH ${key} failed:`, err instanceof Error ? err.message : err);
+    return false;
+  }
+}
+
 // ── Mobius-specific compound operations ──────────────────────
 
 /**
  * Key constants for Mobius state
  */
 export const KV_KEYS = {
+  /** Substrate tokenomics-engine MIC_READINESS_V1 snapshot (canonical when present) */
+  MIC_READINESS_SNAPSHOT: 'mic:readiness:snapshot',
+  /** Rolling feed of posted readiness snapshots (newest-first, capped in writer) */
+  MIC_READINESS_FEED: 'mic:readiness:feed',
   /** Last signal snapshot from micro-agents */
   SIGNAL_SNAPSHOT: 'signals:latest',
   /** Last GI computation result */

--- a/lib/mic/assembleMicReadiness.ts
+++ b/lib/mic/assembleMicReadiness.ts
@@ -1,0 +1,144 @@
+import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
+import { buildMicReadinessV1, type VaultStatusJson } from '@/lib/mic/runtime-readiness';
+import { mergeMicReadinessFromUpstream } from '@/lib/mic/readinessMerge';
+import type { MicReadinessResponse } from '@/lib/mic/types';
+import { withHash } from '@/lib/mic/hash';
+import { loadGIState, kvGet, KV_KEYS } from '@/lib/kv/store';
+import { computeVaultSealLaneSemantics } from '@/lib/vault/lane-status';
+import { getVaultStatusPayload, listVaultDeposits } from '@/lib/vault/vault';
+import { countSeals, getCandidate, getInProgressBalance, getLatestSeal } from '@/lib/vault-v2/store';
+import { SENTINEL_ATTESTATION_COUNT } from '@/lib/vault-v2/constants';
+
+type UpstreamSnapshot = {
+  snapshot?: Partial<MicReadinessResponse> & Record<string, unknown>;
+  received_at?: string;
+  source?: string;
+};
+
+async function getVaultStatusShape(): Promise<VaultStatusJson> {
+  let gi: number | null = null;
+  try {
+    const st = await loadGIState();
+    if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
+      gi = Math.max(0, Math.min(1, st.global_integrity));
+    }
+  } catch {
+    gi = null;
+  }
+
+  const v1 = await getVaultStatusPayload(gi);
+  const [inProgressBalance, sealsCount, latestSeal, candidate] = await Promise.all([
+    getInProgressBalance(),
+    countSeals(),
+    getLatestSeal(),
+    getCandidate(),
+  ]);
+
+  const seal_lane = computeVaultSealLaneSemantics({
+    inProgressBalance,
+    sealsCountAttested: sealsCount,
+    giCurrent: gi,
+    giThreshold: v1.gi_threshold,
+    sustainCyclesRequired: v1.sustain_cycles_required,
+    v1Status: v1.status,
+    candidateInFlight: Boolean(candidate),
+  });
+
+  const candidate_attestation_state = candidate
+    ? {
+        in_flight: true,
+        seal_id: candidate.seal_id,
+        sequence: candidate.sequence,
+        requested_at: candidate.requested_at,
+        timeout_at: candidate.timeout_at,
+        attestations_received: Object.keys(candidate.attestations).length,
+        attestations_needed: SENTINEL_ATTESTATION_COUNT - Object.keys(candidate.attestations).length,
+      }
+    : {
+        in_flight: false,
+        seal_id: null,
+        attestations_received: 0,
+        timeout_at: null,
+      };
+
+  return {
+    ...v1,
+    gi_current: gi,
+    in_progress_balance: inProgressBalance,
+    sealed_reserve_total: seal_lane.sealed_reserve_total,
+    current_tranche_balance: seal_lane.current_tranche_balance,
+    carry_forward_in_tranche: seal_lane.carry_forward_in_tranche,
+    reserve_threshold_met: seal_lane.reserve_threshold_met,
+    gi_threshold_met: seal_lane.gi_threshold_met,
+    sustain_cycles_met: seal_lane.sustain_met,
+    fountain_status: seal_lane.fountain_lane,
+    reserve_lane: seal_lane.reserve_lane,
+    seals_count: sealsCount,
+    latest_seal_id: latestSeal?.seal_id ?? null,
+    latest_seal_at: latestSeal?.sealed_at ?? null,
+    latest_seal_hash: latestSeal?.seal_hash ?? null,
+    candidate_attestation_state,
+  };
+}
+
+export async function resolveReadinessCycle(cycleParam?: string | null): Promise<string> {
+  let cycle = cycleParam?.trim() ?? '';
+  if (!cycle) {
+    try {
+      cycle = (await resolveOperatorCycleId()) ?? '';
+    } catch {
+      cycle = '';
+    }
+  }
+  return cycle;
+}
+
+/** Local MIC_READINESS_V1 from Vault + deposits (no upstream merge). */
+export async function assembleLocalMicReadiness(cycleParam?: string | null): Promise<MicReadinessResponse> {
+  const cycle = await resolveReadinessCycle(cycleParam);
+  const vaultStatus = await getVaultStatusShape();
+  const deposits = await listVaultDeposits(120);
+  return buildMicReadinessV1({
+    vaultStatus,
+    depositsSample: deposits,
+    cycle: cycle || undefined,
+  });
+}
+
+async function loadUpstreamReadiness(): Promise<Partial<MicReadinessResponse> | null> {
+  const raw = await kvGet<string | UpstreamSnapshot | MicReadinessResponse>(KV_KEYS.MIC_READINESS_SNAPSHOT);
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === 'string') {
+    try {
+      const o = JSON.parse(raw) as UpstreamSnapshot & MicReadinessResponse;
+      if (o && typeof o === 'object' && 'snapshot' in o && o.snapshot) {
+        return o.snapshot as Partial<MicReadinessResponse>;
+      }
+      if (o && typeof o === 'object' && (o as MicReadinessResponse).schema === 'MIC_READINESS_V1') {
+        return o as Partial<MicReadinessResponse>;
+      }
+      return o as Partial<MicReadinessResponse>;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof raw === 'object' && raw !== null && 'snapshot' in raw) {
+    return (raw as UpstreamSnapshot).snapshot ?? null;
+  }
+  return raw as Partial<MicReadinessResponse>;
+}
+
+/** Merge Substrate KV snapshot over local when present; re-hash merged body. */
+export async function getMergedMicReadiness(cycleParam?: string | null): Promise<MicReadinessResponse> {
+  const local = await assembleLocalMicReadiness(cycleParam);
+  const upstream = await loadUpstreamReadiness();
+  const merged = mergeMicReadinessFromUpstream(local, upstream);
+  const proof = withHash(merged);
+  return {
+    ...merged,
+    readiness_proof: {
+      hash: proof.hash,
+      hash_algorithm: 'sha256',
+    },
+  };
+}

--- a/lib/mic/readinessMerge.ts
+++ b/lib/mic/readinessMerge.ts
@@ -1,0 +1,30 @@
+import type { MicReadinessResponse } from '@/lib/mic/types';
+
+/**
+ * Merge Substrate-posted MIC_READINESS_V1 over locally assembled readiness.
+ * Incoming fields override when present; local fills gaps.
+ */
+export function mergeMicReadinessFromUpstream(
+  local: MicReadinessResponse,
+  incoming: Partial<MicReadinessResponse> | null,
+): MicReadinessResponse {
+  if (!incoming || typeof incoming !== 'object') return local;
+
+  return {
+    ...local,
+    ...(incoming.cycle !== undefined && incoming.cycle !== '' ? { cycle: incoming.cycle } : {}),
+    ...(incoming.gi !== undefined ? { gi: incoming.gi } : {}),
+    ...(incoming.mintThresholdGi !== undefined ? { mintThresholdGi: incoming.mintThresholdGi } : {}),
+    reserve: incoming.reserve ? { ...local.reserve, ...incoming.reserve } : local.reserve,
+    sustain: incoming.sustain ? { ...local.sustain, ...incoming.sustain } : local.sustain,
+    replay: incoming.replay ? { ...local.replay, ...incoming.replay } : local.replay,
+    novelty: incoming.novelty ? { ...local.novelty, ...incoming.novelty } : local.novelty,
+    quorum: incoming.quorum ? { ...local.quorum, ...incoming.quorum } : local.quorum,
+    fountain: incoming.fountain ? { ...local.fountain, ...incoming.fountain } : local.fountain,
+    ...(incoming.mintReadiness !== undefined ? { mintReadiness: incoming.mintReadiness } : {}),
+    vault: incoming.vault ? { ...local.vault, ...incoming.vault } : local.vault,
+    ...(incoming.updatedAt !== undefined ? { updatedAt: incoming.updatedAt } : {}),
+    readiness_proof: incoming.readiness_proof?.hash ? incoming.readiness_proof : local.readiness_proof,
+    schema: 'MIC_READINESS_V1',
+  };
+}

--- a/lib/terminal/snapshotLanes.ts
+++ b/lib/terminal/snapshotLanes.ts
@@ -16,7 +16,8 @@ export type SnapshotLaneKey =
   | 'promotion'
   | 'eve'
   | 'mii'
-  | 'vault';
+  | 'vault'
+  | 'micReadiness';
 
 export type SnapshotLaneSemanticState = 'healthy' | 'degraded' | 'offline' | 'stale' | 'empty' | 'promotable';
 
@@ -57,6 +58,7 @@ export const SNAPSHOT_LANE_KEYS: readonly SnapshotLaneKey[] = [
   'eve',
   'mii',
   'vault',
+  'micReadiness',
 ] as const;
 
 function asRecord(data: unknown): Record<string, unknown> | null {
@@ -141,6 +143,8 @@ export function extractLaneLastUpdated(key: SnapshotLaneKey, data: unknown): str
       return pick('timestamp');
     case 'vault':
       return pick('timestamp', 'last_deposit');
+    case 'micReadiness':
+      return pick('updatedAt', 'timestamp');
     default:
       return null;
   }
@@ -673,6 +677,44 @@ function normalizeEveLane(leaf: SnapshotLeaf): SnapshotLaneState {
   };
 }
 
+function normalizeMicReadinessLane(leaf: SnapshotLeaf): SnapshotLaneState {
+  const lastUpdated = extractLaneLastUpdated('micReadiness', leaf.data);
+  if (!leaf.ok) {
+    const { state, message } = classifyHttpFailure(leaf.status, leaf.error);
+    return {
+      key: 'micReadiness',
+      ok: false,
+      state,
+      statusCode: leaf.status,
+      message,
+      lastUpdated,
+      fallbackMode: 'offline',
+    };
+  }
+  const row = asRecord(leaf.data);
+  const gi = typeof row?.gi === 'number' && Number.isFinite(row.gi) ? row.gi : null;
+  const mint = typeof row?.mintReadiness === 'string' ? row.mintReadiness : '—';
+  const reserve =
+    row?.reserve && typeof row.reserve === 'object'
+      ? (row.reserve as Record<string, unknown>).inProgressBalance
+      : null;
+  const r =
+    typeof reserve === 'number' && Number.isFinite(reserve) ? (reserve as number).toFixed(2) : '—';
+  const msg =
+    gi !== null
+      ? `MIC readiness: GI ${gi.toFixed(2)} · reserve ${r} · mint ${mint}`
+      : `MIC readiness: reserve ${r} · mint ${mint}`;
+  return {
+    key: 'micReadiness',
+    ok: true,
+    state: 'healthy',
+    statusCode: leaf.status,
+    message: msg,
+    lastUpdated,
+    fallbackMode: 'live',
+  };
+}
+
 function normalizeVaultLane(leaf: SnapshotLeaf): SnapshotLaneState {
   const lastUpdated = extractLaneLastUpdated('vault', leaf.data);
   if (!leaf.ok) {
@@ -781,6 +823,8 @@ export function normalizeSnapshotLane(key: SnapshotLaneKey, leaf: SnapshotLeaf):
       return normalizeMiiLane(leaf);
     case 'vault':
       return normalizeVaultLane(leaf);
+    case 'micReadiness':
+      return normalizeMicReadinessLane(leaf);
     default:
       return {
         key,

--- a/lib/vault/vault.ts
+++ b/lib/vault/vault.ts
@@ -15,6 +15,7 @@ import {
 } from '@/lib/kv/backup-redis';
 import { kvGet, kvSet, loadGIState } from '@/lib/kv/store';
 import { accrueDepositV2 } from '@/lib/vault-v2/deposit';
+import { hashPayload } from '@/lib/mic/hash';
 
 const BALANCE_KEY = 'vault:global:balance';
 const META_KEY = 'vault:global:meta';
@@ -47,6 +48,10 @@ export type VaultDeposit = {
   status: 'sealed';
   /** Normalized text fingerprint for v1 duplication decay (not spendable MIC). */
   content_signature: string;
+  /** SHA-256 over canonical deposit fields (Seal chain / audit). Pre-C-285 rows omit. */
+  deposit_hash?: string;
+  /** When deposit_hash was computed. */
+  hashed_at?: string;
 };
 
 export type VaultState = {
@@ -133,6 +138,22 @@ function parseDepositRow(raw: string | unknown): VaultDeposit | null {
   }
 }
 
+/** Canonical payload for `deposit_hash` (stable key order via hashPayload). */
+export function computeVaultDepositHash(input: {
+  event_type: 'vault_deposit';
+  journal_id: string;
+  vault_id: 'vault-global';
+  agent: string;
+  deposit_amount: number;
+  journal_score: number;
+  gi_at_deposit: number;
+  timestamp: string;
+  status: 'sealed';
+  content_signature: string;
+}): string {
+  return hashPayload(input);
+}
+
 /**
  * Newest-first raw deposit rows from `vault:deposits` (same list as LPUSH in
  * `writeVaultDeposit`, capped at DEPOSITS_MAX).
@@ -167,13 +188,57 @@ export async function getRecentContentSignatures(limit: number): Promise<string[
   return deposits.map((d) => d.content_signature);
 }
 
+/** Scan newest-first deposit list for `deposit_hash` presence (C-285 proof coverage). */
+export async function getVaultDepositHashCoverage(limit = DEPOSITS_MAX): Promise<{
+  hashed_deposits_count: number;
+  legacy_deposits_count: number;
+  rows_scanned: number;
+  hash_coverage_pct: number;
+}> {
+  const deposits = await listVaultDeposits(Math.max(1, Math.min(DEPOSITS_MAX, limit)));
+  let hashed = 0;
+  let legacy = 0;
+  for (const d of deposits) {
+    if (typeof d.deposit_hash === 'string' && d.deposit_hash.length > 0) hashed += 1;
+    else legacy += 1;
+  }
+  const total = deposits.length;
+  const pct = total > 0 ? Number(((100 * hashed) / total).toFixed(2)) : 100;
+  return {
+    hashed_deposits_count: hashed,
+    legacy_deposits_count: legacy,
+    rows_scanned: total,
+    hash_coverage_pct: pct,
+  };
+}
+
 export async function writeVaultDeposit(
   deposit: VaultDeposit,
   opts?: WriteVaultDepositOptions,
 ): Promise<void> {
+  const hashedAt = new Date().toISOString();
+  const baseForHash = {
+    event_type: 'vault_deposit' as const,
+    journal_id: deposit.journal_id,
+    vault_id: deposit.vault_id,
+    agent: deposit.agent,
+    deposit_amount: deposit.deposit_amount,
+    journal_score: deposit.journal_score,
+    gi_at_deposit: deposit.gi_at_deposit,
+    timestamp: deposit.timestamp,
+    status: deposit.status,
+    content_signature: deposit.content_signature,
+  };
+  const deposit_hash = deposit.deposit_hash ?? computeVaultDepositHash(baseForHash);
+  const rowDeposit: VaultDeposit = {
+    ...deposit,
+    deposit_hash,
+    hashed_at: deposit.hashed_at ?? hashedAt,
+  };
+
   const redis = getRedis();
   const prevBalance = (await kvGet<number>(BALANCE_KEY)) ?? 0;
-  const nextBalance = Number((prevBalance + deposit.deposit_amount).toFixed(6));
+  const nextBalance = Number((prevBalance + rowDeposit.deposit_amount).toFixed(6));
 
   await kvSet(BALANCE_KEY, nextBalance);
 
@@ -187,14 +252,14 @@ export async function writeVaultDeposit(
     gi_threshold: GI_THRESHOLD,
     sustain_cycles_required: SUSTAIN_CYCLES_REQUIRED,
     source_entries: sourceEntries,
-    last_deposit: deposit.timestamp,
+    last_deposit: rowDeposit.timestamp,
     updated_at: now,
   };
   await kvSet(META_KEY, meta);
 
   if (redis) {
     try {
-      const row = JSON.stringify(deposit);
+      const row = JSON.stringify(rowDeposit);
       await redis.lpush(DEPOSITS_LIST_KEY, row);
       await redis.ltrim(DEPOSITS_LIST_KEY, 0, DEPOSITS_MAX - 1);
       scheduleBackupMirrorVaultDepositsLpush(DEPOSITS_LIST_KEY, row, DEPOSITS_MAX);
@@ -207,15 +272,15 @@ export async function writeVaultDeposit(
   if (v2) {
     try {
       const r = await accrueDepositV2({
-        deposit_amount: deposit.deposit_amount,
-        content_signature: deposit.content_signature,
+        deposit_amount: rowDeposit.deposit_amount,
+        content_signature: rowDeposit.content_signature,
         cycle: v2.cycle,
         agent_entry: v2.agent_entry,
       });
       console.info('[vault-v2] accrue after v1 write', {
-        journal_id: deposit.journal_id,
-        agent: deposit.agent,
-        deposit_amount: deposit.deposit_amount,
+        journal_id: rowDeposit.journal_id,
+        agent: rowDeposit.agent,
+        deposit_amount: rowDeposit.deposit_amount,
         balance_after: r.balance_after,
         candidate_formed: Boolean(r.candidate_formed),
         candidate_deferred: r.candidate_deferred,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (C-285 — Terminal tokenomics proof convergence)

Implements the **Terminal-safe** parts of the convergence spec without duplicating Vault v2 seal formation (already live: `lib/vault-v2/*`, `POST /api/vault/seal/attest`, etc.).

### 1. `totalMicProvisional` + deprecated `totalMicMinted`

- `lib/echo/integrity-engine.ts` — `CycleIntegritySummary` adds **`totalMicProvisional`**; **`totalMicMinted`** kept as deprecated alias (same value).
- `app/api/integrity-status/route.ts` — echoes **`totalMicProvisional`** + **`totalMicMinted`** from ECHO integrity when present.
- `app/api/eve/cycle-advance/route.ts` — seed integrity includes both fields.
- UI: `IntegrityRatingPanel`, `MICWalletPanel`, `MicPageClient`, `useTerminalData` prefer **`totalMicProvisional`**.

### 2. `deposit_hash` on vault deposits

- `lib/vault/vault.ts` — `computeVaultDepositHash`, optional `deposit_hash` / `hashed_at` on `VaultDeposit`, set on every **`writeVaultDeposit`**.
- `getVaultDepositHashCoverage()` — scan list for hashed vs legacy rows.
- `GET /api/vault/status` — **`hashed_deposits_count`**, **`legacy_deposits_count`**, **`hash_coverage_pct`**, **`hash_coverage_rows_scanned`**, **`_balance_reserve_deprecated`**; response **`Deprecation: true`** header.

### 3. `POST /api/mic/readiness` + KV merge

- `lib/kv/store.ts` — **`KV_KEYS.MIC_READINESS_SNAPSHOT`**, **`MIC_READINESS_FEED`**, **`kvLpushCapped`**.
- `POST /api/mic/readiness` — auth: Bearer **`AGENT_SERVICE_TOKEN`**, **`CRON_SECRET`**, or **`MOBIUS_SERVICE_SECRET`** (constant-time). Accepts flat or **`{ snapshot: { … } }`** body; merges into local readiness; stores JSON with TTL + feed.
- `lib/mic/readinessMerge.ts`, **`lib/mic/assembleMicReadiness.ts`** — shared assembly for readiness route + mic proof routes.
- **`GET /api/mic/readiness`** — returns **merged** readiness (upstream overrides when KV has a snapshot) + **`readiness_proof`** hash.

### 4. Seal formation scaffold

**Not reimplemented** — existing **`/api/vault/seal`**, **`/api/vault/seal/attest`**, **`lib/vault-v2/seal.ts`** remain canonical. This PR avoids a second seal implementation on raw KV keys from the spec draft.

### 5. Snapshot + lane

- `app/api/terminal/snapshot/route.ts` — fetches **`/api/mic/readiness`**; adds **`micReadiness`** leaf + timing.
- `lib/terminal/snapshotLanes.ts` — **`micReadiness`** lane normalization.

### Docs

- `docs/protocols/mic/mic_runtime_reference.md` — POST ingest + KV keys.

## Verification

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- Lint — not configured
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

