### PR TITLE
fix(C-286): closing scan — zombie instruments, GI sync, sustain, replay decay, backup Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,9 +67,8 @@ KV_REST_API_TOKEN=
 
 # Optional TCP Redis backup (Render/Fly/self-hosted). Health in /api/kv/health → backup_redis.
 REDIS_URL=
-# Set to true to mirror successful kvSet / kvSetRawKey to REDIS_URL (same key names as primary)
+# When REDIS_URL is set, mirror + read fallback default to ON (C-286 close). Set explicitly to false to disable.
 MOBIUS_KV_BACKUP_MIRROR=
-# When true, kvGet/kvGetRaw also read from REDIS_URL on primary miss/error
 MOBIUS_KV_READ_FALLBACK=
 
 # Comma-separated extra origins for Handbook / GitHub Pages CORS on public GET routes

--- a/app/api/signals/micro/route.ts
+++ b/app/api/signals/micro/route.ts
@@ -14,7 +14,9 @@ import {
   kvSet,
   KV_KEYS,
   KV_TTL_SECONDS,
+  saveGiStateFromMicroSweep,
 } from '@/lib/kv/store';
+import { updateSustainTrackingFromGi } from '@/lib/mic/sustainTracker';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
 
@@ -45,6 +47,13 @@ export async function GET() {
   try {
     const result = await pollAllMicroAgents();
     cached = { data: result, timestamp: now };
+
+    const signalQuality =
+      result.allSignals.length > 0
+        ? result.allSignals.reduce((s, x) => s + x.value, 0) / result.allSignals.length
+        : result.composite;
+    saveGiStateFromMicroSweep({ composite: result.composite, signalQuality }).catch(() => {});
+    updateSustainTrackingFromGi(result.composite).catch(() => {});
 
     // Persist signal snapshot to Redis for cold-start recovery
     if (isRedisAvailable()) {

--- a/lib/agents/micro/instrument-polls.ts
+++ b/lib/agents/micro/instrument-polls.ts
@@ -560,19 +560,27 @@ export async function pollJadeU3(): Promise<AgentPollResult> {
 }
 
 export async function pollJadeU4(): Promise<AgentPollResult> {
-  const url = 'https://openlibrary.org/authors/OL23466A.json';
-  const data = await safeFetch<{ name?: string; work_count?: number }>(url);
-  if (!data?.name) return wrap('JADE-µ4', null);
-  const wc = data.work_count ?? 0;
-  const value = Number(normalizeDirect(Math.min(wc, 200), 0, 200).toFixed(3));
+  const url =
+    'https://openlibrary.org/search/authors.json?q=governance+civic&limit=1';
+  const meta = await safeFetchWithMeta<{ numFound?: number }>(url, 6000);
+  if (!meta.ok || meta.data == null) {
+    console.warn('[micro] JADE-µ4 OpenLibrary:', meta.error ?? 'no body');
+    return wrap('JADE-µ4', null);
+  }
+  const count =
+    typeof meta.data.numFound === 'number' && Number.isFinite(meta.data.numFound)
+      ? meta.data.numFound
+      : 0;
+  const value = count > 10 ? 0.85 : count > 0 ? 0.6 : 0.45;
+  const severity = count > 0 ? 'nominal' : 'watch';
   return wrap('JADE-µ4', {
     agentName: 'JADE-µ4',
-    source: 'Open Library · author record',
+    source: 'Open Library · governance query',
     timestamp: new Date().toISOString(),
-    value,
-    label: `OL author ${data.name}: ${wc} works`,
-    severity: 'nominal',
-    raw: { work_count: wc },
+    value: Number(value.toFixed(3)),
+    label: `OpenLibrary governance authors: ${count} results`,
+    severity,
+    raw: { numFound: count },
   });
 }
 
@@ -761,18 +769,40 @@ export async function pollEchoU3(): Promise<AgentPollResult> {
 }
 
 export async function pollEchoU4(): Promise<AgentPollResult> {
-  const url = 'https://api.open-notify.org/astros.json';
-  const data = await safeFetch<{ number?: number; people?: { name: string }[] }>(url);
-  const n = data?.number ?? 0;
-  const value = Number(normalizeDirect(n, 0, 12).toFixed(3));
+  const url = 'http://www.howmanypeopleareinspacerightnow.com/peopleinspace.json';
+  const meta = await safeFetchWithMeta<{ number?: number; people?: { name?: string }[] }>(url, 6000);
+  if (!meta.ok || meta.data == null) {
+    console.warn('[micro] ECHO-µ4 people-in-space:', meta.error ?? 'no body');
+    return wrap('ECHO-µ4', {
+      agentName: 'ECHO-µ4',
+      source: 'People In Space API · crew count',
+      timestamp: new Date().toISOString(),
+      value: 0.35,
+      label: `People in space feed unavailable (${meta.error ?? 'unknown'})`,
+      severity: 'watch',
+      raw: { http: meta.status },
+    });
+  }
+  const data = meta.data;
+  const n =
+    typeof data.number === 'number' && Number.isFinite(data.number)
+      ? Math.max(0, Math.floor(data.number))
+      : Array.isArray(data.people)
+        ? data.people.length
+        : 0;
+  const value = n > 0 ? 0.85 : 0.3;
+  const label =
+    n > 0
+      ? `People in space (live feed): ${n}`
+      : 'People in space (live feed): 0 — nominal empty window';
   return wrap('ECHO-µ4', {
     agentName: 'ECHO-µ4',
-    source: 'Open Notify · ISS crew',
+    source: 'People In Space API · crew count',
     timestamp: new Date().toISOString(),
-    value,
-    label: `People in space right now: ${n}`,
+    value: Number(value.toFixed(3)),
+    label,
     severity: 'nominal',
-    raw: { sample: data?.people?.slice(0, 3).map((p) => p.name) },
+    raw: { count: n, sample: data.people?.slice(0, 3).map((p) => p.name) },
   });
 }
 

--- a/lib/echo/kv-persist-ingest.ts
+++ b/lib/echo/kv-persist-ingest.ts
@@ -8,6 +8,7 @@ import type { IngestResult } from '@/lib/echo/transform';
 import type { IntegrityRating } from '@/lib/echo/integrity-engine';
 import { getEchoStatus } from '@/lib/echo/store';
 import { saveEchoState, loadGIState, kvSet, KV_KEYS, KV_TTL_SECONDS } from '@/lib/kv/store';
+import { recordReplayPressureFromIngest } from '@/lib/mic/replayPressure';
 import { readMiiFeed, type MiiEntry } from '@/lib/kv/mii';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 
@@ -121,6 +122,7 @@ async function writeMiiFeedBatch(entries: MiiEntry[]): Promise<void> {
  */
 export async function persistEchoIngestSideEffects(result: IngestResult): Promise<void> {
   const status = getEchoStatus();
+  void recordReplayPressureFromIngest(result.duplicateSuppressedCount).catch(() => {});
   const dedupDenominator = Math.max(1, status.totalIngested + status.duplicateSuppressedCount);
   const dedupRate = Number((status.duplicateSuppressedCount / dedupDenominator).toFixed(3));
   await Promise.all([

--- a/lib/integrity/buildStatus.ts
+++ b/lib/integrity/buildStatus.ts
@@ -152,6 +152,7 @@ export async function computeIntegrityPayload(): Promise<IntegrityPayload> {
       terminal_status: computed.terminal_status,
       primary_driver: driver,
       source,
+      gi_write_source: 'integrity',
       signals: computed.signals,
       timestamp: computed.timestamp,
     };
@@ -218,6 +219,7 @@ export async function recomputeAndSaveGIState(): Promise<GIState | null> {
     terminal_status: computed.terminal_status,
     primary_driver: driver,
     source,
+    gi_write_source: 'integrity',
     signals: computed.signals,
     timestamp: computed.timestamp,
   };

--- a/lib/integrity/resolveGi.ts
+++ b/lib/integrity/resolveGi.ts
@@ -59,7 +59,9 @@ export async function resolveGiForTerminal(opts?: {
   const st = await loadGIState();
   if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
     const age = Date.now() - new Date(st.timestamp).getTime();
-    if (age < 15 * 60 * 1000) {
+    const maxAgeMs =
+      st.gi_write_source === 'micro_sweep' ? 2 * 60 * 1000 : 15 * 60 * 1000;
+    if (age < maxAgeMs) {
       return {
         gi: Math.max(0, Math.min(1, st.global_integrity)),
         mode: st.mode ?? null,

--- a/lib/kv/backup-redis.ts
+++ b/lib/kv/backup-redis.ts
@@ -12,13 +12,20 @@ import Redis from 'ioredis';
 let _backup: Redis | null | undefined;
 
 export function backupMirrorEnabled(): boolean {
+  if (!process.env.REDIS_URL?.trim()) return false;
   const v = process.env.MOBIUS_KV_BACKUP_MIRROR?.trim().toLowerCase();
-  return v === '1' || v === 'true' || v === 'yes';
+  if (v === '0' || v === 'false' || v === 'no') return false;
+  if (v === '1' || v === 'true' || v === 'yes') return true;
+  // C-286 close: when `REDIS_URL` is set, mirror successful writes by default (opt-out via explicit false).
+  return true;
 }
 
 export function backupReadFallbackEnabled(): boolean {
+  if (!process.env.REDIS_URL?.trim()) return false;
   const v = process.env.MOBIUS_KV_READ_FALLBACK?.trim().toLowerCase();
-  return v === '1' || v === 'true' || v === 'yes';
+  if (v === '0' || v === 'false' || v === 'no') return false;
+  if (v === '1' || v === 'true' || v === 'yes') return true;
+  return true;
 }
 
 function getBackupClient(): Redis | null {

--- a/lib/kv/kv-ttl.ts
+++ b/lib/kv/kv-ttl.ts
@@ -12,6 +12,10 @@ export const KV_TTL_SECONDS = {
   GI_STATE: 14_400,
   /** MIC readiness snapshot from upstream */
   MIC_READINESS_SNAPSHOT: 14_400,
+  /** Consecutive GI ≥ threshold cycles (Fountain sustain) */
+  MIC_SUSTAIN_STATE: 604_800,
+  /** Decayed replay pressure from ECHO duplicate suppression */
+  MIC_REPLAY_PRESSURE: 1_209_600,
   /** Agent fleet heartbeat (cron every 5m; TTL 3× interval) */
   HEARTBEAT: 900,
 } as const;

--- a/lib/kv/store.ts
+++ b/lib/kv/store.ts
@@ -18,8 +18,9 @@
  *
  * Optional secondary Redis (TCP `redis://` or `rediss://`):
  *   REDIS_URL — classic Redis URL; health-checked via `/api/kv/health` as `backup_redis`
- *   MOBIUS_KV_BACKUP_MIRROR — mirror successful `kvSet` / `kvSetRawKey` / vault raw writes
- *   MOBIUS_KV_READ_FALLBACK — read from backup when primary GET misses or errors
+ *   MOBIUS_KV_BACKUP_MIRROR — mirror successful `kvSet` / `kvSetRawKey` / vault raw writes (when `REDIS_URL` set,
+ *     defaults to enabled unless explicitly `false`)
+ *   MOBIUS_KV_READ_FALLBACK — read from backup when primary GET misses or errors (defaults on when `REDIS_URL` set)
  *
  *   OAA KV bridge (C-286) — warm tier on Render when Upstash hits monthly limits:
  *   OAA_API_BASE_URL (or OAA_API_BASE / NEXT_PUBLIC_OAA_API_URL) + KV_BRIDGE_SECRET
@@ -30,6 +31,7 @@
  */
 
 import { Redis } from '@upstash/redis';
+import { getGiMode } from '@/lib/gi/mode';
 import {
   backupPrefixedGet,
   backupRawGet,
@@ -384,6 +386,10 @@ export const KV_KEYS = {
   SYSTEM_PULSE: 'system:pulse',
   /** Short-circuit hot ledger API after repeated timeouts (C-286) */
   LEDGER_CIRCUIT_OPEN: 'ledger:circuit_open',
+  /** MIC sustain cycle counter (C-287) */
+  MIC_SUSTAIN_STATE: 'mic:sustain:state',
+  /** MIC replay pressure envelope — ingest duplicate bumps, time-decayed (C-287) */
+  MIC_REPLAY_PRESSURE: 'mic:replay:pressure',
 } as const;
 
 // ── Signal snapshot persistence ──────────────────────────────
@@ -427,6 +433,8 @@ export type GIState = {
   terminal_status: string;
   primary_driver: string;
   source: 'live' | 'mock' | 'cached';
+  /** When set to `micro_sweep`, shorter KV freshness window applies in `resolveGiForTerminal`. */
+  gi_write_source?: 'micro_sweep' | 'integrity';
   signals: {
     quality: number;
     freshness: number;
@@ -442,6 +450,40 @@ export type GIState = {
 export async function saveGIState(state: GIState): Promise<void> {
   await kvSet(KV_KEYS.GI_STATE, state, KV_TTL_SECONDS.GI_STATE);
   await kvSet(KV_KEYS.GI_STATE_CARRY, state, 604800);
+}
+
+/**
+ * After micro-agent sweep: align `GI_STATE.global_integrity` with composite so MIC readiness
+ * and KV-backed surfaces are not 5–15 minutes behind live sweep (C-286 close).
+ * Preserves non-quality signal dimensions from the last full integrity row when present.
+ */
+export async function saveGiStateFromMicroSweep(args: {
+  composite: number;
+  signalQuality: number;
+}): Promise<void> {
+  const gi = Math.max(0, Math.min(1, args.composite));
+  const mode = getGiMode(gi);
+  const terminal_status: GIState['terminal_status'] =
+    mode === 'green' ? 'nominal' : mode === 'yellow' ? 'stressed' : 'critical';
+  const prev = await loadGIState();
+  const q = Math.max(0, Math.min(1, args.signalQuality));
+  const state: GIState = {
+    global_integrity: Number(gi.toFixed(3)),
+    mode,
+    terminal_status,
+    primary_driver:
+      'GI global_integrity aligned to micro-sensor composite after sweep (freshness/stability from last full pass)',
+    source: 'live',
+    gi_write_source: 'micro_sweep',
+    signals: {
+      quality: Number(q.toFixed(3)),
+      freshness: prev?.signals.freshness ?? 0.5,
+      stability: prev?.signals.stability ?? 0.5,
+      system: prev?.signals.system ?? 0.5,
+    },
+    timestamp: new Date().toISOString(),
+  };
+  await saveGIState(state);
 }
 
 /**

--- a/lib/mic/assembleMicReadiness.ts
+++ b/lib/mic/assembleMicReadiness.ts
@@ -5,6 +5,8 @@ import { mergeMicReadinessFromUpstream } from '@/lib/mic/readinessMerge';
 import type { MicReadinessResponse } from '@/lib/mic/types';
 import { withHash } from '@/lib/mic/hash';
 import { kvGet, KV_KEYS } from '@/lib/kv/store';
+import { loadSustainState } from '@/lib/mic/sustainTracker';
+import { resolveReplayPressureWithDecay } from '@/lib/mic/replayPressure';
 import { computeVaultSealLaneSemantics } from '@/lib/vault/lane-status';
 import { getVaultStatusPayload, listVaultDeposits } from '@/lib/vault/vault';
 import { countSeals, getCandidate, getInProgressBalance, getLatestSeal } from '@/lib/vault-v2/store';
@@ -94,10 +96,27 @@ export async function assembleLocalMicReadiness(cycleParam?: string | null): Pro
   const resolvedGi = await resolveGiForTerminal({ micReadinessSnapshotRaw: micSnapRaw });
   const vaultStatus = await getVaultStatusShape(resolvedGi.gi);
   const deposits = await listVaultDeposits(120);
+  const [sustainState, replayResolved] = await Promise.all([
+    loadSustainState(),
+    (async () => {
+      const seen = new Set<string>();
+      let repeats = 0;
+      for (const d of deposits) {
+        if (seen.has(d.content_signature)) repeats += 1;
+        seen.add(d.content_signature);
+      }
+      const ratio = deposits.length > 0 ? repeats / deposits.length : 0;
+      return resolveReplayPressureWithDecay(ratio);
+    })(),
+  ]);
   const base = buildMicReadinessV1({
     vaultStatus,
     depositsSample: deposits,
     cycle: cycle || undefined,
+    sustainState,
+    replayPressure: replayResolved.replayPressure,
+    replayStatus: replayResolved.status,
+    replay_decay_half_life_hours: replayResolved.replay_decay_half_life_hours,
   });
   return {
     ...base,

--- a/lib/mic/readinessMerge.ts
+++ b/lib/mic/readinessMerge.ts
@@ -23,7 +23,11 @@ export function mergeMicReadinessFromUpstream(
           inProgressBalance: local.reserve.inProgressBalance,
         }
       : local.reserve,
-    sustain: incoming.sustain ? { ...local.sustain, ...incoming.sustain } : local.sustain,
+    sustain: incoming.sustain
+      ? local.sustain.sustain_tracking_placeholder
+        ? { ...local.sustain, ...incoming.sustain }
+        : { ...incoming.sustain, ...local.sustain }
+      : local.sustain,
     replay: incoming.replay ? { ...local.replay, ...incoming.replay } : local.replay,
     novelty: incoming.novelty ? { ...local.novelty, ...incoming.novelty } : local.novelty,
     quorum: incoming.quorum ? { ...local.quorum, ...incoming.quorum } : local.quorum,

--- a/lib/mic/replayPressure.ts
+++ b/lib/mic/replayPressure.ts
@@ -1,0 +1,92 @@
+/**
+ * C-287 — replay pressure: ingest-time duplicate bumps (KV, time-decayed) + deposit-window ratio (ephemeral).
+ */
+
+import { kvGet, kvSet, KV_KEYS, KV_TTL_SECONDS } from '@/lib/kv/store';
+import type { MicReplayStatus } from '@/lib/mic/types';
+
+const REPLAY_HALF_LIFE_HOURS = 24;
+const PER_DUPLICATE_SUPPRESSED = 0.005;
+const INGEST_BATCH_CAP = 0.3;
+const DEPOSIT_RATIO_WEIGHT = 0.45;
+
+export type ReplayPressureKvV1 = {
+  schema: 'MIC_REPLAY_PRESSURE_V1';
+  /** Accumulated pressure from ECHO duplicate suppression (decayed by time). */
+  ingestPressure: number;
+  lastUpdatedAt: string;
+};
+
+type LegacyReplayKv = {
+  schema?: string;
+  decayedPressure?: number;
+  lastUpdatedAt?: string;
+};
+
+function statusFromPressure(p: number): MicReplayStatus {
+  if (p >= 0.35) return 'blocked';
+  if (p >= 0.15) return 'elevated';
+  return 'clear';
+}
+
+function decayValue(prev: number, lastIso: string, nowMs: number): number {
+  const last = new Date(lastIso).getTime();
+  if (!Number.isFinite(last)) return prev;
+  const hoursElapsed = Math.max(0, (nowMs - last) / (1000 * 60 * 60));
+  const decayFactor = Math.pow(0.5, hoursElapsed / REPLAY_HALF_LIFE_HOURS);
+  return prev * decayFactor;
+}
+
+async function loadEnvelope(): Promise<{ ingestPressure: number; lastUpdatedAt: string }> {
+  const raw = await kvGet<ReplayPressureKvV1 | LegacyReplayKv>(KV_KEYS.MIC_REPLAY_PRESSURE);
+  const now = new Date().toISOString();
+  if (!raw || typeof raw !== 'object') {
+    return { ingestPressure: 0, lastUpdatedAt: now };
+  }
+  if ('ingestPressure' in raw && typeof raw.ingestPressure === 'number' && Number.isFinite(raw.ingestPressure)) {
+    return { ingestPressure: raw.ingestPressure, lastUpdatedAt: raw.lastUpdatedAt ?? now };
+  }
+  if ('decayedPressure' in raw && typeof raw.decayedPressure === 'number' && Number.isFinite(raw.decayedPressure)) {
+    return { ingestPressure: raw.decayedPressure, lastUpdatedAt: raw.lastUpdatedAt ?? now };
+  }
+  return { ingestPressure: 0, lastUpdatedAt: now };
+}
+
+/**
+ * ECHO ingest: bump ingest-side pressure from duplicate suppressions (bounded per batch).
+ */
+export async function recordReplayPressureFromIngest(duplicateSuppressedCount: number): Promise<void> {
+  const dups = Math.max(0, Math.floor(duplicateSuppressedCount));
+  if (dups === 0) return;
+
+  const nowMs = Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const { ingestPressure, lastUpdatedAt } = await loadEnvelope();
+  const decayed = decayValue(ingestPressure, lastUpdatedAt, nowMs);
+  const bump = Math.min(dups * PER_DUPLICATE_SUPPRESSED, INGEST_BATCH_CAP);
+  const next: ReplayPressureKvV1 = {
+    schema: 'MIC_REPLAY_PRESSURE_V1',
+    ingestPressure: Number(Math.min(decayed + bump, 1).toFixed(4)),
+    lastUpdatedAt: nowIso,
+  };
+  await kvSet(KV_KEYS.MIC_REPLAY_PRESSURE, next, KV_TTL_SECONDS.MIC_REPLAY_PRESSURE);
+}
+
+/**
+ * MIC readiness: decayed ingest pressure + current deposit-list replay ratio (read-only merge).
+ */
+export async function resolveReplayPressureWithDecay(
+  depositSampleRatio: number,
+): Promise<{ replayPressure: number; status: MicReplayStatus; replay_decay_half_life_hours: number }> {
+  const ratio = Number.isFinite(depositSampleRatio) ? Math.max(0, Math.min(1, depositSampleRatio)) : 0;
+  const nowMs = Date.now();
+  const { ingestPressure, lastUpdatedAt } = await loadEnvelope();
+  const decayedIngest = decayValue(ingestPressure, lastUpdatedAt, nowMs);
+  const fromDeposits = ratio * DEPOSIT_RATIO_WEIGHT;
+  const total = Number(Math.min(decayedIngest + fromDeposits, 1).toFixed(4));
+  return {
+    replayPressure: total,
+    status: statusFromPressure(total),
+    replay_decay_half_life_hours: REPLAY_HALF_LIFE_HOURS,
+  };
+}

--- a/lib/mic/runtime-readiness.ts
+++ b/lib/mic/runtime-readiness.ts
@@ -5,7 +5,15 @@
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { VAULT_RESERVE_PARCEL_UNITS } from '@/lib/vault-v2/constants';
 import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
-import type { MicReadinessResponse, MicMintReadiness, MicNoveltyStatus, MicQuorumStatus, MicReplayStatus } from '@/lib/mic/types';
+import type {
+  MicReadinessResponse,
+  MicMintReadiness,
+  MicNoveltyStatus,
+  MicQuorumStatus,
+  MicReplayStatus,
+  MicSustainStatus,
+} from '@/lib/mic/types';
+import type { MicSustainStateV1 } from '@/lib/mic/sustainTracker';
 
 export type VaultStatusJson = {
   balance_reserve?: number;
@@ -129,6 +137,10 @@ export function buildMicReadinessV1(args: {
   vaultStatus: VaultStatusJson;
   depositsSample: { content_signature: string; journal_score?: number }[];
   cycle?: string;
+  sustainState?: MicSustainStateV1 | null;
+  replayPressure?: number;
+  replayStatus?: MicReplayStatus;
+  replay_decay_half_life_hours?: number;
 }): MicReadinessResponse {
   const v = args.vaultStatus;
   const cycle = args.cycle?.trim() || currentCycleId();
@@ -137,17 +149,44 @@ export function buildMicReadinessV1(args: {
   const trancheTarget = v.activation_threshold ?? VAULT_RESERVE_PARCEL_UNITS;
   const inProgress = v.in_progress_balance ?? 0;
   const sealed = v.sealed_reserve_total ?? 0;
-  const sustainPlaceholder = true;
   const sustainMet = Boolean(v.sustain_cycles_met);
   const requiredSustain = v.sustain_cycles_required ?? 5;
+  const st = args.sustainState;
+  const consecutiveFromKv =
+    st && typeof st.consecutiveEligibleCycles === 'number' && Number.isFinite(st.consecutiveEligibleCycles)
+      ? Math.max(0, Math.floor(st.consecutiveEligibleCycles))
+      : 0;
+  const sustainPlaceholder = !st;
+  let sustainStatus: MicSustainStatus = 'not_started';
+  if (sustainMet) sustainStatus = 'satisfied';
+  else if (consecutiveFromKv >= requiredSustain) sustainStatus = 'satisfied';
+  else if (consecutiveFromKv > 0) sustainStatus = 'in_progress';
+
+  const displayConsecutive = sustainMet
+    ? requiredSustain
+    : sustainPlaceholder
+      ? 0
+      : Math.min(consecutiveFromKv, requiredSustain);
+
   const sustain: MicReadinessResponse['sustain'] = {
-    consecutiveEligibleCycles: sustainPlaceholder ? 0 : sustainMet ? requiredSustain : 0,
+    consecutiveEligibleCycles: displayConsecutive,
     requiredCycles: requiredSustain,
-    status: sustainPlaceholder ? 'not_started' : sustainMet ? 'satisfied' : 'in_progress',
+    status: sustainPlaceholder ? 'not_started' : sustainStatus,
     sustain_tracking_placeholder: sustainPlaceholder,
+    lastEligibleCycle: st?.lastEligibleCycle ?? null,
+    lastCheckedCycle: st?.lastCheckedCycle ?? null,
   };
 
-  const { pressure, status: replayStatus } = replayFromDeposits(args.depositsSample);
+  const depositReplay = replayFromDeposits(args.depositsSample);
+  const pressure =
+    typeof args.replayPressure === 'number' && Number.isFinite(args.replayPressure)
+      ? args.replayPressure
+      : depositReplay.pressure;
+  const replayStatus =
+    args.replayStatus ??
+    (typeof args.replayPressure === 'number' && Number.isFinite(args.replayPressure)
+      ? (pressure >= 0.35 ? 'blocked' : pressure >= 0.15 ? 'elevated' : 'clear')
+      : depositReplay.status);
   const { score: noveltyScore, status: noveltyStatus } = noveltyFromDeposits(args.depositsSample);
   const fountainLane = v.fountain_status ?? 'locked';
   const fountain = { ...fountainTriplet(fountainLane), lane: fountainLane };
@@ -167,7 +206,13 @@ export function buildMicReadinessV1(args: {
       balanceReserveV1: v.balance_reserve ?? 0,
     },
     sustain,
-    replay: { replayPressure: pressure, status: replayStatus },
+    replay: {
+      replayPressure: pressure,
+      status: replayStatus,
+      ...(typeof args.replay_decay_half_life_hours === 'number'
+        ? { replay_decay_half_life_hours: args.replay_decay_half_life_hours }
+        : {}),
+    },
     novelty: { noveltyScore, status: noveltyStatus },
     quorum,
     fountain,

--- a/lib/mic/sustainTracker.ts
+++ b/lib/mic/sustainTracker.ts
@@ -1,0 +1,81 @@
+/**
+ * C-287 — consecutive GI ≥ threshold cycles for Fountain sustain gate (KV-backed).
+ */
+
+import { currentCycleId } from '@/lib/eve/cycle-engine';
+import { kvGet, kvSet, KV_KEYS, KV_TTL_SECONDS } from '@/lib/kv/store';
+
+export const SUSTAIN_GI_THRESHOLD = 0.95;
+export const SUSTAIN_REQUIRED_CYCLES = 5;
+
+import type { MicSustainStatus } from '@/lib/mic/types';
+
+export interface MicSustainStateV1 {
+  schema: 'MIC_SUSTAIN_STATE_V1';
+  consecutiveEligibleCycles: number;
+  lastEligibleCycle: string | null;
+  lastCheckedCycle: string;
+  status: MicSustainStatus;
+  updatedAt: string;
+}
+
+function defaultState(cycle: string): MicSustainStateV1 {
+  const now = new Date().toISOString();
+  return {
+    schema: 'MIC_SUSTAIN_STATE_V1',
+    consecutiveEligibleCycles: 0,
+    lastEligibleCycle: null,
+    lastCheckedCycle: cycle,
+    status: 'not_started',
+    updatedAt: now,
+  };
+}
+
+function deriveStatus(consecutive: number): MicSustainStatus {
+  if (consecutive >= SUSTAIN_REQUIRED_CYCLES) return 'satisfied';
+  if (consecutive > 0) return 'in_progress';
+  return 'not_started';
+}
+
+/**
+ * Advance sustain counter once per operator cycle when GI is known.
+ * Idempotent: same `currentCycle` returns stored state without double-counting.
+ */
+export async function updateSustainTrackingFromGi(
+  currentGi: number | null,
+  currentCycle?: string,
+): Promise<MicSustainStateV1 | null> {
+  const cycle = (currentCycle ?? currentCycleId()).trim();
+  if (!cycle) return null;
+
+  if (currentGi === null || !Number.isFinite(currentGi)) {
+    return null;
+  }
+
+  const gi = Math.max(0, Math.min(1, currentGi));
+  const prev = (await kvGet<MicSustainStateV1>(KV_KEYS.MIC_SUSTAIN_STATE)) ?? defaultState(cycle);
+
+  if (prev.lastCheckedCycle === cycle) {
+    return prev;
+  }
+
+  const eligible = gi >= SUSTAIN_GI_THRESHOLD;
+  const consecutive = eligible ? prev.consecutiveEligibleCycles + 1 : 0;
+  const status = deriveStatus(consecutive);
+
+  const next: MicSustainStateV1 = {
+    schema: 'MIC_SUSTAIN_STATE_V1',
+    consecutiveEligibleCycles: consecutive,
+    lastEligibleCycle: eligible ? cycle : prev.lastEligibleCycle,
+    lastCheckedCycle: cycle,
+    status,
+    updatedAt: new Date().toISOString(),
+  };
+
+  await kvSet(KV_KEYS.MIC_SUSTAIN_STATE, next, KV_TTL_SECONDS.MIC_SUSTAIN_STATE);
+  return next;
+}
+
+export async function loadSustainState(): Promise<MicSustainStateV1 | null> {
+  return kvGet<MicSustainStateV1>(KV_KEYS.MIC_SUSTAIN_STATE);
+}

--- a/lib/mic/types.ts
+++ b/lib/mic/types.ts
@@ -47,11 +47,15 @@ export interface MicReadinessResponse {
     requiredCycles: number;
     status: MicSustainStatus;
     sustain_tracking_placeholder: boolean;
+    lastEligibleCycle?: string | null;
+    lastCheckedCycle?: string | null;
   };
 
   replay: {
     replayPressure: number;
     status: MicReplayStatus;
+    /** Hours for half-life decay of ingest-side duplicate pressure (when KV-backed). */
+    replay_decay_half_life_hours?: number;
   };
 
   novelty: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the C-286 close audit: replace two micro-instruments that produced structural zeros, align `GI_STATE` KV with the live micro-sweep composite immediately after each sweep, implement real sustain-cycle tracking and time-decayed replay pressure in KV, and default-enable backup Redis mirror + read fallback when `REDIS_URL` is configured.

## Changes

### O1 — Zombie instruments
- **ECHO-µ4:** Open Notify → `howmanypeopleareinspacerightnow.com/peopleinspace.json` (0.85 if crew &gt; 0, else 0.3 nominal empty; watch on fetch failure).
- **JADE-µ4:** Fixed OL author → Open Library `search/authors.json?q=governance+civic` with scored `numFound`.

### O2 — GI staleness
- `saveGiStateFromMicroSweep()` writes `GI_STATE` / carry after each successful `/api/signals/micro` sweep (`global_integrity` = composite, `gi_write_source: micro_sweep`).
- `resolveGiForTerminal` treats `micro_sweep` rows as fresh for **2 minutes** (vs 15m for full integrity rows) so MIC readiness / KV consumers track sweep cadence.

### O3 — Sustain tracking
- New `lib/mic/sustainTracker.ts` + `KV_KEYS.MIC_SUSTAIN_STATE` / TTL.
- `updateSustainTrackingFromGi(composite)` runs after each micro sweep (same GI used for proof alignment).
- `buildMicReadinessV1` reads KV sustain; placeholder only when key missing. Upstream merge preserves local sustain when tracking is live.

### O4 — Replay pressure decay
- New `lib/mic/replayPressure.ts`: ingest duplicate bumps stored in `KV_KEYS.MIC_REPLAY_PRESSURE` with **24h half-life**; readiness merges **decayed ingest pressure** + **0.45 × deposit duplicate ratio** (read-only on readiness path).
- `persistEchoIngestSideEffects` calls `recordReplayPressureFromIngest` on each ingest.

### O5 — Backup Redis
- When `REDIS_URL` is set, `MOBIUS_KV_BACKUP_MIRROR` and `MOBIUS_KV_READ_FALLBACK` default to **enabled** unless explicitly `false`/`0`/`no`.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm build`

## Lint

ESLint not configured in repo (`pnpm lint` not run as canonical pass).

## Notes

- People-in-space endpoint is **HTTP**; Vercel serverless fetch must allow outbound HTTP to that host.
- Sustain counter advances on **micro-sweep composite** (not ECHO-only `recomputeAndSaveGIState`) so it matches the GI written to KV for MIC readiness.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

