### PR TITLE
feat: Mobius Slack Agent v1 — manifest, router, Events API bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,12 @@ REDIS_URL=
 MOBIUS_KV_BACKUP_MIRROR=
 MOBIUS_KV_READ_FALLBACK=
 
+# Mobius Slack Agent v1 — Events API bridge (`POST /api/slack/agent`)
+# Signing secret from Slack app "Basic Information" (verify inbound requests).
+SLACK_SIGNING_SECRET=
+# Bot User OAuth Token (starts with xoxb-) — used for chat.postMessage replies after ack.
+SLACK_BOT_TOKEN=
+
 # Comma-separated extra origins for Handbook / GitHub Pages CORS on public GET routes
 # (defaults include https://kaizencycle.github.io and mobius-browser-shell.vercel.app)
 MOBIUS_HANDBOOK_CORS_ORIGINS=

--- a/app/api/slack/agent/route.ts
+++ b/app/api/slack/agent/route.ts
@@ -1,0 +1,157 @@
+import type { NextRequest } from 'next/server';
+import { after, NextResponse } from 'next/server';
+import { executeSlackCommand, channelAllowed } from '@/lib/slack-agent/router';
+import { loadMobiusManifest } from '@/lib/slack-agent/loadManifest';
+import { parseSlackCommandText } from '@/lib/slack-agent/parseCommand';
+import { postSlackChatMessage } from '@/lib/slack-agent/postSlackReply';
+import { verifySlackRequest } from '@/lib/slack-agent/verifySlackSignature';
+
+export const dynamic = 'force-dynamic';
+
+type SlackEnvelope = {
+  type?: string;
+  challenge?: string;
+  event_id?: string;
+  event?: {
+    type?: string;
+    text?: string;
+    user?: string;
+    channel?: string;
+    thread_ts?: string;
+    subtype?: string;
+    bot_id?: string;
+  };
+  team_id?: string;
+};
+
+const seenEventIds = new Set<string>();
+const SEEN_MAX = 500;
+
+function rememberEventId(id: string): boolean {
+  if (seenEventIds.has(id)) return false;
+  seenEventIds.add(id);
+  if (seenEventIds.size > SEEN_MAX) {
+    const first = seenEventIds.values().next().value as string | undefined;
+    if (first) seenEventIds.delete(first);
+  }
+  return true;
+}
+
+function json(data: unknown, status = 200) {
+  return NextResponse.json(data, { status });
+}
+
+export async function POST(req: NextRequest) {
+  const signingSecret = process.env.SLACK_SIGNING_SECRET?.trim();
+  if (!signingSecret) {
+    return json({ ok: false, error: 'SLACK_SIGNING_SECRET not configured' }, 503);
+  }
+
+  const rawBody = await req.text();
+  const sig = verifySlackRequest({
+    signingSecret,
+    rawBody,
+    timestampHeader: req.headers.get('x-slack-request-timestamp'),
+    signatureHeader: req.headers.get('x-slack-signature'),
+  });
+  if (!sig.ok) {
+    return json({ ok: false, error: sig.reason }, 401);
+  }
+
+  let body: SlackEnvelope;
+  try {
+    body = JSON.parse(rawBody) as SlackEnvelope;
+  } catch {
+    return json({ ok: false, error: 'invalid_json' }, 400);
+  }
+
+  if (body.type === 'url_verification' && typeof body.challenge === 'string') {
+    return new NextResponse(body.challenge, {
+      status: 200,
+      headers: { 'Content-Type': 'text/plain' },
+    });
+  }
+
+  if (body.type !== 'event_callback' || !body.event || typeof body.event !== 'object') {
+    return json({ ok: true });
+  }
+
+  const ev = body.event;
+  if (ev.type !== 'app_mention') {
+    return json({ ok: true });
+  }
+  if (ev.subtype === 'message_changed' || ev.bot_id) {
+    return json({ ok: true });
+  }
+
+  const eventId = typeof body.event_id === 'string' ? body.event_id : '';
+  if (eventId && !rememberEventId(eventId)) {
+    return json({ ok: true });
+  }
+
+  const text = typeof ev.text === 'string' ? ev.text : '';
+  const user = typeof ev.user === 'string' ? ev.user : 'unknown';
+  const channel = typeof ev.channel === 'string' ? ev.channel : undefined;
+  const threadTs = typeof ev.thread_ts === 'string' ? ev.thread_ts : undefined;
+
+  let manifest;
+  try {
+    manifest = loadMobiusManifest();
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'manifest_error';
+    return json({ ok: false, error: msg }, 500);
+  }
+
+  if (!channelAllowed(manifest, channel)) {
+    return json({ ok: true });
+  }
+
+  const botToken = process.env.SLACK_BOT_TOKEN?.trim();
+  if (!botToken) {
+    return json({ ok: false, error: 'SLACK_BOT_TOKEN not configured (required to post replies)' }, 503);
+  }
+
+  if (!channel) {
+    return json({ ok: true });
+  }
+
+  const parsed = parseSlackCommandText(text);
+  if ('error' in parsed) {
+    const hint =
+      parsed.error === 'empty_command'
+        ? 'Say `@Mobius status` (or vault, cycle, pulse, propose …).'
+        : `Parse error: ${parsed.error}`;
+    try {
+      after(() => {
+        void postSlackChatMessage({ botToken, channel, text: hint, threadTs });
+      });
+    } catch {
+      void postSlackChatMessage({ botToken, channel, text: hint, threadTs });
+    }
+    return json({ ok: true });
+  }
+
+  try {
+    after(() => {
+      void (async () => {
+        const result = await executeSlackCommand({
+          manifest,
+          parsed,
+          actorUserId: user,
+        });
+        await postSlackChatMessage({ botToken, channel, text: result.text, threadTs });
+      })();
+    });
+  } catch {
+    void (async () => {
+      const result = await executeSlackCommand({
+        manifest,
+        parsed,
+        actorUserId: user,
+      });
+      await postSlackChatMessage({ botToken, channel, text: result.text, threadTs });
+    })();
+  }
+
+  return json({ ok: true });
+}

--- a/lib/oaa/publishSnapshot.ts
+++ b/lib/oaa/publishSnapshot.ts
@@ -17,7 +17,12 @@ async function fetchJson(path: string): Promise<unknown> {
   return res.json();
 }
 
-export type PublishKind = 'mic_readiness' | 'vault_status' | 'heartbeat' | 'reconciliation';
+export type PublishKind =
+  | 'mic_readiness'
+  | 'vault_status'
+  | 'heartbeat'
+  | 'reconciliation'
+  | 'slack_agent_command';
 
 export async function publishToOaaAndLedger(args: {
   kind: PublishKind;

--- a/lib/slack-agent/loadManifest.ts
+++ b/lib/slack-agent/loadManifest.ts
@@ -1,0 +1,67 @@
+import { readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import type { MobiusManifestV1 } from '@/lib/slack-agent/types';
+
+let cached: { mtimeMs: number; doc: MobiusManifestV1 } | null = null;
+
+function manifestPath(): string {
+  return join(process.cwd(), 'mobius-manifest.json');
+}
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === 'string');
+}
+
+function asBool(v: unknown, fallback: boolean): boolean {
+  return typeof v === 'boolean' ? v : fallback;
+}
+
+function parseManifest(raw: string): MobiusManifestV1 {
+  const j = JSON.parse(raw) as Record<string, unknown>;
+  const sa = j.slack_agent;
+  if (!sa || typeof sa !== 'object') {
+    throw new Error('manifest_missing_slack_agent');
+  }
+  const o = sa as Record<string, unknown>;
+  const allowed = o.allowed_commands;
+  const workflows = o.allowed_workflows;
+  const wp = o.write_policy;
+  if (!isStringArray(allowed)) throw new Error('manifest_invalid_allowed_commands');
+  if (!isStringArray(workflows)) throw new Error('manifest_invalid_allowed_workflows');
+  if (!wp || typeof wp !== 'object') throw new Error('manifest_invalid_write_policy');
+  const w = wp as Record<string, unknown>;
+
+  return {
+    schema: typeof j.schema === 'string' ? j.schema : undefined,
+    slack_agent: {
+      enabled: asBool(o.enabled, false),
+      mode: typeof o.mode === 'string' ? o.mode : undefined,
+      allowed_commands: allowed,
+      allowed_workflows: workflows,
+      allowed_channel_ids: isStringArray(o.allowed_channel_ids) ? o.allowed_channel_ids : undefined,
+      write_policy: {
+        oaa_logging_required: asBool(w.oaa_logging_required, true),
+        ledger_logging_for_meaningful_actions: asBool(w.ledger_logging_for_meaningful_actions, true),
+        auto_merge_allowed: asBool(w.auto_merge_allowed, false),
+        protected_truth_files_read_only: asBool(w.protected_truth_files_read_only, true),
+      },
+    },
+    repo_touch: typeof j.repo_touch === 'object' && j.repo_touch !== null ? (j.repo_touch as Record<string, unknown>) : undefined,
+  };
+}
+
+export function loadMobiusManifest(force = false): MobiusManifestV1 {
+  const path = manifestPath();
+  let mtimeMs = 0;
+  try {
+    mtimeMs = statSync(path).mtimeMs;
+  } catch {
+    throw new Error('manifest_file_missing');
+  }
+  if (!force && cached && cached.mtimeMs === mtimeMs) return cached.doc;
+
+  const raw = readFileSync(path, 'utf8');
+  const doc = parseManifest(raw);
+  cached = { mtimeMs, doc };
+  return doc;
+}

--- a/lib/slack-agent/parseCommand.ts
+++ b/lib/slack-agent/parseCommand.ts
@@ -1,0 +1,32 @@
+import type { ParsedSlackCommand, SlackAgentCommandName } from '@/lib/slack-agent/types';
+
+const NAMES: SlackAgentCommandName[] = [
+  'status',
+  'vault',
+  'cycle',
+  'pulse',
+  'readiness',
+  'journal',
+  'quest',
+  'propose',
+  'draft-pr',
+  'run',
+];
+
+function stripMention(text: string): string {
+  return text.replace(/^<@[A-Z0-9]+>\s*/i, '').trim();
+}
+
+export function parseSlackCommandText(text: string): ParsedSlackCommand | { error: string } {
+  const raw = stripMention(text).replace(/^\/?mobius\s+/i, '').trim();
+  if (!raw) return { error: 'empty_command' };
+
+  const lower = raw.toLowerCase();
+  for (const name of NAMES) {
+    if (lower === name || lower.startsWith(`${name} `)) {
+      const rest = raw.slice(name.length).trim();
+      return { name, args: rest, raw };
+    }
+  }
+  return { error: `unknown_command:${raw.split(/\s+/)[0] ?? ''}` };
+}

--- a/lib/slack-agent/postSlackReply.ts
+++ b/lib/slack-agent/postSlackReply.ts
@@ -1,0 +1,34 @@
+/**
+ * Post a message to Slack (Events API follow-up — initial HTTP response must be empty/ack only).
+ */
+
+export async function postSlackChatMessage(args: {
+  botToken: string;
+  channel: string;
+  text: string;
+  threadTs?: string;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const res = await fetch('https://slack.com/api/chat.postMessage', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${args.botToken}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({
+        channel: args.channel,
+        text: args.text,
+        ...(args.threadTs ? { thread_ts: args.threadTs } : {}),
+      }),
+      cache: 'no-store',
+      signal: AbortSignal.timeout(15000),
+    });
+    const data = (await res.json().catch(() => null)) as { ok?: boolean; error?: string } | null;
+    if (!data || data.ok !== true) {
+      return { ok: false, error: data?.error ?? `http_${res.status}` };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'slack_post_failed' };
+  }
+}

--- a/lib/slack-agent/router.ts
+++ b/lib/slack-agent/router.ts
@@ -1,0 +1,301 @@
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { terminalInternalOrigin } from '@/lib/oaa/internalOrigin';
+import { publishToOaaAndLedger } from '@/lib/oaa/publishSnapshot';
+import { OAADataClient } from '@/lib/ingestion/OAADataClient';
+import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
+import { loadMobiusManifest } from '@/lib/slack-agent/loadManifest';
+import type { MobiusManifestV1, ParsedSlackCommand, SlackCommandResult } from '@/lib/slack-agent/types';
+
+async function fetchJson(path: string): Promise<unknown> {
+  const origin = terminalInternalOrigin();
+  const url = `${origin}${path.startsWith('/') ? path : `/${path}`}`;
+  const res = await fetch(url, { headers: { Accept: 'application/json' }, cache: 'no-store', signal: AbortSignal.timeout(20000) });
+  if (!res.ok) throw new Error(`fetch_${path}_${res.status}`);
+  return res.json();
+}
+
+function fmtStatus(lite: Record<string, unknown>): string {
+  const cycle = typeof lite.cycle === 'string' ? lite.cycle : '?';
+  const gi = typeof lite.gi === 'number' ? lite.gi.toFixed(2) : String(lite.gi ?? 'n/a');
+  const degraded = lite.degraded === true;
+  const lanes = lite.lanes && typeof lite.lanes === 'object' ? (lite.lanes as Record<string, unknown>) : {};
+  const kv = lanes.kv && typeof lanes.kv === 'object' ? (lanes.kv as Record<string, unknown>) : {};
+  const kvOk = kv.ok === true;
+  const integ = lanes.integrity && typeof lanes.integrity === 'object' ? (lanes.integrity as Record<string, unknown>) : {};
+  const giSource = typeof integ.source === 'string' ? integ.source : 'unknown';
+  const tw = lanes.tripwire && typeof lanes.tripwire === 'object' ? (lanes.tripwire as Record<string, unknown>) : {};
+  const twElev = tw.elevated === true;
+  const hb = lite.heartbeat && typeof lite.heartbeat === 'object' ? (lite.heartbeat as Record<string, unknown>) : {};
+  const runtimeHb = hb.runtime != null ? JSON.stringify(hb.runtime) : 'n/a';
+
+  const lines = [
+    `${cycle} · GI ${gi} · KV ${kvOk ? 'ok' : 'degraded'} · degraded=${degraded}`,
+    `GI source: ${giSource} · tripwires elevated=${twElev}`,
+    `heartbeat runtime: ${runtimeHb}`,
+    `Source: /api/terminal/snapshot-lite`,
+  ];
+  return lines.join('\n');
+}
+
+function pickVaultSummary(vault: Record<string, unknown>): string {
+  const balance =
+    typeof vault.balance_reserve === 'number'
+      ? vault.balance_reserve
+      : typeof vault.in_progress_balance === 'number'
+        ? vault.in_progress_balance
+        : null;
+  const thr = typeof vault.activation_threshold === 'number' ? vault.activation_threshold : null;
+  const seal = vault.seal_lane && typeof vault.seal_lane === 'object' ? (vault.seal_lane as Record<string, unknown>) : {};
+  const fountain = typeof seal.fountain === 'string' ? seal.fountain : JSON.stringify(seal.fountain ?? seal);
+  const gi = typeof vault.gi_current === 'number' ? vault.gi_current.toFixed(2) : String(vault.gi_current ?? 'n/a');
+  const giThr = typeof vault.gi_threshold === 'number' ? vault.gi_threshold.toFixed(2) : String(vault.gi_threshold ?? 'n/a');
+
+  const lines = [
+    balance != null && thr != null ? `Reserve in window: ${balance} / ${thr}` : `Vault payload keys: ${Object.keys(vault).slice(0, 8).join(', ')}…`,
+    `Fountain / seal lane: ${fountain}`,
+    `GI ${gi} vs threshold ${giThr}`,
+    `Source: /api/vault/status + /api/mic/readiness (MIC line below)`,
+  ];
+  return lines.join('\n');
+}
+
+function fmtMicLine(mic: Record<string, unknown>): string {
+  const snap = mic.snapshot && typeof mic.snapshot === 'object' ? (mic.snapshot as Record<string, unknown>) : mic;
+  const ready = snap.mint_eligible === true ? 'mint eligible (upstream)' : 'mint eligibility per upstream / snapshot';
+  return `MIC readiness: ${ready} (see /api/mic/readiness for full envelope)`;
+}
+
+function fmtCycle(cycleFile: Record<string, unknown>, lite: Record<string, unknown> | null): string {
+  const c = typeof cycleFile.cycle === 'string' ? cycleFile.cycle : '?';
+  const mode = typeof cycleFile.mode === 'string' ? cycleFile.mode : String(cycleFile.mode ?? '');
+  const deg = cycleFile.degraded === true;
+  const blockers = deg ? 'degraded=true (from cycle-state)' : 'no cycle-state degraded flag';
+  const fetched = typeof cycleFile.fetched_at === 'string' ? cycleFile.fetched_at : '';
+  const lines = [
+    `Cycle: ${c} · mode ${mode}`,
+    `Blockers / state: ${blockers}`,
+    `cycle-state fetched_at: ${fetched}`,
+  ];
+  if (lite?.meta && typeof lite.meta === 'object') {
+    const m = lite.meta as Record<string, unknown>;
+    lines.push(`snapshot-lite cycle_source: ${String(m.cycle_source ?? '')}`);
+  }
+  lines.push(`Source: ledger/cycle-state.json (+ snapshot-lite when available)`);
+  return lines.join('\n');
+}
+
+function fmtPulse(lite: Record<string, unknown>): string {
+  const lanes = lite.lanes && typeof lite.lanes === 'object' ? (lite.lanes as Record<string, unknown>) : {};
+  const pulse = lanes.pulse && typeof lanes.pulse === 'object' ? (lanes.pulse as Record<string, unknown>) : {};
+  const integ = lanes.integrity && typeof lanes.integrity === 'object' ? (lanes.integrity as Record<string, unknown>) : {};
+  const lines = [
+    `pulse ok=${pulse.ok === true} composite=${String(pulse.composite ?? 'n/a')} instruments=${String(pulse.instruments ?? 'n/a')} anomalies=${String(pulse.anomalies ?? 'n/a')}`,
+    `pulse freshness=${String(pulse.freshness ?? '')} age_seconds=${String(pulse.age_seconds ?? '')}`,
+    `integrity GI=${String(integ.gi ?? '')} verified=${String(integ.verified ?? '')}`,
+    `Source: snapshot-lite lanes (SYSTEM_PULSE in KV)`,
+  ];
+  return lines.join('\n');
+}
+
+function fmtReadiness(mic: Record<string, unknown>): string {
+  return `MIC readiness (truncated):\n${JSON.stringify(mic).slice(0, 3500)}${JSON.stringify(mic).length > 3500 ? '…' : ''}`;
+}
+
+function fmtJournal(lite: Record<string, unknown>): string {
+  const hb = lite.heartbeat && typeof lite.heartbeat === 'object' ? (lite.heartbeat as Record<string, unknown>) : {};
+  const j = hb.journal;
+  return `Journal heartbeat: ${j != null ? JSON.stringify(j) : 'n/a'}\nFull feed: GET /api/agents/journal (service auth on host)`;
+}
+
+async function logOaaAudit(args: {
+  manifest: MobiusManifestV1;
+  actor: string;
+  command: string;
+  cycle: string;
+  intent: string;
+}): Promise<SlackCommandResult['oaa']> {
+  if (!args.manifest.slack_agent.write_policy.oaa_logging_required) {
+    return { ok: true, skipped: true };
+  }
+  const client = OAADataClient.fromEnv();
+  if (!client) {
+    return { ok: false, skipped: true, error: 'oaa_client_unconfigured' };
+  }
+  const r = await client.write({
+    key: `slack:agent:audit:${randomUUID()}`,
+    value: {
+      type: 'SLACK_AGENT_AUDIT_V1',
+      source: 'slack-agent',
+      actor: args.actor,
+      command: args.command,
+      cycle: args.cycle,
+      intent: args.intent,
+      timestamp: new Date().toISOString(),
+    },
+    agent: 'SLACK_AGENT',
+    cycle: args.cycle,
+    intent: `slack_audit:${args.command}`,
+    previousHash: null,
+  });
+  if (r.ok) return { ok: true, hash: r.hash };
+  return { ok: false, error: 'error' in r ? r.error : 'oaa_failed' };
+}
+
+export async function executeSlackCommand(args: {
+  manifest: MobiusManifestV1;
+  parsed: ParsedSlackCommand;
+  actorUserId: string;
+  actorDisplay?: string;
+}): Promise<SlackCommandResult> {
+  const { manifest, parsed } = args;
+  const actor = args.actorDisplay?.trim() || args.actorUserId;
+  const cycle = await resolveOperatorCycleId().catch(() => 'unknown');
+
+  if (!manifest.slack_agent.enabled) {
+    return { text: 'Mobius Slack agent is disabled in mobius-manifest.json.' };
+  }
+  if (!manifest.slack_agent.allowed_commands.includes(parsed.name)) {
+    await logOaaAudit({ manifest, actor, command: parsed.name, cycle, intent: parsed.raw }).catch(() => null);
+    return { text: `Command \`${parsed.name}\` is not allowed by manifest.` };
+  }
+
+  const audit = await logOaaAudit({ manifest, actor, command: parsed.name, cycle, intent: parsed.raw });
+
+  try {
+    switch (parsed.name) {
+      case 'status': {
+        const lite = (await fetchJson('/api/terminal/snapshot-lite')) as Record<string, unknown>;
+        return { text: fmtStatus(lite), oaa: audit };
+      }
+      case 'vault': {
+        const [vault, mic] = await Promise.all([
+          fetchJson('/api/vault/status') as Promise<Record<string, unknown>>,
+          fetchJson('/api/mic/readiness') as Promise<Record<string, unknown>>,
+        ]);
+        return { text: `${pickVaultSummary(vault)}\n${fmtMicLine(mic)}`, oaa: audit };
+      }
+      case 'cycle': {
+        let cycleFile: Record<string, unknown> = {};
+        try {
+          const raw = readFileSync(join(process.cwd(), 'ledger/cycle-state.json'), 'utf8');
+          cycleFile = JSON.parse(raw) as Record<string, unknown>;
+        } catch {
+          cycleFile = { error: 'cycle_state_unreadable' };
+        }
+        let lite: Record<string, unknown> | null = null;
+        try {
+          lite = (await fetchJson('/api/terminal/snapshot-lite')) as Record<string, unknown>;
+        } catch {
+          lite = null;
+        }
+        return { text: fmtCycle(cycleFile, lite), oaa: audit };
+      }
+      case 'pulse': {
+        const lite = (await fetchJson('/api/terminal/snapshot-lite')) as Record<string, unknown>;
+        return { text: fmtPulse(lite), oaa: audit };
+      }
+      case 'readiness': {
+        const mic = (await fetchJson('/api/mic/readiness')) as Record<string, unknown>;
+        return { text: fmtReadiness(mic), oaa: audit };
+      }
+      case 'journal': {
+        const lite = (await fetchJson('/api/terminal/snapshot-lite')) as Record<string, unknown>;
+        return { text: fmtJournal(lite), oaa: audit };
+      }
+      case 'quest': {
+        const task = parsed.args.trim().length > 0 ? parsed.args.trim() : '(no quest text)';
+        const proposal = await publishToOaaAndLedger({
+          kind: 'slack_agent_command',
+          key: `slack:agent:quest:${randomUUID()}`,
+          value: {
+            type: 'SLACK_AGENT_QUEST_V1',
+            source: 'slack-agent',
+            actor,
+            cycle,
+            task,
+            timestamp: new Date().toISOString(),
+          },
+          agent: 'SLACK_AGENT',
+          intent: `slack_quest:${task}`,
+        });
+        return {
+          text: `Logged quest proposal to OAA.\nTask: ${task}\nOAA: ${proposal.oaa.ok ? 'ok' : proposal.oaa.error ?? 'failed'}${proposal.oaa.hash ? ` hash=${proposal.oaa.hash}` : ''}`,
+          oaa: audit,
+          ledger: proposal.ledger,
+        };
+      }
+      case 'propose': {
+        if (!parsed.args.trim()) {
+          return { text: 'Usage: `@Mobius propose <task>`', oaa: audit };
+        }
+        const proposal = await publishToOaaAndLedger({
+          kind: 'slack_agent_command',
+          key: `slack:agent:proposal:${randomUUID()}`,
+          value: {
+            type: 'SLACK_AGENT_PROPOSAL_V1',
+            source: 'slack-agent',
+            actor,
+            command: 'propose',
+            cycle,
+            task: parsed.args.trim(),
+            timestamp: new Date().toISOString(),
+          },
+          agent: 'SLACK_AGENT',
+          intent: `slack_propose:${parsed.args.trim()}`,
+        });
+        return {
+          text: [
+            `Logged proposal to OAA.`,
+            `Task: ${parsed.args.trim()}`,
+            `OAA: ${proposal.oaa.ok ? 'ok' : proposal.oaa.error ?? 'failed'}${proposal.oaa.hash ? ` · hash=${proposal.oaa.hash}` : ''}`,
+            manifest.slack_agent.write_policy.ledger_logging_for_meaningful_actions
+              ? `Ledger proof: ${proposal.ledger.ok ? 'ok' : proposal.ledger.skipped ? `skipped (${proposal.ledger.reason ?? ''})` : 'failed'}`
+              : '',
+          ]
+            .filter(Boolean)
+            .join('\n'),
+          oaa: audit,
+          ledger: proposal.ledger,
+        };
+      }
+      case 'draft-pr': {
+        const title = parsed.args.trim() || '(untitled)';
+        return {
+          text: `Draft PR is not wired in v1 (requires GitHub app token + repo owner).\nWould open draft for: ${title}\nConfigure ops GitHub integration; manifest blocks auto-merge.`,
+          oaa: audit,
+        };
+      }
+      case 'run': {
+        const wf = parsed.args.trim().replace(/\s+/g, '-').toLowerCase();
+        if (!wf) {
+          return { text: 'Usage: `@Mobius run <workflow-id>`\nAllowed: ' + manifest.slack_agent.allowed_workflows.join(', '), oaa: audit };
+        }
+        if (!manifest.slack_agent.allowed_workflows.includes(wf)) {
+          return { text: `Workflow \`${wf}\` is not in manifest allowlist.`, oaa: audit };
+        }
+        return {
+          text: `Workflow \`${wf}\` is allowlisted but dispatch is not wired in this build.\nSet GITHUB_TOKEN with workflow scope and implement dispatch to .github/workflows/*.yml.`,
+          oaa: audit,
+        };
+      }
+      default: {
+        return { text: 'Unknown command.', oaa: audit };
+      }
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      text: `Command failed (operator truth): ${msg}`,
+      oaa: audit,
+    };
+  }
+}
+
+export function channelAllowed(manifest: MobiusManifestV1, channelId: string | undefined): boolean {
+  const allow = manifest.slack_agent.allowed_channel_ids;
+  if (!allow || allow.length === 0) return true;
+  if (!channelId) return false;
+  return allow.includes(channelId);
+}

--- a/lib/slack-agent/types.ts
+++ b/lib/slack-agent/types.ts
@@ -1,0 +1,43 @@
+export type SlackAgentCommandName =
+  | 'status'
+  | 'vault'
+  | 'cycle'
+  | 'pulse'
+  | 'readiness'
+  | 'journal'
+  | 'quest'
+  | 'propose'
+  | 'draft-pr'
+  | 'run';
+
+export type ParsedSlackCommand = {
+  name: SlackAgentCommandName;
+  args: string;
+  raw: string;
+};
+
+export type MobiusManifestV1 = {
+  schema?: string;
+  slack_agent: {
+    enabled: boolean;
+    mode?: string;
+    allowed_commands: string[];
+    allowed_workflows: string[];
+    allowed_channel_ids?: string[];
+    write_policy: {
+      oaa_logging_required: boolean;
+      ledger_logging_for_meaningful_actions: boolean;
+      auto_merge_allowed: boolean;
+      protected_truth_files_read_only: boolean;
+    };
+  };
+  repo_touch?: Record<string, unknown>;
+};
+
+export type SlackCommandResult = {
+  text: string;
+  blocks?: unknown[];
+  /** Echo of structured audit when OAA accepted */
+  oaa?: { ok: boolean; hash?: string; skipped?: boolean; error?: string };
+  ledger?: { ok: boolean; skipped?: boolean; reason?: string };
+};

--- a/lib/slack-agent/verifySlackSignature.ts
+++ b/lib/slack-agent/verifySlackSignature.ts
@@ -1,0 +1,40 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Slack Signing Secret verification (Events API).
+ * @see https://api.slack.com/authentication/verifying-requests-from-slack
+ */
+export function verifySlackRequest(args: {
+  signingSecret: string;
+  rawBody: string;
+  timestampHeader: string | null;
+  signatureHeader: string | null;
+}): { ok: true } | { ok: false; reason: string } {
+  const { signingSecret, rawBody, timestampHeader, signatureHeader } = args;
+  if (!timestampHeader || !signatureHeader) {
+    return { ok: false, reason: 'missing_signature_headers' };
+  }
+  const ts = Number(timestampHeader);
+  if (!Number.isFinite(ts)) {
+    return { ok: false, reason: 'bad_timestamp' };
+  }
+  const ageSec = Math.abs(Date.now() / 1000 - ts);
+  if (ageSec > 60 * 5) {
+    return { ok: false, reason: 'stale_timestamp' };
+  }
+  const basestring = `v0:${timestampHeader}:${rawBody}`;
+  const hmac = createHmac('sha256', signingSecret).update(basestring).digest('hex');
+  const expected = `v0=${hmac}`;
+  const sig = signatureHeader.trim();
+  if (sig.length !== expected.length) {
+    return { ok: false, reason: 'signature_mismatch' };
+  }
+  try {
+    if (!timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+      return { ok: false, reason: 'signature_mismatch' };
+    }
+  } catch {
+    return { ok: false, reason: 'signature_mismatch' };
+  }
+  return { ok: true };
+}

--- a/mobius-manifest.json
+++ b/mobius-manifest.json
@@ -1,0 +1,55 @@
+{
+  "$schema_comment": "Mobius policy surface — Slack agent and cross-repo touch rules (v1).",
+  "schema": "MOBIUS_MANIFEST_V1",
+  "slack_agent": {
+    "enabled": true,
+    "mode": "read_first",
+    "allowed_commands": [
+      "status",
+      "vault",
+      "cycle",
+      "pulse",
+      "readiness",
+      "journal",
+      "quest",
+      "propose",
+      "draft-pr",
+      "run"
+    ],
+    "allowed_workflows": [
+      "publish-cycle-state",
+      "fetch-hive-world",
+      "mesh-aggregate",
+      "world-update"
+    ],
+    "allowed_channel_ids": [],
+    "write_policy": {
+      "oaa_logging_required": true,
+      "ledger_logging_for_meaningful_actions": true,
+      "auto_merge_allowed": false,
+      "protected_truth_files_read_only": true
+    }
+  },
+  "repo_touch": {
+    "read": [
+      "Mobius-Substrate",
+      "mobius-civic-ai-terminal",
+      "mobius-browser-shell",
+      "mobius-hive",
+      "OAA-API-Library",
+      "Civic-Protocol-Core"
+    ],
+    "write_v1": [
+      "oaa_memory",
+      "draft_pr_branches",
+      "hive_non_protected_proposals",
+      "workflow_dispatch_requests"
+    ],
+    "write_blocked_v1": [
+      "ledger_canonical_history",
+      "mic_auth_files",
+      "manifest_without_review",
+      "main_branch_protected_files"
+    ]
+  }
+}

--- a/mobius-slack-agent.md
+++ b/mobius-slack-agent.md
@@ -1,0 +1,113 @@
+# Mobius Slack Agent v1
+
+**Purpose:** Turn Slack into a **safe command surface** for Mobius.
+
+```
+Slack → command → Mobius agent wrapper → manifest validation
+  → allowed endpoint / workflow / PR → OAA log → optional ledger proof → Slack reply
+```
+
+## Core rule
+
+- **Slack** is the interface.
+- **Mobius** is the constitution.
+- **Agents** are executors, not rulers.
+
+## Operating model
+
+**Slack asks. Manifest permits. Mobius acts. OAA remembers. Ledger proves.**
+
+## v1 scope
+
+### Allowed in v1
+
+- Read system state
+- Read cycle state
+- Read vault / MIC readiness
+- Read pulse / integrity snapshot
+- Append memory notes (OAA)
+- Open draft PRs (when GitHub wiring is configured — stub returns explicit “not configured”)
+- Trigger safe workflows (manifest allowlist — stub until `GITHUB_TOKEN` + repo owner wiring)
+- Propose HIVE world updates (logged as structured proposal to OAA)
+
+### Not allowed in v1
+
+- Auto-merge PRs
+- Direct writes to protected truth files
+- Direct MIC minting
+- Direct ledger rewrites
+- Unrestricted multi-repo code edits
+- Privileged destructive actions from Slack
+
+## First command set
+
+1. `@Mobius status`
+2. `@Mobius vault`
+3. `@Mobius cycle`
+4. `@Mobius pulse`
+5. `@Mobius propose <task>`
+
+## Expanded safe set
+
+`status` · `vault` · `cycle` · `pulse` · `readiness` · `journal` · `quest` · `propose <task>` · `draft-pr <title>` · `run <safe_workflow>`
+
+## Command behavior (sources of truth)
+
+| Command | Returns (summary) | Primary sources |
+|--------|-------------------|-----------------|
+| **status** | GI, KV, cycle, heartbeat, tripwires, GI source mode | `GET /api/terminal/snapshot-lite` |
+| **vault** | Reserve / tranche / seal lane / MIC readiness hints | `GET /api/vault/status`, `GET /api/mic/readiness` |
+| **cycle** | Current cycle, blockers/degraded, snapshot meta | `ledger/cycle-state.json` (repo), snapshot-lite |
+| **pulse** | Mesh pulse lane, node freshness, anomalies | Snapshot-lite `lanes.pulse` + integrity |
+| **readiness** | MIC readiness envelope (as returned by API) | `GET /api/mic/readiness` |
+| **journal** | Short journal heartbeat + pointer to full journal API | Snapshot-lite + optional `GET /api/agents/journal` when service auth is available on the bridge host |
+| **quest** | Treated as `propose` with a `[quest]` prefix for OAA |
+| **propose** | OAA memory entry + Slack plan text | OAA `/api/oaa/kv` via `OAADataClient` |
+| **draft-pr** | v1 stub: requires GitHub app token wiring (no illusion) | — |
+| **run** | v1 stub: requires `GITHUB_TOKEN` + dispatch wiring | Manifest `allowed_workflows` |
+
+## Architecture
+
+| Layer | Role |
+|-------|------|
+| **A. Slack app** | Receives mentions / slash commands; POSTs signed payloads to the Terminal bridge. |
+| **B. Mobius agent wrapper** | Parses command → intent class (`read_only` / `write_candidate` / `github_draft_only`). |
+| **C. `mobius-manifest.json`** | Policy engine: enabled flag, allowed commands/workflows, write policy. |
+| **D. Execution targets** | Terminal HTTP routes, `ledger/cycle-state.json`, OAA KV journal, (optional) GitHub API. |
+| **E. Logging** | Every command: OAA audit entry `{ source, actor, command, cycle, intent }`. Meaningful actions: optional ledger proof via existing ingest path when configured. |
+
+## Permission classes
+
+1. **Read** — `status`, `vault`, `pulse`, `cycle`, `readiness`, `journal`
+2. **Propose** — `propose`, `quest` (maps to propose)
+3. **Trigger** — `run` (allowlisted workflows only; v1 stub until wired)
+4. **Protected** — Blocked in v1: merge, manifest edit, MIC mint, ledger rewrite, destructive ops
+
+## Slack channel map (organizational)
+
+| Channel | Use |
+|---------|-----|
+| `#mobius-control-room` | status, pulse, cycle, vault |
+| `#hive-world` | quests, events, sentinel dialogue, world proposals |
+| `#mobius-build` | draft PRs, workflow runs, repo proposals |
+
+Optional enforcement: set `slack_agent.allowed_channel_ids` in `mobius-manifest.json` to non-empty to restrict which Slack channel IDs the bridge accepts.
+
+## HTTP bridge (this repo)
+
+- **Route:** `POST /api/slack/agent`
+- **Verification:** Slack signing secret (`SLACK_SIGNING_SECRET`). Handles `url_verification` challenges.
+- **Auth:** Requests must include valid `X-Slack-Signature` + `X-Slack-Request-Timestamp` (Slack Events API).
+- **Replies:** Slack’s Events API expects a quick `200` ack; the bridge posts the operator response with `chat.postMessage` using `SLACK_BOT_TOKEN` (`xoxb-…`, `chat:write`).
+
+## Guardrails
+
+**Hard:** No auto-merge, no main writes, no destructive commands, no mint authorization, no direct truth overwrite.
+
+**Soft:** OAA audit on every command when OAA client is configured; optional ledger proof for meaningful writes when ingest is configured; workflow allowlist only.
+
+## Related files
+
+- `mobius-manifest.json` — policy
+- `lib/slack-agent/*` — parser, manifest load, command router
+- `app/api/slack/agent/route.ts` — Slack Events entrypoint


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Mobius Slack Agent v1** as specified: root `mobius-manifest.json` policy, operator documentation, a small command parser and router, and a **Slack Events API** entrypoint at `POST /api/slack/agent` that verifies Slack signatures, acknowledges quickly, then posts replies via `chat.postMessage`.

Read commands aggregate **real** Terminal data (`/api/terminal/snapshot-lite`, `/api/vault/status`, `/api/mic/readiness`, `ledger/cycle-state.json`). **propose** / **quest** append structured payloads through the existing `publishToOaaAndLedger` path (OAA + optional ledger when configured). **draft-pr** and **run** remain explicit stubs (no fake success).

## Cycle / type

- **Cycle:** C-287 
- **Type:** feat  
- **Primary area:** infra  

## Files changed

- `mobius-manifest.json` (new)  
- `mobius-slack-agent.md` (new)  
- `lib/slack-agent/*` (new)  
- `app/api/slack/agent/route.ts` (new)  
- `lib/oaa/publishSnapshot.ts` — add `PublishKind` value `slack_agent_command`  
- `.env.example` — `SLACK_SIGNING_SECRET`, `SLACK_BOT_TOKEN`  

## Configuration

Set `SLACK_SIGNING_SECRET` and `SLACK_BOT_TOKEN` (`xoxb-…` with `chat:write`). Point the Slack app Request URL to `/api/slack/agent` on the deployed Terminal host.

## Verification

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- **Lint:** ESLint not configured in repo (per AGENTS.md); not run interactively  

## Notes / follow-ups

- GitHub **workflow_dispatch** and **draft PR** creation are intentionally not implemented in this PR (operator truth).  
- Optional: populate `slack_agent.allowed_channel_ids` in the manifest to restrict channels.  
- In-memory `event_id` dedupe is best-effort per instance; production may want KV-backed idempotency.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://mobius-substrate.slack.com/archives/D0AU7DJDL9W/p1776709153359049?thread_ts=1776709153.359049&cid=D0AU7DJDL9W)

<div><a href="https://cursor.com/agents/bc-749f75ef-d3e1-5bff-9b9a-4962d732b9b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-749f75ef-d3e1-5bff-9b9a-4962d732b9b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

