### PR TITLE
feat(C-288): Mobius Mesh Workflow v1 — Terminal cycle state + jobs contract

### DIFF
--- a/.github/workflows/publish-cycle-state.yml
+++ b/.github/workflows/publish-cycle-state.yml
@@ -1,0 +1,50 @@
+# C-288 — Mobius Mesh Workflow v1 (Terminal)
+# Declared in mobius.yaml → jobs.workflows (id: publish-cycle-state).
+# Fetches public snapshot-lite, writes ledger/cycle-state.json for HIVE / Substrate / shell.
+
+name: Publish cycle state
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-cycle-state
+  cancel-in-progress: true
+
+env:
+  # Override via repo Actions variable TERMINAL_BASE_URL if staging; default is production Terminal.
+  TERMINAL_BASE_URL: ${{ vars.TERMINAL_BASE_URL }}
+
+jobs:
+  publish-cycle-state:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch snapshot-lite
+        run: |
+          set -euo pipefail
+          BASE="${TERMINAL_BASE_URL:-https://mobius-civic-ai-terminal.vercel.app}"
+          curl -fsSL "${BASE}/api/terminal/snapshot-lite" -o snapshot.json
+          test -s snapshot.json
+
+      - name: Write cycle state
+        run: node scripts/mesh/write-cycle-state.js snapshot.json
+
+      - name: Commit cycle state
+        run: |
+          set -euo pipefail
+          git config user.name "mobius-bot"
+          git config user.email "bot@mobius.systems"
+          git add ledger/cycle-state.json
+          if git diff --staged --quiet; then
+            echo "No changes to cycle-state.json"
+            exit 0
+          fi
+          git commit -m "chore(mesh): refresh cycle state from snapshot-lite"
+          git push

--- a/ledger/README.md
+++ b/ledger/README.md
@@ -1,0 +1,16 @@
+# Terminal ledger artifacts (C-288)
+
+This directory holds **committed mesh continuity artifacts** produced by GitHub Actions (not runtime secrets).
+
+| File | Producer | Purpose |
+|------|----------|---------|
+| `cycle-state.json` | `.github/workflows/publish-cycle-state.yml` | Latest `snapshot-lite` summary for HIVE / Substrate / shell consumers |
+
+Re-run locally after fetching a snapshot:
+
+```bash
+curl -fsSL "https://mobius-civic-ai-terminal.vercel.app/api/terminal/snapshot-lite" -o snapshot.json
+node scripts/mesh/write-cycle-state.js snapshot.json
+```
+
+Do not hand-edit `cycle-state.json` for production truth; let the workflow refresh it.

--- a/ledger/cycle-state.json
+++ b/ledger/cycle-state.json
@@ -1,0 +1,15 @@
+{
+  "schema": "MOBIUS_CYCLE_STATE_V1",
+  "node_id": "mobius-terminal",
+  "source": "snapshot-lite",
+  "cycle": "placeholder",
+  "fetched_at": "1970-01-01T00:00:00.000Z",
+  "gi": null,
+  "mode": null,
+  "degraded": true,
+  "gi_provenance": null,
+  "gi_verified": false,
+  "memory_mode": null,
+  "deployment": null,
+  "snapshot_meta": null
+}

--- a/mesh/mobius-yaml-spec.md
+++ b/mesh/mobius-yaml-spec.md
@@ -85,6 +85,25 @@ Implementation: `app/api/mcp/route.ts`, `lib/mcp/mobius-terminal-mcp.ts`, `docs/
 | `policy.canonical_ledger_node` | Node id of the durable ledger (e.g. `civic-protocol-core`) |
 | `policy.hash_algorithm` | e.g. `sha256` |
 
+## `jobs:` — mesh execution fabric (C-288)
+
+**Rule:** `jobs` declares **which GitHub Actions workflows** implement this node’s mesh duties. It does not execute them; CI/cron does.
+
+| Field | Description |
+|-------|-------------|
+| `jobs.enabled` | Whether this node publishes workflow-backed artifacts |
+| `jobs.workflows[]` | `id`, `file` (path under `.github/workflows/`), `trigger` (`schedule` \| `workflow_dispatch`), optional `cron`, `description` |
+
+**Terminal (this repo):** `publish-cycle-state` → fetches `pulse.snapshot_url` / `GET /api/terminal/snapshot-lite`, runs `scripts/mesh/write-cycle-state.js`, commits `ledger/cycle-state.json`.
+
+## `governance:` — agent PR safety (C-288)
+
+| Field | Description |
+|-------|-------------|
+| `governance.agent_prs_allowed` | Agents may open PRs for mesh/world updates |
+| `governance.auto_merge_allowed` | Must stay `false` for world-facing repos unless human policy changes |
+| `governance.required_reviewers` | Sentinel / human gate (e.g. `ZEUS`, `ATLAS`) |
+
 ## Payload vocabulary (v1)
 
 Tight list for `ingest.targets[].accepts` and cross-node contracts:
@@ -121,3 +140,4 @@ Tight list for `ingest.targets[].accepts` and cross-node contracts:
 - `mobius.yaml` (repository root) — live Terminal manifest.  
 - `mesh/mcp-discovery.json` — MCP discovery slice.  
 - `docs/09-MESH/MNS_MCP_BRIDGE.md` — MCP doctrine.
+- C-288 mesh workflow (cycle state artifact): `ledger/cycle-state.json`, `scripts/mesh/write-cycle-state.js`, `.github/workflows/publish-cycle-state.yml`

--- a/mobius.yaml
+++ b/mobius.yaml
@@ -156,3 +156,20 @@ policy:
   mirror_feed_to_repo: true
   canonical_ledger_node: "civic-protocol-core"
   hash_algorithm: "sha256"
+
+# C-288 — Mesh execution fabric (declaration only; Actions run the jobs).
+jobs:
+  enabled: true
+  workflows:
+    - id: "publish-cycle-state"
+      file: ".github/workflows/publish-cycle-state.yml"
+      trigger: "schedule"
+      cron: "*/10 * * * *"
+      description: "Fetch snapshot-lite → ledger/cycle-state.json for HIVE / Substrate / browser-shell"
+
+governance:
+  agent_prs_allowed: true
+  auto_merge_allowed: false
+  required_reviewers:
+    - "ZEUS"
+    - "ATLAS"

--- a/scripts/mesh/write-cycle-state.js
+++ b/scripts/mesh/write-cycle-state.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * C-288 — Build `ledger/cycle-state.json` from a fetched Terminal snapshot-lite (or full snapshot) JSON.
+ * Usage: node scripts/mesh/write-cycle-state.js <path-to-snapshot.json>
+ * Env: SNAPSHOT_FILE (default: snapshot.json)
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const inPath = process.argv[2] || process.env.SNAPSHOT_FILE || 'snapshot.json';
+if (!fs.existsSync(inPath)) {
+  console.error(`Input not found: ${inPath}`);
+  process.exit(1);
+}
+let snap;
+try {
+  const raw = fs.readFileSync(inPath, 'utf8');
+  snap = JSON.parse(raw);
+} catch (e) {
+  console.error('Failed to read or parse snapshot JSON:', e instanceof Error ? e.message : e);
+  process.exit(1);
+}
+if (!snap || typeof snap !== 'object') {
+  console.error('Snapshot must be a JSON object');
+  process.exit(1);
+}
+
+const cycle =
+  (typeof snap.cycle === 'string' && snap.cycle.trim() ? snap.cycle.trim() : null) ??
+  (snap.lanes && typeof snap.lanes === 'object' && snap.lanes.echo && typeof snap.lanes.echo.cycle === 'string'
+    ? snap.lanes.echo.cycle
+    : null) ??
+  'unknown';
+
+const memoryMode =
+  snap.memory_mode && typeof snap.memory_mode === 'object'
+    ? {
+        degraded: Boolean(snap.memory_mode.degraded),
+        gi_provenance: snap.memory_mode.gi_provenance ?? null,
+        gi_verified: Boolean(snap.memory_mode.gi_verified),
+        gi_value: typeof snap.memory_mode.gi_value === 'number' ? snap.memory_mode.gi_value : null,
+        lite_ok: snap.memory_mode.lite_ok !== false,
+      }
+    : null;
+
+const out = {
+  schema: 'MOBIUS_CYCLE_STATE_V1',
+  node_id: 'mobius-terminal',
+  source: snap.lite === true ? 'snapshot-lite' : 'snapshot',
+  cycle,
+  fetched_at: new Date().toISOString(),
+  gi: typeof snap.gi === 'number' && Number.isFinite(snap.gi) ? snap.gi : null,
+  mode: typeof snap.mode === 'string' ? snap.mode : null,
+  degraded: Boolean(snap.degraded),
+  gi_provenance: typeof snap.gi_provenance === 'string' ? snap.gi_provenance : null,
+  gi_verified: Boolean(snap.gi_verified),
+  memory_mode: memoryMode,
+  deployment: snap.deployment && typeof snap.deployment === 'object' ? snap.deployment : null,
+  snapshot_meta:
+    snap.meta && typeof snap.meta === 'object'
+      ? { total_ms: snap.meta.total_ms ?? null, lane_ms: snap.meta.lane_ms ?? null }
+      : null,
+};
+
+const outDir = path.join(process.cwd(), 'ledger');
+fs.mkdirSync(outDir, { recursive: true });
+const outFile = path.join(outDir, 'cycle-state.json');
+fs.writeFileSync(outFile, `${JSON.stringify(out, null, 2)}\n`, 'utf8');
+console.log(`Wrote ${outFile} (cycle=${cycle})`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

C-288 **Terminal slice**: `mobius.yaml` declares the **mesh jobs** execution fabric; GitHub Actions publishes **`ledger/cycle-state.json`** from live **`/api/terminal/snapshot-lite`** so HIVE, Substrate, and `mobius-browser-shell` can consume cycle continuity without scraping the app ad hoc.

## mobius.yaml

- **`jobs`**: `publish-cycle-state` → `.github/workflows/publish-cycle-state.yml`, schedule `*/10 * * * *`, matches workflow cron.
- **`governance`**: `agent_prs_allowed`, `auto_merge_allowed: false`, `required_reviewers: [ZEUS, ATLAS]` (declaration; merge policy remains in GitHub branch protection).

## Workflow

- **`.github/workflows/publish-cycle-state.yml`** — `curl` snapshot-lite (base URL from Actions variable **`TERMINAL_BASE_URL`**, default `https://mobius-civic-ai-terminal.vercel.app`), `node scripts/mesh/write-cycle-state.js`, commit `ledger/cycle-state.json` if changed.

## Script + artifact

- **`scripts/mesh/write-cycle-state.js`** — builds **`MOBIUS_CYCLE_STATE_V1`** (cycle, gi, mode, degraded, provenance, `memory_mode`, deployment, meta).
- **`ledger/cycle-state.json`** — placeholder until first successful workflow run.
- **`ledger/README.md`** — operator notes.

## Spec

- **`mesh/mobius-yaml-spec.md`** — documents `jobs` and `governance` blocks.

## Out of scope (other repos)

Substrate `mesh-sync.yml`, OAA `seal-memory.yml`, HIVE `world-update.yml` / `quest-proposal.yml`, and browser-shell rendering stay in their respective repositories.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm build`

## Ops

- Ensure **`GITHUB_TOKEN`** default `contents: write`** is allowed to push from Actions (branch protection may require a PAT or bypass rules for `mobius-bot` commits).
- Optional: set repo variable **`TERMINAL_BASE_URL`** for non-production snapshot sources.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c151a1-b229-4f70-92f1-c9debb6731e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

