### PR TITLE
feat(kv-bridge): Terminal OAA warm fallback for KV ceiling / outages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,8 +20,12 @@ MOBIUS_INGEST_BEARER_TOKEN=
 # C-286 OAA sovereign memory (dual-write): Terminal → POST OAA /api/oaa/kv → optional Civic Core proof
 # Base URL of OAA-API-Library (no trailing slash). Falls back to NEXT_PUBLIC_OAA_API_URL if unset.
 OAA_API_BASE=
+# Optional explicit base for OAA KV bridge (defaults to OAA_API_BASE then NEXT_PUBLIC_OAA_API_URL)
+OAA_API_BASE_URL=
 # Shared secret for HMAC body signing (OAA verifies the same). Alias: KV_HMAC_SECRET
 OAA_HMAC_SECRET=
+# C-286 KV bridge: same secret as OAA `KV_BRIDGE_SECRET` — warm fallback when Upstash hits monthly limits
+KV_BRIDGE_SECRET=
 # WRITE_MODE=dual enables cron publish to OAA + ledger proof. DATA_SOURCE reserved for future read migration.
 WRITE_MODE=dual
 DATA_SOURCE=kv

--- a/lib/kv/kvBridgeClient.ts
+++ b/lib/kv/kvBridgeClient.ts
@@ -1,0 +1,181 @@
+/**
+ * OAA KV bridge client — warm fallback when Upstash REST hits monthly limits or errors.
+ * Server-side only; requires OAA_API_BASE_URL (or OAA_API_BASE / NEXT_PUBLIC_OAA_API_URL) + KV_BRIDGE_SECRET.
+ */
+
+import {
+  prefixedRedisKeyToBridgeSymbol,
+  rawRedisKeyToBridgeSymbol,
+  VAULT_BRIDGE_SYMBOL,
+} from '@/lib/kv/kvBridgeKeys';
+
+function oaaBaseUrl(): string {
+  const u =
+    process.env.OAA_API_BASE_URL?.trim() ||
+    process.env.OAA_API_BASE?.trim() ||
+    process.env.NEXT_PUBLIC_OAA_API_URL?.trim() ||
+    '';
+  return u.replace(/\/$/, '');
+}
+
+export function kvBridgeConfigured(): boolean {
+  return Boolean(oaaBaseUrl() && process.env.KV_BRIDGE_SECRET?.trim());
+}
+
+export interface KvBridgeReadResult {
+  ok: boolean;
+  key: string;
+  value: unknown;
+  written_at: string;
+  source?: string;
+}
+
+function abortMs(ms: number): AbortSignal | undefined {
+  try {
+    return AbortSignal.timeout(ms);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Upstash / network conditions where OAA warm tier should be tried. */
+export function isKvCapacityOrTransportError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  const lower = msg.toLowerCase();
+  return (
+    lower.includes('max requests limit exceeded') ||
+    lower.includes('max requests exceeded') ||
+    lower.includes('limit: 500000') ||
+    lower.includes('econnrefused') ||
+    lower.includes('etimedout') ||
+    lower.includes('enotfound') ||
+    lower.includes('fetch failed') ||
+    lower.includes('socket hang up') ||
+    lower.includes('network error')
+  );
+}
+
+/**
+ * POST snapshot to OAA. `key` must be a bridge allowlist symbol (e.g. GI_STATE).
+ */
+export async function kvBridgeWrite(
+  bridgeKey: string,
+  value: unknown,
+  ttlSeconds?: number,
+): Promise<boolean> {
+  const base = oaaBaseUrl();
+  const secret = process.env.KV_BRIDGE_SECRET?.trim();
+  if (!base || !secret) return false;
+
+  try {
+    const res = await fetch(`${base}/api/kv-bridge/write`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${secret}`,
+      },
+      body: JSON.stringify({
+        key: bridgeKey,
+        value,
+        ttl_seconds: ttlSeconds,
+        source: 'terminal',
+      }),
+      signal: abortMs(8000),
+    });
+    return res.ok;
+  } catch (err) {
+    console.warn(
+      '[mobius-kv:bridge] write failed:',
+      err instanceof Error ? err.message : err,
+    );
+    return false;
+  }
+}
+
+export async function kvBridgeRead(bridgeKey: string): Promise<KvBridgeReadResult | null> {
+  const base = oaaBaseUrl();
+  if (!base) return null;
+
+  try {
+    const res = await fetch(
+      `${base}/api/kv-bridge/read?key=${encodeURIComponent(bridgeKey)}`,
+      { signal: abortMs(8000) },
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as KvBridgeReadResult | null;
+    if (!data || typeof data !== 'object' || !data.ok) return null;
+    return data;
+  } catch (err) {
+    console.warn(
+      '[mobius-kv:bridge] read failed:',
+      err instanceof Error ? err.message : err,
+    );
+    return null;
+  }
+}
+
+/** Fire-and-forget mirror after successful primary SET (prefixed `mobius:` key). */
+export function scheduleKvBridgeMirrorPrefixed(prefixedKey: string, value: unknown, ttlSeconds?: number): void {
+  if (!kvBridgeConfigured()) return;
+  const symbol = prefixedRedisKeyToBridgeSymbol(prefixedKey);
+  if (!symbol || symbol === VAULT_BRIDGE_SYMBOL) return;
+  void kvBridgeWrite(symbol, value, ttlSeconds).catch(() => {});
+}
+
+/** Fire-and-forget mirror for raw Redis keys (legacy TRIPWIRE_STATE, etc.). */
+export function scheduleKvBridgeMirrorRaw(rawKey: string, value: unknown, ttlSeconds?: number): void {
+  if (!kvBridgeConfigured()) return;
+  const symbol = rawRedisKeyToBridgeSymbol(rawKey);
+  if (!symbol) return;
+  void kvBridgeWrite(symbol, value, ttlSeconds).catch(() => {});
+}
+
+export async function kvBridgeReadForPrefixedKey<T>(prefixedKey: string): Promise<T | null> {
+  const symbol = prefixedRedisKeyToBridgeSymbol(prefixedKey);
+  if (!symbol) return null;
+  const row = await kvBridgeRead(symbol);
+  return (row?.value as T) ?? null;
+}
+
+export async function kvBridgeReadForRawKey<T>(rawKey: string): Promise<T | null> {
+  const symbol = rawRedisKeyToBridgeSymbol(rawKey);
+  if (!symbol) return null;
+  const row = await kvBridgeRead(symbol);
+  return (row?.value as T) ?? null;
+}
+
+export type VaultBridgePayload = {
+  balance: unknown;
+  meta: unknown;
+  bridged_at: string;
+};
+
+/** Single bridge slot for `mobius:vault:global:balance` + `mobius:vault:global:meta`. */
+export async function kvBridgeWriteVaultSnapshot(
+  balance: unknown,
+  meta: unknown,
+  ttlSeconds?: number,
+): Promise<boolean> {
+  if (!kvBridgeConfigured()) return false;
+  const payload: VaultBridgePayload = {
+    balance,
+    meta,
+    bridged_at: new Date().toISOString(),
+  };
+  return kvBridgeWrite(VAULT_BRIDGE_SYMBOL, payload, ttlSeconds);
+}
+
+export async function kvBridgeReadVaultComposite<TBalance, TMeta>(): Promise<{
+  balance: TBalance | null;
+  meta: TMeta | null;
+} | null> {
+  const row = await kvBridgeRead(VAULT_BRIDGE_SYMBOL);
+  if (!row?.ok || row.value === null || row.value === undefined) return null;
+  const v = row.value as Record<string, unknown>;
+  if (typeof v !== 'object' || v === null) return null;
+  if (!('balance' in v) && !('meta' in v)) return null;
+  return {
+    balance: ('balance' in v ? v.balance : null) as TBalance | null,
+    meta: ('meta' in v ? v.meta : null) as TMeta | null,
+  };
+}

--- a/lib/kv/kvBridgeKeys.ts
+++ b/lib/kv/kvBridgeKeys.ts
@@ -1,0 +1,55 @@
+/**
+ * Maps Terminal Redis key names to OAA KV bridge allowlist symbols.
+ * Bridge accepts logical names (e.g. GI_STATE); Terminal stores `mobius:gi:latest`.
+ */
+
+/** Keys accepted by OAA POST /api/kv-bridge/write (must match OAA allowlist). */
+export const KV_BRIDGE_SYMBOLS = new Set([
+  'GI_STATE',
+  'GI_STATE_CARRY',
+  'SIGNAL_SNAPSHOT',
+  'HEARTBEAT',
+  'SYSTEM_PULSE',
+  'LAST_INGEST',
+  'ECHO_STATE',
+  'CURRENT_CYCLE',
+  'MIC_READINESS_SNAPSHOT',
+  'VAULT_STATE',
+  'VAULT_GLOBAL_META',
+  'TRIPWIRE_STATE',
+  'TRIPWIRE_STATE_KV',
+]);
+
+const RAW_TO_SYMBOL: Record<string, string> = {
+  TRIPWIRE_STATE: 'TRIPWIRE_STATE',
+};
+
+const LOGICAL_TO_SYMBOL: Record<string, string> = {
+  'gi:latest': 'GI_STATE',
+  'gi:latest_carry': 'GI_STATE_CARRY',
+  'signals:latest': 'SIGNAL_SNAPSHOT',
+  'heartbeat:last': 'HEARTBEAT',
+  'system:pulse': 'SYSTEM_PULSE',
+  'ingest:last': 'LAST_INGEST',
+  'echo:state': 'ECHO_STATE',
+  'operator:current_cycle': 'CURRENT_CYCLE',
+  'mic:readiness:snapshot': 'MIC_READINESS_SNAPSHOT',
+  'tripwire:state': 'TRIPWIRE_STATE',
+  'tripwire:kv:heartbeat': 'TRIPWIRE_STATE_KV',
+};
+
+/** Vault balance/meta share one bridge slot (`VAULT_STATE`) as `{ balance, meta }`. */
+export const VAULT_BRIDGE_SYMBOL = 'VAULT_STATE' as const;
+
+export function rawRedisKeyToBridgeSymbol(rawKey: string): string | null {
+  return RAW_TO_SYMBOL[rawKey] ?? null;
+}
+
+export function prefixedRedisKeyToBridgeSymbol(prefixedKey: string): string | null {
+  if (!prefixedKey.startsWith('mobius:')) return null;
+  const logical = prefixedKey.slice('mobius:'.length);
+  if (logical === 'vault:global:balance' || logical === 'vault:global:meta') {
+    return VAULT_BRIDGE_SYMBOL;
+  }
+  return LOGICAL_TO_SYMBOL[logical] ?? null;
+}

--- a/lib/kv/store.ts
+++ b/lib/kv/store.ts
@@ -21,7 +21,10 @@
  *   MOBIUS_KV_BACKUP_MIRROR — mirror successful `kvSet` / `kvSetRawKey` / vault raw writes
  *   MOBIUS_KV_READ_FALLBACK — read from backup when primary GET misses or errors
  *
- * Free tier: 500K commands/month, more than enough for this project.
+ *   OAA KV bridge (C-286) — warm tier on Render when Upstash hits monthly limits:
+ *   OAA_API_BASE_URL (or OAA_API_BASE / NEXT_PUBLIC_OAA_API_URL) + KV_BRIDGE_SECRET
+ *
+ * Free tier: 500K commands/month — bridge absorbs writes / serves reads when primary fails.
  *
  * CC0 Public Domain
  */
@@ -36,8 +39,31 @@ import {
   scheduleBackupMirrorRawKey,
 } from '@/lib/kv/backup-redis';
 import { KV_TTL_SECONDS } from '@/lib/kv/kv-ttl';
+import {
+  isKvCapacityOrTransportError,
+  kvBridgeConfigured,
+  kvBridgeReadForPrefixedKey,
+  kvBridgeReadForRawKey,
+  kvBridgeReadVaultComposite,
+  kvBridgeWrite,
+  kvBridgeWriteVaultSnapshot,
+  scheduleKvBridgeMirrorPrefixed,
+  scheduleKvBridgeMirrorRaw,
+} from '@/lib/kv/kvBridgeClient';
+import {
+  prefixedRedisKeyToBridgeSymbol,
+  rawRedisKeyToBridgeSymbol,
+  VAULT_BRIDGE_SYMBOL,
+} from '@/lib/kv/kvBridgeKeys';
 
 export { KV_TTL_SECONDS };
+
+const VAULT_BALANCE_LOGICAL = 'vault:global:balance';
+const VAULT_META_LOGICAL = 'vault:global:meta';
+
+function isVaultBalanceOrMetaKey(key: string): boolean {
+  return key === VAULT_BALANCE_LOGICAL || key === VAULT_META_LOGICAL;
+}
 
 // ── Redis client (lazy singleton) ────────────────────────────
 
@@ -92,17 +118,47 @@ export async function kvGet<T>(key: string): Promise<T | null> {
   const fullKey = prefixKey(key);
 
   if (!redis) {
-    return backupPrefixedGet<T>(key);
+    const fb = await backupPrefixedGet<T>(key);
+    if (fb !== null) return fb;
+    if (kvBridgeConfigured()) {
+      if (isVaultBalanceOrMetaKey(key)) {
+        const comp = await kvBridgeReadVaultComposite<T, unknown>();
+        if (!comp) return null;
+        return (key === VAULT_BALANCE_LOGICAL ? comp.balance : (comp.meta as T)) ?? null;
+      }
+      return kvBridgeReadForPrefixedKey<T>(fullKey);
+    }
+    return null;
   }
 
   try {
     const value = await redis.get<T>(fullKey);
     if (value !== null && value !== undefined) return value;
-    return backupPrefixedGet<T>(key);
+    const fb = await backupPrefixedGet<T>(key);
+    if (fb !== null) return fb;
+    if (kvBridgeConfigured()) {
+      if (isVaultBalanceOrMetaKey(key)) {
+        const comp = await kvBridgeReadVaultComposite<T, unknown>();
+        if (!comp) return null;
+        return (key === VAULT_BALANCE_LOGICAL ? comp.balance : (comp.meta as T)) ?? null;
+      }
+      const bridgedMiss = await kvBridgeReadForPrefixedKey<T>(fullKey);
+      if (bridgedMiss !== null) return bridgedMiss;
+    }
+    return null;
   } catch (err) {
     console.warn(`[mobius-kv] GET ${key} failed:`, err instanceof Error ? err.message : err);
     const fb = await backupPrefixedGet<T>(key);
     if (fb !== null) return fb;
+    if (kvBridgeConfigured() && isKvCapacityOrTransportError(err)) {
+      if (isVaultBalanceOrMetaKey(key)) {
+        const comp = await kvBridgeReadVaultComposite<T, unknown>();
+        if (!comp) return null;
+        return (key === VAULT_BALANCE_LOGICAL ? comp.balance : (comp.meta as T)) ?? null;
+      }
+      const bridged = await kvBridgeReadForPrefixedKey<T>(fullKey);
+      if (bridged !== null) return bridged;
+    }
     return null;
   }
 }
@@ -111,16 +167,28 @@ export async function kvGet<T>(key: string): Promise<T | null> {
 export async function kvGetRaw<T>(rawKey: string): Promise<T | null> {
   const redis = getRedis();
   if (!redis) {
-    return backupRawGet<T>(rawKey);
+    const fb = await backupRawGet<T>(rawKey);
+    if (fb !== null) return fb;
+    return kvBridgeConfigured() ? kvBridgeReadForRawKey<T>(rawKey) : null;
   }
   try {
     const value = await redis.get<T>(rawKey);
     if (value !== null && value !== undefined) return value;
-    return backupRawGet<T>(rawKey);
+    const fb = await backupRawGet<T>(rawKey);
+    if (fb !== null) return fb;
+    if (kvBridgeConfigured()) {
+      const bridged = await kvBridgeReadForRawKey<T>(rawKey);
+      if (bridged !== null) return bridged;
+    }
+    return null;
   } catch (err) {
     console.warn(`[mobius-kv] GET raw ${rawKey} failed:`, err instanceof Error ? err.message : err);
     const fb = await backupRawGet<T>(rawKey);
     if (fb !== null) return fb;
+    if (kvBridgeConfigured() && isKvCapacityOrTransportError(err)) {
+      const b = await kvBridgeReadForRawKey<T>(rawKey);
+      if (b !== null) return b;
+    }
     return null;
   }
 }
@@ -131,7 +199,15 @@ export async function kvGetRaw<T>(rawKey: string): Promise<T | null> {
  */
 export async function kvSet<T>(key: string, value: T, ttlSeconds?: number): Promise<boolean> {
   const redis = getRedis();
-  if (!redis) return false;
+  if (!redis) {
+    if (!kvBridgeConfigured()) return false;
+    if (isVaultBalanceOrMetaKey(key)) {
+      return kvSetVaultViaBridgeOnly(key, value, ttlSeconds);
+    }
+    const symbol = prefixedRedisKeyToBridgeSymbol(prefixKey(key));
+    if (!symbol || symbol === VAULT_BRIDGE_SYMBOL) return false;
+    return kvBridgeWrite(symbol, value, ttlSeconds);
+  }
 
   try {
     const fullKey = prefixKey(key);
@@ -141,10 +217,49 @@ export async function kvSet<T>(key: string, value: T, ttlSeconds?: number): Prom
       await redis.set(fullKey, value);
     }
     scheduleBackupMirrorPrefixedKey(fullKey, value, ttlSeconds);
+    if (isVaultBalanceOrMetaKey(key)) {
+      void mirrorVaultCompositeToOaaBridge();
+    } else {
+      scheduleKvBridgeMirrorPrefixed(fullKey, value, ttlSeconds);
+    }
     return true;
   } catch (err) {
     console.warn(`[mobius-kv] SET ${key} failed:`, err instanceof Error ? err.message : err);
+    if (kvBridgeConfigured() && isKvCapacityOrTransportError(err)) {
+      if (isVaultBalanceOrMetaKey(key)) {
+        return kvSetVaultViaBridgeOnly(key, value, ttlSeconds);
+      }
+      const symbol = prefixedRedisKeyToBridgeSymbol(prefixKey(key));
+      if (!symbol || symbol === VAULT_BRIDGE_SYMBOL) return false;
+      return kvBridgeWrite(symbol, value, ttlSeconds);
+    }
     return false;
+  }
+}
+
+/** When only one vault field is written to the bridge, merge with the other field from the last composite snapshot. */
+async function kvSetVaultViaBridgeOnly(
+  key: string,
+  value: unknown,
+  ttlSeconds?: number,
+): Promise<boolean> {
+  const comp = await kvBridgeReadVaultComposite<unknown, unknown>();
+  const balance = key === VAULT_BALANCE_LOGICAL ? value : (comp?.balance ?? null);
+  const meta = key === VAULT_META_LOGICAL ? value : (comp?.meta ?? null);
+  return kvBridgeWriteVaultSnapshot(balance, meta, ttlSeconds);
+}
+
+/** After a successful primary vault row write, mirror `{ balance, meta }` to OAA (one allowlist slot). */
+async function mirrorVaultCompositeToOaaBridge(): Promise<void> {
+  if (!kvBridgeConfigured()) return;
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    const balance = await redis.get<number>(prefixKey(VAULT_BALANCE_LOGICAL));
+    const meta = await redis.get<unknown>(prefixKey(VAULT_META_LOGICAL));
+    void kvBridgeWriteVaultSnapshot(balance, meta).catch(() => {});
+  } catch {
+    /* non-fatal */
   }
 }
 
@@ -153,7 +268,12 @@ export async function kvSet<T>(key: string, value: T, ttlSeconds?: number): Prom
  */
 export async function kvSetRawKey<T>(rawKey: string, value: T, ttlSeconds?: number): Promise<boolean> {
   const redis = getRedis();
-  if (!redis) return false;
+  if (!redis) {
+    if (!kvBridgeConfigured()) return false;
+    const sym = rawRedisKeyToBridgeSymbol(rawKey);
+    if (!sym) return false;
+    return kvBridgeWrite(sym, value, ttlSeconds);
+  }
   try {
     if (ttlSeconds) {
       await redis.set(rawKey, value, { ex: ttlSeconds });
@@ -161,9 +281,15 @@ export async function kvSetRawKey<T>(rawKey: string, value: T, ttlSeconds?: numb
       await redis.set(rawKey, value);
     }
     scheduleBackupMirrorRawKey(rawKey, value, ttlSeconds);
+    scheduleKvBridgeMirrorRaw(rawKey, value, ttlSeconds);
     return true;
   } catch (err) {
     console.warn(`[mobius-kv] SET raw ${rawKey} failed:`, err instanceof Error ? err.message : err);
+    if (kvBridgeConfigured() && isKvCapacityOrTransportError(err)) {
+      const sym = rawRedisKeyToBridgeSymbol(rawKey);
+      if (!sym) return false;
+      return kvBridgeWrite(sym, value, ttlSeconds);
+    }
     return false;
   }
 }

--- a/lib/kv/withFallback.ts
+++ b/lib/kv/withFallback.ts
@@ -1,0 +1,18 @@
+/**
+ * OAA KV bridge is integrated into `kvGet` / `kvSet` / `kvGetRaw` / `kvSetRawKey` in `store.ts`.
+ * This module exposes the C-286 spec names as thin aliases for clarity at call sites.
+ */
+
+import { kvGet, kvSet } from '@/lib/kv/store';
+
+export async function kvGetWithFallback<T>(key: string): Promise<T | null> {
+  return kvGet<T>(key);
+}
+
+export async function kvSetWithFallback(
+  key: string,
+  value: unknown,
+  ttlSeconds?: number,
+): Promise<boolean> {
+  return kvSet(key, value, ttlSeconds);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the **Terminal** side of the C-286 OAA KV bridge: when Upstash REST is unavailable, at monthly request limits, or returns null for hot keys, the Terminal can read/write through OAA’s `/api/kv-bridge/*` endpoints (once those routes exist on OAA-API-Library).

## What changed

- **`lib/kv/kvBridgeClient.ts`** — `kvBridgeRead` / `kvBridgeWrite`, optional `OAA_API_BASE_URL` (falls back to `OAA_API_BASE` / `NEXT_PUBLIC_OAA_API_URL`), `KV_BRIDGE_SECRET` Bearer auth, 8s timeout, capacity/transport error detection.
- **`lib/kv/kvBridgeKeys.ts`** — Maps `mobius:*` logical keys to OAA allowlist symbols; vault balance + meta share **`VAULT_STATE`** as `{ balance, meta, bridged_at }`.
- **`lib/kv/store.ts`** — Integrated fallback: backup Redis → OAA bridge on primary miss; on primary **GET** errors matching capacity/transport, try bridge; on **SET** failure with same errors, write bridge only. Successful primary SETs **fire-and-forget** mirror to bridge (except vault uses explicit composite snapshot after each write).
- **`lib/kv/withFallback.ts`** — Thin aliases `kvGetWithFallback` / `kvSetWithFallback` → `kvGet` / `kvSet` (bridge is in the core layer).
- **`.env.example`** — `OAA_API_BASE_URL`, `KV_BRIDGE_SECRET`.

## Pairing with OAA-API-Library

This PR does **not** add OAA `pages/api/kv-bridge/*` (different repo). Deploy OAA routes + `KV_BRIDGE_SECRET` / `KV_BRIDGE_PATH` there, then set the same secret and base URL on Vercel.

## Ops note

Enabling **`MOBIUS_KV_READ_FALLBACK=true`** (with `REDIS_URL`) remains the fastest mitigation when backup Redis is already healthy; the OAA bridge adds a separate infra path.

## Tests

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- `pnpm lint` — not configured (no ESLint config; wizard blocks non-TTY)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

