### PR TITLE
feat(mesh): Terminal MeshClient for hybrid IPFS gateway reads (Phase 1–2 slice)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,13 @@ NEXT_PUBLIC_MOBIUS_GATEWAY_URL=http://localhost:8000/api/v1
 # Public site URL (used by MCP bridge server-side fetches to same-origin APIs). Production: https://mobius-civic-ai-terminal.vercel.app
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
+# Decentralization Phase 1–2 (Terminal): optional IPFS HTTP gateway for content-addressed reads.
+# When unset or false, Terminal keeps federated REST-only behavior (no operator illusion).
+NEXT_PUBLIC_MESH_ENABLED=false
+NEXT_PUBLIC_MESH_GATEWAY_URL=http://127.0.0.1:8080
+NEXT_PUBLIC_MESH_TIMEOUT_MS=8000
+NEXT_PUBLIC_MESH_API_TIMEOUT_MS=12000
+
 # Fallback service URLs
 NEXT_PUBLIC_THOUGHT_BROKER_URL=https://thought-broker.onrender.com
 NEXT_PUBLIC_CIVIC_LEDGER_URL=https://civic-protocol-core-ledger.onrender.com

--- a/hooks/useMeshClient.ts
+++ b/hooks/useMeshClient.ts
@@ -1,0 +1,12 @@
+'use client';
+
+import { useMemo } from 'react';
+import { MeshClient, type MeshClientConfig } from '@/lib/mesh/MeshClient';
+
+/**
+ * Stable `MeshClient` for hybrid IPFS gateway + Terminal API reads.
+ * Pass `config` only in tests; production uses `NEXT_PUBLIC_*` env.
+ */
+export function useMeshClient(config?: Partial<MeshClientConfig>): MeshClient {
+  return useMemo(() => new MeshClient(config), [config]);
+}

--- a/lib/mesh/MeshClient.ts
+++ b/lib/mesh/MeshClient.ts
@@ -1,0 +1,163 @@
+/**
+ * Terminal mesh / content-addressed read client (Phase 1–2 hybrid).
+ *
+ * When `NEXT_PUBLIC_MESH_ENABLED` is true and `NEXT_PUBLIC_MESH_GATEWAY_URL` is set,
+ * `resolveIpfs` reads via the Kubo (or compatible) HTTP gateway (`/ipfs/<cid>`).
+ * All normal Terminal JSON routes use the **API origin** (same as today).
+ *
+ * Phase 2 (libp2p mesh node) can extend this module to hit a mesh HTTP API or
+ * WebSocket without changing call sites if they use `MeshClient.fetchApi`.
+ */
+
+export type MeshContentTransport = 'mesh' | 'unavailable';
+
+export type MeshApiTransport = 'api';
+
+export type IpfsResolveResult = {
+  ok: boolean;
+  /** Raw body when `ok` */
+  body?: string;
+  transport: MeshContentTransport;
+  status?: number;
+  error?: string;
+};
+
+export type MeshFetchApiResult = {
+  response: Response;
+  transport: MeshApiTransport;
+};
+
+export type MeshClientConfig = {
+  /** Read from env in browser / Node */
+  meshEnabled: boolean;
+  /** Base URL of IPFS HTTP gateway (no trailing slash), e.g. http://127.0.0.1:8080 */
+  meshGatewayBase: string | null;
+  /** Terminal public origin for `/api/*` (defaults to relative "" in browser) */
+  apiBase: string;
+  /** Abort timeout for mesh gateway reads (ms) */
+  meshTimeoutMs: number;
+  /** Abort timeout for API reads (ms) */
+  apiTimeoutMs: number;
+};
+
+function readBoolEnv(value: string | undefined, defaultWhenUnset: boolean): boolean {
+  if (value === undefined || value === '') return defaultWhenUnset;
+  const v = value.trim().toLowerCase();
+  if (v === '1' || v === 'true' || v === 'yes') return true;
+  if (v === '0' || v === 'false' || v === 'no') return false;
+  return defaultWhenUnset;
+}
+
+function trimSlash(s: string): string {
+  return s.replace(/\/+$/, '');
+}
+
+export function meshClientConfigFromEnv(): MeshClientConfig {
+  const meshFlag = readBoolEnv(process.env.NEXT_PUBLIC_MESH_ENABLED, false);
+  const gw = process.env.NEXT_PUBLIC_MESH_GATEWAY_URL?.trim();
+  const meshEnabled = meshFlag && Boolean(gw && gw.length > 0);
+  const apiBase = (process.env.NEXT_PUBLIC_SITE_URL ?? '').trim().replace(/\/+$/, '');
+  const meshTimeout = Number(process.env.NEXT_PUBLIC_MESH_TIMEOUT_MS ?? '8000');
+  const apiTimeout = Number(process.env.NEXT_PUBLIC_MESH_API_TIMEOUT_MS ?? '12000');
+  return {
+    meshEnabled,
+    meshGatewayBase: gw && gw.length > 0 ? trimSlash(gw) : null,
+    apiBase,
+    meshTimeoutMs: Number.isFinite(meshTimeout) ? meshTimeout : 8000,
+    apiTimeoutMs: Number.isFinite(apiTimeout) ? apiTimeout : 12000,
+  };
+}
+
+/** Loose CID / path check for gateway addressing */
+export function looksLikeIpfsPath(resource: string): boolean {
+  const s = resource.trim();
+  if (s.startsWith('/ipfs/')) return true;
+  if (s.startsWith('ipfs/')) return true;
+  if (/^(Qm[1-9A-HJ-NP-Za-km-z]{44,}|bafy[a-z0-9]{50,})$/i.test(s)) return true;
+  return false;
+}
+
+export class MeshClient {
+  readonly config: MeshClientConfig;
+
+  constructor(config?: Partial<MeshClientConfig>) {
+    const base = meshClientConfigFromEnv();
+    this.config = { ...base, ...config };
+  }
+
+  get isMeshReadsEnabled(): boolean {
+    return this.config.meshEnabled && this.config.meshGatewayBase !== null;
+  }
+
+  /**
+   * Resolve IPFS content by CID or `/ipfs/...` path via HTTP gateway.
+   * Does not fabricate payloads — returns `ok: false` when mesh reads are off or fetch fails.
+   */
+  async resolveIpfs(cidOrPath: string): Promise<IpfsResolveResult> {
+    if (!this.isMeshReadsEnabled || !this.config.meshGatewayBase) {
+      return { ok: false, transport: 'unavailable', error: 'mesh_reads_disabled' };
+    }
+
+    const path = (() => {
+      const t = cidOrPath.trim();
+      if (t.startsWith('/ipfs/')) return t;
+      if (t.startsWith('ipfs/')) return `/${t}`;
+      return `/ipfs/${t}`;
+    })();
+
+    const url = `${this.config.meshGatewayBase}${path}`;
+    try {
+      const res = await fetch(url, {
+        method: 'GET',
+        cache: 'no-store',
+        signal: AbortSignal.timeout(this.config.meshTimeoutMs),
+      });
+      if (!res.ok) {
+        return {
+          ok: false,
+          transport: 'mesh',
+          status: res.status,
+          error: `gateway_http_${res.status}`,
+        };
+      }
+      const body = await res.text();
+      return { ok: true, body, transport: 'mesh', status: res.status };
+    } catch (e) {
+      return {
+        ok: false,
+        transport: 'mesh',
+        error: e instanceof Error ? e.message : 'mesh_fetch_failed',
+      };
+    }
+  }
+
+  /**
+   * Fetch a Terminal JSON API path (e.g. `/api/terminal/snapshot-lite`).
+   * Always uses the API origin — mesh does not replace `/api/*` until a mirror exists.
+   */
+  async fetchApi(path: string, init?: RequestInit): Promise<MeshFetchApiResult> {
+    const p = path.startsWith('/') ? path : `/${path}`;
+    const base = this.config.apiBase;
+    const url = base ? `${base}${p}` : p;
+    const response = await fetch(url, {
+      ...init,
+      signal: init?.signal ?? AbortSignal.timeout(this.config.apiTimeoutMs),
+      cache: init?.cache ?? 'no-store',
+    });
+    return { response, transport: 'api' };
+  }
+
+  /**
+   * Hybrid read: if `resource` looks like IPFS and mesh is on, use gateway; otherwise `fetchApi`.
+   */
+  async fetchHybrid(resource: string, init?: RequestInit): Promise<
+    | { kind: 'ipfs'; result: IpfsResolveResult }
+    | { kind: 'api'; result: MeshFetchApiResult }
+  > {
+    if (this.isMeshReadsEnabled && looksLikeIpfsPath(resource)) {
+      const cidPart = resource.trim().replace(/^\/?ipfs\//i, '');
+      return { kind: 'ipfs', result: await this.resolveIpfs(cidPart) };
+    }
+    return { kind: 'api', result: await this.fetchApi(resource, init) };
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the **Terminal-only** slice of the decentralization bundle: `lib/mesh/MeshClient.ts` and `hooks/useMeshClient.ts`. When `NEXT_PUBLIC_MESH_ENABLED=true` **and** `NEXT_PUBLIC_MESH_GATEWAY_URL` is set, `resolveIpfs` / `fetchHybrid` can read content via an HTTP IPFS gateway (`/ipfs/<cid>`). **`fetchApi`** always targets the existing Terminal REST surface (`NEXT_PUBLIC_SITE_URL` or relative paths). Default remains **off** so there is no operator illusion without a real gateway.

**Out of scope in this repo (per bundle mapping):** Civic-Protocol-Core (`ipfs_bridge.py`, indexer), Mobius-Substrate (`ipfs-resolver`, mesh-node, CRDT) — those require separate PRs in those repositories.

## Env

Documented in `.env.example`: `NEXT_PUBLIC_MESH_ENABLED`, `NEXT_PUBLIC_MESH_GATEWAY_URL`, optional timeouts.

## Tests

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  

## Lint

Not configured.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

