### PR TITLE
fix(C-286): heartbeat stale, KV TTLs, GI resolution, snapshot-lite, ledger circuit + optimizations

### DIFF
--- a/app/api/admin/seed-kv/route.ts
+++ b/app/api/admin/seed-kv/route.ts
@@ -12,7 +12,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceAuthError } from '@/lib/security/serviceAuth';
-import { kvSet, KV_KEYS, saveGIState, saveSignalSnapshot, isRedisAvailable } from '@/lib/kv/store';
+import { kvSet, KV_KEYS, saveGIState, saveSignalSnapshot, isRedisAvailable, KV_TTL_SECONDS } from '@/lib/kv/store';
 import { computeGI } from '@/lib/gi/compute';
 import { getEchoEpicon } from '@/lib/echo/store';
 import { scoreBatch } from '@/lib/echo/signal-engine';
@@ -85,6 +85,7 @@ export async function POST(request: NextRequest) {
       timestamp,
       source: 'manual-seed',
     }),
+    KV_TTL_SECONDS.HEARTBEAT,
   );
   seeded.push('HEARTBEAT');
 

--- a/app/api/cron/heartbeat/route.ts
+++ b/app/api/cron/heartbeat/route.ts
@@ -1,0 +1,36 @@
+/**
+ * GET/POST /api/cron/heartbeat — refresh fleet HEARTBEAT in KV (C-286).
+ *
+ * Schedule: every 5 minutes (`vercel.json`). Marks all canonical agents active
+ * so `/api/agents/status` does not degrade on cycle-open KV gaps.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getEveSynthesisAuthError } from '@/lib/security/serviceAuth';
+import { writeFleetHeartbeatKV } from '@/lib/runtime/agent-heartbeat-kv';
+
+export const dynamic = 'force-dynamic';
+
+async function run(req: NextRequest) {
+  const authErr = getEveSynthesisAuthError(req);
+  if (authErr) return authErr;
+
+  const ok = await writeFleetHeartbeatKV('cron-heartbeat');
+  const timestamp = new Date().toISOString();
+  if (!ok) {
+    return NextResponse.json(
+      { ok: false, error: 'kv_unavailable_or_write_failed', timestamp },
+      { status: 503 },
+    );
+  }
+  return NextResponse.json({ ok: true, timestamp, source: 'cron-heartbeat' });
+}
+
+export async function GET(request: NextRequest) {
+  return run(request);
+}
+
+export async function POST(request: NextRequest) {
+  return run(request);
+}

--- a/app/api/cron/watchdog/route.ts
+++ b/app/api/cron/watchdog/route.ts
@@ -3,7 +3,7 @@ import { getServiceAuthError, serviceAuthorizationHeaderValue } from '@/lib/secu
 import { appendAgentJournalEntry } from '@/lib/agents/journal';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
-import { kvSet, kvSetRawKey, KV_KEYS, isRedisAvailable } from '@/lib/kv/store';
+import { kvSet, kvSetRawKey, KV_KEYS, isRedisAvailable, KV_TTL_SECONDS } from '@/lib/kv/store';
 
 import { GET as getKvHealth } from '@/app/api/kv/health/route';
 import { POST as postSeedKv } from '@/app/api/admin/seed-kv/route';
@@ -155,9 +155,9 @@ export async function GET(request: NextRequest) {
         timestamp: new Date().toISOString(),
       };
       await Promise.all([
-        kvSetRawKey('TRIPWIRE_STATE', JSON.stringify(seedPayload), 1800),
-        kvSet(KV_KEYS.TRIPWIRE_STATE, seedPayload, 1800),
-        kvSet(KV_KEYS.TRIPWIRE_STATE_KV, seedPayload, 1800),
+        kvSetRawKey('TRIPWIRE_STATE', JSON.stringify(seedPayload), KV_TTL_SECONDS.TRIPWIRE_STATE),
+        kvSet(KV_KEYS.TRIPWIRE_STATE, seedPayload, KV_TTL_SECONDS.TRIPWIRE_STATE),
+        kvSet(KV_KEYS.TRIPWIRE_STATE_KV, seedPayload, KV_TTL_SECONDS.TRIPWIRE_STATE),
       ]).catch(() => {});
       actions.push('tripwire-seed:ok');
     }

--- a/app/api/epicon/feed/route.ts
+++ b/app/api/epicon/feed/route.ts
@@ -4,7 +4,7 @@ import { isEveSynthesisLedgerSource } from '@/lib/epicon/eveLedgerSource';
 import { getPublicEpiconFeed } from '@/lib/epicon/feedStore';
 import { getMemoryLedgerEntries } from '@/lib/epicon/memoryLedgerFeed';
 import type { EpiconLedgerFeedEntry } from '@/lib/epicon/ledgerFeedTypes';
-import { loadGIState } from '@/lib/kv/store';
+import { loadGIState, kvGet, kvSet, KV_KEYS } from '@/lib/kv/store';
 import { getAgentBearerToken } from '@/lib/substrate/client';
 
 export const dynamic = 'force-dynamic';
@@ -332,6 +332,8 @@ function describeLedgerHost(url: string): string {
   }
 }
 
+const LEDGER_CIRCUIT_TTL_SEC = 300;
+
 async function fetchRenderLedgerEntries(limit = 100): Promise<LedgerFetchResult> {
   const renderLedgerUrl = normalizeLedgerBaseUrl(
     process.env.RENDER_LEDGER_URL ?? 'https://civic-protocol-core-ledger.onrender.com',
@@ -344,17 +346,28 @@ async function fetchRenderLedgerEntries(limit = 100): Promise<LedgerFetchResult>
     console.warn(`[ledger-api] RENDER_LEDGER_URL missing, using fallback host=${ledgerHost}`);
   }
 
+  const circuit = await kvGet<string>(KV_KEYS.LEDGER_CIRCUIT_OPEN);
+  if (circuit) {
+    return {
+      entries: [],
+      degraded: true,
+      error: 'ledger_circuit_open',
+      statusCode: 503,
+    };
+  }
+
   try {
     console.info(
       `[ledger-api] connecting host=${ledgerHost} limit=${limit} hasAgentToken=${agentToken.length > 0}`,
     );
     const health = await fetch(`${renderLedgerUrl}/health`, {
       method: 'GET',
-      signal: AbortSignal.timeout(5000),
+      signal: AbortSignal.timeout(3000),
       cache: 'no-store',
     });
     if (!health.ok) {
       console.error(`[ledger-api] ledger health check failed host=${ledgerHost} status=${health.status}`);
+      await kvSet(KV_KEYS.LEDGER_CIRCUIT_OPEN, '1', LEDGER_CIRCUIT_TTL_SEC).catch(() => {});
       return { entries: [], degraded: true, error: `ledger_health_http_${health.status}`, statusCode: health.status };
     }
 
@@ -364,7 +377,7 @@ async function fetchRenderLedgerEntries(limit = 100): Promise<LedgerFetchResult>
         Accept: 'application/json',
         ...(authorization ? { Authorization: authorization } : {}),
       },
-      signal: AbortSignal.timeout(5000),
+      signal: AbortSignal.timeout(3000),
       cache: 'no-store',
     });
 
@@ -372,6 +385,7 @@ async function fetchRenderLedgerEntries(limit = 100): Promise<LedgerFetchResult>
       const bodyPreview = (await response.text()).slice(0, 200).replace(/\s+/g, ' ').trim();
       const error = `ledger_api_http_${response.status}`;
       console.error(`[ledger-api] ${error} host=${ledgerHost} path=/ledger/events body="${bodyPreview}"`);
+      await kvSet(KV_KEYS.LEDGER_CIRCUIT_OPEN, '1', LEDGER_CIRCUIT_TTL_SEC).catch(() => {});
       return { entries: [], degraded: true, error, statusCode: response.status };
     }
 
@@ -392,6 +406,7 @@ async function fetchRenderLedgerEntries(limit = 100): Promise<LedgerFetchResult>
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown_fetch_error';
     console.error(`[ledger-api] request_failed host=${ledgerHost} error="${message}"`);
+    await kvSet(KV_KEYS.LEDGER_CIRCUIT_OPEN, '1', LEDGER_CIRCUIT_TTL_SEC).catch(() => {});
     return { entries: [], degraded: true, error: `ledger_api_unreachable:${message}` };
   }
 }

--- a/app/api/kv/health/route.ts
+++ b/app/api/kv/health/route.ts
@@ -23,6 +23,9 @@ export async function GET() {
     }
     const legacyTripwire = await kvGetRaw<string>('TRIPWIRE_STATE');
     keys.TRIPWIRE_STATE_REDIS = legacyTripwire !== null && legacyTripwire !== undefined;
+    const bal = await kvGet<number>(KV_KEYS.VAULT_GLOBAL_BALANCE);
+    const meta = await kvGet<unknown>(KV_KEYS.VAULT_GLOBAL_META);
+    keys.VAULT_STATE = bal !== null || meta !== null;
   }
 
   return NextResponse.json({

--- a/app/api/mic/readiness/route.ts
+++ b/app/api/mic/readiness/route.ts
@@ -6,10 +6,11 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { bearerMatchesToken } from '@/lib/vault-v2/auth';
+import { resolveGiForTerminal } from '@/lib/integrity/resolveGi';
 import { assembleLocalMicReadiness, getMergedMicReadiness, resolveReadinessCycle } from '@/lib/mic/assembleMicReadiness';
 import { mergeMicReadinessFromUpstream } from '@/lib/mic/readinessMerge';
 import type { MicReadinessResponse } from '@/lib/mic/types';
-import { kvSet, kvLpushCapped, KV_KEYS } from '@/lib/kv/store';
+import { kvSet, kvLpushCapped, KV_KEYS, kvGet, KV_TTL_SECONDS } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
 
@@ -26,14 +27,26 @@ function micReadinessPostAuth(req: NextRequest): boolean {
 
 export async function GET(req: NextRequest) {
   const cycleParam = req.nextUrl.searchParams.get('cycle')?.trim();
+  const micSnapRaw = await kvGet<string>(KV_KEYS.MIC_READINESS_SNAPSHOT);
+  const giMeta = await resolveGiForTerminal({ micReadinessSnapshotRaw: micSnapRaw });
   const readiness = await getMergedMicReadiness(cycleParam);
 
-  return NextResponse.json(readiness, {
-    headers: {
-      'Cache-Control': 'no-store',
-      'X-Mobius-Source': 'mic-readiness-v1',
+  return NextResponse.json(
+    {
+      ...readiness,
+      gi: giMeta.gi ?? readiness.gi,
+      gi_resolution: {
+        source: giMeta.source,
+        timestamp: giMeta.timestamp,
+      },
     },
-  });
+    {
+      headers: {
+        'Cache-Control': 'no-store',
+        'X-Mobius-Source': 'mic-readiness-v1',
+      },
+    },
+  );
 }
 
 export async function POST(req: NextRequest) {
@@ -72,7 +85,7 @@ export async function POST(req: NextRequest) {
     source: 'tokenomics-engine',
   };
 
-  await kvSet(KV_KEYS.MIC_READINESS_SNAPSHOT, JSON.stringify(snapshot), 7200);
+  await kvSet(KV_KEYS.MIC_READINESS_SNAPSHOT, JSON.stringify(snapshot), KV_TTL_SECONDS.MIC_READINESS_SNAPSHOT);
   await kvLpushCapped(KV_KEYS.MIC_READINESS_FEED, JSON.stringify(snapshot), 100);
 
   return NextResponse.json({ ok: true, received_at: snapshot.received_at });

--- a/app/api/runtime/heartbeat/route.ts
+++ b/app/api/runtime/heartbeat/route.ts
@@ -13,7 +13,7 @@ import {
   isValidCronSecretBearer,
   isVercelCronInvocation,
 } from '@/lib/security/serviceAuth';
-import { kvSet, KV_KEYS, isRedisAvailable } from '@/lib/kv/store';
+import { kvSet, KV_KEYS, isRedisAvailable, KV_TTL_SECONDS } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
 
@@ -27,7 +27,11 @@ async function writeHeartbeatKV() {
   const timestamp = new Date().toISOString();
   const giScore = integrityStatus.global_integrity;
   await Promise.allSettled([
-    kvSet(KV_KEYS.HEARTBEAT, JSON.stringify({ ok: true, gi: giScore, timestamp, source: 'heartbeat' })),
+    kvSet(
+      KV_KEYS.HEARTBEAT,
+      JSON.stringify({ ok: true, gi: giScore, timestamp, source: 'heartbeat' }),
+      KV_TTL_SECONDS.HEARTBEAT,
+    ),
     kvSet(KV_KEYS.LAST_INGEST, timestamp),
   ]);
 }

--- a/app/api/signals/micro/route.ts
+++ b/app/api/signals/micro/route.ts
@@ -7,7 +7,14 @@
 
 import { NextResponse } from 'next/server';
 import { pollAllMicroAgents } from '@/lib/agents/micro';
-import { saveSignalSnapshot, loadSignalSnapshot, isRedisAvailable, kvSet, KV_KEYS } from '@/lib/kv/store';
+import {
+  saveSignalSnapshot,
+  loadSignalSnapshot,
+  isRedisAvailable,
+  kvSet,
+  KV_KEYS,
+  KV_TTL_SECONDS,
+} from '@/lib/kv/store';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
 
@@ -56,25 +63,33 @@ export async function GET() {
         healthy: result.healthy,
       }).catch(() => {});
 
-      kvSet(KV_KEYS.HEARTBEAT, JSON.stringify({
-        ok: true,
-        gi: result.composite,
-        cycle: currentCycleId(),
-        anomalies: result.anomalies?.length ?? 0,
-        familyCount: 8,
-        instrumentCount: result.instrumentCount ?? 40,
-        timestamp: result.timestamp,
-        source: 'micro-sweep',
-      })).catch(() => {});
+      kvSet(
+        KV_KEYS.HEARTBEAT,
+        JSON.stringify({
+          ok: true,
+          gi: result.composite,
+          cycle: currentCycleId(),
+          anomalies: result.anomalies?.length ?? 0,
+          familyCount: 8,
+          instrumentCount: result.instrumentCount ?? 40,
+          timestamp: result.timestamp,
+          source: 'micro-sweep',
+        }),
+        KV_TTL_SECONDS.HEARTBEAT,
+      ).catch(() => {});
 
-      kvSet(KV_KEYS.SYSTEM_PULSE, {
-        ok: true,
-        composite: result.composite,
-        cycle: currentCycleId(),
-        instruments: result.instrumentCount ?? 40,
-        anomalies: result.anomalies?.length ?? 0,
-        timestamp: result.timestamp,
-      }, 7200).catch(() => {});
+      kvSet(
+        KV_KEYS.SYSTEM_PULSE,
+        {
+          ok: true,
+          composite: result.composite,
+          cycle: currentCycleId(),
+          instruments: result.instrumentCount ?? 40,
+          anomalies: result.anomalies?.length ?? 0,
+          timestamp: result.timestamp,
+        },
+        KV_TTL_SECONDS.SYSTEM_PULSE,
+      ).catch(() => {});
 
       if (now - lastLedgerPushMs > LEDGER_PUSH_INTERVAL_MS) {
         lastLedgerPushMs = now;
@@ -95,10 +110,15 @@ export async function GET() {
       }
     }
 
+    const degradedInstruments = result.allSignals
+      .filter((s) => s.severity === 'elevated' || s.severity === 'critical')
+      .map((s) => ({ agentName: s.agentName, source: s.source, severity: s.severity, label: s.label }));
+
     return NextResponse.json({
       ok: true,
       cached: false,
       kv: isRedisAvailable(),
+      degraded_instruments: degradedInstruments,
       ...result,
     }, {
       headers: {
@@ -111,6 +131,9 @@ export async function GET() {
     if (isRedisAvailable()) {
       const snapshot = await loadSignalSnapshot();
       if (snapshot) {
+        const degradedInstruments = snapshot.allSignals
+          .filter((s) => s.severity === 'elevated' || s.severity === 'critical')
+          .map((s) => ({ agentName: s.agentName, source: s.source, severity: s.severity, label: s.label }));
         return NextResponse.json({
           ok: true,
           cached: true,
@@ -120,6 +143,7 @@ export async function GET() {
           allSignals: snapshot.allSignals,
           timestamp: snapshot.timestamp,
           healthy: snapshot.healthy,
+          degraded_instruments: degradedInstruments,
         }, {
           headers: {
             'X-Mobius-Source': 'micro-agents-kv-fallback',

--- a/app/api/terminal/snapshot-lite/route.ts
+++ b/app/api/terminal/snapshot-lite/route.ts
@@ -6,13 +6,13 @@ import {
   kvGet,
   kvHealth,
   KV_KEYS,
-  loadGIState,
   loadSignalSnapshot,
   loadEchoState,
   loadTripwireState,
 } from '@/lib/kv/store';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { getHeartbeat, getJournalHeartbeat } from '@/lib/runtime/heartbeat';
+import { resolveGiForTerminal } from '@/lib/integrity/resolveGi';
 
 export const dynamic = 'force-dynamic';
 
@@ -51,14 +51,34 @@ export async function GET(req: NextRequest) {
   const start = Date.now();
   const cors = handbookCorsHeaders(req.headers.get('origin'));
 
-  const [kv, gi, signals, echo, tripwire, pulse] = await Promise.all([
+  const [kv, micSnapRaw, signals, echo, tripwire, pulse] = await Promise.all([
     kvHealth(),
-    loadGIState(),
+    kvGet<string>(KV_KEYS.MIC_READINESS_SNAPSHOT),
     loadSignalSnapshot(),
     loadEchoState(),
     loadTripwireState(),
     kvGet<SystemPulse>(KV_KEYS.SYSTEM_PULSE),
   ]);
+  const giResolved = await resolveGiForTerminal({ micReadinessSnapshotRaw: micSnapRaw });
+  const gi =
+    giResolved.source === 'kv'
+      ? giResolved.kv
+      : giResolved.gi !== null
+        ? {
+            global_integrity: giResolved.gi,
+            mode: typeof giResolved.mode === 'string' ? giResolved.mode : 'yellow',
+            terminal_status: giResolved.terminal_status ?? 'stressed',
+            primary_driver: giResolved.primary_driver ?? '',
+            source: giResolved.source === 'live_compute' ? 'live' : 'cached',
+            signals: {
+              quality: 0.5,
+              freshness: 0.5,
+              stability: 0.5,
+              system: 0.5,
+            },
+            timestamp: giResolved.timestamp ?? new Date().toISOString(),
+          }
+        : null;
 
   const cycle =
     (typeof pulse?.cycle === 'string' && pulse.cycle.trim().length > 0 ? pulse.cycle.trim() : null) ??
@@ -72,11 +92,16 @@ export async function GET(req: NextRequest) {
   const lanes = {
     kv: { ok: kv.available, latency_ms: kv.latencyMs },
     integrity: {
-      ok: Boolean(gi),
-      gi: gi?.global_integrity ?? null,
-      mode: gi?.mode ?? null,
-      terminal_status: gi?.terminal_status ?? null,
-      source: gi?.source ?? null,
+      ok: giResolved.gi !== null,
+      gi: giResolved.gi ?? gi?.global_integrity ?? null,
+      mode: (giResolved.mode as string | null) ?? gi?.mode ?? null,
+      terminal_status: giResolved.terminal_status ?? gi?.terminal_status ?? null,
+      source:
+        giResolved.source === 'kv' || giResolved.source === 'kv_carry_forward'
+          ? 'kv'
+          : giResolved.source === 'readiness_snapshot' || giResolved.source === 'live_compute'
+            ? 'readiness_fallback'
+            : 'null',
       freshness: freshness(giAge),
       age_seconds: giAge,
     },
@@ -110,11 +135,12 @@ export async function GET(req: NextRequest) {
     },
   };
 
+  const modeStr = (giResolved.mode as string | null) ?? gi?.mode ?? null;
   const degraded =
     !lanes.kv.ok ||
     !lanes.integrity.ok ||
     lanes.integrity.freshness === 'degraded' ||
-    (gi?.mode === 'red') ||
+    modeStr === 'red' ||
     lanes.tripwire.elevated;
 
   return NextResponse.json({
@@ -126,8 +152,14 @@ export async function GET(req: NextRequest) {
       commit_sha: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
       environment: process.env.VERCEL_ENV ?? null,
     },
-    gi: gi?.global_integrity ?? null,
-    mode: gi?.mode ?? null,
+    gi: giResolved.gi ?? gi?.global_integrity ?? null,
+    mode: modeStr,
+    gi_source:
+      giResolved.source === 'kv' || giResolved.source === 'kv_carry_forward'
+        ? 'kv'
+        : giResolved.source === 'readiness_snapshot' || giResolved.source === 'live_compute'
+          ? 'readiness_fallback'
+          : 'null',
     degraded,
     lanes,
     heartbeat: {

--- a/lib/agents/micro/core.ts
+++ b/lib/agents/micro/core.ts
@@ -105,3 +105,42 @@ export async function safeFetchText(url: string, timeoutMs = 8000, init?: Reques
     return null;
   }
 }
+
+export type SafeFetchMeta<T> = {
+  ok: boolean;
+  status: number | null;
+  data: T | null;
+  error: string | null;
+};
+
+/** Like `safeFetch` but preserves HTTP status for operator-visible error strings (C-286). */
+export async function safeFetchWithMeta<T>(url: string, timeoutMs = 8000, init?: RequestInit): Promise<SafeFetchMeta<T>> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(url, {
+      ...(init ?? {}),
+      signal: controller.signal,
+      cache: init?.cache ?? 'no-store',
+    });
+    clearTimeout(timer);
+    const status = res.status;
+    if (!res.ok) {
+      return {
+        ok: false,
+        status,
+        data: null,
+        error: `HTTP ${status} ${res.statusText}`.trim(),
+      };
+    }
+    return {
+      ok: true,
+      status,
+      data: ((await res.json()) as T) ?? null,
+      error: null,
+    };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'fetch failed';
+    return { ok: false, status: null, data: null, error: msg };
+  }
+}

--- a/lib/agents/micro/index.ts
+++ b/lib/agents/micro/index.ts
@@ -31,7 +31,8 @@ export interface MicroAgentSweepResult {
   instrumentCount: number;
 }
 
-const CONCURRENCY = 8;
+/** C-286: higher fan-out so 40 instruments finish closer to slowest single poll, not sum of waves. */
+const CONCURRENCY = 20;
 
 async function mapLimit<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
   const out: R[] = new Array(items.length);

--- a/lib/agents/micro/instrument-polls.ts
+++ b/lib/agents/micro/instrument-polls.ts
@@ -5,7 +5,14 @@
  */
 
 import type { AgentPollResult, MicroSignal } from './core';
-import { classifySeverity, normalizeDirect, normalizeInverse, safeFetch, safeFetchText } from './core';
+import {
+  classifySeverity,
+  normalizeDirect,
+  normalizeInverse,
+  safeFetch,
+  safeFetchText,
+  safeFetchWithMeta,
+} from './core';
 import { fetchEonetEvents, scoreEonetEvents } from '@/lib/signals/eonet';
 
 const UA_HEADERS: HeadersInit = {
@@ -177,9 +184,22 @@ export async function pollZeusU2(): Promise<AgentPollResult> {
 
 export async function pollZeusU3(): Promise<AgentPollResult> {
   const url = 'https://api.coincap.io/v2/assets?limit=8';
-  const data = await safeFetch<{ data?: Array<{ id?: string; changePercent24Hr?: string }> }>(url);
-  const rows = data?.data ?? [];
-  if (rows.length === 0) return wrap('ZEUS-µ3', null);
+  const meta = await safeFetchWithMeta<{ data?: Array<{ id?: string; changePercent24Hr?: string }> }>(url);
+  if (!meta.ok || meta.data === null) {
+    return wrap(
+      'ZEUS-µ3',
+      null,
+      `ZEUS-µ3: no signal — source: ${url} status: ${meta.status ?? 'n/a'} reason: ${meta.error ?? 'unknown'}`,
+    );
+  }
+  const rows = meta.data.data ?? [];
+  if (rows.length === 0) {
+    return wrap(
+      'ZEUS-µ3',
+      null,
+      `ZEUS-µ3: no signal — source: ${url} status: ${meta.status ?? 200} reason: empty assets list`,
+    );
+  }
   const changes = rows
     .map((r) => Number.parseFloat(r.changePercent24Hr ?? '0'))
     .filter((n) => Number.isFinite(n));
@@ -284,51 +304,79 @@ export async function pollHermesU2(): Promise<AgentPollResult> {
 export async function pollHermesU3(): Promise<AgentPollResult> {
   const queries = ['governance OR democracy OR civic', 'transparency OR regulation OR policy'];
   let n = 0;
+  let lastMeta: Awaited<ReturnType<typeof safeFetchWithMeta<{ articles?: unknown[] }>>> | null = null;
   for (const q of queries) {
     const url =
       `https://api.gdeltproject.org/api/v2/doc/doc?query=${encodeURIComponent(q)}&mode=artlist&maxrecords=8&format=json&timespan=1d`;
-    const data = await safeFetch<{ articles?: unknown[] }>(url, 12000);
-    n += data?.articles?.length ?? 0;
+    const meta = await safeFetchWithMeta<{ articles?: unknown[] }>(url, 12000);
+    lastMeta = meta;
+    if (meta.ok && meta.data) {
+      n += meta.data.articles?.length ?? 0;
+    }
     if (n > 0) break;
   }
-  const value = Number(normalizeDirect(Math.min(n, 16), 0, 16).toFixed(3));
-  const severity = n === 0 ? 'watch' : classifySeverity(value, { watch: 0.45, elevated: 0.3, critical: 0.15 });
+  const d = new Date();
+  const weekend = d.getUTCDay() === 0 || d.getUTCDay() === 6;
+  const quietHour = d.getUTCHours() >= 0 && d.getUTCHours() <= 8;
+  const httpOk = Boolean(lastMeta?.ok);
+  const quietContext = httpOk && n === 0 && (weekend || quietHour);
+  const value = Number((quietContext ? 0.5 : normalizeDirect(Math.min(n, 16), 0, 16)).toFixed(3));
+  const severity = quietContext
+    ? 'nominal'
+    : n === 0
+      ? 'watch'
+      : classifySeverity(value, { watch: 0.45, elevated: 0.3, critical: 0.15 });
   return wrap('HERMES-µ3', {
     agentName: 'HERMES-µ3',
     source: 'GDELT · governance artlist',
     timestamp: new Date().toISOString(),
     value,
-    label: `GDELT: ${n} articles (24h governance+civic)`,
+    label: quietContext
+      ? `GDELT: 0 articles (quiet window — HTTP ${lastMeta?.status ?? 'ok'}, nominal)`
+      : `GDELT: ${n} articles (24h governance+civic)`,
     severity,
-    raw: { count: n },
+    raw: { count: n, httpOk, quietContext },
   });
 }
 
 export async function pollHermesU4(): Promise<AgentPollResult> {
   const subs = ['worldnews', 'technology', 'civictech'];
   let kids: Array<{ data?: { score?: number; title?: string } }> = [];
+  let lastStatus: number | null = null;
+  let lastOk = false;
   for (const sub of subs) {
     const url = `https://www.reddit.com/r/${sub}/hot.json?limit=8`;
-    const data = await safeFetch<{ data?: { children?: Array<{ data?: { score?: number; title?: string } }> } }>(
+    const meta = await safeFetchWithMeta<{ data?: { children?: Array<{ data?: { score?: number; title?: string } }> } }>(
       url,
       12000,
       { headers: { ...UA_HEADERS, Accept: 'application/json' } },
     );
-    kids = data?.data?.children ?? [];
+    lastStatus = meta.status;
+    lastOk = meta.ok;
+    if (meta.ok && meta.data) {
+      kids = meta.data.data?.children ?? [];
+    }
     if (kids.length > 0) break;
   }
   const scores = kids.map((c) => c.data?.score ?? 0);
   const avg = scores.length ? scores.reduce((a, b) => a + b, 0) / scores.length : 0;
-  const value = Number(normalizeDirect(avg, 0, 2000).toFixed(3));
-  const severity = kids.length === 0 ? 'watch' : classifySeverity(value, { watch: 0.4, elevated: 0.22, critical: 0.08 });
+  const d = new Date();
+  const weekend = d.getUTCDay() === 0 || d.getUTCDay() === 6;
+  const quietHour = d.getUTCHours() >= 0 && d.getUTCHours() <= 8;
+  const quietContext = lastOk && kids.length === 0 && (weekend || quietHour);
+  const value = Number((quietContext ? 0.5 : normalizeDirect(avg, 0, 2000)).toFixed(3));
+  const severity =
+    quietContext ? 'nominal' : kids.length === 0 ? 'watch' : classifySeverity(value, { watch: 0.4, elevated: 0.22, critical: 0.08 });
   return wrap('HERMES-µ4', {
     agentName: 'HERMES-µ4',
     source: 'Reddit · narrative feed',
     timestamp: new Date().toISOString(),
     value,
-    label: `Reddit narrative: avg score ${Math.round(avg)} on ${kids.length} posts`,
+    label: quietContext
+      ? `Reddit: 0 posts in sample (quiet window — HTTP ${lastStatus ?? 'ok'}, nominal)`
+      : `Reddit narrative: avg score ${Math.round(avg)} on ${kids.length} posts`,
     severity,
-    raw: { count: kids.length },
+    raw: { count: kids.length, httpOk: lastOk, quietContext },
   });
 }
 
@@ -355,25 +403,51 @@ export async function pollAureaU1(): Promise<AgentPollResult> {
   const url = `https://www.federalregister.gov/api/v1/documents.json?conditions[publication_date][is]=${today}&per_page=10&order=newest`;
   const data = await safeFetch<{ count?: number }>(url);
   const count = data?.count ?? 0;
+  const dow = new Date().getUTCDay();
+  const weekend = dow === 0 || dow === 6;
+  const nominalZero = count === 0 && weekend;
   const value = Number(
-    (count === 0 ? 0.5 : count <= 100 ? normalizeDirect(count, 0, 100) : Math.max(0.7, 1 - (count - 100) / 500)).toFixed(3),
+    (
+      nominalZero
+        ? 1
+        : count === 0
+          ? 0.5
+          : count <= 100
+            ? normalizeDirect(count, 0, 100)
+            : Math.max(0.7, 1 - (count - 100) / 500)
+    ).toFixed(3),
   );
   return wrap('AUREA-µ1', {
     agentName: 'AUREA-µ1',
     source: 'Federal Register · volume',
     timestamp: new Date().toISOString(),
     value,
-    label: `FR today: ${count} documents`,
-    severity: classifySeverity(value, { watch: 0.4, elevated: 0.2, critical: 0.05 }),
-    raw: { date: today, count },
+    label: nominalZero
+      ? `FR today: ${count} documents (weekend — nominal)`
+      : `FR today: ${count} documents`,
+    severity: nominalZero ? 'nominal' : classifySeverity(value, { watch: 0.4, elevated: 0.2, critical: 0.05 }),
+    raw: { date: today, count, weekendNominalZero: nominalZero },
   });
 }
 
 export async function pollAureaU2(): Promise<AgentPollResult> {
   const url = 'https://catalog.data.gov/api/3/action/package_search?rows=5&sort=metadata_modified+desc';
-  const data = await safeFetch<{ result?: { count?: number } }>(url);
-  const n = data?.result?.count;
-  if (typeof n !== 'number') return wrap('AUREA-µ2', null);
+  const meta = await safeFetchWithMeta<{ result?: { count?: number } }>(url);
+  if (!meta.ok || meta.data === null) {
+    return wrap(
+      'AUREA-µ2',
+      null,
+      `AUREA-µ2: no signal — source: ${url} status: ${meta.status ?? 'n/a'} reason: ${meta.error ?? 'unknown'}`,
+    );
+  }
+  const n = meta.data.result?.count;
+  if (typeof n !== 'number') {
+    return wrap(
+      'AUREA-µ2',
+      null,
+      `AUREA-µ2: no signal — source: ${url} status: ${meta.status ?? 200} reason: missing result.count`,
+    );
+  }
   const value = Number(normalizeDirect(Math.min(n, 500_000), 0, 500_000).toFixed(3));
   return wrap('AUREA-µ2', {
     agentName: 'AUREA-µ2',

--- a/lib/echo/kv-persist-ingest.ts
+++ b/lib/echo/kv-persist-ingest.ts
@@ -7,7 +7,7 @@ import { Redis } from '@upstash/redis';
 import type { IngestResult } from '@/lib/echo/transform';
 import type { IntegrityRating } from '@/lib/echo/integrity-engine';
 import { getEchoStatus } from '@/lib/echo/store';
-import { saveEchoState, loadGIState, kvSet, KV_KEYS } from '@/lib/kv/store';
+import { saveEchoState, loadGIState, kvSet, KV_KEYS, KV_TTL_SECONDS } from '@/lib/kv/store';
 import { readMiiFeed, type MiiEntry } from '@/lib/kv/mii';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 
@@ -93,7 +93,7 @@ export async function writeEchoKvHeartbeatToMobius(
   };
   try {
     // ECHO_STATE write
-    await kvSet(KV_KEYS.ECHO_STATE_KV, payload, 7200);
+    await kvSet(KV_KEYS.ECHO_STATE_KV, payload, KV_TTL_SECONDS.ECHO_STATE);
   } catch (error) {
     console.error('[echo] ECHO_STATE KV heartbeat failed:', error);
   }

--- a/lib/integrity/buildStatus.ts
+++ b/lib/integrity/buildStatus.ts
@@ -12,7 +12,7 @@ import { getStalenessStatus } from '@/lib/runtime/staleness';
 import { scoreBatch } from '@/lib/echo/signal-engine';
 import { mockAgents, mockEpicon } from '@/lib/terminal/mock';
 import { getTripwireState } from '@/lib/tripwire/store';
-import { saveGIState, loadGIState, isRedisAvailable, type GIState } from '@/lib/kv/store';
+import { saveGIState, loadGIState, loadGIStateCarry, isRedisAvailable, type GIState } from '@/lib/kv/store';
 
 function resolveSignalQuality() {
   const epicon = getEchoEpicon();
@@ -72,32 +72,53 @@ export async function computeIntegrityPayload(): Promise<IntegrityPayload> {
   // 1. Primary: read from KV when available
   if (isRedisAvailable()) {
     const cached = await loadGIState();
-    if (cached) {
-      const age = Date.now() - new Date(cached.timestamp).getTime();
-      const mode = parseGIMode(cached.mode);
-      const terminal_status = parseTerminalStatus(cached.terminal_status);
-      if (age < 15 * 60 * 1000 && mode && terminal_status) {
-        return {
-          cycle: currentCycleId(),
-          timestamp: cached.timestamp,
-          global_integrity: cached.global_integrity,
-          mode,
-          mii_baseline: integrityStatus.mii_baseline,
-          mic_supply: integrityStatus.mic_supply,
-          terminal_status,
-          primary_driver: cached.primary_driver,
-          summary: 'GI reflects signal quality, freshness, tripwire stability, and active system health.',
-          source: 'kv',
-          kv: true,
-          signals: {
-            ...cached.signals,
-            geopolitics: cached.signals.quality,
-            economy: cached.signals.system,
-            sentiment: cached.signals.stability,
-            information: cached.signals.freshness,
-          },
-        };
+    const carry = await loadGIStateCarry();
+    const pick = (() => {
+      if (cached) {
+        const age = Date.now() - new Date(cached.timestamp).getTime();
+        const mode = parseGIMode(cached.mode);
+        const terminal_status = parseTerminalStatus(cached.terminal_status);
+        if (age < 15 * 60 * 1000 && mode && terminal_status) return { row: cached, source: 'kv' as const };
       }
+      if (carry) {
+        const cachedStale =
+          cached &&
+          typeof cached.global_integrity === 'number' &&
+          Date.now() - new Date(cached.timestamp).getTime() >= 15 * 60 * 1000;
+        const useCarry = !cached || cachedStale;
+        if (useCarry) {
+          const mode = parseGIMode(carry.mode);
+          const terminal_status = parseTerminalStatus(carry.terminal_status);
+          if (mode && terminal_status) return { row: carry, source: 'kv_carry_forward' as const };
+        }
+      }
+      return null;
+    })();
+    if (pick) {
+      const { row, source } = pick;
+      return {
+        cycle: currentCycleId(),
+        timestamp: row.timestamp,
+        global_integrity: row.global_integrity,
+        mode: parseGIMode(row.mode)!,
+        mii_baseline: integrityStatus.mii_baseline,
+        mic_supply: integrityStatus.mic_supply,
+        terminal_status: parseTerminalStatus(row.terminal_status)!,
+        primary_driver:
+          source === 'kv_carry_forward'
+            ? `${row.primary_driver} (carried forward; primary gi:latest stale or missing)`
+            : row.primary_driver,
+        summary: 'GI reflects signal quality, freshness, tripwire stability, and active system health.',
+        source: source === 'kv_carry_forward' ? 'cached' : 'kv',
+        kv: true,
+        signals: {
+          ...row.signals,
+          geopolitics: row.signals.quality,
+          economy: row.signals.system,
+          sentiment: row.signals.stability,
+          information: row.signals.freshness,
+        },
+      };
     }
   }
 

--- a/lib/integrity/resolveGi.ts
+++ b/lib/integrity/resolveGi.ts
@@ -1,0 +1,126 @@
+/**
+ * C-286 — single GI resolution for MIC readiness, snapshot-lite, and ops surfaces.
+ */
+
+import type { GIMode } from '@/lib/gi/mode';
+import { computeIntegrityPayload } from '@/lib/integrity/buildStatus';
+import { loadGIState, loadGIStateCarry, type GIState } from '@/lib/kv/store';
+
+export type GiResolutionSource =
+  | 'kv'
+  | 'kv_carry_forward'
+  | 'live_compute'
+  | 'readiness_snapshot'
+  | 'null';
+
+export type ResolvedGi = {
+  gi: number | null;
+  mode: GIMode | string | null;
+  terminal_status: string | null;
+  primary_driver: string | null;
+  source: GiResolutionSource;
+  timestamp: string | null;
+  /** When `source === 'kv'`, the underlying row (for staleness / carry-forward flags). */
+  kv?: GIState | null;
+};
+
+function modeFromGi(gi: number): GIMode {
+  if (gi >= 0.85) return 'green';
+  if (gi >= 0.7) return 'yellow';
+  return 'red';
+}
+
+function parseMicReadinessSnapshotGi(raw: unknown): number | null {
+  if (raw === null || raw === undefined) return null;
+  let o: Record<string, unknown>;
+  if (typeof raw === 'string') {
+    try {
+      o = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  } else if (typeof raw === 'object') {
+    o = raw as Record<string, unknown>;
+  } else {
+    return null;
+  }
+  const nested = o.snapshot && typeof o.snapshot === 'object' ? (o.snapshot as Record<string, unknown>) : o;
+  const g = nested.gi;
+  if (typeof g === 'number' && Number.isFinite(g)) return Math.max(0, Math.min(1, g));
+  return null;
+}
+
+/**
+ * Resolve GI: prefer fresh-enough KV, else live `computeIntegrityPayload`, else MIC readiness snapshot body.
+ */
+export async function resolveGiForTerminal(opts?: {
+  micReadinessSnapshotRaw?: string | null;
+}): Promise<ResolvedGi> {
+  const st = await loadGIState();
+  if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
+    const age = Date.now() - new Date(st.timestamp).getTime();
+    if (age < 15 * 60 * 1000) {
+      return {
+        gi: Math.max(0, Math.min(1, st.global_integrity)),
+        mode: st.mode ?? null,
+        terminal_status: st.terminal_status ?? null,
+        primary_driver: st.primary_driver ?? null,
+        source: 'kv',
+        timestamp: st.timestamp,
+        kv: st,
+      };
+    }
+  }
+
+  try {
+    const live = await computeIntegrityPayload();
+    return {
+      gi: live.global_integrity,
+      mode: live.mode,
+      terminal_status: live.terminal_status,
+      primary_driver: live.primary_driver,
+      source: 'live_compute',
+      timestamp: live.timestamp,
+      kv: st,
+    };
+  } catch {
+    // fall through
+  }
+
+  const carry = await loadGIStateCarry();
+  if (carry && typeof carry.global_integrity === 'number' && Number.isFinite(carry.global_integrity)) {
+    return {
+      gi: Math.max(0, Math.min(1, carry.global_integrity)),
+      mode: carry.mode ?? null,
+      terminal_status: carry.terminal_status ?? null,
+      primary_driver: `${carry.primary_driver ?? 'GI'} (carried forward; primary gi:latest missing or stale)`,
+      source: 'kv_carry_forward',
+      timestamp: carry.timestamp,
+      kv: st,
+    };
+  }
+
+  const snapGi =
+    opts?.micReadinessSnapshotRaw != null ? parseMicReadinessSnapshotGi(opts.micReadinessSnapshotRaw) : null;
+  if (snapGi !== null) {
+    return {
+      gi: snapGi,
+      mode: modeFromGi(snapGi),
+      terminal_status: null,
+      primary_driver: 'GI from MIC_READINESS_SNAPSHOT fallback (KV gi:latest missing/stale)',
+      source: 'readiness_snapshot',
+      timestamp: new Date().toISOString(),
+      kv: st,
+    };
+  }
+
+  return {
+    gi: null,
+    mode: null,
+    terminal_status: null,
+    primary_driver: null,
+    source: 'null',
+    timestamp: null,
+    kv: st,
+  };
+}

--- a/lib/kv/kv-ttl.ts
+++ b/lib/kv/kv-ttl.ts
@@ -1,0 +1,17 @@
+/** Mobius KV TTL defaults (seconds). C-286: extend overnight survival for critical lanes. */
+export const KV_TTL_SECONDS = {
+  /** Signal micro-sweep snapshot */
+  SIGNAL_SNAPSHOT: 14_400,
+  /** ECHO summary row */
+  ECHO_STATE: 14_400,
+  /** Tripwire summary */
+  TRIPWIRE_STATE: 14_400,
+  /** System pulse row */
+  SYSTEM_PULSE: 14_400,
+  /** GI latest — was 15m; align with other critical keys so cycle-open is not null-only */
+  GI_STATE: 14_400,
+  /** MIC readiness snapshot from upstream */
+  MIC_READINESS_SNAPSHOT: 14_400,
+  /** Agent fleet heartbeat (cron every 5m; TTL 3× interval) */
+  HEARTBEAT: 900,
+} as const;

--- a/lib/kv/store.ts
+++ b/lib/kv/store.ts
@@ -35,6 +35,9 @@ import {
   scheduleBackupMirrorRawDel,
   scheduleBackupMirrorRawKey,
 } from '@/lib/kv/backup-redis';
+import { KV_TTL_SECONDS } from '@/lib/kv/kv-ttl';
+
+export { KV_TTL_SECONDS };
 
 // ── Redis client (lazy singleton) ────────────────────────────
 
@@ -228,6 +231,14 @@ export const KV_KEYS = {
   SIGNAL_SNAPSHOT: 'signals:latest',
   /** Last GI computation result */
   GI_STATE: 'gi:latest',
+  /** Last successful GI row (long TTL) — C-286 carry-forward when primary TTL expires */
+  GI_STATE_CARRY: 'gi:latest_carry',
+  /** v1 vault cumulative balance (prefixed mobius:…) */
+  VAULT_GLOBAL_BALANCE: 'vault:global:balance',
+  /** v1 vault meta row */
+  VAULT_GLOBAL_META: 'vault:global:meta',
+  /** Operator cycle hint (written by heartbeat cron) */
+  CURRENT_CYCLE: 'operator:current_cycle',
   /** ECHO store state (epicon, ledger, alerts) */
   ECHO_STATE: 'echo:state',
   /**
@@ -245,6 +256,8 @@ export const KV_KEYS = {
   LAST_INGEST: 'ingest:last',
   /** High-frequency system pulse — updated on every micro sweep and journal write */
   SYSTEM_PULSE: 'system:pulse',
+  /** Short-circuit hot ledger API after repeated timeouts (C-286) */
+  LEDGER_CIRCUIT_OPEN: 'ledger:circuit_open',
 } as const;
 
 // ── Signal snapshot persistence ──────────────────────────────
@@ -270,7 +283,7 @@ export type SignalSnapshot = {
  * Freshness is tracked via the embedded timestamp, not TTL expiry.
  */
 export async function saveSignalSnapshot(snapshot: SignalSnapshot): Promise<void> {
-  await kvSet(KV_KEYS.SIGNAL_SNAPSHOT, snapshot, 7200);
+  await kvSet(KV_KEYS.SIGNAL_SNAPSHOT, snapshot, KV_TTL_SECONDS.SIGNAL_SNAPSHOT);
 }
 
 /**
@@ -298,10 +311,11 @@ export type GIState = {
 };
 
 /**
- * Save the latest GI state. TTL: 15 minutes.
+ * Save the latest GI state. TTL: see `KV_TTL_SECONDS.GI_STATE` (C-286 extended for cycle-open).
  */
 export async function saveGIState(state: GIState): Promise<void> {
-  await kvSet(KV_KEYS.GI_STATE, state, 900);
+  await kvSet(KV_KEYS.GI_STATE, state, KV_TTL_SECONDS.GI_STATE);
+  await kvSet(KV_KEYS.GI_STATE_CARRY, state, 604800);
 }
 
 /**
@@ -309,6 +323,11 @@ export async function saveGIState(state: GIState): Promise<void> {
  */
 export async function loadGIState(): Promise<GIState | null> {
   return kvGet<GIState>(KV_KEYS.GI_STATE);
+}
+
+/** Long-TTL duplicate of last `saveGIState` write — for cycle-open / KV primary expiry. */
+export async function loadGIStateCarry(): Promise<GIState | null> {
+  return kvGet<GIState>(KV_KEYS.GI_STATE_CARRY);
 }
 
 // ── ECHO state persistence ───────────────────────────────────
@@ -329,7 +348,7 @@ export type EchoKVState = {
  * Save ECHO store summary. TTL: 2 hours (matches /api/cron/echo-ingest cadence).
  */
 export async function saveEchoState(state: EchoKVState): Promise<void> {
-  await kvSet(KV_KEYS.ECHO_STATE, state, 7200);
+  await kvSet(KV_KEYS.ECHO_STATE, state, KV_TTL_SECONDS.ECHO_STATE);
 }
 
 /**
@@ -352,7 +371,7 @@ export type TripwireKVState = {
  * Save tripwire state. TTL: 30 minutes.
  */
 export async function saveTripwireState(state: TripwireKVState): Promise<void> {
-  await kvSet(KV_KEYS.TRIPWIRE_STATE, state, 1800);
+  await kvSet(KV_KEYS.TRIPWIRE_STATE, state, KV_TTL_SECONDS.TRIPWIRE_STATE);
 }
 
 /**

--- a/lib/mic/assembleMicReadiness.ts
+++ b/lib/mic/assembleMicReadiness.ts
@@ -1,9 +1,10 @@
+import { resolveGiForTerminal } from '@/lib/integrity/resolveGi';
 import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
 import { buildMicReadinessV1, type VaultStatusJson } from '@/lib/mic/runtime-readiness';
 import { mergeMicReadinessFromUpstream } from '@/lib/mic/readinessMerge';
 import type { MicReadinessResponse } from '@/lib/mic/types';
 import { withHash } from '@/lib/mic/hash';
-import { loadGIState, kvGet, KV_KEYS } from '@/lib/kv/store';
+import { kvGet, KV_KEYS } from '@/lib/kv/store';
 import { computeVaultSealLaneSemantics } from '@/lib/vault/lane-status';
 import { getVaultStatusPayload, listVaultDeposits } from '@/lib/vault/vault';
 import { countSeals, getCandidate, getInProgressBalance, getLatestSeal } from '@/lib/vault-v2/store';
@@ -15,16 +16,9 @@ type UpstreamSnapshot = {
   source?: string;
 };
 
-async function getVaultStatusShape(): Promise<VaultStatusJson> {
-  let gi: number | null = null;
-  try {
-    const st = await loadGIState();
-    if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
-      gi = Math.max(0, Math.min(1, st.global_integrity));
-    }
-  } catch {
-    gi = null;
-  }
+async function getVaultStatusShape(giOverride: number | null): Promise<VaultStatusJson> {
+  const gi =
+    typeof giOverride === 'number' && Number.isFinite(giOverride) ? Math.max(0, Math.min(1, giOverride)) : null;
 
   const v1 = await getVaultStatusPayload(gi);
   const [inProgressBalance, sealsCount, latestSeal, candidate] = await Promise.all([
@@ -96,13 +90,19 @@ export async function resolveReadinessCycle(cycleParam?: string | null): Promise
 /** Local MIC_READINESS_V1 from Vault + deposits (no upstream merge). */
 export async function assembleLocalMicReadiness(cycleParam?: string | null): Promise<MicReadinessResponse> {
   const cycle = await resolveReadinessCycle(cycleParam);
-  const vaultStatus = await getVaultStatusShape();
+  const micSnapRaw = await kvGet<string>(KV_KEYS.MIC_READINESS_SNAPSHOT);
+  const resolvedGi = await resolveGiForTerminal({ micReadinessSnapshotRaw: micSnapRaw });
+  const vaultStatus = await getVaultStatusShape(resolvedGi.gi);
   const deposits = await listVaultDeposits(120);
-  return buildMicReadinessV1({
+  const base = buildMicReadinessV1({
     vaultStatus,
     depositsSample: deposits,
     cycle: cycle || undefined,
   });
+  return {
+    ...base,
+    gi: resolvedGi.gi,
+  };
 }
 
 async function loadUpstreamReadiness(): Promise<Partial<MicReadinessResponse> | null> {
@@ -132,7 +132,13 @@ async function loadUpstreamReadiness(): Promise<Partial<MicReadinessResponse> | 
 export async function getMergedMicReadiness(cycleParam?: string | null): Promise<MicReadinessResponse> {
   const local = await assembleLocalMicReadiness(cycleParam);
   const upstream = await loadUpstreamReadiness();
-  const merged = mergeMicReadinessFromUpstream(local, upstream);
+  const mergedBase = mergeMicReadinessFromUpstream(local, upstream);
+  const micSnapRaw = await kvGet<string>(KV_KEYS.MIC_READINESS_SNAPSHOT);
+  const giResolved = await resolveGiForTerminal({ micReadinessSnapshotRaw: micSnapRaw });
+  const merged: MicReadinessResponse = {
+    ...mergedBase,
+    gi: giResolved.gi ?? mergedBase.gi,
+  };
   const proof = withHash(merged);
   return {
     ...merged,

--- a/lib/mic/readinessMerge.ts
+++ b/lib/mic/readinessMerge.ts
@@ -13,9 +13,16 @@ export function mergeMicReadinessFromUpstream(
   return {
     ...local,
     ...(incoming.cycle !== undefined && incoming.cycle !== '' ? { cycle: incoming.cycle } : {}),
-    ...(incoming.gi !== undefined ? { gi: incoming.gi } : {}),
+    ...(typeof incoming.gi === 'number' && Number.isFinite(incoming.gi) ? { gi: incoming.gi } : {}),
     ...(incoming.mintThresholdGi !== undefined ? { mintThresholdGi: incoming.mintThresholdGi } : {}),
-    reserve: incoming.reserve ? { ...local.reserve, ...incoming.reserve } : local.reserve,
+    // C-286: `in_progress_balance` is canonical from this Terminal's Vault KV — never override from upstream proxy.
+    reserve: incoming.reserve
+      ? {
+          ...local.reserve,
+          ...incoming.reserve,
+          inProgressBalance: local.reserve.inProgressBalance,
+        }
+      : local.reserve,
     sustain: incoming.sustain ? { ...local.sustain, ...incoming.sustain } : local.sustain,
     replay: incoming.replay ? { ...local.replay, ...incoming.replay } : local.replay,
     novelty: incoming.novelty ? { ...local.novelty, ...incoming.novelty } : local.novelty,

--- a/lib/runtime/agent-heartbeat-kv.ts
+++ b/lib/runtime/agent-heartbeat-kv.ts
@@ -1,0 +1,62 @@
+/**
+ * C-286 — KV heartbeat for `/api/agents/status` (fleet roster, not process-local `setHeartbeat()`).
+ */
+
+import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
+import { isRedisAvailable, kvSet, KV_KEYS, KV_TTL_SECONDS } from '@/lib/kv/store';
+
+/** Canonical Terminal fleet IDs (lowercase) — matches `app/api/agents/status/route.ts` roster order. */
+export const CANONICAL_AGENT_IDS = [
+  'atlas',
+  'zeus',
+  'hermes',
+  'aurea',
+  'jade',
+  'daedalus',
+  'echo',
+  'eve',
+] as const;
+
+export type AgentHeartbeatFleetPayload = {
+  ok: true;
+  timestamp: string;
+  cycle: string;
+  source: 'cron-heartbeat' | 'heartbeat-refresh';
+  agents: Array<{
+    id: string;
+    status: 'active';
+    last_action: string;
+    heartbeat_ok: true;
+  }>;
+};
+
+/**
+ * Writes `mobius:heartbeat:last` JSON expected by `GET /api/agents/status`.
+ * TTL: 15 minutes (3× a 5-minute cron interval).
+ */
+export async function writeFleetHeartbeatKV(source: AgentHeartbeatFleetPayload['source']): Promise<boolean> {
+  if (!isRedisAvailable()) return false;
+  const timestamp = new Date().toISOString();
+  let cycle = '';
+  try {
+    cycle = await resolveOperatorCycleId();
+  } catch {
+    cycle = '';
+  }
+  const payload: AgentHeartbeatFleetPayload = {
+    ok: true,
+    timestamp,
+    cycle: cycle || 'unknown',
+    source,
+    agents: CANONICAL_AGENT_IDS.map((id) => ({
+      id,
+      status: 'active',
+      last_action: 'heartbeat-refresh',
+      heartbeat_ok: true,
+    })),
+  };
+  const ok =
+    (await kvSet(KV_KEYS.HEARTBEAT, JSON.stringify(payload), KV_TTL_SECONDS.HEARTBEAT)) &&
+    (await kvSet(KV_KEYS.CURRENT_CYCLE, payload.cycle, KV_TTL_SECONDS.HEARTBEAT));
+  return ok;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,10 @@
     {
       "path": "/api/cron/vault-attestation",
       "schedule": "*/2 * * * *"
+    },
+    {
+      "path": "/api/cron/heartbeat",
+      "schedule": "*/5 * * * *"
     }
   ],
   "installCommand": "pnpm install --no-frozen-lockfile"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the C-286 live-audit bundle: fleet **HEARTBEAT** refresh on a **5-minute cron**, extended **KV TTLs** (4h) for critical lanes, **GI carry-forward** (`gi:latest_carry`) so cycle-open is not stuck on null GI, unified **`resolveGiForTerminal`** used by **MIC readiness** (proof hash) and **`snapshot-lite`** (with `gi_source` mapping), **upstream MIC readiness no longer overrides** `reserve.inProgressBalance`, **ledger API circuit breaker** (3s timeout, 5m open), **micro sweep** concurrency bump + **`degraded_instruments`** on `/api/signals/micro`, **AUREA-µ1** weekend zero-FR scoring, **HERMES-µ3/µ4** quiet-window nominal scoring, **ZEUS-µ3 / AUREA-µ2** explicit error strings with URL + HTTP status, and **KV health** extras (`CURRENT_CYCLE`, `VAULT_STATE` composite, `LEDGER_CIRCUIT_OPEN`).

## What changed (by issue)

- **I1 Heartbeat:** `GET/POST /api/cron/heartbeat` + `vercel.json` `*/5 * * * *` writes fleet JSON to `mobius:heartbeat:last` (TTL 15m) and `mobius:operator:current_cycle`. Micro-sweep and runtime heartbeat also set HEARTBEAT TTL.
- **I2 KV gaps:** `GI_STATE`, `SIGNAL_SNAPSHOT`, `ECHO_STATE`, `TRIPWIRE_STATE`, `SYSTEM_PULSE`, `MIC_READINESS_SNAPSHOT` TTLs → **4h** via `lib/kv/kv-ttl.ts`. `saveGIState` also mirrors to **`gi:latest_carry`** (7d) for rollover survival.
- **I3 snapshot-lite:** Uses `resolveGiForTerminal`; top-level **`gi_source`**: `kv` | `readiness_fallback` | `null` (mapped from internal resolution). `lanes.integrity.source` uses the same three-value contract.
- **I4 inProgressBalance:** `mergeMicReadinessFromUpstream` preserves local **`inProgressBalance`**; merged readiness re-applies resolved GI before hashing.
- **I5 no-signal diagnostics:** `safeFetchWithMeta` + richer errors for **ZEUS-µ3** and **AUREA-µ2**; `degraded_instruments` array on micro route response.

## Testing

- `pnpm exec tsc --noEmit` — pass
- `pnpm build` — pass

## Lint

Not configured (per AGENTS.md).

## Notes / checklist deltas

- **`gi_source: "readiness_fallback"`** maps both live recompute and MIC snapshot fallback (and carry-forward is **`kv`**) so consumers get exactly the three requested labels at the top level.
- **Federal holidays** for AUREA-µ1 are not implemented (weekend UTC zero-doc nominal only); can follow in a small follow-up if required.
- **`snapshot total_ms < 4000`** is environment-dependent; micro sweep should be faster with concurrency **20** but is not hard-capped.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

