### PR TITLE
feat(C-287): read resilience — Verified Memory Mode, heartbeat dual-write, GI fallback chain

### DIFF
--- a/app/api/integrity-status/route.ts
+++ b/app/api/integrity-status/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { computeIntegrityPayload } from '@/lib/integrity/buildStatus';
 import { getEchoIntegrity } from '@/lib/echo/store';
+import { resolveGiChain } from '@/lib/gi/resolveGiChain';
+import { loadMicReadinessSnapshotRaw } from '@/lib/mic/loadReadinessSnapshot';
 
 export const dynamic = 'force-dynamic';
 
@@ -45,6 +47,24 @@ function buildAuthority(payload: Awaited<ReturnType<typeof computeIntegrityPaylo
 
 export async function GET() {
   const payload = await computeIntegrityPayload();
+  const micRaw = await loadMicReadinessSnapshotRaw();
+  const chain = await resolveGiChain({ micReadinessSnapshotRaw: micRaw.raw });
+  const mergedPayload = {
+    ...payload,
+    ...(chain.gi !== null
+      ? {
+          global_integrity: chain.gi,
+          mode: (chain.mode as typeof payload.mode) ?? payload.mode,
+          terminal_status: (chain.terminal_status as typeof payload.terminal_status) ?? payload.terminal_status,
+          timestamp: chain.timestamp ?? payload.timestamp,
+        }
+      : {}),
+    gi_provenance: chain.source,
+    gi_verified: chain.verified,
+    gi_degraded: chain.degraded,
+    gi_age_seconds: chain.age_seconds,
+    mic_readiness_snapshot_source: micRaw.source,
+  };
   const renderGicUrl = process.env.RENDER_GIC_URL;
 
   if (!renderGicUrl) {
@@ -52,7 +72,7 @@ export async function GET() {
     return NextResponse.json({
       ok: true as const,
       degraded: true,
-      ...payload,
+      ...mergedPayload,
       ...mic,
       authority: buildAuthority(payload, false, false),
     });
@@ -66,8 +86,8 @@ export async function GET() {
         Accept: 'application/json',
       },
       body: JSON.stringify({
-        signals: payload.signals,
-        cycle: payload.cycle,
+        signals: mergedPayload.signals,
+        cycle: mergedPayload.cycle,
       }),
       signal: AbortSignal.timeout(5000),
       cache: 'no-store',
@@ -79,7 +99,7 @@ export async function GET() {
       return NextResponse.json({
         ok: true as const,
         degraded: true,
-        ...payload,
+        ...mergedPayload,
         ...mic,
         authority: buildAuthority(payload, true, false),
       });
@@ -97,16 +117,16 @@ export async function GET() {
         ? remote.global_integrity
         : typeof remote.gi === 'number'
           ? remote.gi
-          : payload.global_integrity;
+          : mergedPayload.global_integrity;
 
     const mic = echoMicProvisional();
     return NextResponse.json({
       ok: true as const,
-      ...payload,
+      ...mergedPayload,
       ...mic,
       global_integrity: computedGi,
-      mode: remote.mode ?? payload.mode,
-      summary: remote.summary ?? payload.summary,
+      mode: remote.mode ?? mergedPayload.mode,
+      summary: remote.summary ?? mergedPayload.summary,
       source: 'gic-indexer',
       degraded: false,
       authority: buildAuthority(payload, true, true),
@@ -117,7 +137,7 @@ export async function GET() {
     return NextResponse.json({
       ok: true as const,
       degraded: true,
-      ...payload,
+      ...mergedPayload,
       ...mic,
       authority: buildAuthority(payload, true, false),
     });

--- a/app/api/mic/readiness/route.ts
+++ b/app/api/mic/readiness/route.ts
@@ -10,7 +10,9 @@ import { resolveGiForTerminal } from '@/lib/integrity/resolveGi';
 import { assembleLocalMicReadiness, getMergedMicReadiness, resolveReadinessCycle } from '@/lib/mic/assembleMicReadiness';
 import { mergeMicReadinessFromUpstream } from '@/lib/mic/readinessMerge';
 import type { MicReadinessResponse } from '@/lib/mic/types';
+import { loadMicReadinessSnapshotRaw } from '@/lib/mic/loadReadinessSnapshot';
 import { kvSet, kvLpushCapped, KV_KEYS, kvGet, KV_TTL_SECONDS } from '@/lib/kv/store';
+import { scheduleKvBridgeDualWrite } from '@/lib/kv/kvBridgeClient';
 
 export const dynamic = 'force-dynamic';
 
@@ -27,7 +29,7 @@ function micReadinessPostAuth(req: NextRequest): boolean {
 
 export async function GET(req: NextRequest) {
   const cycleParam = req.nextUrl.searchParams.get('cycle')?.trim();
-  const micSnapRaw = await kvGet<string>(KV_KEYS.MIC_READINESS_SNAPSHOT);
+  const { raw: micSnapRaw, source: micSnapSource } = await loadMicReadinessSnapshotRaw();
   const giMeta = await resolveGiForTerminal({ micReadinessSnapshotRaw: micSnapRaw });
   const readiness = await getMergedMicReadiness(cycleParam);
 
@@ -37,7 +39,12 @@ export async function GET(req: NextRequest) {
       gi: giMeta.gi ?? readiness.gi,
       gi_resolution: {
         source: giMeta.source,
+        provenance: giMeta.gi_provenance,
+        verified: giMeta.verified,
+        degraded: giMeta.degraded,
+        age_seconds: giMeta.age_seconds,
         timestamp: giMeta.timestamp,
+        mic_readiness_snapshot_source: micSnapSource,
       },
     },
     {
@@ -85,8 +92,15 @@ export async function POST(req: NextRequest) {
     source: 'tokenomics-engine',
   };
 
-  await kvSet(KV_KEYS.MIC_READINESS_SNAPSHOT, JSON.stringify(snapshot), KV_TTL_SECONDS.MIC_READINESS_SNAPSHOT);
-  await kvLpushCapped(KV_KEYS.MIC_READINESS_FEED, JSON.stringify(snapshot), 100);
+  const snapStr = JSON.stringify(snapshot);
+  await kvSet(KV_KEYS.MIC_READINESS_SNAPSHOT, snapStr, KV_TTL_SECONDS.MIC_READINESS_SNAPSHOT);
+  scheduleKvBridgeDualWrite(
+    'MIC_READINESS_SNAPSHOT',
+    snapshot as unknown,
+    KV_TTL_SECONDS.MIC_READINESS_SNAPSHOT,
+    'mic-readiness-dual-write',
+  );
+  await kvLpushCapped(KV_KEYS.MIC_READINESS_FEED, snapStr, 100);
 
   return NextResponse.json({ ok: true, received_at: snapshot.received_at });
 }

--- a/app/api/terminal/snapshot-lite/route.ts
+++ b/app/api/terminal/snapshot-lite/route.ts
@@ -13,6 +13,7 @@ import {
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { getHeartbeat, getJournalHeartbeat } from '@/lib/runtime/heartbeat';
 import { resolveGiForTerminal } from '@/lib/integrity/resolveGi';
+import { loadMicReadinessSnapshotRaw } from '@/lib/mic/loadReadinessSnapshot';
 
 export const dynamic = 'force-dynamic';
 
@@ -51,14 +52,15 @@ export async function GET(req: NextRequest) {
   const start = Date.now();
   const cors = handbookCorsHeaders(req.headers.get('origin'));
 
-  const [kv, micSnapRaw, signals, echo, tripwire, pulse] = await Promise.all([
+  const [kv, micSnap, signals, echo, tripwire, pulse] = await Promise.all([
     kvHealth(),
-    kvGet<string>(KV_KEYS.MIC_READINESS_SNAPSHOT),
+    loadMicReadinessSnapshotRaw(),
     loadSignalSnapshot(),
     loadEchoState(),
     loadTripwireState(),
     kvGet<SystemPulse>(KV_KEYS.SYSTEM_PULSE),
   ]);
+  const micSnapRaw = micSnap.raw;
   const giResolved = await resolveGiForTerminal({ micReadinessSnapshotRaw: micSnapRaw });
   const gi =
     giResolved.source === 'kv'
@@ -91,17 +93,31 @@ export async function GET(req: NextRequest) {
 
   const lanes = {
     kv: { ok: kv.available, latency_ms: kv.latencyMs },
+    backup_redis: {
+      configured: kv.backup_redis.configured,
+      available: kv.backup_redis.available,
+      mirror_enabled: kv.backup_redis.mirror_enabled,
+      read_fallback_enabled: kv.backup_redis.read_fallback_enabled,
+      latency_ms: kv.backup_redis.latency_ms,
+    },
     integrity: {
       ok: giResolved.gi !== null,
       gi: giResolved.gi ?? gi?.global_integrity ?? null,
       mode: (giResolved.mode as string | null) ?? gi?.mode ?? null,
       terminal_status: giResolved.terminal_status ?? gi?.terminal_status ?? null,
       source:
-        giResolved.source === 'kv' || giResolved.source === 'kv_carry_forward'
+        giResolved.source === 'kv' ||
+        giResolved.source === 'kv_carry_forward' ||
+        giResolved.source === 'oaa_verified'
           ? 'kv'
-          : giResolved.source === 'readiness_snapshot' || giResolved.source === 'live_compute'
-            ? 'readiness_fallback'
-            : 'null',
+          : giResolved.source === 'live_compute'
+            ? 'live'
+            : giResolved.source === 'readiness_snapshot'
+              ? 'readiness_fallback'
+              : 'null',
+      provenance: giResolved.gi_provenance,
+      verified: giResolved.verified,
+      mic_readiness_snapshot_source: micSnap.source,
       freshness: freshness(giAge),
       age_seconds: giAge,
     },
@@ -137,6 +153,7 @@ export async function GET(req: NextRequest) {
 
   const modeStr = (giResolved.mode as string | null) ?? gi?.mode ?? null;
   const degraded =
+    giResolved.degraded ||
     !lanes.kv.ok ||
     !lanes.integrity.ok ||
     lanes.integrity.freshness === 'degraded' ||
@@ -155,11 +172,17 @@ export async function GET(req: NextRequest) {
     gi: giResolved.gi ?? gi?.global_integrity ?? null,
     mode: modeStr,
     gi_source:
-      giResolved.source === 'kv' || giResolved.source === 'kv_carry_forward'
+      giResolved.source === 'kv' ||
+      giResolved.source === 'kv_carry_forward' ||
+      giResolved.source === 'oaa_verified'
         ? 'kv'
-        : giResolved.source === 'readiness_snapshot' || giResolved.source === 'live_compute'
-          ? 'readiness_fallback'
-          : 'null',
+        : giResolved.source === 'live_compute'
+          ? 'live'
+          : giResolved.source === 'readiness_snapshot'
+            ? 'readiness_fallback'
+            : 'null',
+    gi_provenance: giResolved.gi_provenance,
+    gi_verified: giResolved.verified,
     degraded,
     lanes,
     heartbeat: {

--- a/app/api/terminal/snapshot/route.ts
+++ b/app/api/terminal/snapshot/route.ts
@@ -12,6 +12,7 @@ import { GET as getEve } from '@/app/api/eve/cycle-advance/route';
 import { GET as getMii } from '@/app/api/mii/feed/route';
 import { GET as getVault } from '@/app/api/vault/status/route';
 import { GET as getMicReadiness } from '@/app/api/mic/readiness/route';
+import { GET as getSnapshotLite } from '@/app/api/terminal/snapshot-lite/route';
 import { loadSignalSnapshot, isRedisAvailable } from '@/lib/kv/store';
 import {
   normalizeAllSnapshotLanes,
@@ -88,7 +89,8 @@ export async function GET(request: NextRequest) {
     timedHandler(makeRequest(baseUrl, '/api/mic/readiness'), getMicReadiness),
   ]);
 
-  const [cached, results] = await Promise.all([cachedPromise, lanesPromise]);
+  const litePromise = timedHandler(makeRequest(baseUrl, '/api/terminal/snapshot-lite'), getSnapshotLite);
+  const [cached, results, liteResult] = await Promise.all([cachedPromise, lanesPromise, litePromise]);
 
   let signals: SnapshotLeaf;
   let signalsDuration: number;
@@ -105,8 +107,14 @@ export async function GET(request: NextRequest) {
   const [integrity, kvHealth, agents, epicon, echo, journal, sentiment, runtime, promotion, eve, mii, vault, micReadiness] =
     results;
 
+  const litePayload = liteResult.leaf.data as Record<string, unknown> | null;
+  const lanesLite = litePayload?.lanes as Record<string, unknown> | undefined;
+  const kvLane = lanesLite?.kv as Record<string, unknown> | undefined;
+  const backupRedisLite = lanesLite?.backup_redis as { available?: boolean } | undefined;
+
   const timings: Record<string, number> = {
     signals: signalsDuration,
+    snapshot_lite: liteResult.duration_ms,
     integrity: integrity.duration_ms,
     kvHealth: kvHealth.duration_ms,
     agents: agents.duration_ms,
@@ -183,6 +191,23 @@ export async function GET(request: NextRequest) {
 
   const totalMs = Date.now() - totalStart;
 
+  const memoryMode =
+    litePayload && typeof litePayload === 'object'
+      ? {
+          degraded: Boolean(litePayload.degraded),
+          gi_provenance: typeof litePayload.gi_provenance === 'string' ? litePayload.gi_provenance : null,
+          gi_verified: Boolean(litePayload.gi_verified),
+          gi_source: typeof litePayload.gi_source === 'string' ? litePayload.gi_source : null,
+          gi_age_seconds:
+            typeof (litePayload.lanes as Record<string, unknown> | undefined)?.integrity === 'object'
+              ? ((litePayload.lanes as Record<string, { age_seconds?: number }>).integrity?.age_seconds ?? null)
+              : null,
+          kv_available: kvLane?.ok === true,
+          kv_latency_ms: typeof kvLane?.latency_ms === 'number' ? kvLane.latency_ms : null,
+          backup_redis_available: Boolean(backupRedisLite?.available),
+        }
+      : null;
+
   return NextResponse.json({
     ok: criticalOk && !criticalFail,
     cycle: eveCycle ?? cycle ?? null,
@@ -193,6 +218,7 @@ export async function GET(request: NextRequest) {
       environment: process.env.VERCEL_ENV ?? null,
     },
     meta: { total_ms: totalMs, lane_ms: timings },
+    memory_mode: memoryMode,
     lanes,
     integrity: integrity.leaf, signals, kvHealth: kvHealth.leaf, agents: agents.leaf,
     epicon: epicon.leaf, echo: echo.leaf, journal: journal.leaf, sentiment: sentiment.leaf,

--- a/app/api/vault/status/route.ts
+++ b/app/api/vault/status/route.ts
@@ -16,6 +16,8 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { handbookCorsHeaders } from '@/lib/http/handbook-cors';
 import { loadGIState } from '@/lib/kv/store';
+import { resolveGiForTerminal } from '@/lib/integrity/resolveGi';
+import { loadMicReadinessSnapshotRaw } from '@/lib/mic/loadReadinessSnapshot';
 import { computeVaultSealLaneSemantics } from '@/lib/vault/lane-status';
 import { getVaultDepositHashCoverage, getVaultStatusPayload } from '@/lib/vault/vault';
 import {
@@ -38,10 +40,24 @@ export async function OPTIONS(req: NextRequest) {
 export async function GET(req: NextRequest) {
   const cors = handbookCorsHeaders(req.headers.get('origin'));
   let gi: number | null = null;
+  let gi_provenance: string | null = null;
   try {
     const st = await loadGIState();
     if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
-      gi = Math.max(0, Math.min(1, st.global_integrity));
+      const age = Date.now() - new Date(st.timestamp).getTime();
+      const maxAgeMs = st.gi_write_source === 'micro_sweep' ? 2 * 60 * 1000 : 10 * 60 * 1000;
+      if (age < maxAgeMs) {
+        gi = Math.max(0, Math.min(1, st.global_integrity));
+        gi_provenance = 'kv-live';
+      }
+    }
+    if (gi === null) {
+      const micRaw = await loadMicReadinessSnapshotRaw();
+      const chain = await resolveGiForTerminal({ micReadinessSnapshotRaw: micRaw.raw });
+      if (typeof chain.gi === 'number' && Number.isFinite(chain.gi)) {
+        gi = chain.gi;
+        gi_provenance = chain.gi_provenance;
+      }
     }
   } catch {
     gi = null;
@@ -71,6 +87,7 @@ export async function GET(req: NextRequest) {
 
   const body = {
     ...v1,
+    gi_resolution: gi_provenance ? { provenance: gi_provenance } : undefined,
     in_progress_balance: inProgressBalance,
     sealed_reserve_total: seal_lane.sealed_reserve_total,
     current_tranche_balance: seal_lane.current_tranche_balance,

--- a/components/terminal/DegradedBanner.tsx
+++ b/components/terminal/DegradedBanner.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { GISourceDisplay } from '@/lib/gi/resolveGiChain';
+
+export type MemoryModePayload = {
+  degraded?: boolean;
+  gi_provenance?: GISourceDisplay | string | null;
+  gi_verified?: boolean;
+  gi_source?: string | null;
+  gi_age_seconds?: number | null;
+  kv_available?: boolean;
+  kv_latency_ms?: number | null;
+  backup_redis_available?: boolean;
+};
+
+function formatAge(sec: number | null | undefined): string {
+  if (sec == null || !Number.isFinite(sec)) return 'unknown';
+  if (sec < 120) return `${Math.round(sec)}s`;
+  return `${Math.round(sec / 60)}min`;
+}
+
+function message(m: MemoryModePayload): string {
+  const prov = (m.gi_provenance ?? '') as GISourceDisplay;
+  const kvOk = m.kv_available !== false;
+  const backup = Boolean(m.backup_redis_available);
+
+  if (!kvOk && !backup) {
+    return 'Primary KV unavailable · backup Redis offline · OAA bridge may apply for continuity reads';
+  }
+  if (!kvOk && backup) {
+    return 'Primary KV unavailable · backup Redis active · continuity reads preserved where mirrored';
+  }
+  if (prov === 'oaa-verified') {
+    return 'GI from OAA verified memory (warm tier) · live KV row stale or missing';
+  }
+  if (prov === 'readiness-fallback') {
+    return `GI from readiness cache · age ${formatAge(m.gi_age_seconds)}`;
+  }
+  if (prov === 'kv-carry') {
+    return 'GI from KV carry-forward row · primary gi:latest stale';
+  }
+  if (prov === 'unknown') {
+    return 'GI unavailable from all recorded tiers · operator truth: no estimate';
+  }
+  return 'Terminal operating in degraded read mode · check lane diagnostics';
+}
+
+export function DegradedBanner({ memoryMode }: { memoryMode: MemoryModePayload | null | undefined }) {
+  if (!memoryMode || memoryMode.degraded !== true) return null;
+  return (
+    <div className="border-b border-amber-500/30 bg-amber-950/50 px-3 py-1.5 text-[11px] text-amber-100/95 md:px-4">
+      <span className="mr-2 inline-block h-1.5 w-1.5 rounded-full bg-amber-400 align-middle" aria-hidden />
+      <span className="align-middle">{message(memoryMode)}</span>
+    </div>
+  );
+}

--- a/components/terminal/TerminalShell.tsx
+++ b/components/terminal/TerminalShell.tsx
@@ -4,6 +4,7 @@ import { Suspense, useEffect, useMemo, useState, type ReactNode } from 'react';
 import ChamberSwitcher from '@/components/terminal/ChamberSwitcher';
 import OnboardingOverlay from '@/components/terminal/OnboardingOverlay';
 import ShellBridgeBanner from '@/components/terminal/ShellBridgeBanner';
+import { DegradedBanner } from '@/components/terminal/DegradedBanner';
 import SnapshotDiagnostics from '@/components/terminal/SnapshotDiagnostics';
 import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
 import type { SnapshotLaneState } from '@/lib/terminal/snapshotLanes';
@@ -66,6 +67,19 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
     if (typeof integrityData?.global_integrity === 'number') return integrityData.global_integrity;
     return 0;
   }, [snapshot, integrityData]);
+
+  const memoryMode = snapshot?.memory_mode;
+  const giProvenance = (memoryMode?.gi_provenance ?? null) as string | null;
+  const giVerified = Boolean(memoryMode?.gi_verified);
+
+  const provenanceBadge = useMemo(() => {
+    const p = giProvenance ?? '';
+    if (p === 'kv-live' || p === 'live-compute') return { label: 'LIVE', cls: 'text-emerald-300/90' };
+    if (p === 'kv-carry') return { label: 'CARRY', cls: 'text-amber-300/90' };
+    if (p === 'oaa-verified') return { label: 'MEMORY', cls: 'text-sky-300/90' };
+    if (p === 'readiness-fallback') return { label: 'CACHED', cls: 'text-orange-300/90' };
+    return { label: '—', cls: 'text-slate-500' };
+  }, [giProvenance]);
 
   const cycle = snapshot?.cycle ?? integrityData?.cycle ?? 'C-—';
   const mode = (snapshot?.mode ?? integrityData?.mode ?? null)?.toString().toLowerCase() ?? null;
@@ -135,8 +149,19 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
             </a>
           </div>
           <div className="flex items-center gap-1.5 text-[10px] font-mono md:gap-2 md:text-[11px]">
-            <span className={cn('rounded border px-1.5 py-0.5 md:px-2 md:py-1', loading ? 'border-slate-700 text-slate-500' : giTone)}>
-              GI {loading ? '—' : gi.toFixed(2)}
+            <span
+              className={cn(
+                'flex items-center gap-1 rounded border px-1.5 py-0.5 md:px-2 md:py-1',
+                loading ? 'border-slate-700 text-slate-500' : giTone,
+              )}
+            >
+              <span>GI {loading ? '—' : gi.toFixed(2)}</span>
+              {!loading && giProvenance ? (
+                <span className={cn('rounded border border-white/10 px-1 font-mono text-[9px] uppercase', provenanceBadge.cls)}>
+                  {provenanceBadge.label}
+                  {giVerified ? <span title="Warm-tier mirror (OAA)">✓</span> : null}
+                </span>
+              ) : null}
             </span>
             <span
               className={cn(
@@ -165,6 +190,8 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
           </button>
         </div>
       </header>
+
+      <DegradedBanner memoryMode={memoryMode ?? null} />
 
       {showLaneDiagnostics && lanes.length > 0 ? (
         <div className="border-b border-slate-800 bg-slate-950/80 px-3 py-2 md:px-4">

--- a/hooks/useTerminalSnapshot.ts
+++ b/hooks/useTerminalSnapshot.ts
@@ -26,6 +26,16 @@ export type TerminalSnapshot = {
   gi?: number | null;
   mode?: string | null;
   degraded?: boolean;
+  memory_mode?: {
+    degraded?: boolean;
+    gi_provenance?: string | null;
+    gi_verified?: boolean;
+    gi_source?: string | null;
+    gi_age_seconds?: number | null;
+    kv_available?: boolean;
+    kv_latency_ms?: number | null;
+    backup_redis_available?: boolean;
+  };
   meta?: { total_ms?: number };
   lanes?: SnapshotLaneState[];
   integrity?: SnapshotLeaf;

--- a/lib/gi/resolveGiChain.ts
+++ b/lib/gi/resolveGiChain.ts
@@ -1,0 +1,211 @@
+/**
+ * C-287 — Verified Memory Mode: GI read chain (no estimation; real recorded tiers only).
+ * Order: KV live → live compute → KV carry → OAA bridge → MIC readiness snapshot → unknown.
+ */
+
+import type { GIMode } from '@/lib/gi/mode';
+import { getGiMode } from '@/lib/gi/mode';
+import { computeIntegrityPayload } from '@/lib/integrity/buildStatus';
+import { loadGIState, loadGIStateCarry, type GIState } from '@/lib/kv/store';
+import { kvBridgeConfigured, kvBridgeRead } from '@/lib/kv/kvBridgeClient';
+
+/** Operator-facing GI provenance (C-287). */
+export type GISourceDisplay =
+  | 'kv-live'
+  | 'live-compute'
+  | 'kv-carry'
+  | 'oaa-verified'
+  | 'readiness-fallback'
+  | 'unknown';
+
+const KV_LIVE_MAX_AGE_MS = 10 * 60 * 1000;
+
+export type GiChainResolution = {
+  gi: number | null;
+  mode: GIMode | string | null;
+  terminal_status: string | null;
+  primary_driver: string | null;
+  /** C-287 display tier */
+  source: GISourceDisplay;
+  /** Legacy bucket for snapshot-lite / APIs */
+  source_legacy: 'kv' | 'kv_carry_forward' | 'live_compute' | 'readiness_snapshot' | 'null';
+  timestamp: string | null;
+  age_seconds: number | null;
+  /** OAA bridge row includes server `written_at`; we treat bridge-backed GI as verified for UI. */
+  verified: boolean;
+  degraded: boolean;
+  kv?: GIState | null;
+};
+
+function ageSeconds(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  const ms = new Date(iso).getTime();
+  if (!Number.isFinite(ms)) return null;
+  return Math.max(0, Math.floor((Date.now() - ms) / 1000));
+}
+
+function modeFromGi(gi: number): GIMode {
+  return getGiMode(gi);
+}
+
+function parseMicReadinessSnapshotGi(raw: unknown): { gi: number; updatedAt: string | null } | null {
+  if (raw === null || raw === undefined) return null;
+  let o: Record<string, unknown>;
+  if (typeof raw === 'string') {
+    try {
+      o = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  } else if (typeof raw === 'object') {
+    o = raw as Record<string, unknown>;
+  } else {
+    return null;
+  }
+  const nested = o.snapshot && typeof o.snapshot === 'object' ? (o.snapshot as Record<string, unknown>) : o;
+  const g = nested.gi;
+  if (typeof g !== 'number' || !Number.isFinite(g)) return null;
+  const updatedAt =
+    typeof nested.updatedAt === 'string'
+      ? nested.updatedAt
+      : typeof o.updatedAt === 'string'
+        ? o.updatedAt
+        : typeof o.received_at === 'string'
+          ? o.received_at
+          : null;
+  return { gi: Math.max(0, Math.min(1, g)), updatedAt };
+}
+
+function parseGiStateValue(value: unknown): GIState | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Record<string, unknown>;
+  const gi = v.global_integrity;
+  if (typeof gi !== 'number' || !Number.isFinite(gi)) return null;
+  return value as GIState;
+}
+
+export async function resolveGiChain(opts?: {
+  micReadinessSnapshotRaw?: string | null;
+}): Promise<GiChainResolution> {
+  const st = await loadGIState();
+  if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
+    const ageMs = Date.now() - new Date(st.timestamp).getTime();
+    const maxAgeMs =
+      st.gi_write_source === 'micro_sweep' ? 2 * 60 * 1000 : KV_LIVE_MAX_AGE_MS;
+    if (ageMs < maxAgeMs) {
+      const gi = Math.max(0, Math.min(1, st.global_integrity));
+      return {
+        gi,
+        mode: st.mode ?? null,
+        terminal_status: st.terminal_status ?? null,
+        primary_driver: st.primary_driver ?? null,
+        source: 'kv-live',
+        source_legacy: 'kv',
+        timestamp: st.timestamp,
+        age_seconds: ageSeconds(st.timestamp),
+        verified: false,
+        degraded: false,
+        kv: st,
+      };
+    }
+  }
+
+  try {
+    const live = await computeIntegrityPayload();
+    return {
+      gi: live.global_integrity,
+      mode: live.mode,
+      terminal_status: live.terminal_status,
+      primary_driver: live.primary_driver,
+      source: 'live-compute',
+      source_legacy: 'live_compute',
+      timestamp: live.timestamp,
+      age_seconds: ageSeconds(live.timestamp),
+      verified: false,
+      degraded: false,
+      kv: st,
+    };
+  } catch {
+    // continue
+  }
+
+  const carry = await loadGIStateCarry();
+  if (carry && typeof carry.global_integrity === 'number' && Number.isFinite(carry.global_integrity)) {
+    const gi = Math.max(0, Math.min(1, carry.global_integrity));
+    return {
+      gi,
+      mode: carry.mode ?? null,
+      terminal_status: carry.terminal_status ?? null,
+      primary_driver: `${carry.primary_driver ?? 'GI'} (carried forward; primary gi:latest missing or stale)`,
+      source: 'kv-carry',
+      source_legacy: 'kv_carry_forward',
+      timestamp: carry.timestamp,
+      age_seconds: ageSeconds(carry.timestamp),
+      verified: false,
+      degraded: true,
+      kv: st,
+    };
+  }
+
+  if (kvBridgeConfigured()) {
+    try {
+      const row = await kvBridgeRead('GI_STATE');
+      if (row?.ok && row.value != null) {
+        const parsed = parseGiStateValue(row.value);
+        if (parsed && typeof parsed.global_integrity === 'number') {
+          const gi = Math.max(0, Math.min(1, parsed.global_integrity));
+          const ts = parsed.timestamp ?? row.written_at ?? null;
+          return {
+            gi,
+            mode: parsed.mode ?? modeFromGi(gi),
+            terminal_status: parsed.terminal_status ?? null,
+            primary_driver: parsed.primary_driver ?? 'GI from OAA KV bridge (last recorded)',
+            source: 'oaa-verified',
+            source_legacy: 'kv',
+            timestamp: ts,
+            age_seconds: ts ? ageSeconds(ts) : ageSeconds(row.written_at),
+            verified: true,
+            degraded: true,
+            kv: st,
+          };
+        }
+      }
+    } catch {
+      // fall through
+    }
+  }
+
+  const snap =
+    opts?.micReadinessSnapshotRaw != null ? parseMicReadinessSnapshotGi(opts.micReadinessSnapshotRaw) : null;
+  if (snap) {
+    const gi = snap.gi;
+    const ts = snap.updatedAt ?? new Date().toISOString();
+    return {
+      gi,
+      mode: modeFromGi(gi),
+      terminal_status: null,
+      primary_driver: 'GI from MIC_READINESS_SNAPSHOT (readiness cache)',
+      source: 'readiness-fallback',
+      source_legacy: 'readiness_snapshot',
+      timestamp: ts,
+      age_seconds: ageSeconds(snap.updatedAt),
+      verified: false,
+      degraded: true,
+      kv: st,
+    };
+  }
+
+  return {
+    gi: null,
+    mode: null,
+    terminal_status: null,
+    primary_driver: null,
+    source: 'unknown',
+    source_legacy: 'null',
+    timestamp: null,
+    age_seconds: null,
+    verified: false,
+    degraded: true,
+    kv: st,
+  };
+}

--- a/lib/integrity/resolveGi.ts
+++ b/lib/integrity/resolveGi.ts
@@ -1,16 +1,17 @@
 /**
- * C-286 — single GI resolution for MIC readiness, snapshot-lite, and ops surfaces.
+ * C-286 / C-287 — single GI resolution for MIC readiness, snapshot-lite, and ops surfaces.
  */
 
 import type { GIMode } from '@/lib/gi/mode';
-import { computeIntegrityPayload } from '@/lib/integrity/buildStatus';
-import { loadGIState, loadGIStateCarry, type GIState } from '@/lib/kv/store';
+import { resolveGiChain, type GISourceDisplay } from '@/lib/gi/resolveGiChain';
+import type { GIState } from '@/lib/kv/store';
 
 export type GiResolutionSource =
   | 'kv'
   | 'kv_carry_forward'
   | 'live_compute'
   | 'readiness_snapshot'
+  | 'oaa_verified'
   | 'null';
 
 export type ResolvedGi = {
@@ -20,109 +21,50 @@ export type ResolvedGi = {
   primary_driver: string | null;
   source: GiResolutionSource;
   timestamp: string | null;
+  /** C-287 operator-facing tier */
+  gi_provenance: GISourceDisplay;
+  verified: boolean;
+  degraded: boolean;
+  age_seconds: number | null;
   /** When `source === 'kv'`, the underlying row (for staleness / carry-forward flags). */
   kv?: GIState | null;
 };
 
-function modeFromGi(gi: number): GIMode {
-  if (gi >= 0.85) return 'green';
-  if (gi >= 0.7) return 'yellow';
-  return 'red';
-}
-
-function parseMicReadinessSnapshotGi(raw: unknown): number | null {
-  if (raw === null || raw === undefined) return null;
-  let o: Record<string, unknown>;
-  if (typeof raw === 'string') {
-    try {
-      o = JSON.parse(raw) as Record<string, unknown>;
-    } catch {
-      return null;
-    }
-  } else if (typeof raw === 'object') {
-    o = raw as Record<string, unknown>;
-  } else {
-    return null;
+function mapProvenanceToLegacy(p: GISourceDisplay): GiResolutionSource {
+  switch (p) {
+    case 'kv-live':
+      return 'kv';
+    case 'live-compute':
+      return 'live_compute';
+    case 'kv-carry':
+      return 'kv_carry_forward';
+    case 'oaa-verified':
+      return 'oaa_verified';
+    case 'readiness-fallback':
+      return 'readiness_snapshot';
+    default:
+      return 'null';
   }
-  const nested = o.snapshot && typeof o.snapshot === 'object' ? (o.snapshot as Record<string, unknown>) : o;
-  const g = nested.gi;
-  if (typeof g === 'number' && Number.isFinite(g)) return Math.max(0, Math.min(1, g));
-  return null;
 }
 
 /**
- * Resolve GI: prefer fresh-enough KV, else live `computeIntegrityPayload`, else MIC readiness snapshot body.
+ * Resolve GI via C-287 chain (KV → live → carry → OAA → readiness → unknown). No estimation.
  */
 export async function resolveGiForTerminal(opts?: {
   micReadinessSnapshotRaw?: string | null;
 }): Promise<ResolvedGi> {
-  const st = await loadGIState();
-  if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
-    const age = Date.now() - new Date(st.timestamp).getTime();
-    const maxAgeMs =
-      st.gi_write_source === 'micro_sweep' ? 2 * 60 * 1000 : 15 * 60 * 1000;
-    if (age < maxAgeMs) {
-      return {
-        gi: Math.max(0, Math.min(1, st.global_integrity)),
-        mode: st.mode ?? null,
-        terminal_status: st.terminal_status ?? null,
-        primary_driver: st.primary_driver ?? null,
-        source: 'kv',
-        timestamp: st.timestamp,
-        kv: st,
-      };
-    }
-  }
-
-  try {
-    const live = await computeIntegrityPayload();
-    return {
-      gi: live.global_integrity,
-      mode: live.mode,
-      terminal_status: live.terminal_status,
-      primary_driver: live.primary_driver,
-      source: 'live_compute',
-      timestamp: live.timestamp,
-      kv: st,
-    };
-  } catch {
-    // fall through
-  }
-
-  const carry = await loadGIStateCarry();
-  if (carry && typeof carry.global_integrity === 'number' && Number.isFinite(carry.global_integrity)) {
-    return {
-      gi: Math.max(0, Math.min(1, carry.global_integrity)),
-      mode: carry.mode ?? null,
-      terminal_status: carry.terminal_status ?? null,
-      primary_driver: `${carry.primary_driver ?? 'GI'} (carried forward; primary gi:latest missing or stale)`,
-      source: 'kv_carry_forward',
-      timestamp: carry.timestamp,
-      kv: st,
-    };
-  }
-
-  const snapGi =
-    opts?.micReadinessSnapshotRaw != null ? parseMicReadinessSnapshotGi(opts.micReadinessSnapshotRaw) : null;
-  if (snapGi !== null) {
-    return {
-      gi: snapGi,
-      mode: modeFromGi(snapGi),
-      terminal_status: null,
-      primary_driver: 'GI from MIC_READINESS_SNAPSHOT fallback (KV gi:latest missing/stale)',
-      source: 'readiness_snapshot',
-      timestamp: new Date().toISOString(),
-      kv: st,
-    };
-  }
-
+  const chain = await resolveGiChain({ micReadinessSnapshotRaw: opts?.micReadinessSnapshotRaw });
   return {
-    gi: null,
-    mode: null,
-    terminal_status: null,
-    primary_driver: null,
-    source: 'null',
-    timestamp: null,
-    kv: st,
+    gi: chain.gi,
+    mode: chain.mode,
+    terminal_status: chain.terminal_status,
+    primary_driver: chain.primary_driver,
+    source: mapProvenanceToLegacy(chain.source),
+    timestamp: chain.timestamp,
+    gi_provenance: chain.source,
+    verified: chain.verified,
+    degraded: chain.degraded,
+    age_seconds: chain.age_seconds,
+    kv: chain.kv,
   };
 }

--- a/lib/kv/kvBridgeClient.ts
+++ b/lib/kv/kvBridgeClient.ts
@@ -62,6 +62,7 @@ export async function kvBridgeWrite(
   bridgeKey: string,
   value: unknown,
   ttlSeconds?: number,
+  sourceTag?: string,
 ): Promise<boolean> {
   const base = oaaBaseUrl();
   const secret = process.env.KV_BRIDGE_SECRET?.trim();
@@ -78,7 +79,7 @@ export async function kvBridgeWrite(
         key: bridgeKey,
         value,
         ttl_seconds: ttlSeconds,
-        source: 'terminal',
+        source: sourceTag?.trim() || 'terminal',
       }),
       signal: abortMs(8000),
     });
@@ -112,6 +113,17 @@ export async function kvBridgeRead(bridgeKey: string): Promise<KvBridgeReadResul
     );
     return null;
   }
+}
+
+/** C-287 — explicit dual-write (cron / hot paths); never blocks callers. */
+export function scheduleKvBridgeDualWrite(
+  bridgeKey: string,
+  value: unknown,
+  ttlSeconds?: number,
+  sourceTag?: string,
+): void {
+  if (!kvBridgeConfigured()) return;
+  void kvBridgeWrite(bridgeKey, value, ttlSeconds, sourceTag).catch(() => {});
 }
 
 /** Fire-and-forget mirror after successful primary SET (prefixed `mobius:` key). */

--- a/lib/kv/store.ts
+++ b/lib/kv/store.ts
@@ -49,6 +49,7 @@ import {
   kvBridgeReadVaultComposite,
   kvBridgeWrite,
   kvBridgeWriteVaultSnapshot,
+  scheduleKvBridgeDualWrite,
   scheduleKvBridgeMirrorPrefixed,
   scheduleKvBridgeMirrorRaw,
 } from '@/lib/kv/kvBridgeClient';
@@ -416,6 +417,7 @@ export type SignalSnapshot = {
  */
 export async function saveSignalSnapshot(snapshot: SignalSnapshot): Promise<void> {
   await kvSet(KV_KEYS.SIGNAL_SNAPSHOT, snapshot, KV_TTL_SECONDS.SIGNAL_SNAPSHOT);
+  scheduleKvBridgeDualWrite('SIGNAL_SNAPSHOT', snapshot, KV_TTL_SECONDS.SIGNAL_SNAPSHOT, 'c287-dual-write');
 }
 
 /**
@@ -450,6 +452,7 @@ export type GIState = {
 export async function saveGIState(state: GIState): Promise<void> {
   await kvSet(KV_KEYS.GI_STATE, state, KV_TTL_SECONDS.GI_STATE);
   await kvSet(KV_KEYS.GI_STATE_CARRY, state, 604800);
+  scheduleKvBridgeDualWrite('GI_STATE', state, KV_TTL_SECONDS.GI_STATE, 'c287-dual-write');
 }
 
 /**

--- a/lib/mic/assembleMicReadiness.ts
+++ b/lib/mic/assembleMicReadiness.ts
@@ -5,6 +5,7 @@ import { mergeMicReadinessFromUpstream } from '@/lib/mic/readinessMerge';
 import type { MicReadinessResponse } from '@/lib/mic/types';
 import { withHash } from '@/lib/mic/hash';
 import { kvGet, KV_KEYS } from '@/lib/kv/store';
+import { loadMicReadinessSnapshotRaw } from '@/lib/mic/loadReadinessSnapshot';
 import { loadSustainState } from '@/lib/mic/sustainTracker';
 import { resolveReplayPressureWithDecay } from '@/lib/mic/replayPressure';
 import { computeVaultSealLaneSemantics } from '@/lib/vault/lane-status';
@@ -92,7 +93,7 @@ export async function resolveReadinessCycle(cycleParam?: string | null): Promise
 /** Local MIC_READINESS_V1 from Vault + deposits (no upstream merge). */
 export async function assembleLocalMicReadiness(cycleParam?: string | null): Promise<MicReadinessResponse> {
   const cycle = await resolveReadinessCycle(cycleParam);
-  const micSnapRaw = await kvGet<string>(KV_KEYS.MIC_READINESS_SNAPSHOT);
+  const { raw: micSnapRaw } = await loadMicReadinessSnapshotRaw();
   const resolvedGi = await resolveGiForTerminal({ micReadinessSnapshotRaw: micSnapRaw });
   const vaultStatus = await getVaultStatusShape(resolvedGi.gi);
   const deposits = await listVaultDeposits(120);
@@ -125,8 +126,9 @@ export async function assembleLocalMicReadiness(cycleParam?: string | null): Pro
 }
 
 async function loadUpstreamReadiness(): Promise<Partial<MicReadinessResponse> | null> {
-  const raw = await kvGet<string | UpstreamSnapshot | MicReadinessResponse>(KV_KEYS.MIC_READINESS_SNAPSHOT);
-  if (raw === null || raw === undefined) return null;
+  const { raw: rawStr } = await loadMicReadinessSnapshotRaw();
+  if (rawStr === null || rawStr === '') return null;
+  const raw = rawStr as string | UpstreamSnapshot | MicReadinessResponse;
   if (typeof raw === 'string') {
     try {
       const o = JSON.parse(raw) as UpstreamSnapshot & MicReadinessResponse;
@@ -152,7 +154,7 @@ export async function getMergedMicReadiness(cycleParam?: string | null): Promise
   const local = await assembleLocalMicReadiness(cycleParam);
   const upstream = await loadUpstreamReadiness();
   const mergedBase = mergeMicReadinessFromUpstream(local, upstream);
-  const micSnapRaw = await kvGet<string>(KV_KEYS.MIC_READINESS_SNAPSHOT);
+  const { raw: micSnapRaw } = await loadMicReadinessSnapshotRaw();
   const giResolved = await resolveGiForTerminal({ micReadinessSnapshotRaw: micSnapRaw });
   const merged: MicReadinessResponse = {
     ...mergedBase,

--- a/lib/mic/loadReadinessSnapshot.ts
+++ b/lib/mic/loadReadinessSnapshot.ts
@@ -1,0 +1,36 @@
+/**
+ * C-287 — MIC readiness snapshot: KV first, then OAA bridge (same envelope as KV).
+ */
+
+import { kvBridgeConfigured, kvBridgeRead } from '@/lib/kv/kvBridgeClient';
+import { kvGet, KV_KEYS } from '@/lib/kv/store';
+
+export type MicReadinessSnapshotSource = 'kv' | 'oaa' | 'none';
+
+export async function loadMicReadinessSnapshotRaw(): Promise<{
+  raw: string | null;
+  source: MicReadinessSnapshotSource;
+}> {
+  const fromKv = await kvGet<string>(KV_KEYS.MIC_READINESS_SNAPSHOT);
+  if (fromKv !== null && fromKv !== undefined && String(fromKv).trim() !== '') {
+    return {
+      raw: typeof fromKv === 'string' ? fromKv : JSON.stringify(fromKv),
+      source: 'kv',
+    };
+  }
+  if (!kvBridgeConfigured()) {
+    return { raw: null, source: 'none' };
+  }
+  const row = await kvBridgeRead('MIC_READINESS_SNAPSHOT');
+  if (!row?.ok || row.value == null) {
+    return { raw: null, source: 'none' };
+  }
+  if (typeof row.value === 'string') {
+    return { raw: row.value, source: 'oaa' };
+  }
+  try {
+    return { raw: JSON.stringify(row.value), source: 'oaa' };
+  } catch {
+    return { raw: null, source: 'none' };
+  }
+}

--- a/lib/runtime/agent-heartbeat-kv.ts
+++ b/lib/runtime/agent-heartbeat-kv.ts
@@ -4,6 +4,7 @@
 
 import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
 import { isRedisAvailable, kvSet, KV_KEYS, KV_TTL_SECONDS } from '@/lib/kv/store';
+import { scheduleKvBridgeDualWrite } from '@/lib/kv/kvBridgeClient';
 
 /** Canonical Terminal fleet IDs (lowercase) — matches `app/api/agents/status/route.ts` roster order. */
 export const CANONICAL_AGENT_IDS = [
@@ -58,5 +59,9 @@ export async function writeFleetHeartbeatKV(source: AgentHeartbeatFleetPayload['
   const ok =
     (await kvSet(KV_KEYS.HEARTBEAT, JSON.stringify(payload), KV_TTL_SECONDS.HEARTBEAT)) &&
     (await kvSet(KV_KEYS.CURRENT_CYCLE, payload.cycle, KV_TTL_SECONDS.HEARTBEAT));
+  if (ok) {
+    scheduleKvBridgeDualWrite('HEARTBEAT', payload, KV_TTL_SECONDS.HEARTBEAT, 'heartbeat-dual-write');
+    scheduleKvBridgeDualWrite('CURRENT_CYCLE', payload.cycle, KV_TTL_SECONDS.HEARTBEAT, 'heartbeat-dual-write');
+  }
   return ok;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **C-287 read resilience**: a real GI read chain that includes OAA KV bridge before readiness cache, fire-and-forget dual-writes for hot keys, and Terminal UI that surfaces **Verified Memory Mode** (provenance badge + degraded banner) without inventing GI.

## GI resolution (`lib/gi/resolveGiChain.ts` + `resolveGiForTerminal`)

Order (no interpolation):

1. **KV live** — `GI_STATE` if age &lt; 10m (micro_sweep rows still use 2m window)
2. **Live compute** — `computeIntegrityPayload()` when KV row missing/stale
3. **KV carry** — `GI_STATE_CARRY`
4. **OAA** — `GET …/api/kv-bridge/read?key=GI_STATE` when bridge configured
5. **Readiness** — `MIC_READINESS_SNAPSHOT` from KV **or** OAA (`loadMicReadinessSnapshotRaw`)
6. **Unknown** — `gi: null`

`ResolvedGi` gains `gi_provenance`, `verified`, `degraded`, `age_seconds`; legacy `source` includes `oaa_verified` where applicable.

## Dual-write (OAA bridge)

- `scheduleKvBridgeDualWrite` + optional `source` on `kvBridgeWrite`
- `saveGIState` / `saveSignalSnapshot` → dual-write `GI_STATE`, `SIGNAL_SNAPSHOT`
- `writeFleetHeartbeatKV` → `HEARTBEAT`, `CURRENT_CYCLE`
- `POST /api/mic/readiness` → `MIC_READINESS_SNAPSHOT` object (not only string mirror)

## API / snapshot

- `snapshot-lite`: `backup_redis` lane, `gi_provenance`, `gi_verified`, refined `gi_source` (`live` / `kv` / `oaa_verified` / `readiness_fallback` / `null`)
- `GET /api/terminal/snapshot`: parallel `snapshot-lite` → `memory_mode` for shell
- `GET /api/integrity-status`: merges chain GI + provenance fields into JSON
- `GET /api/vault/status`: if fresh KV GI missing, uses same chain as readiness for `gi_current` + optional `gi_resolution`
- `GET /api/mic/readiness`: richer `gi_resolution` + OAA-backed snapshot load

## UI

- `DegradedBanner` — amber bar when `memory_mode.degraded`
- Header GI chip — LIVE / CARRY / MEMORY / CACHED / `—` + ✓ when `gi_verified`

## Note on “cryptographic verification”

OAA bridge rows are **server-recorded** warm tier values. UI `verified` means “read from OAA bridge,” not a separate hash proof in this PR.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm build`

## Env

Uses existing `OAA_API_BASE_URL` / `OAA_API_BASE` / `NEXT_PUBLIC_OAA_API_URL` + `KV_BRIDGE_SECRET` from PR #341.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

