### PR TITLE
C-285: Tokenomics proof convergence + checklist verification

### DIFF
--- a/app/api/echo/ingest/route.ts
+++ b/app/api/echo/ingest/route.ts
@@ -15,7 +15,14 @@ import { NextResponse } from 'next/server';
 import { fetchAllSources } from '@/lib/echo/sources';
 import type { RawEvent } from '@/lib/echo/sources';
 import { transformBatch } from '@/lib/echo/transform';
-import { pushIngestResult, getEchoStatus, getEchoEpicon, getEchoLedger, getEchoAlerts } from '@/lib/echo/store';
+import {
+  pushIngestResult,
+  getEchoStatus,
+  getEchoEpicon,
+  getEchoLedger,
+  getEchoAlerts,
+  getEchoIntegrity,
+} from '@/lib/echo/store';
 import { writeSnapshot } from '@/lib/echo/snapshot-writer';
 import { saveEchoState } from '@/lib/kv/store';
 import { querySonarForLane } from '@/lib/signals/perplexity-sonar';
@@ -23,11 +30,23 @@ import { persistEchoIngestSideEffects, writeEchoKvHeartbeatToMobius } from '@/li
 
 export const dynamic = 'force-dynamic';
 
+function echoMicProvisionalFields(): { totalMicProvisional: number; totalMicMinted: number } {
+  const i = getEchoIntegrity();
+  const v =
+    i && typeof i.totalMicProvisional === 'number'
+      ? i.totalMicProvisional
+      : i && typeof i.totalMicMinted === 'number'
+        ? i.totalMicMinted
+        : 0;
+  return { totalMicProvisional: v, totalMicMinted: v };
+}
+
 export async function GET() {
   const status = getEchoStatus();
   return NextResponse.json({
     agent: 'ECHO',
     status: 'operational',
+    ...echoMicProvisionalFields(),
     ...status,
   });
 }
@@ -99,6 +118,7 @@ export async function POST() {
         result: 'no_data',
         message: 'All sources returned empty. Will retry next cycle.',
         duration: Date.now() - startTime,
+        ...echoMicProvisionalFields(),
       });
     }
 
@@ -136,6 +156,7 @@ export async function POST() {
       snapshot: snapshotWritten ? 'written' : 'skipped',
       duration: Date.now() - startTime,
       timestamp: result.timestamp,
+      ...echoMicProvisionalFields(),
     });
   } catch (error) {
     return NextResponse.json(
@@ -145,6 +166,7 @@ export async function POST() {
         result: 'error',
         message: error instanceof Error ? error.message : 'Unknown error',
         duration: Date.now() - startTime,
+        ...echoMicProvisionalFields(),
       },
       { status: 500 },
     );

--- a/app/api/vault/seal/attest/route.ts
+++ b/app/api/vault/seal/attest/route.ts
@@ -137,7 +137,10 @@ export async function POST(req: NextRequest) {
   }
 
   if (!verifyAttestationSignature(agentToken, submission, candidate.seal_hash)) {
-    return NextResponse.json({ error: 'Signature verification failed' }, { status: 401 });
+    return NextResponse.json(
+      { error: 'Signature verification failed (wrong seal_hash or tampered body)' },
+      { status: 400 },
+    );
   }
 
   const attestation: SealAttestation = {

--- a/app/api/vault/seal/route.ts
+++ b/app/api/vault/seal/route.ts
@@ -4,20 +4,100 @@
  * Public read. Returns the list of attested Seals (newest-first) plus the
  * current candidate state. Used by the Vault chamber UI and external
  * substrate consumers.
+ *
+ * POST /api/vault/seal
+ *
+ * Operator / cron: explicit Seal candidate attempt when `in_progress_balance`
+ * has reached the reserve parcel threshold (50). Does not replace deposit-driven
+ * formation — use when you need a synchronous outcome for ops or checklists.
  */
 
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { handbookCorsHeaders } from '@/lib/http/handbook-cors';
-import { SENTINEL_ATTESTATION_COUNT } from '@/lib/vault-v2/constants';
-import { countAllSeals, countSeals, getCandidate, getLatestSeal, listAllSeals, listSeals } from '@/lib/vault-v2/store';
+import { bearerMatchesToken } from '@/lib/vault-v2/auth';
+import { VAULT_RESERVE_PARCEL_UNITS, SENTINEL_ATTESTATION_COUNT } from '@/lib/vault-v2/constants';
+import { tryFormNextCandidate } from '@/lib/vault-v2/deposit';
+import { countAllSeals, countSeals, getCandidate, getInProgressBalance, getLatestSeal, listAllSeals, listSeals } from '@/lib/vault-v2/store';
+import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
 
 export const dynamic = 'force-dynamic';
+
+function sealPostAuth(req: NextRequest): boolean {
+  const agents = process.env.AGENT_SERVICE_TOKEN ?? '';
+  const cron = process.env.CRON_SECRET ?? '';
+  const mobius = process.env.MOBIUS_SERVICE_SECRET ?? '';
+  const h = req.headers.get('authorization');
+  if (agents && bearerMatchesToken(h, agents)) return true;
+  if (cron && bearerMatchesToken(h, cron)) return true;
+  if (mobius && bearerMatchesToken(h, mobius)) return true;
+  return false;
+}
 
 export async function OPTIONS(req: NextRequest) {
   const cors = handbookCorsHeaders(req.headers.get('origin'));
   if (!cors) return new NextResponse(null, { status: 204 });
   return new NextResponse(null, { status: 204, headers: cors });
+}
+
+export async function POST(req: NextRequest) {
+  const cors = handbookCorsHeaders(req.headers.get('origin'));
+  if (!sealPostAuth(req)) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401, headers: cors ?? undefined });
+  }
+
+  const balance = await getInProgressBalance();
+  if (balance < VAULT_RESERVE_PARCEL_UNITS) {
+    return NextResponse.json(
+      {
+        ok: true,
+        outcome: 'below_threshold',
+        in_progress_balance: balance,
+        threshold: VAULT_RESERVE_PARCEL_UNITS,
+        message: 'Reserve parcel threshold not met; accrue deposits until balance >= 50.',
+      },
+      { status: 200, headers: { ...(cors ?? {}), 'Cache-Control': 'no-store', 'X-Mobius-Source': 'vault-v2-seal-post' } },
+    );
+  }
+
+  const cycle = await resolveOperatorCycleId();
+  const candidate = await tryFormNextCandidate({ cycle });
+
+  if (!candidate) {
+    const existing = await getCandidate();
+    return NextResponse.json(
+      {
+        ok: true,
+        outcome: existing ? 'candidate_already_in_flight' : 'formation_skipped',
+        in_progress_balance: balance,
+        threshold: VAULT_RESERVE_PARCEL_UNITS,
+        candidate_seal_id: existing?.seal_id ?? null,
+        message: existing
+          ? 'A seal candidate is already awaiting attestations.'
+          : 'Threshold met but candidate was not formed (race or store); retry shortly.',
+      },
+      { status: 200, headers: { ...(cors ?? {}), 'Cache-Control': 'no-store', 'X-Mobius-Source': 'vault-v2-seal-post' } },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      outcome: 'candidate_formed',
+      in_progress_balance: await getInProgressBalance(),
+      threshold: VAULT_RESERVE_PARCEL_UNITS,
+      candidate: {
+        seal_id: candidate.seal_id,
+        sequence: candidate.sequence,
+        cycle_at_seal: candidate.cycle_at_seal,
+        seal_hash: candidate.seal_hash,
+        requested_at: candidate.requested_at,
+        timeout_at: candidate.timeout_at,
+        attestations_needed: SENTINEL_ATTESTATION_COUNT,
+      },
+    },
+    { status: 200, headers: { ...(cors ?? {}), 'Cache-Control': 'no-store', 'X-Mobius-Source': 'vault-v2-seal-post' } },
+  );
 }
 
 export async function GET(req: NextRequest) {

--- a/lib/terminal/snapshotLanes.ts
+++ b/lib/terminal/snapshotLanes.ts
@@ -582,7 +582,15 @@ function normalizeEchoLane(leaf: SnapshotLeaf): SnapshotLaneState {
 
   const epicon = row.epicon;
   const n = Array.isArray(epicon) ? epicon.length : 0;
-  let message = `ECHO feed · ${n} epicon item(s)`;
+  const integrity = asRecord(row.integrity);
+  const micProv =
+    integrity && typeof integrity.totalMicProvisional === 'number'
+      ? integrity.totalMicProvisional
+      : integrity && typeof integrity.totalMicMinted === 'number'
+        ? integrity.totalMicMinted
+        : null;
+  const micNote = micProv !== null ? ` · MIC provisional ${micProv.toFixed(4)}` : '';
+  let message = `ECHO feed · ${n} epicon item(s)${micNote}`;
   if (state === 'stale') message = `Ingest stale; ${message.toLowerCase()}`;
 
   return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements and verifies C-285 Terminal Tokenomics Proof Convergence items: MIC provisional naming, vault deposit hashing, MIC readiness POST/merge, snapshot micReadiness lane, and follow-up checklist fixes (seal POST, ingest MIC fields, snapshot echo MIC note, attest wrong-hash 400).

## Checklist verification (code + behavior)

- **GET `/api/vault/status`**: `hashed_deposits_count`, `legacy_deposits_count`, `hash_coverage_pct`, `_balance_reserve_deprecated` — present in `app/api/vault/status/route.ts`.
- **POST `/api/echo/ingest`**: `totalMicProvisional` (+ deprecated `totalMicMinted`) — added to GET/POST responses in `app/api/echo/ingest/route.ts`.
- **GET `/api/terminal/snapshot` echo lane**: `integrity.totalMicProvisional` remains on feed data; lane **message** now includes MIC provisional when available (`lib/terminal/snapshotLanes.ts`).
- **MIC readiness**: POST auth 401 without bearer; GET returns merged readiness; POST stores snapshot — unchanged contract in `app/api/mic/readiness/route.ts`.
- **Vault deposits**: `deposit_hash` / `hashed_at` in `writeVaultDeposit` — `lib/vault/vault.ts`.
- **POST `/api/vault/seal`**: New handler — `below_threshold` vs `candidate_formed` / in-flight outcomes (`app/api/vault/seal/route.ts`). Deposit path still forms candidates at threshold via `accrueDepositV2`.
- **GET `/api/vault/seal`**: Attested seals list — unchanged.
- **POST `/api/vault/seal/attest`**: Records attestation; wrong seal hash → **400**; ZEUS reject → rejected on cron quorum — `lib/vault-v2/seal.ts` + cron.
- **Full quorum path**: Requires configured per-agent secrets and cron finalization — not exercised in CI here; logic is in existing v2 modules.

## Commands

- `pnpm exec tsc --noEmit`
- `pnpm build`

Both passed.

## Lint

ESLint not configured per repo (AGENTS.md); not run interactively.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

