### PR TITLE
feat(mesh): mobius.yaml v1 — pulse, ingest, policy + hash ingest client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@ NEXT_PUBLIC_MESH_GATEWAY_URL=http://127.0.0.1:8080
 NEXT_PUBLIC_MESH_TIMEOUT_MS=8000
 NEXT_PUBLIC_MESH_API_TIMEOUT_MS=12000
 
+# mobius.yaml v1 ingest: durable ledger POST target (when ingest.targets[0].write_url is empty)
+# Example: https://civic-protocol-core.example.com/mesh/ingest
+MOBIUS_INGEST_WRITE_URL=
+# Optional dedicated bearer for ingest; falls back to AGENT_SERVICE_TOKEN then MOBIUS_SERVICE_SECRET
+MOBIUS_INGEST_BEARER_TOKEN=
+
 # Fallback service URLs
 NEXT_PUBLIC_THOUGHT_BROKER_URL=https://thought-broker.onrender.com
 NEXT_PUBLIC_CIVIC_LEDGER_URL=https://civic-protocol-core-ledger.onrender.com

--- a/lib/mesh/ingestClient.ts
+++ b/lib/mesh/ingestClient.ts
@@ -1,0 +1,81 @@
+/**
+ * POST hashed payloads to the durable ledger ingest URL declared in mobius.yaml (ingest.targets).
+ * Does not invent URLs or tokens — returns null URL / structured skip when undeclared.
+ */
+
+import { hashPayload } from '@/lib/mic/hash';
+import { loadMobiusYaml, resolveDeclaredIngestWriteUrl, resolveIngestBearerToken } from '@/lib/mesh/loadMobiusYaml';
+
+export type MobiusIngestPostResult =
+  | { ok: true; status: number; body: unknown }
+  | { ok: false; skipped: true; reason: 'no_write_url' | 'no_bearer' | 'ingest_disabled' }
+  | { ok: false; skipped: false; status?: number; error: string };
+
+export type MobiusIngestEnvelope<T> = {
+  type: string;
+  payload: T;
+  hash: string;
+  hash_algorithm: 'sha256';
+  source_node_id: string;
+};
+
+function meshNodeId(): string {
+  const doc = loadMobiusYaml();
+  const id = doc.mesh && typeof (doc.mesh as { node_id?: string }).node_id === 'string'
+    ? (doc.mesh as { node_id: string }).node_id
+    : 'mobius-terminal';
+  return id;
+}
+
+/**
+ * POST `{ type, payload, hash, hash_algorithm, source_node_id }` to declared ingest.
+ * `hash` must match `hashPayload(payload)` or the envelope is not sent (operator truth).
+ */
+export async function postMobiusIngest<T>(args: {
+  type: string;
+  payload: T;
+}): Promise<MobiusIngestPostResult> {
+  const doc = loadMobiusYaml();
+  if (doc.ingest?.enabled === false) {
+    return { ok: false, skipped: true, reason: 'ingest_disabled' };
+  }
+
+  const url = resolveDeclaredIngestWriteUrl(doc);
+  if (!url) {
+    return { ok: false, skipped: true, reason: 'no_write_url' };
+  }
+
+  const token = resolveIngestBearerToken();
+  if (!token) {
+    return { ok: false, skipped: true, reason: 'no_bearer' };
+  }
+
+  const envelope: MobiusIngestEnvelope<T> = {
+    type: args.type,
+    payload: args.payload,
+    hash: hashPayload(args.payload),
+    hash_algorithm: 'sha256',
+    source_node_id: meshNodeId(),
+  };
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(envelope),
+      cache: 'no-store',
+      signal: AbortSignal.timeout(15000),
+    });
+    const body = await res.json().catch(() => null);
+    if (!res.ok) {
+      return { ok: false, skipped: false, status: res.status, error: typeof body === 'object' && body && 'error' in body ? String((body as { error: unknown }).error) : `http_${res.status}` };
+    }
+    return { ok: true, status: res.status, body };
+  } catch (e) {
+    return { ok: false, skipped: false, error: e instanceof Error ? e.message : 'ingest_fetch_failed' };
+  }
+}

--- a/lib/mesh/loadMobiusYaml.ts
+++ b/lib/mesh/loadMobiusYaml.ts
@@ -1,0 +1,87 @@
+/**
+ * Load and parse root `mobius.yaml` (v1) — declaration contract only; no writes.
+ */
+
+import { readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+export const MOBIUS_PAYLOAD_TYPES_V1 = [
+  'EPICON_ENTRY_V1',
+  'MIC_READINESS_V1',
+  'MIC_SEAL_V1',
+  'MIC_RESERVE_RECONCILIATION_V1',
+  'MIC_GENESIS_BLOCK',
+  'MOBIUS_PULSE_V1',
+] as const;
+
+export type MobiusPayloadTypeV1 = (typeof MOBIUS_PAYLOAD_TYPES_V1)[number];
+
+export type IngestTargetV1 = {
+  node_id: string;
+  purpose?: string;
+  write_url: string;
+  auth?: string;
+  accepts?: string[];
+};
+
+export type MobiusYamlV1 = {
+  version?: string;
+  mesh?: Record<string, unknown>;
+  pulse?: Record<string, unknown>;
+  ingest?: {
+    enabled?: boolean;
+    mode?: string;
+    targets?: IngestTargetV1[];
+    accepts?: string[];
+    write_url?: string;
+    auth?: string;
+  };
+  mcp?: Record<string, unknown>;
+  policy?: Record<string, unknown>;
+};
+
+let cached: { mtimeMs: number; doc: MobiusYamlV1 } | null = null;
+
+function mobiusPath(): string {
+  return join(process.cwd(), 'mobius.yaml');
+}
+
+export function loadMobiusYaml(force = false): MobiusYamlV1 {
+  const path = mobiusPath();
+  let mtimeMs = 0;
+  try {
+    mtimeMs = statSync(path).mtimeMs;
+  } catch {
+    return {};
+  }
+  if (!force && cached && cached.mtimeMs === mtimeMs) return cached.doc;
+
+  const raw = readFileSync(path, 'utf8');
+  const doc = parseYaml(raw) as MobiusYamlV1;
+  cached = { mtimeMs, doc };
+  return doc;
+}
+
+/**
+ * Resolved durable ledger ingest URL for the first `ingest.targets[]` entry.
+ * Priority: target.write_url (if non-empty) → MOBIUS_INGEST_WRITE_URL → null.
+ */
+export function resolveDeclaredIngestWriteUrl(doc: MobiusYamlV1 = loadMobiusYaml()): string | null {
+  const t = doc.ingest?.targets?.[0];
+  const fromYaml = typeof t?.write_url === 'string' ? t.write_url.trim() : '';
+  if (fromYaml.length > 0) return fromYaml;
+  const env = process.env.MOBIUS_INGEST_WRITE_URL?.trim();
+  return env && env.length > 0 ? env : null;
+}
+
+export function resolveIngestBearerToken(): string | null {
+  const t = loadMobiusYaml().ingest?.targets?.[0];
+  const auth = (t?.auth ?? 'bearer').toLowerCase();
+  if (auth !== 'bearer') return null;
+  const tok =
+    process.env.MOBIUS_INGEST_BEARER_TOKEN?.trim() ||
+    process.env.AGENT_SERVICE_TOKEN?.trim() ||
+    process.env.MOBIUS_SERVICE_SECRET?.trim();
+  return tok && tok.length > 0 ? tok : null;
+}

--- a/mesh/mcp-discovery.json
+++ b/mesh/mcp-discovery.json
@@ -4,10 +4,10 @@
   "updated_at": "2026-04-19T00:00:00Z",
   "servers": [
     {
-      "node_id": "mobius-civic-ai-terminal",
+      "node_id": "mobius-terminal",
       "server_url": "https://mobius-civic-ai-terminal.vercel.app/api/mcp",
       "transport": "streamable-http",
-      "tier": "contributor",
+      "tier": "operator",
       "covenant": "integrity",
       "integrity_gate": 0.5,
       "tools": [

--- a/mesh/mobius-yaml-spec.md
+++ b/mesh/mobius-yaml-spec.md
@@ -1,88 +1,115 @@
-# `mobius.yaml` — mesh + MCP bridge (spec)
+# `mobius.yaml` v1 — pulse, ingest, and trust (Terminal canon)
 
-This document describes the **`mesh`** root object used by Mobius Neural Substrate nodes and the optional **`mcp`** bridge block (C-286).
+This document is the **declaration contract** for a Mobius node in this repository. Runtime code may **read** it; **`mobius.yaml` does not perform writes**.
 
-## Root
+## Canon
 
-All fields live under **`mesh:`** (see repository root `mobius.yaml`).
+1. **`mobius.yaml` declares** who the node is, what it emits (`pulse`), where it publishes, where **others** should send durable writes (`ingest`), which lanes it is **authoritative** for, and **policy** (canonical ledger node, hashing).
+2. **The write path stays:** KV / runtime state → writer / orchestrator → **declared ingest target** → durable ledger → optional feed mirror.
+3. **Operator nodes** (Terminal) must not declare themselves **`canonical_ledger_node`**; that belongs to the ledger tier (`civic-protocol-core`).
 
-## Core mesh fields (summary)
+## Root `version`
 
-| Path | Description |
-|------|-------------|
-| `mesh.node_id` | Stable node identifier (e.g. `mobius-civic-ai-terminal`) |
-| `mesh.node_type` | `app` \| `service` \| `library` (extensible) |
-| `mesh.substrate_ref` | GitHub `org/repo` for constitutional / doctrine source |
-| `mesh.version` | Semver string for this manifest |
-| `mesh.tier` | Participation tier (e.g. `contributor`) |
-| `mesh.covenant` | High-level covenant label (e.g. `integrity`) |
-| `mesh.agent_affinity` | Sentinel / steward agents most involved with this node |
-| `mesh.ledger` | Ledger integration (enabled, backend, `feed_url`, `push_to_substrate`) |
-| `mesh.mii` | MII tracking preferences |
-| `mesh.epicon` | EPICON policy (intent blocks, push on merge) |
-| `mesh.mic` | MIC participation flags |
+| Field | Description |
+|-------|-------------|
+| `version` | Schema string, e.g. `"1.0"` |
 
-## MCP bridge block — `mesh.mcp`
+## `mesh:` — identity and mesh participation
 
-When **`mesh.mcp.enabled`** is `true`, the node advertises a **Model Context Protocol** server so AI clients (Cursor, Claude, Codex, etc.) can invoke **declared tools** with **integrity metadata** recorded in `mobius.yaml`.
+| Field | Description |
+|-------|-------------|
+| `mesh.enabled` | Whether this manifest is active |
+| `mesh.node_id` | Stable id (e.g. `mobius-terminal`) |
+| `mesh.node_name` | Human-readable name |
+| `mesh.tier` | `sentinel` \| `operator` \| `ledger` \| `client` \| `service` |
+| `mesh.role` | `protocol_cortex` \| `operator_console` \| `ledger_node` \| … |
+| `mesh.repository` | `full_name`, `default_branch` |
+| `mesh.discovery` | `enabled`, `registry_participation` |
 
-### Example (abbreviated)
+Legacy fields (`node_type`, `substrate_ref`, `ledger`, `mii`, `epicon`, `mic`) may remain for backward compatibility until all nodes migrate.
 
-```yaml
-mesh:
-  mcp:
-    enabled: true
-    server_url: "https://mobius-civic-ai-terminal.vercel.app/api/mcp"
-    transport: "streamable-http"
-    schema_version: "MCP-2025-03-26"
-    integrity:
-      require_gi_above: 0.5
-      log_all_invocations: true
-      invocation_agent: "HERMES"
-      verification_agent: "ZEUS"
-      mic_reward_on_invocation: false
-    tools:
-      - name: "get_integrity_snapshot"
-        description: "…"
-        endpoint: "/api/terminal/snapshot-lite"
-        method: "GET"
-        auth: "none"
-        epicon_tag: "tool:integrity-read"
-```
+## `pulse:` — what the node emits and exposes
 
-### Field reference — `mcp`
+**Rule:** `pulse` describes **emissions and public surfaces**, not durable ingest.
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `mcp.enabled` | yes | If `true`, this node exposes an MCP server |
-| `mcp.server_url` | yes | HTTPS URL of the MCP HTTP endpoint |
-| `mcp.transport` | yes | `streamable-http` (default), `sse`, or `stdio` |
-| `mcp.schema_version` | no | MCP protocol / schema label (default `MCP-2025-03-26`) |
-| `mcp.integrity.require_gi_above` | no | Minimum GI for **node-level** tool gate (0 = off). Unknown GI must not block reads (Terminal implementation). |
-| `mcp.integrity.log_all_invocations` | yes | When `true`, each tool call produces an EPICON ledger row (`source: mcp-bridge`) |
-| `mcp.integrity.invocation_agent` | no | Agent name for routing / classification metadata |
-| `mcp.integrity.verification_agent` | no | Agent name for verification posture (ZEUS) |
-| `mcp.integrity.mic_reward_on_invocation` | no | Future: MIC reward on verified invocations |
+| Field | Description |
+|-------|-------------|
+| `pulse.enabled` | Pulse lane active |
+| `pulse.health_url` | Liveness URL |
+| `pulse.feed_url` | Operator-visible feed (e.g. EPICON) |
+| `pulse.snapshot_url` | Compact snapshot (e.g. snapshot-lite) |
+| `pulse.freshness_sla_seconds` | Staleness budget for pulse consumers |
+| `pulse.integrity_weight` | Weight in aggregated pulse (Substrate-side) |
+| `pulse.lanes` | Lane vocabulary (see below) |
+| `pulse.authoritative_for` | Capability keys this node owns (prevents lane confusion) |
+| `pulse.emits` | Booleans: `heartbeat`, `gi`, `mii`, `mic`, `vault`, `tripwire`, `anomalies` |
 
-### Field reference — `mcp.tools[]`
+## `ingest:` — where this node accepts or forwards durable writes
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `name` | yes | Tool id (`snake_case`), must match server registration |
-| `description` | yes | Human + model-readable capability description |
-| `endpoint` | yes | Path on this node (relative to public origin) |
-| `method` | yes | HTTP verb the bridge uses internally |
-| `auth` | yes | `none` \| `bearer` \| `api-key` |
-| `auth_env` | if auth ≠ `none` | Env var holding secret material |
-| `epicon_tag` | yes | Tag applied on invocation log rows |
-| `requires_gi_above` | no | Per-tool GI floor (overrides node default for that tool) |
+**Rule:** `ingest` describes **targets and accepted payload types**, not execution.
 
-## Discovery
+| Field | Description |
+|-------|-------------|
+| `ingest.enabled` | Ingest client/target active |
+| `ingest.mode` | `ledger_target` \| `client_of_other_node` \| `aggregator_only` |
+| `ingest.targets[]` | For `client_of_other_node`: `node_id`, `purpose`, `write_url`, `auth`, `accepts` |
+| `ingest.write_url` | Ledger nodes may set a single URL (alternative to `targets`) |
 
-- **Per-node:** `mobius.yaml` `mesh.mcp` block.
-- **Aggregator index:** `mesh/mcp-discovery.json` (this repo carries a Terminal slice; Substrate may publish the union).
-- **HTTP discovery:** `/.well-known/mcp.json` — this Terminal serves `public/.well-known/mcp.json`.
+**Terminal resolution:** if `ingest.targets[0].write_url` is empty, the runtime uses **`MOBIUS_INGEST_WRITE_URL`**. Bearer material uses **`MOBIUS_INGEST_BEARER_TOKEN`**, then `AGENT_SERVICE_TOKEN`, then `MOBIUS_SERVICE_SECRET` (see `.env.example`).
 
-## Doctrine
+Only **`ledger_target`** nodes should be the canonical acceptor for hashed ledger payloads.
 
-See `docs/09-MESH/MNS_MCP_BRIDGE.md`.
+## `mcp:` — MCP edge (Terminal)
+
+| Field | Description |
+|-------|-------------|
+| `mcp.enabled` | Expose `/api/mcp` |
+| `mcp.server_url` | Public MCP URL |
+| `mcp.discovery_url` | `/.well-known/mcp.json` or equivalent |
+| `mcp.transport` | e.g. `streamable-http` |
+| `mcp.tools[]` | Declared tools (name, endpoint, method, auth, …) |
+
+Implementation: `app/api/mcp/route.ts`, `lib/mcp/mobius-terminal-mcp.ts`, `docs/09-MESH/MNS_MCP_BRIDGE.md`.
+
+## `policy:` — trust boundaries
+
+| Field | Description |
+|-------|-------------|
+| `policy.write_truth_locally` | If true, this node persists canonical truth locally (ledger nodes) |
+| `policy.mirror_feed_to_repo` | Optional GitHub / feed mirror |
+| `policy.canonical_ledger_node` | Node id of the durable ledger (e.g. `civic-protocol-core`) |
+| `policy.hash_algorithm` | e.g. `sha256` |
+
+## Payload vocabulary (v1)
+
+Tight list for `ingest.targets[].accepts` and cross-node contracts:
+
+- `EPICON_ENTRY_V1`
+- `MIC_READINESS_V1`
+- `MIC_SEAL_V1`
+- `MIC_RESERVE_RECONCILIATION_V1`
+- `MIC_GENESIS_BLOCK`
+- `MOBIUS_PULSE_V1` (future: `MOBIUS_PULSE_V2`)
+
+## Lane vocabulary
+
+`integrity`, `signals`, `tripwire`, `heartbeat`, `mic_readiness`, `vault`, `ledger`, `mesh`, `mcp` (extend only with mesh-wide agreement).
+
+## Rules (summary)
+
+1. **Pulse** = what the node emits.  
+2. **Ingest** = what it accepts / where others write.  
+3. **`authoritative_for`** = prevents lane confusion.  
+4. Only **ledger** nodes use `ingest.mode: ledger_target` as canonical acceptor.  
+5. **Operator** nodes forward hashed payloads to the declared target; they do not claim canonical ledger.
+
+## Runtime helpers (this repo)
+
+- `lib/mesh/loadMobiusYaml.ts` — parse `mobius.yaml`, resolve ingest URL / bearer.  
+- `lib/mesh/ingestClient.ts` — `postMobiusIngest({ type, payload })` with **hash envelope** before POST.
+
+## Related
+
+- `mobius.yaml` (repository root) — live Terminal manifest.  
+- `mesh/mcp-discovery.json` — MCP discovery slice.  
+- `docs/09-MESH/MNS_MCP_BRIDGE.md` — MCP doctrine.

--- a/mobius.yaml
+++ b/mobius.yaml
@@ -1,16 +1,31 @@
-# Mobius mesh node manifest — Terminal (C-286 MCP bridge)
-# Canonical spec: mesh/mobius-yaml-spec.md
+# mobius.yaml — Node declaration contract v1 (C-286)
+# Canon: this file declares identity, pulse, ingest targets, MCP, and policy — it does not perform writes.
+# Write path: KV / runtime → writer / orchestrator → declared ingest target → durable ledger → optional feed mirror.
+
+version: "1.0"
 
 mesh:
-  node_id: "mobius-civic-ai-terminal"
+  enabled: true
+  node_id: "mobius-terminal"
+  node_name: "Mobius Civic AI Terminal"
+  tier: "operator"
+  role: "operator_console"
   node_type: "app"
   substrate_ref: "kaizencycle/Mobius-Substrate"
-  version: "1.0.0"
-  tier: "contributor"
   covenant: "integrity"
   agent_affinity:
     - ZEUS
     - ATLAS
+
+  repository:
+    full_name: "kaizencycle/mobius-civic-ai-terminal"
+    default_branch: "main"
+
+  discovery:
+    enabled: true
+    registry_participation: true
+
+  # Legacy mesh blocks (retained for backward compatibility with prior manifests)
   ledger:
     enabled: true
     backend: "github-actions"
@@ -26,52 +41,104 @@ mesh:
     participate: true
     reward_type: "MIC_REWARD_V2"
 
-  mcp:
-    enabled: true
-    server_url: "https://mobius-civic-ai-terminal.vercel.app/api/mcp"
-    transport: "streamable-http"
-    schema_version: "MCP-2025-03-26"
-    integrity:
-      require_gi_above: 0.5
-      log_all_invocations: true
-      invocation_agent: "HERMES"
-      verification_agent: "ZEUS"
-      mic_reward_on_invocation: false
-    tools:
-      - name: "get_integrity_snapshot"
-        description: "Returns snapshot-lite GI, mode, lane freshness, deployment meta."
-        endpoint: "/api/terminal/snapshot-lite"
-        method: "GET"
-        auth: "none"
-        epicon_tag: "tool:integrity-read"
-      - name: "get_epicon_feed"
-        description: "Returns recent EPICON / civic ledger rows from the Terminal feed."
-        endpoint: "/api/epicon/feed"
-        method: "GET"
-        auth: "none"
-        epicon_tag: "tool:ledger-read"
-      - name: "get_vault_status"
-        description: "Returns MIC vault state — reserve, tranche, Seal lane, hash coverage."
-        endpoint: "/api/vault/status"
-        method: "GET"
-        auth: "none"
-        epicon_tag: "tool:vault-read"
-      - name: "get_agent_journal"
-        description: "Returns recent sentinel journal entries (substrate-backed)."
-        endpoint: "/api/agents/journal"
-        method: "GET"
-        auth: "none"
-        epicon_tag: "tool:journal-read"
-      - name: "post_epicon_entry"
-        description: "Triggers ECHO ingest (POST /api/echo/ingest) — operational write; intent fields logged in MCP EPICON row."
-        endpoint: "/api/echo/ingest"
-        method: "POST"
-        auth: "none"
-        epicon_tag: "tool:ledger-write"
-        requires_gi_above: 0.6
-      - name: "get_mic_readiness"
-        description: "Returns MIC_READINESS_V1 (merged) + proof metadata."
-        endpoint: "/api/mic/readiness"
-        method: "GET"
-        auth: "none"
-        epicon_tag: "tool:mic-read"
+pulse:
+  enabled: true
+  health_url: "https://mobius-civic-ai-terminal.vercel.app/api/health"
+  feed_url: "https://mobius-civic-ai-terminal.vercel.app/api/epicon/feed"
+  snapshot_url: "https://mobius-civic-ai-terminal.vercel.app/api/terminal/snapshot-lite"
+  freshness_sla_seconds: 900
+  integrity_weight: 1.0
+  lanes:
+    - integrity
+    - signals
+    - tripwire
+    - heartbeat
+    - mic_readiness
+    - vault
+    - mcp
+  authoritative_for:
+    - terminal_snapshot
+    - mic_readiness
+    - vault_runtime
+  emits:
+    heartbeat: true
+    gi: true
+    mii: false
+    mic: true
+    vault: true
+    tripwire: true
+    anomalies: true
+
+ingest:
+  enabled: true
+  mode: "client_of_other_node"
+  targets:
+    - node_id: "civic-protocol-core"
+      purpose: "durable_ledger"
+      # If empty, runtime resolves from MOBIUS_INGEST_WRITE_URL (see .env.example).
+      write_url: ""
+      auth: "bearer"
+      accepts:
+        - EPICON_ENTRY_V1
+        - MIC_READINESS_V1
+        - MIC_SEAL_V1
+        - MIC_RESERVE_RECONCILIATION_V1
+        - MIC_GENESIS_BLOCK
+        - MOBIUS_PULSE_V1
+
+mcp:
+  enabled: true
+  server_url: "https://mobius-civic-ai-terminal.vercel.app/api/mcp"
+  discovery_url: "https://mobius-civic-ai-terminal.vercel.app/.well-known/mcp.json"
+  transport: "streamable-http"
+  schema_version: "MCP-2025-03-26"
+  integrity:
+    require_gi_above: 0.5
+    log_all_invocations: true
+    invocation_agent: "HERMES"
+    verification_agent: "ZEUS"
+    mic_reward_on_invocation: false
+  tools:
+    - name: "get_integrity_snapshot"
+      description: "Returns snapshot-lite GI, mode, lane freshness, deployment meta."
+      endpoint: "/api/terminal/snapshot-lite"
+      method: "GET"
+      auth: "none"
+      epicon_tag: "tool:integrity-read"
+    - name: "get_epicon_feed"
+      description: "Returns recent EPICON / civic ledger rows from the Terminal feed."
+      endpoint: "/api/epicon/feed"
+      method: "GET"
+      auth: "none"
+      epicon_tag: "tool:ledger-read"
+    - name: "get_vault_status"
+      description: "Returns MIC vault state — reserve, tranche, Seal lane, hash coverage."
+      endpoint: "/api/vault/status"
+      method: "GET"
+      auth: "none"
+      epicon_tag: "tool:vault-read"
+    - name: "get_agent_journal"
+      description: "Returns recent sentinel journal entries (substrate-backed)."
+      endpoint: "/api/agents/journal"
+      method: "GET"
+      auth: "none"
+      epicon_tag: "tool:journal-read"
+    - name: "post_epicon_entry"
+      description: "Triggers ECHO ingest (POST /api/echo/ingest) — operational write; MCP logs intent to EPICON feed."
+      endpoint: "/api/echo/ingest"
+      method: "POST"
+      auth: "none"
+      epicon_tag: "tool:ledger-write"
+      requires_gi_above: 0.6
+    - name: "get_mic_readiness"
+      description: "Returns MIC_READINESS_V1 (merged) + proof metadata."
+      endpoint: "/api/mic/readiness"
+      method: "GET"
+      auth: "none"
+      epicon_tag: "tool:mic-read"
+
+policy:
+  write_truth_locally: false
+  mirror_feed_to_repo: true
+  canonical_ledger_node: "civic-protocol-core"
+  hash_algorithm: "sha256"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "tailwind-merge": "^3.3.1",
     "topojson-client": "^3.1.0",
     "world-atlas": "^2.0.2",
+    "yaml": "2.7.0",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       world-atlas:
         specifier: ^2.0.2
         version: 2.0.2
+      yaml:
+        specifier: 2.7.0
+        version: 2.7.0
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -92,7 +95,7 @@ importers:
         version: 8.5.8
       tailwindcss:
         specifier: ^3.4.13
-        version: 3.4.19
+        version: 3.4.19(yaml@2.7.0)
       typescript:
         specifier: ^5.6.2
         version: 5.9.3
@@ -1450,6 +1453,11 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
+  yaml@2.7.0:
+    resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
+    engines: {node: '>= 14'}
+    hasBin: true
+
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
@@ -2328,12 +2336,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.8
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.8):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.8)(yaml@2.7.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.8
+      yaml: 2.7.0
 
   postcss-nested@6.2.0(postcss@8.5.8):
     dependencies:
@@ -2608,7 +2617,7 @@ snapshots:
 
   tailwind-merge@3.5.0: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(yaml@2.7.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -2627,7 +2636,7 @@ snapshots:
       postcss: 8.5.8
       postcss-import: 15.1.0(postcss@8.5.8)
       postcss-js: 4.1.0(postcss@8.5.8)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.8)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.8)(yaml@2.7.0)
       postcss-nested: 6.2.0(postcss@8.5.8)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -2715,6 +2724,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   yallist@4.0.0: {}
+
+  yaml@2.7.0: {}
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:

--- a/public/.well-known/mcp.json
+++ b/public/.well-known/mcp.json
@@ -6,7 +6,7 @@
   "integrity_doctrine": "https://raw.githubusercontent.com/kaizencycle/Mobius-Substrate/main/docs/09-MESH/MNS_PROTOCOL.md",
   "servers": [
     {
-      "node_id": "mobius-civic-ai-terminal",
+      "node_id": "mobius-terminal",
       "url": "https://mobius-civic-ai-terminal.vercel.app/api/mcp",
       "transport": "streamable-http"
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adopts **mobius.yaml v1** as the Terminal **declaration contract**: `version`, `mesh` (identity + discovery + legacy blocks), **`pulse`** (URLs, lanes, `authoritative_for`, `emits`), **`ingest`** (`client_of_other_node`, targets, `accepts` payload vocabulary), **`mcp`** (aligned with existing bridge), and **`policy`** (`canonical_ledger_node: civic-protocol-core`, `write_truth_locally: false`).

Adds **`lib/mesh/loadMobiusYaml.ts`** (YAML parse + ingest URL / bearer resolution) and **`lib/mesh/ingestClient.ts`** (`postMobiusIngest` with **SHA-256 hash envelope** before POST). Rewrites **`mesh/mobius-yaml-spec.md`** to document canon, rules, lanes, and payload types. Documents **`MOBIUS_INGEST_WRITE_URL`** / **`MOBIUS_INGEST_BEARER_TOKEN`** in `.env.example`. Dependency: **`yaml`** parser.

**Not in this repo:** Substrate schema authority PR, Civic Protocol Core `/mesh/ingest` implementation — callers get `skipped` until `MOBIUS_INGEST_WRITE_URL` and bearer are set and the target accepts the envelope.

## Tests

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  

## Lint

Not configured.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

