### PR TITLE
feat(C-286): Terminal OAA dual-write — KV → OAA → Civic Core proof

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,15 @@ MOBIUS_INGEST_WRITE_URL=
 # Optional dedicated bearer for ingest; falls back to AGENT_SERVICE_TOKEN then MOBIUS_SERVICE_SECRET
 MOBIUS_INGEST_BEARER_TOKEN=
 
+# C-286 OAA sovereign memory (dual-write): Terminal → POST OAA /api/oaa/kv → optional Civic Core proof
+# Base URL of OAA-API-Library (no trailing slash). Falls back to NEXT_PUBLIC_OAA_API_URL if unset.
+OAA_API_BASE=
+# Shared secret for HMAC body signing (OAA verifies the same). Alias: KV_HMAC_SECRET
+OAA_HMAC_SECRET=
+# WRITE_MODE=dual enables cron publish to OAA + ledger proof. DATA_SOURCE reserved for future read migration.
+WRITE_MODE=dual
+DATA_SOURCE=kv
+
 # Fallback service URLs
 NEXT_PUBLIC_THOUGHT_BROKER_URL=https://thought-broker.onrender.com
 NEXT_PUBLIC_CIVIC_LEDGER_URL=https://civic-protocol-core-ledger.onrender.com

--- a/app/api/cron/publish-oaa-snapshots/route.ts
+++ b/app/api/cron/publish-oaa-snapshots/route.ts
@@ -1,0 +1,48 @@
+/**
+ * GET/POST /api/cron/publish-oaa-snapshots
+ *
+ * Dual-write (WRITE_MODE=dual): append MIC readiness + vault status to OAA,
+ * then forward OAA_MEMORY_ENTRY_V1 proof to Civic Core when configured.
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getEveSynthesisAuthError } from '@/lib/security/serviceAuth';
+import {
+  publishMicReadinessFromTerminal,
+  publishVaultStatusFromTerminal,
+} from '@/lib/oaa/publishSnapshot';
+import { isOaaPublishEnabled } from '@/lib/mesh/loadMobiusYaml';
+
+export const dynamic = 'force-dynamic';
+
+async function run() {
+  if (!isOaaPublishEnabled()) {
+    return NextResponse.json({
+      ok: true,
+      skipped: true,
+      reason: 'WRITE_MODE not dual or OAA URL/HMAC missing — see .env.example and mobius.yaml ingest.sovereign_memory',
+    });
+  }
+
+  const [mic, vault] = await Promise.all([publishMicReadinessFromTerminal(), publishVaultStatusFromTerminal()]);
+
+  return NextResponse.json({
+    ok: true,
+    mic_readiness: mic,
+    vault_status: vault,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+export async function GET(request: NextRequest) {
+  const authErr = getEveSynthesisAuthError(request);
+  if (authErr) return authErr;
+  return run();
+}
+
+export async function POST(request: NextRequest) {
+  const authErr = getEveSynthesisAuthError(request);
+  if (authErr) return authErr;
+  return run();
+}

--- a/hooks/useOAADataClient.ts
+++ b/hooks/useOAADataClient.ts
@@ -1,0 +1,9 @@
+'use client';
+
+import { useMemo } from 'react';
+import { OAADataClient } from '@/lib/ingestion/OAADataClient';
+
+/** Returns configured OAA client or null when URL/HMAC missing (browser env). */
+export function useOAADataClient(): OAADataClient | null {
+  return useMemo(() => OAADataClient.fromEnv(), []);
+}

--- a/lib/ingestion/OAADataClient.ts
+++ b/lib/ingestion/OAADataClient.ts
@@ -1,0 +1,72 @@
+import { signOaaWritePayload } from '@/lib/oaa/signWrite';
+import { resolveOaaHmacSecret, resolveOaaKvPostUrl } from '@/lib/mesh/loadMobiusYaml';
+
+export type OaaWriteInput = {
+  key: string;
+  value: unknown;
+  agent: string;
+  cycle: string;
+  intent?: string;
+  previousHash?: string | null;
+};
+
+export type OaaWriteResult = { ok: true; hash: string; previous_hash?: string | null; ts?: number } | { ok: false; error: string };
+
+/**
+ * POST structured KV journal entries to OAA `/api/oaa/kv` (HMAC).
+ * Requires `OAA_API_BASE` or `mobius.yaml` `ingest.sovereign_memory.write_url` + `OAA_HMAC_SECRET` or `KV_HMAC_SECRET`.
+ */
+export class OAADataClient {
+  constructor(
+    private readonly postUrl: string,
+    private readonly hmacSecret: string,
+  ) {}
+
+  static fromEnv(): OAADataClient | null {
+    const url = resolveOaaKvPostUrl();
+    const secret = resolveOaaHmacSecret();
+    if (!url || !secret) return null;
+    return new OAADataClient(url, secret);
+  }
+
+  async write(input: OaaWriteInput): Promise<OaaWriteResult> {
+    const signable: Record<string, unknown> = {
+      key: input.key,
+      value: input.value,
+      agent: input.agent,
+      cycle: input.cycle,
+      ...(input.intent !== undefined ? { intent: input.intent } : {}),
+      previousHash: input.previousHash ?? null,
+    };
+    const signature = signOaaWritePayload(signable, this.hmacSecret);
+
+    try {
+      const res = await fetch(this.postUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ ...signable, signature }),
+        cache: 'no-store',
+        signal: AbortSignal.timeout(20000),
+      });
+      const data = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+      if (!res.ok) {
+        const err = data && typeof data.error === 'string' ? data.error : `http_${res.status}`;
+        return { ok: false, error: err };
+      }
+      if (!data) return { ok: false, error: 'empty_json_response' };
+      const hash = typeof data.hash === 'string' ? data.hash : '';
+      if (!hash) return { ok: false, error: 'missing_hash_in_response' };
+      return {
+        ok: true,
+        hash,
+        previous_hash:
+          typeof data.previous_hash === 'string' || data.previous_hash === null
+            ? (data.previous_hash as string | null)
+            : undefined,
+        ts: typeof data.ts === 'number' ? data.ts : undefined,
+      };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : 'oaa_fetch_failed' };
+    }
+  }
+}

--- a/lib/mesh/loadMobiusYaml.ts
+++ b/lib/mesh/loadMobiusYaml.ts
@@ -13,6 +13,7 @@ export const MOBIUS_PAYLOAD_TYPES_V1 = [
   'MIC_RESERVE_RECONCILIATION_V1',
   'MIC_GENESIS_BLOCK',
   'MOBIUS_PULSE_V1',
+  'OAA_MEMORY_ENTRY_V1',
 ] as const;
 
 export type MobiusPayloadTypeV1 = (typeof MOBIUS_PAYLOAD_TYPES_V1)[number];
@@ -32,6 +33,18 @@ export type MobiusYamlV1 = {
   ingest?: {
     enabled?: boolean;
     mode?: string;
+    hot_state?: { type?: string };
+    sovereign_memory?: {
+      node_id?: string;
+      write_url?: string;
+      auth?: string;
+      accepts?: string[];
+    };
+    durable_ledger?: {
+      node_id?: string;
+      write_url?: string;
+      auth?: string;
+    };
     targets?: IngestTargetV1[];
     accepts?: string[];
     write_url?: string;
@@ -68,6 +81,9 @@ export function loadMobiusYaml(force = false): MobiusYamlV1 {
  * Priority: target.write_url (if non-empty) → MOBIUS_INGEST_WRITE_URL → null.
  */
 export function resolveDeclaredIngestWriteUrl(doc: MobiusYamlV1 = loadMobiusYaml()): string | null {
+  const dl = doc.ingest?.durable_ledger;
+  const fromDl = typeof dl?.write_url === 'string' ? dl.write_url.trim() : '';
+  if (fromDl.length > 0) return fromDl;
   const t = doc.ingest?.targets?.[0];
   const fromYaml = typeof t?.write_url === 'string' ? t.write_url.trim() : '';
   if (fromYaml.length > 0) return fromYaml;
@@ -84,4 +100,43 @@ export function resolveIngestBearerToken(): string | null {
     process.env.AGENT_SERVICE_TOKEN?.trim() ||
     process.env.MOBIUS_SERVICE_SECRET?.trim();
   return tok && tok.length > 0 ? tok : null;
+}
+
+/** OAA POST /api/oaa/kv base (no trailing slash). YAML `ingest.sovereign_memory.write_url` or `OAA_API_BASE`. */
+export function resolveOaaBaseUrl(doc: MobiusYamlV1 = loadMobiusYaml()): string | null {
+  const sm = doc.ingest?.sovereign_memory;
+  const fromYaml = typeof sm?.write_url === 'string' ? sm.write_url.trim() : '';
+  if (fromYaml.length > 0) {
+    return fromYaml.replace(/\/api\/oaa\/kv\/?$/i, '').replace(/\/+$/, '');
+  }
+  const env = process.env.OAA_API_BASE?.trim() ?? process.env.NEXT_PUBLIC_OAA_API_URL?.trim();
+  if (!env) return null;
+  return env.replace(/\/+$/, '');
+}
+
+export function resolveOaaKvPostUrl(doc: MobiusYamlV1 = loadMobiusYaml()): string | null {
+  const sm = doc.ingest?.sovereign_memory;
+  const raw = typeof sm?.write_url === 'string' ? sm.write_url.trim() : '';
+  if (raw.includes('/api/oaa/kv')) return raw.replace(/\/+$/, '');
+  const base = resolveOaaBaseUrl(doc);
+  if (!base) return null;
+  return `${base}/api/oaa/kv`;
+}
+
+export function resolveOaaHmacSecret(): string | null {
+  const s =
+    process.env.OAA_HMAC_SECRET?.trim() ||
+    process.env.KV_HMAC_SECRET?.trim();
+  return s && s.length > 0 ? s : null;
+}
+
+export function isDualWriteMode(): boolean {
+  const m = (process.env.WRITE_MODE ?? 'dual').trim().toLowerCase();
+  return m === 'dual' || m === 'oaa' || m === 'oaa+dual';
+}
+
+export function isOaaPublishEnabled(): boolean {
+  if (loadMobiusYaml().ingest?.enabled === false) return false;
+  if (!isDualWriteMode()) return false;
+  return resolveOaaKvPostUrl() !== null && resolveOaaHmacSecret() !== null;
 }

--- a/lib/oaa/internalOrigin.ts
+++ b/lib/oaa/internalOrigin.ts
@@ -1,0 +1,9 @@
+/** Same-origin base for server-side Terminal fetches (cron, MCP-style). */
+
+export function terminalInternalOrigin(): string {
+  const site = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (site) return site.replace(/\/+$/, '');
+  const vercel = process.env.VERCEL_URL?.trim();
+  if (vercel) return `https://${vercel.replace(/^https?:\/\//, '')}`;
+  return 'http://localhost:3000';
+}

--- a/lib/oaa/publishSnapshot.ts
+++ b/lib/oaa/publishSnapshot.ts
@@ -1,0 +1,125 @@
+/**
+ * Dual-write: publish Terminal snapshots to OAA sovereign memory, then optional Civic Core proof.
+ * KV remains source of hot reads; this path is append-only journal + durable envelope.
+ */
+
+import { terminalInternalOrigin } from '@/lib/oaa/internalOrigin';
+import { OAADataClient } from '@/lib/ingestion/OAADataClient';
+import { isOaaPublishEnabled } from '@/lib/mesh/loadMobiusYaml';
+import { postMobiusIngest } from '@/lib/mesh/ingestClient';
+import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
+
+async function fetchJson(path: string): Promise<unknown> {
+  const origin = terminalInternalOrigin();
+  const url = `${origin}${path.startsWith('/') ? path : `/${path}`}`;
+  const res = await fetch(url, { headers: { Accept: 'application/json' }, cache: 'no-store', signal: AbortSignal.timeout(15000) });
+  if (!res.ok) throw new Error(`fetch_${path}_${res.status}`);
+  return res.json();
+}
+
+export type PublishKind = 'mic_readiness' | 'vault_status' | 'heartbeat' | 'reconciliation';
+
+export async function publishToOaaAndLedger(args: {
+  kind: PublishKind;
+  key: string;
+  value: unknown;
+  agent?: string;
+  intent?: string;
+}): Promise<{
+  oaa: { ok: boolean; skipped?: boolean; error?: string; hash?: string };
+  ledger: { ok: boolean; skipped?: boolean; reason?: string };
+}> {
+  if (!isOaaPublishEnabled()) {
+    return { oaa: { ok: false, skipped: true, error: 'oaa_publish_disabled' }, ledger: { ok: false, skipped: true, reason: 'oaa_publish_disabled' } };
+  }
+
+  const client = OAADataClient.fromEnv();
+  if (!client) {
+    return { oaa: { ok: false, skipped: true, error: 'oaa_client_unconfigured' }, ledger: { ok: false, skipped: true, reason: 'oaa_client_unconfigured' } };
+  }
+
+  let cycle = 'unknown';
+  try {
+    cycle = await resolveOperatorCycleId();
+  } catch {
+    cycle = 'unknown';
+  }
+
+  const oaa = await client.write({
+    key: args.key,
+    value: args.value,
+    agent: args.agent ?? 'TERMINAL',
+    cycle,
+    intent: args.intent ?? `publish:${args.kind}`,
+    previousHash: null,
+  });
+
+  let ledger: { ok: boolean; skipped?: boolean; reason?: string } = { ok: false, skipped: true, reason: 'oaa_not_ok' };
+  if (oaa.ok && oaa.hash) {
+    const proof = {
+      type: 'OAA_MEMORY_ENTRY_V1',
+      kind: args.kind,
+      key: args.key,
+      agent: args.agent ?? 'TERMINAL',
+      cycle,
+      intent: args.intent ?? `publish:${args.kind}`,
+      hash: oaa.hash,
+      previous_hash: oaa.previous_hash ?? null,
+      timestamp: new Date().toISOString(),
+    };
+    const r = await postMobiusIngest({ type: 'OAA_MEMORY_ENTRY_V1', payload: proof });
+    if (r.ok) ledger = { ok: true };
+    else if ('skipped' in r && r.skipped) ledger = { ok: false, skipped: true, reason: r.reason };
+    else ledger = { ok: false, skipped: false, reason: 'error' in r ? r.error : 'ledger_failed' };
+  }
+
+  return {
+    oaa: oaa.ok ? { ok: true, hash: oaa.hash } : { ok: false, error: 'error' in oaa ? oaa.error : 'oaa_failed' },
+    ledger,
+  };
+}
+
+export async function publishMicReadinessFromTerminal(): Promise<ReturnType<typeof publishToOaaAndLedger>> {
+  const data = await fetchJson('/api/mic/readiness');
+  return publishToOaaAndLedger({
+    kind: 'mic_readiness',
+    key: 'mic:readiness',
+    value: data,
+    intent: 'terminal mic readiness snapshot',
+  });
+}
+
+export async function publishVaultStatusFromTerminal(): Promise<ReturnType<typeof publishToOaaAndLedger>> {
+  const data = await fetchJson('/api/vault/status');
+  return publishToOaaAndLedger({
+    kind: 'vault_status',
+    key: 'vault:status',
+    value: data,
+    intent: 'terminal vault status snapshot',
+  });
+}
+
+export async function publishHeartbeatFromTerminal(): Promise<ReturnType<typeof publishToOaaAndLedger>> {
+  const data = await fetchJson('/api/terminal/snapshot-lite');
+  return publishToOaaAndLedger({
+    kind: 'heartbeat',
+    key: 'terminal:snapshot-lite',
+    value: data,
+    intent: 'terminal snapshot-lite heartbeat',
+  });
+}
+
+export async function publishReconciliationFromTerminal(args: {
+  historicalObservedReserve: number;
+  sealedReserveTotal: number;
+  currentTrancheBalance: number;
+  legacyCarryforwardBalance: number;
+  unreconciledGap: number;
+}): Promise<ReturnType<typeof publishToOaaAndLedger>> {
+  return publishToOaaAndLedger({
+    kind: 'reconciliation',
+    key: 'vault:reconciliation',
+    value: { ...args, ts: new Date().toISOString() },
+    intent: 'reserve reconciliation snapshot',
+  });
+}

--- a/lib/oaa/signWrite.ts
+++ b/lib/oaa/signWrite.ts
@@ -1,0 +1,20 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { canonicalStringify } from '@/lib/mic/canonicalJson';
+
+/** HMAC-SHA256 hex over canonical JSON of the signable object (OAA /api/oaa/kv contract). */
+export function signOaaWritePayload(payload: Record<string, unknown>, secret: string): string {
+  const body = canonicalStringify(payload);
+  return createHmac('sha256', secret).update(body, 'utf8').digest('hex');
+}
+
+export function verifyOaaWritePayload(payload: Record<string, unknown>, signatureHex: string, secret: string): boolean {
+  const expected = signOaaWritePayload(payload, secret);
+  try {
+    const a = Buffer.from(expected, 'hex');
+    const b = Buffer.from(signatureHex, 'hex');
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}

--- a/mesh/mobius-yaml-spec.md
+++ b/mesh/mobius-yaml-spec.md
@@ -51,11 +51,16 @@ Legacy fields (`node_type`, `substrate_ref`, `ledger`, `mii`, `epicon`, `mic`) m
 | Field | Description |
 |-------|-------------|
 | `ingest.enabled` | Ingest client/target active |
-| `ingest.mode` | `ledger_target` \| `client_of_other_node` \| `aggregator_only` |
+| `ingest.mode` | `ledger_target` \| `client_of_other_node` \| `write_through` \| `aggregator_only` |
+| `ingest.hot_state` | e.g. `{ type: upstash_kv }` — hot operator state (Terminal) |
+| `ingest.sovereign_memory` | OAA layer: `node_id`, `write_url` (full `/api/oaa/kv` or base resolved via `OAA_API_BASE`), `auth: hmac` |
+| `ingest.durable_ledger` | Civic Core: `write_url` for `/mesh/ingest` (optional; also `ingest.targets[0]`) |
 | `ingest.targets[]` | For `client_of_other_node`: `node_id`, `purpose`, `write_url`, `auth`, `accepts` |
 | `ingest.write_url` | Ledger nodes may set a single URL (alternative to `targets`) |
 
-**Terminal resolution:** if `ingest.targets[0].write_url` is empty, the runtime uses **`MOBIUS_INGEST_WRITE_URL`**. Bearer material uses **`MOBIUS_INGEST_BEARER_TOKEN`**, then `AGENT_SERVICE_TOKEN`, then `MOBIUS_SERVICE_SECRET` (see `.env.example`).
+**`write_through` (C-286 OAA-centric):** hot KV stays authoritative for reads; Terminal **writer** appends to **OAA** (`POST /api/oaa/kv` with HMAC), then posts **`OAA_MEMORY_ENTRY_V1`** proof envelope to **Civic Core** via `postMobiusIngest` when `MOBIUS_INGEST_WRITE_URL` + bearer are set.
+
+**Terminal resolution:** durable URL: `ingest.durable_ledger.write_url` → `ingest.targets[0].write_url` → **`MOBIUS_INGEST_WRITE_URL`**. Bearer: **`MOBIUS_INGEST_BEARER_TOKEN`**, then `AGENT_SERVICE_TOKEN`, then `MOBIUS_SERVICE_SECRET` (see `.env.example`). OAA: **`OAA_API_BASE`** or `ingest.sovereign_memory.write_url` + **`OAA_HMAC_SECRET`** (or `KV_HMAC_SECRET`).
 
 Only **`ledger_target`** nodes should be the canonical acceptor for hashed ledger payloads.
 
@@ -107,6 +112,9 @@ Tight list for `ingest.targets[].accepts` and cross-node contracts:
 
 - `lib/mesh/loadMobiusYaml.ts` — parse `mobius.yaml`, resolve ingest URL / bearer.  
 - `lib/mesh/ingestClient.ts` — `postMobiusIngest({ type, payload })` with **hash envelope** before POST.
+- `lib/oaa/signWrite.ts` — HMAC over **`canonicalStringify`** of the signed fields (must match OAA-API-Library verification).
+- `lib/ingestion/OAADataClient.ts` — POST `/api/oaa/kv`.
+- `lib/oaa/publishSnapshot.ts` — dual-write publisher + `app/api/cron/publish-oaa-snapshots`.
 
 ## Related
 

--- a/mobius.yaml
+++ b/mobius.yaml
@@ -71,7 +71,20 @@ pulse:
 
 ingest:
   enabled: true
-  mode: "client_of_other_node"
+  # write_through: hot KV + sovereign OAA append + durable Civic Core (see mesh/mobius-yaml-spec.md)
+  mode: "write_through"
+  hot_state:
+    type: "upstash_kv"
+  sovereign_memory:
+    node_id: "oaa-api-library"
+    # Full URL to POST /api/oaa/kv — if empty, use OAA_API_BASE from env (see .env.example)
+    write_url: ""
+    auth: "hmac"
+  durable_ledger:
+    node_id: "civic-protocol-core"
+    # Same as ingest.targets[0]; bearer ingest to /mesh/ingest
+    write_url: ""
+    auth: "bearer"
   targets:
     - node_id: "civic-protocol-core"
       purpose: "durable_ledger"
@@ -85,6 +98,7 @@ ingest:
         - MIC_RESERVE_RECONCILIATION_V1
         - MIC_GENESIS_BLOCK
         - MOBIUS_PULSE_V1
+        - OAA_MEMORY_ENTRY_V1
 
 mcp:
   enabled: true

--- a/vercel.json
+++ b/vercel.json
@@ -29,6 +29,10 @@
     {
       "path": "/api/cron/heartbeat",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/cron/publish-oaa-snapshots",
+      "schedule": "*/15 * * * *"
     }
   ],
   "installCommand": "pnpm install --no-frozen-lockfile"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the **Terminal writer slice** of the OAA-centric C-286 bundle: **`mobius.yaml`** `ingest.mode: write_through` with **`hot_state`**, **`sovereign_memory`**, **`durable_ledger`**, payload **`OAA_MEMORY_ENTRY_V1`** on durable targets, env **`OAA_API_BASE`**, **`OAA_HMAC_SECRET`**, **`WRITE_MODE`**, **`DATA_SOURCE`**.

- **`OAADataClient`** — POST `/api/oaa/kv` with HMAC over **`canonicalStringify`** of `{ key, value, agent, cycle, intent?, previousHash }` (align signing with OAA when you implement verify there).
- **`publishSnapshot`** — fetches `/api/mic/readiness` + `/api/vault/status`, writes to OAA, then **`postMobiusIngest({ type: OAA_MEMORY_ENTRY_V1, payload })`** for Civic Core proof (skipped if ingest URL/bearer unset).
- **Cron** — `/api/cron/publish-oaa-snapshots` every 15m (`vercel.json`), gated by **`WRITE_MODE=dual`** + OAA URL + HMAC (`isOaaPublishEnabled()`).
- **`hooks/useOAADataClient.ts`** — optional client hook.

**Not in this repo:** OAA-API-Library route implementation, Civic Core `OAA_MEMORY_ENTRY_V1` acceptor, Substrate doctrine PRs.

## Tests

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  

## Lint

Not configured.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

