### PR TITLE
feat(slack-agent): phase 2 — GitHub draft PR + workflow dispatch, KV dedupe, source footers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,15 @@ SLACK_SIGNING_SECRET=
 # Bot User OAuth Token (starts with xoxb-) — used for chat.postMessage replies after ack.
 SLACK_BOT_TOKEN=
 
+# Slack agent: GitHub draft PR + workflow_dispatch (repo `contents` + `pull_requests` + `actions:write`)
+GITHUB_TOKEN=
+# Override when not running in GitHub Actions (format: owner/repo)
+SLACK_AGENT_GITHUB_REPO=
+# Branch ref for workflow_dispatch (default: main)
+SLACK_AGENT_GITHUB_REF=
+# Base branch for draft PRs (default: main)
+SLACK_AGENT_GITHUB_BASE=
+
 # Comma-separated extra origins for Handbook / GitHub Pages CORS on public GET routes
 # (defaults include https://kaizencycle.github.io and mobius-browser-shell.vercel.app)
 MOBIUS_HANDBOOK_CORS_ORIGINS=

--- a/.github/workflows/fetch-hive-world.yml
+++ b/.github/workflows/fetch-hive-world.yml
@@ -1,0 +1,17 @@
+# Declared in mobius.yaml — safe manual trigger from Mobius Slack Agent v1 (`@Mobius run fetch-hive-world`).
+# Placeholder: extend with HIVE fetch steps when wired to browser-shell / HIVE APIs.
+
+name: Fetch HIVE world
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "fetch-hive-world stub — operator-defined steps go here"

--- a/.github/workflows/mesh-aggregate.yml
+++ b/.github/workflows/mesh-aggregate.yml
@@ -1,0 +1,16 @@
+# Declared in mobius.yaml — safe manual trigger from Mobius Slack Agent v1 (`@Mobius run mesh-aggregate`).
+
+name: Mesh aggregate
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "mesh-aggregate stub — operator-defined steps go here"

--- a/.github/workflows/world-update.yml
+++ b/.github/workflows/world-update.yml
@@ -1,0 +1,16 @@
+# Declared in mobius.yaml — safe manual trigger from Mobius Slack Agent v1 (`@Mobius run world-update`).
+
+name: World update
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "world-update stub — operator-defined steps go here"

--- a/.mobius/slack-agent/drafts/README.md
+++ b/.mobius/slack-agent/drafts/README.md
@@ -1,0 +1,5 @@
+# Slack agent draft proposals
+
+Markdown files committed on `cursor/slack-draft-*` branches by `@Mobius draft-pr <title>` are **non-canonical proposals**.
+
+They are not ledger truth, MIC authorization, or protected manifest edits. Sentinel + human review applies before merge.

--- a/app/api/slack/agent/route.ts
+++ b/app/api/slack/agent/route.ts
@@ -5,6 +5,7 @@ import { loadMobiusManifest } from '@/lib/slack-agent/loadManifest';
 import { parseSlackCommandText } from '@/lib/slack-agent/parseCommand';
 import { postSlackChatMessage } from '@/lib/slack-agent/postSlackReply';
 import { verifySlackRequest } from '@/lib/slack-agent/verifySlackSignature';
+import { claimSlackEventId } from '@/lib/slack-agent/slackEventDedupe';
 
 export const dynamic = 'force-dynamic';
 
@@ -23,19 +24,6 @@ type SlackEnvelope = {
   };
   team_id?: string;
 };
-
-const seenEventIds = new Set<string>();
-const SEEN_MAX = 500;
-
-function rememberEventId(id: string): boolean {
-  if (seenEventIds.has(id)) return false;
-  seenEventIds.add(id);
-  if (seenEventIds.size > SEEN_MAX) {
-    const first = seenEventIds.values().next().value as string | undefined;
-    if (first) seenEventIds.delete(first);
-  }
-  return true;
-}
 
 function json(data: unknown, status = 200) {
   return NextResponse.json(data, { status });
@@ -85,8 +73,11 @@ export async function POST(req: NextRequest) {
   }
 
   const eventId = typeof body.event_id === 'string' ? body.event_id : '';
-  if (eventId && !rememberEventId(eventId)) {
-    return json({ ok: true });
+  if (eventId) {
+    const firstTime = await claimSlackEventId(eventId);
+    if (!firstTime) {
+      return json({ ok: true });
+    }
   }
 
   const text = typeof ev.text === 'string' ? ev.text : '';

--- a/lib/mesh/loadMobiusYaml.ts
+++ b/lib/mesh/loadMobiusYaml.ts
@@ -30,6 +30,10 @@ export type MobiusYamlV1 = {
   version?: string;
   mesh?: Record<string, unknown>;
   pulse?: Record<string, unknown>;
+  jobs?: {
+    enabled?: boolean;
+    workflows?: Array<{ id?: string; file?: string; trigger?: string; cron?: string; description?: string }>;
+  };
   ingest?: {
     enabled?: boolean;
     mode?: string;
@@ -139,4 +143,17 @@ export function isOaaPublishEnabled(): boolean {
   if (loadMobiusYaml().ingest?.enabled === false) return false;
   if (!isDualWriteMode()) return false;
   return resolveOaaKvPostUrl() !== null && resolveOaaHmacSecret() !== null;
+}
+
+/** Workflow ids declared under `jobs.workflows` in mobius.yaml (for Slack agent allowlist validation). */
+export function loadDeclaredWorkflowIdsFromMobiusYaml(doc: MobiusYamlV1 = loadMobiusYaml()): string[] {
+  const list = doc.jobs?.workflows;
+  if (!Array.isArray(list)) return [];
+  const ids: string[] = [];
+  for (const w of list) {
+    if (w && typeof w === 'object' && typeof w.id === 'string' && w.id.trim().length > 0) {
+      ids.push(w.id.trim());
+    }
+  }
+  return ids;
 }

--- a/lib/slack-agent/githubOps.ts
+++ b/lib/slack-agent/githubOps.ts
@@ -1,0 +1,274 @@
+/**
+ * GitHub API helpers for Mobius Slack Agent — draft PR + workflow_dispatch.
+ * Uses operator-provided token; never invents success.
+ */
+
+const GITHUB_API = 'https://api.github.com';
+
+export type GithubDispatchResult =
+  | { ok: true; status: number; workflow_id: string; html_url?: string }
+  | { ok: false; error: string; status?: number };
+
+export type GithubDraftPrResult =
+  | { ok: true; status: number; html_url: string; number: number }
+  | { ok: false; error: string; status?: number };
+
+function bearer(): string | null {
+  const t = process.env.GITHUB_TOKEN?.trim();
+  return t && t.length > 0 ? t : null;
+}
+
+/** owner/repo for this Terminal repo when dispatching / opening PRs from Slack. */
+export function resolveSlackAgentGithubRepo(): string | null {
+  const explicit =
+    process.env.SLACK_AGENT_GITHUB_REPO?.trim() ||
+    process.env.MOBIUS_GITHUB_REPO?.trim() ||
+    process.env.GITHUB_REPOSITORY?.trim();
+  if (explicit && explicit.includes('/')) return explicit;
+
+  const vercel = process.env.VERCEL_GIT_REPOSITORY_URL?.trim();
+  if (vercel) {
+    try {
+      const u = new URL(vercel.replace(/^git@github\.com:/, 'https://github.com/'));
+      const path = u.pathname.replace(/^\/|\/$/g, '');
+      if (path.endsWith('.git')) return path.slice(0, -4);
+      if (path.includes('/')) return path;
+    } catch {
+      /* ignore */
+    }
+  }
+  return null;
+}
+
+export function slackAgentWorkflowFilename(workflowId: string): string {
+  const map: Record<string, string> = {
+    'publish-cycle-state': 'publish-cycle-state.yml',
+    'fetch-hive-world': 'fetch-hive-world.yml',
+    'mesh-aggregate': 'mesh-aggregate.yml',
+    'world-update': 'world-update.yml',
+  };
+  return map[workflowId] ?? `${workflowId}.yml`;
+}
+
+export async function dispatchGithubWorkflow(args: {
+  repo: string;
+  workflowId: string;
+  ref?: string;
+}): Promise<GithubDispatchResult> {
+  const token = bearer();
+  if (!token) {
+    return { ok: false, error: 'GITHUB_TOKEN not set (needs repo workflow scope)' };
+  }
+  const file = slackAgentWorkflowFilename(args.workflowId);
+  const ref = (args.ref ?? process.env.SLACK_AGENT_GITHUB_REF?.trim() ?? 'main').replace(/^refs\/heads\//, '');
+  const url = `${GITHUB_API}/repos/${args.repo}/actions/workflows/${encodeURIComponent(file)}/dispatches`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({ ref }),
+    signal: AbortSignal.timeout(25000),
+  });
+  if (res.status === 204 || res.status === 200) {
+    return { ok: true, status: res.status, workflow_id: args.workflowId };
+  }
+  let detail = '';
+  try {
+    const j = (await res.json()) as { message?: string };
+    detail = j.message ? `: ${j.message}` : '';
+  } catch {
+    /* ignore */
+  }
+  return { ok: false, error: `github_dispatch_failed${detail}`, status: res.status };
+}
+
+export async function createGithubDraftPullRequest(args: {
+  repo: string;
+  title: string;
+  headBranch: string;
+  baseBranch?: string;
+}): Promise<GithubDraftPrResult> {
+  const token = bearer();
+  if (!token) {
+    return { ok: false, error: 'GITHUB_TOKEN not set (needs contents + pull_requests)' };
+  }
+  const base = args.baseBranch?.trim() || process.env.SLACK_AGENT_GITHUB_BASE?.trim() || 'main';
+  const url = `${GITHUB_API}/repos/${args.repo}/pulls`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({
+      title: args.title,
+      head: args.headBranch,
+      base,
+      draft: true,
+    }),
+    signal: AbortSignal.timeout(25000),
+  });
+  if (!res.ok) {
+    let detail = '';
+    try {
+      const j = (await res.json()) as { message?: string };
+      detail = j.message ? `: ${j.message}` : '';
+    } catch {
+      /* ignore */
+    }
+    return { ok: false, error: `github_pr_create_failed${detail}`, status: res.status };
+  }
+  const data = (await res.json()) as { html_url?: string; number?: number };
+  const html = typeof data.html_url === 'string' ? data.html_url : '';
+  const num = typeof data.number === 'number' ? data.number : 0;
+  if (!html) return { ok: false, error: 'github_pr_missing_html_url', status: res.status };
+  return { ok: true, status: res.status, html_url: html, number: num };
+}
+
+export async function createGithubBranchRef(args: {
+  repo: string;
+  branchName: string;
+  fromSha: string;
+}): Promise<{ ok: true } | { ok: false; error: string; status?: number }> {
+  const token = bearer();
+  if (!token) {
+    return { ok: false, error: 'GITHUB_TOKEN not set' };
+  }
+  const url = `${GITHUB_API}/repos/${args.repo}/git/refs`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({
+      ref: `refs/heads/${args.branchName}`,
+      sha: args.fromSha,
+    }),
+    signal: AbortSignal.timeout(25000),
+  });
+  if (res.status === 201) return { ok: true };
+  let detail = '';
+  try {
+    const j = (await res.json()) as { message?: string };
+    detail = j.message ? `: ${j.message}` : '';
+  } catch {
+    /* ignore */
+  }
+  return { ok: false, error: `github_ref_create_failed${detail}`, status: res.status };
+}
+
+export async function getDefaultBranchSha(repo: string): Promise<{ ok: true; sha: string } | { ok: false; error: string }> {
+  const token = bearer();
+  if (!token) {
+    return { ok: false, error: 'GITHUB_TOKEN not set' };
+  }
+  const url = `${GITHUB_API}/repos/${repo}`;
+  const res = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    signal: AbortSignal.timeout(20000),
+  });
+  if (!res.ok) {
+    return { ok: false, error: `github_repo_meta_${res.status}` };
+  }
+  const data = (await res.json()) as { default_branch?: string };
+  const branch = typeof data.default_branch === 'string' ? data.default_branch : 'main';
+  const refUrl = `${GITHUB_API}/repos/${repo}/git/ref/heads/${encodeURIComponent(branch)}`;
+  const refRes = await fetch(refUrl, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    signal: AbortSignal.timeout(20000),
+  });
+  if (!refRes.ok) {
+    return { ok: false, error: `github_ref_resolve_${refRes.status}` };
+  }
+  const refData = (await refRes.json()) as { object?: { sha?: string } };
+  const sha = refData.object?.sha;
+  if (typeof sha !== 'string' || sha.length < 7) {
+    return { ok: false, error: 'github_ref_missing_sha' };
+  }
+  return { ok: true, sha };
+}
+
+export async function getRepoFileSha(args: {
+  repo: string;
+  path: string;
+  branch: string;
+}): Promise<{ ok: true; sha: string | null } | { ok: false; error: string }> {
+  const token = bearer();
+  if (!token) {
+    return { ok: false, error: 'GITHUB_TOKEN not set' };
+  }
+  const pathInUrl = args.path.split('/').map(encodeURIComponent).join('/');
+  const url = `${GITHUB_API}/repos/${args.repo}/contents/${pathInUrl}?ref=${encodeURIComponent(args.branch)}`;
+  const res = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    signal: AbortSignal.timeout(20000),
+  });
+  if (res.status === 404) {
+    return { ok: true, sha: null };
+  }
+  if (!res.ok) {
+    return { ok: false, error: `github_contents_get_${res.status}` };
+  }
+  const data = (await res.json()) as { sha?: string };
+  return { ok: true, sha: typeof data.sha === 'string' ? data.sha : null };
+}
+
+export async function putRepoFileOnBranch(args: {
+  repo: string;
+  path: string;
+  branch: string;
+  message: string;
+  contentUtf8: string;
+  /** When updating an existing blob */
+  sha?: string;
+}): Promise<{ ok: true } | { ok: false; error: string; status?: number }> {
+  const token = bearer();
+  if (!token) {
+    return { ok: false, error: 'GITHUB_TOKEN not set' };
+  }
+  const pathInUrl = args.path.split('/').map(encodeURIComponent).join('/');
+  const url = `${GITHUB_API}/repos/${args.repo}/contents/${pathInUrl}`;
+  const body: Record<string, string> = {
+    message: args.message,
+    content: Buffer.from(args.contentUtf8, 'utf8').toString('base64'),
+    branch: args.branch,
+  };
+  if (args.sha) body.sha = args.sha;
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(25000),
+  });
+  if (res.status === 200 || res.status === 201) return { ok: true };
+  let detail = '';
+  try {
+    const j = (await res.json()) as { message?: string };
+    detail = j.message ? `: ${j.message}` : '';
+  } catch {
+    /* ignore */
+  }
+  return { ok: false, error: `github_contents_put_failed${detail}`, status: res.status };
+}

--- a/lib/slack-agent/loadManifest.ts
+++ b/lib/slack-agent/loadManifest.ts
@@ -26,10 +26,21 @@ function parseManifest(raw: string): MobiusManifestV1 {
   const allowed = o.allowed_commands;
   const workflows = o.allowed_workflows;
   const wp = o.write_policy;
+  const ghRaw = o.github;
   if (!isStringArray(allowed)) throw new Error('manifest_invalid_allowed_commands');
   if (!isStringArray(workflows)) throw new Error('manifest_invalid_allowed_workflows');
   if (!wp || typeof wp !== 'object') throw new Error('manifest_invalid_write_policy');
   const w = wp as Record<string, unknown>;
+
+  let github: MobiusManifestV1['slack_agent']['github'];
+  if (ghRaw && typeof ghRaw === 'object') {
+    const g = ghRaw as Record<string, unknown>;
+    github = {
+      repo: typeof g.repo === 'string' && g.repo.includes('/') ? g.repo : undefined,
+      default_branch: typeof g.default_branch === 'string' ? g.default_branch : undefined,
+      draft_pr_path: typeof g.draft_pr_path === 'string' ? g.draft_pr_path : undefined,
+    };
+  }
 
   return {
     schema: typeof j.schema === 'string' ? j.schema : undefined,
@@ -39,6 +50,7 @@ function parseManifest(raw: string): MobiusManifestV1 {
       allowed_commands: allowed,
       allowed_workflows: workflows,
       allowed_channel_ids: isStringArray(o.allowed_channel_ids) ? o.allowed_channel_ids : undefined,
+      github,
       write_policy: {
         oaa_logging_required: asBool(w.oaa_logging_required, true),
         ledger_logging_for_meaningful_actions: asBool(w.ledger_logging_for_meaningful_actions, true),

--- a/lib/slack-agent/router.ts
+++ b/lib/slack-agent/router.ts
@@ -5,7 +5,18 @@ import { terminalInternalOrigin } from '@/lib/oaa/internalOrigin';
 import { publishToOaaAndLedger } from '@/lib/oaa/publishSnapshot';
 import { OAADataClient } from '@/lib/ingestion/OAADataClient';
 import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
-import { loadMobiusManifest } from '@/lib/slack-agent/loadManifest';
+import { loadDeclaredWorkflowIdsFromMobiusYaml } from '@/lib/mesh/loadMobiusYaml';
+import { provenanceShortLabel } from '@/lib/terminal/memoryMode';
+import {
+  createGithubBranchRef,
+  createGithubDraftPullRequest,
+  dispatchGithubWorkflow,
+  getDefaultBranchSha,
+  getRepoFileSha,
+  putRepoFileOnBranch,
+  resolveSlackAgentGithubRepo,
+  slackAgentWorkflowFilename,
+} from '@/lib/slack-agent/githubOps';
 import type { MobiusManifestV1, ParsedSlackCommand, SlackCommandResult } from '@/lib/slack-agent/types';
 
 async function fetchJson(path: string): Promise<unknown> {
@@ -14,6 +25,28 @@ async function fetchJson(path: string): Promise<unknown> {
   const res = await fetch(url, { headers: { Accept: 'application/json' }, cache: 'no-store', signal: AbortSignal.timeout(20000) });
   if (!res.ok) throw new Error(`fetch_${path}_${res.status}`);
   return res.json();
+}
+
+function fmtSourceFooterFromLite(lite: Record<string, unknown>): string {
+  const meta = lite.meta && typeof lite.meta === 'object' ? (lite.meta as Record<string, unknown>) : {};
+  const kvAvail = meta.kv_available === true;
+  const prov = typeof lite.gi_provenance === 'string' ? lite.gi_provenance : null;
+  const verified = lite.gi_verified === true;
+  const giSrc = typeof lite.gi_source === 'string' ? lite.gi_source : 'unknown';
+  const memShort = provenanceShortLabel(prov);
+  const ledgerLine =
+    verified && prov === 'oaa-verified'
+      ? 'Ledger-backed: OAA verified GI (warm mirror)'
+      : verified
+        ? 'Ledger-backed: GI marked verified (see snapshot provenance)'
+        : 'Ledger-backed: no (GI not OAA-verified in this snapshot)';
+  return [
+    '— Source mode —',
+    `KV: ${kvAvail ? 'available' : 'unavailable / degraded'}`,
+    `Verified memory: ${verified ? 'yes' : 'no'} (${memShort}${prov ? ` · ${prov}` : ''})`,
+    `GI lane: ${giSrc}`,
+    ledgerLine,
+  ].join('\n');
 }
 
 function fmtStatus(lite: Record<string, unknown>): string {
@@ -35,6 +68,8 @@ function fmtStatus(lite: Record<string, unknown>): string {
     `GI source: ${giSource} · tripwires elevated=${twElev}`,
     `heartbeat runtime: ${runtimeHb}`,
     `Source: /api/terminal/snapshot-lite`,
+    '',
+    fmtSourceFooterFromLite(lite),
   ];
   return lines.join('\n');
 }
@@ -83,7 +118,13 @@ function fmtCycle(cycleFile: Record<string, unknown>, lite: Record<string, unkno
     lines.push(`snapshot-lite cycle_source: ${String(m.cycle_source ?? '')}`);
   }
   lines.push(`Source: ledger/cycle-state.json (+ snapshot-lite when available)`);
-  return lines.join('\n');
+  let out = lines.join('\n');
+  if (lite) {
+    out += `\n\n${fmtSourceFooterFromLite(lite)}`;
+  } else {
+    out += '\n\n— Source mode —\nsnapshot-lite unavailable (KV / verified-memory footer skipped)';
+  }
+  return out;
 }
 
 function fmtPulse(lite: Record<string, unknown>): string {
@@ -95,6 +136,8 @@ function fmtPulse(lite: Record<string, unknown>): string {
     `pulse freshness=${String(pulse.freshness ?? '')} age_seconds=${String(pulse.age_seconds ?? '')}`,
     `integrity GI=${String(integ.gi ?? '')} verified=${String(integ.verified ?? '')}`,
     `Source: snapshot-lite lanes (SYSTEM_PULSE in KV)`,
+    '',
+    fmtSourceFooterFromLite(lite),
   ];
   return lines.join('\n');
 }
@@ -106,7 +149,12 @@ function fmtReadiness(mic: Record<string, unknown>): string {
 function fmtJournal(lite: Record<string, unknown>): string {
   const hb = lite.heartbeat && typeof lite.heartbeat === 'object' ? (lite.heartbeat as Record<string, unknown>) : {};
   const j = hb.journal;
-  return `Journal heartbeat: ${j != null ? JSON.stringify(j) : 'n/a'}\nFull feed: GET /api/agents/journal (service auth on host)`;
+  return [
+    `Journal heartbeat: ${j != null ? JSON.stringify(j) : 'n/a'}`,
+    `Full feed: GET /api/agents/journal (service auth on host)`,
+    '',
+    fmtSourceFooterFromLite(lite),
+  ].join('\n');
 }
 
 async function logOaaAudit(args: {
@@ -170,11 +218,15 @@ export async function executeSlackCommand(args: {
         return { text: fmtStatus(lite), oaa: audit };
       }
       case 'vault': {
-        const [vault, mic] = await Promise.all([
+        const [vault, mic, lite] = await Promise.all([
           fetchJson('/api/vault/status') as Promise<Record<string, unknown>>,
           fetchJson('/api/mic/readiness') as Promise<Record<string, unknown>>,
+          fetchJson('/api/terminal/snapshot-lite') as Promise<Record<string, unknown>>,
         ]);
-        return { text: `${pickVaultSummary(vault)}\n${fmtMicLine(mic)}`, oaa: audit };
+        return {
+          text: `${pickVaultSummary(vault)}\n${fmtMicLine(mic)}\n\n${fmtSourceFooterFromLite(lite)}`,
+          oaa: audit,
+        };
       }
       case 'cycle': {
         let cycleFile: Record<string, unknown> = {};
@@ -198,7 +250,10 @@ export async function executeSlackCommand(args: {
       }
       case 'readiness': {
         const mic = (await fetchJson('/api/mic/readiness')) as Record<string, unknown>;
-        return { text: fmtReadiness(mic), oaa: audit };
+        return {
+          text: `${fmtReadiness(mic)}\n\n— Source mode —\nMIC readiness is a dedicated API envelope (not snapshot-lite).\nUse \`@Mobius status\` for KV + verified-memory + GI lane in one view.`,
+          oaa: audit,
+        };
       }
       case 'journal': {
         const lite = (await fetchJson('/api/terminal/snapshot-lite')) as Record<string, unknown>;
@@ -261,10 +316,104 @@ export async function executeSlackCommand(args: {
         };
       }
       case 'draft-pr': {
+        if (manifest.slack_agent.write_policy.auto_merge_allowed) {
+          return { text: 'Refusing draft-pr: manifest has auto_merge_allowed (must stay false for Slack agent).', oaa: audit };
+        }
         const title = parsed.args.trim() || '(untitled)';
+        const repo =
+          manifest.slack_agent.github?.repo?.trim() ||
+          resolveSlackAgentGithubRepo();
+        if (!repo) {
+          return {
+            text: `Draft PR not configured: set \`slack_agent.github.repo\` (owner/repo) or env \`GITHUB_REPOSITORY\` / \`SLACK_AGENT_GITHUB_REPO\`, plus \`GITHUB_TOKEN\` with contents + pull_requests.\nTitle requested: ${title}`,
+            oaa: audit,
+          };
+        }
+        const baseBranch =
+          manifest.slack_agent.github?.default_branch?.trim() ||
+          process.env.SLACK_AGENT_GITHUB_BASE?.trim() ||
+          'main';
+        const relPath =
+          manifest.slack_agent.github?.draft_pr_path?.trim() ||
+          '.mobius/slack-agent/drafts/README.md';
+        const baseSha = await getDefaultBranchSha(repo);
+        if (!baseSha.ok) {
+          return { text: `Draft PR failed: ${baseSha.error}`, oaa: audit };
+        }
+        const slug = randomUUID().replace(/-/g, '').slice(0, 10);
+        const branchName = `cursor/slack-draft-${slug}`;
+        const refOk = await createGithubBranchRef({ repo, branchName, fromSha: baseSha.sha });
+        if (!refOk.ok) {
+          return { text: `Draft PR failed (branch): ${refOk.error}`, oaa: audit };
+        }
+        const existing = await getRepoFileSha({ repo, path: relPath, branch: branchName });
+        if (!existing.ok) {
+          return { text: `Draft PR failed (read path): ${existing.error}`, oaa: audit };
+        }
+        const body = [
+          `# ${title}`,
+          '',
+          `Opened from Mobius Slack Agent · cycle ${cycle} · actor ${actor}`,
+          '',
+          `Timestamp: ${new Date().toISOString()}`,
+          '',
+          '_Non-protected proposal file — not ledger truth._',
+        ].join('\n');
+        const put = await putRepoFileOnBranch({
+          repo,
+          path: relPath,
+          branch: branchName,
+          message: `chore(slack-agent): draft proposal — ${title.slice(0, 72)}`,
+          contentUtf8: body,
+          sha: existing.sha ?? undefined,
+        });
+        if (!put.ok) {
+          return { text: `Draft PR failed (commit): ${put.error}`, oaa: audit };
+        }
+        const pr = await createGithubDraftPullRequest({
+          repo,
+          title: `[slack-agent] ${title}`,
+          headBranch: branchName,
+          baseBranch,
+        });
+        if (!pr.ok) {
+          return {
+            text: `Branch ${branchName} pushed with proposal file, but draft PR failed: ${pr.error}`,
+            oaa: audit,
+          };
+        }
+        const proof = await publishToOaaAndLedger({
+          kind: 'slack_agent_command',
+          key: `slack:agent:draft-pr:${randomUUID()}`,
+          value: {
+            type: 'SLACK_AGENT_DRAFT_PR_V1',
+            source: 'slack-agent',
+            actor,
+            cycle,
+            title,
+            repo,
+            branch: branchName,
+            path: relPath,
+            pr_number: pr.number,
+            pr_url: pr.html_url,
+            timestamp: new Date().toISOString(),
+          },
+          agent: 'SLACK_AGENT',
+          intent: `slack_draft_pr:${title}`,
+        });
         return {
-          text: `Draft PR is not wired in v1 (requires GitHub app token + repo owner).\nWould open draft for: ${title}\nConfigure ops GitHub integration; manifest blocks auto-merge.`,
+          text: [
+            `Opened **draft** PR #${pr.number}: ${pr.html_url}`,
+            `Branch: \`${branchName}\` · file: \`${relPath}\``,
+            `OAA: ${proof.oaa.ok ? 'ok' : proof.oaa.error ?? 'failed'}${proof.oaa.hash ? ` · hash=${proof.oaa.hash}` : ''}`,
+            manifest.slack_agent.write_policy.ledger_logging_for_meaningful_actions
+              ? `Ledger proof: ${proof.ledger.ok ? 'ok' : proof.ledger.skipped ? `skipped (${proof.ledger.reason ?? ''})` : 'failed'}`
+              : '',
+          ]
+            .filter(Boolean)
+            .join('\n'),
           oaa: audit,
+          ledger: proof.ledger,
         };
       }
       case 'run': {
@@ -275,9 +424,57 @@ export async function executeSlackCommand(args: {
         if (!manifest.slack_agent.allowed_workflows.includes(wf)) {
           return { text: `Workflow \`${wf}\` is not in manifest allowlist.`, oaa: audit };
         }
+        const declared = loadDeclaredWorkflowIdsFromMobiusYaml();
+        if (declared.length > 0 && !declared.includes(wf)) {
+          return {
+            text: `Workflow \`${wf}\` is not declared in mobius.yaml \`jobs.workflows\`.\nDeclared ids: ${declared.join(', ') || '(none)'}\nUpdate mobius.yaml or manifest before dispatch.`,
+            oaa: audit,
+          };
+        }
+        const repo =
+          manifest.slack_agent.github?.repo?.trim() ||
+          resolveSlackAgentGithubRepo();
+        if (!repo) {
+          return {
+            text: `Cannot dispatch \`${wf}\`: set \`slack_agent.github.repo\` or \`GITHUB_REPOSITORY\` / \`SLACK_AGENT_GITHUB_REPO\`, plus \`GITHUB_TOKEN\` with workflow scope.`,
+            oaa: audit,
+          };
+        }
+        const dispatch = await dispatchGithubWorkflow({ repo, workflowId: wf });
+        if (!dispatch.ok) {
+          return {
+            text: `Dispatch failed for \`${wf}\` (${slackAgentWorkflowFilename(wf)}): ${dispatch.error}`,
+            oaa: audit,
+          };
+        }
+        const proof = await publishToOaaAndLedger({
+          kind: 'slack_agent_command',
+          key: `slack:agent:workflow:${randomUUID()}`,
+          value: {
+            type: 'SLACK_AGENT_WORKFLOW_DISPATCH_V1',
+            source: 'slack-agent',
+            actor,
+            cycle,
+            workflow_id: wf,
+            workflow_file: slackAgentWorkflowFilename(wf),
+            repo,
+            timestamp: new Date().toISOString(),
+          },
+          agent: 'SLACK_AGENT',
+          intent: `slack_workflow:${wf}`,
+        });
         return {
-          text: `Workflow \`${wf}\` is allowlisted but dispatch is not wired in this build.\nSet GITHUB_TOKEN with workflow scope and implement dispatch to .github/workflows/*.yml.`,
+          text: [
+            `Triggered \`workflow_dispatch\` for **${wf}** (\`${slackAgentWorkflowFilename(wf)}\`) on \`${repo}\`.`,
+            `OAA: ${proof.oaa.ok ? 'ok' : proof.oaa.error ?? 'failed'}${proof.oaa.hash ? ` · hash=${proof.oaa.hash}` : ''}`,
+            manifest.slack_agent.write_policy.ledger_logging_for_meaningful_actions
+              ? `Ledger proof: ${proof.ledger.ok ? 'ok' : proof.ledger.skipped ? `skipped (${proof.ledger.reason ?? ''})` : 'failed'}`
+              : '',
+          ]
+            .filter(Boolean)
+            .join('\n'),
           oaa: audit,
+          ledger: proof.ledger,
         };
       }
       default: {

--- a/lib/slack-agent/slackEventDedupe.ts
+++ b/lib/slack-agent/slackEventDedupe.ts
@@ -1,0 +1,53 @@
+import { createClient, kv } from '@vercel/kv';
+
+const KEY_PREFIX = 'mobius:slack-agent:event:';
+const TTL_SECONDS = 60 * 60 * 48; // 48h — Slack may retry
+
+/** In-process fallback when KV is not configured (single-instance only). */
+const memorySeen = new Set<string>();
+const MEMORY_MAX = 500;
+
+function getKvClient(): ReturnType<typeof createClient> | typeof kv | null {
+  if (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN) {
+    return kv;
+  }
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (url && token) {
+    return createClient({ url, token });
+  }
+  return null;
+}
+
+/** True when Upstash / Vercel KV env is present (KV-backed Slack event dedupe available). */
+export function slackDedupeKvConfigured(): boolean {
+  return getKvClient() != null;
+}
+
+/**
+ * Returns true if this event_id should be processed (first time),
+ * false if duplicate (Slack retry or another instance already handled).
+ */
+export async function claimSlackEventId(eventId: string): Promise<boolean> {
+  if (!eventId) return true;
+  const client = getKvClient();
+  if (!client) {
+    if (memorySeen.has(eventId)) return false;
+    memorySeen.add(eventId);
+    if (memorySeen.size > MEMORY_MAX) {
+      const first = memorySeen.values().next().value as string | undefined;
+      if (first) memorySeen.delete(first);
+    }
+    return true;
+  }
+  const key = `${KEY_PREFIX}${eventId}`;
+  try {
+    const r = await client.set(key, '1', { nx: true, ex: TTL_SECONDS });
+    return r === 'OK';
+  } catch (err) {
+    console.error('[slack-event-dedupe] KV claim failed:', err);
+    if (memorySeen.has(eventId)) return false;
+    memorySeen.add(eventId);
+    return true;
+  }
+}

--- a/lib/slack-agent/types.ts
+++ b/lib/slack-agent/types.ts
@@ -24,6 +24,12 @@ export type MobiusManifestV1 = {
     allowed_commands: string[];
     allowed_workflows: string[];
     allowed_channel_ids?: string[];
+    /** Optional `owner/repo` for GitHub draft PR + workflow_dispatch (falls back to env). */
+    github?: {
+      repo?: string;
+      default_branch?: string;
+      draft_pr_path?: string;
+    };
     write_policy: {
       oaa_logging_required: boolean;
       ledger_logging_for_meaningful_actions: boolean;

--- a/mobius-manifest.json
+++ b/mobius-manifest.json
@@ -23,6 +23,11 @@
       "world-update"
     ],
     "allowed_channel_ids": [],
+    "github": {
+      "repo": "",
+      "default_branch": "main",
+      "draft_pr_path": ".mobius/slack-agent/drafts/README.md"
+    },
     "write_policy": {
       "oaa_logging_required": true,
       "ledger_logging_for_meaningful_actions": true,

--- a/mobius-slack-agent.md
+++ b/mobius-slack-agent.md
@@ -26,8 +26,8 @@ Slack → command → Mobius agent wrapper → manifest validation
 - Read vault / MIC readiness
 - Read pulse / integrity snapshot
 - Append memory notes (OAA)
-- Open draft PRs (when GitHub wiring is configured — stub returns explicit “not configured”)
-- Trigger safe workflows (manifest allowlist — stub until `GITHUB_TOKEN` + repo owner wiring)
+- Open draft PRs (when `GITHUB_TOKEN` + repo resolution are configured — otherwise explicit operator-truth error)
+- Trigger safe workflows (`workflow_dispatch` for ids in manifest **and** declared in `mobius.yaml` `jobs.workflows`)
 - Propose HIVE world updates (logged as structured proposal to OAA)
 
 ### Not allowed in v1
@@ -63,8 +63,8 @@ Slack → command → Mobius agent wrapper → manifest validation
 | **journal** | Short journal heartbeat + pointer to full journal API | Snapshot-lite + optional `GET /api/agents/journal` when service auth is available on the bridge host |
 | **quest** | Treated as `propose` with a `[quest]` prefix for OAA |
 | **propose** | OAA memory entry + Slack plan text | OAA `/api/oaa/kv` via `OAADataClient` |
-| **draft-pr** | v1 stub: requires GitHub app token wiring (no illusion) | — |
-| **run** | v1 stub: requires `GITHUB_TOKEN` + dispatch wiring | Manifest `allowed_workflows` |
+| **draft-pr** | Creates branch + proposal markdown + **draft** PR (no auto-merge) | GitHub REST + `slack_agent.github` / env repo |
+| **run** | `POST .../actions/workflows/{file}/dispatches` for allowlisted + YAML-declared workflows | GitHub REST + `mobius-manifest.json` + `mobius.yaml` |
 
 ## Architecture
 
@@ -80,7 +80,7 @@ Slack → command → Mobius agent wrapper → manifest validation
 
 1. **Read** — `status`, `vault`, `pulse`, `cycle`, `readiness`, `journal`
 2. **Propose** — `propose`, `quest` (maps to propose)
-3. **Trigger** — `run` (allowlisted workflows only; v1 stub until wired)
+3. **Trigger** — `run` (allowlisted workflows only; must match `mobius.yaml` declarations when that section is non-empty)
 4. **Protected** — Blocked in v1: merge, manifest edit, MIC mint, ledger rewrite, destructive ops
 
 ## Slack channel map (organizational)
@@ -91,7 +91,9 @@ Slack → command → Mobius agent wrapper → manifest validation
 | `#hive-world` | quests, events, sentinel dialogue, world proposals |
 | `#mobius-build` | draft PRs, workflow runs, repo proposals |
 
-Optional enforcement: set `slack_agent.allowed_channel_ids` in `mobius-manifest.json` to non-empty to restrict which Slack channel IDs the bridge accepts.
+Optional enforcement: set `slack_agent.allowed_channel_ids` in `mobius-manifest.json` to non-empty to restrict which Slack channel IDs the bridge accepts (Slack channel IDs look like `C0123456789`).
+
+**GitHub (draft PR + workflow dispatch):** set `slack_agent.github.repo` to `owner/repo` (or `SLACK_AGENT_GITHUB_REPO` / `GITHUB_REPOSITORY` in Actions). Set `GITHUB_TOKEN` with `contents`, `pull_requests`, and `actions:write` for this repository. Event dedupe uses **KV** (`KV_REST_*` or `UPSTASH_REDIS_*`) when configured; otherwise a single-instance in-memory set (Slack retries only dedupe on that instance).
 
 ## HTTP bridge (this repo)
 

--- a/mobius.yaml
+++ b/mobius.yaml
@@ -166,6 +166,18 @@ jobs:
       trigger: "schedule"
       cron: "*/10 * * * *"
       description: "Fetch snapshot-lite → ledger/cycle-state.json for HIVE / Substrate / browser-shell"
+    - id: "fetch-hive-world"
+      file: ".github/workflows/fetch-hive-world.yml"
+      trigger: "manual"
+      description: "Slack-agent allowlisted stub — extend for HIVE world fetch"
+    - id: "mesh-aggregate"
+      file: ".github/workflows/mesh-aggregate.yml"
+      trigger: "manual"
+      description: "Slack-agent allowlisted stub — extend for mesh aggregation"
+    - id: "world-update"
+      file: ".github/workflows/world-update.yml"
+      trigger: "manual"
+      description: "Slack-agent allowlisted stub — extend for world update pipeline"
 
 governance:
   agent_prs_allowed: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to merged Slack Agent v1: wires `draft-pr` and `run` to real GitHub REST flows (operator-truth errors when misconfigured), adds KV-backed Slack `event_id` dedupe with in-memory fallback, appends explicit **source mode** lines (KV / verified memory / GI lane / ledger-backed hint) to read commands that use snapshot-lite, and aligns `mobius.yaml` job declarations with the three previously manifest-only workflow ids via **stub** `workflow_dispatch` workflows.

## Details

- **draft-pr:** resolve repo from `slack_agent.github.repo` or `SLACK_AGENT_GITHUB_REPO` / `GITHUB_REPOSITORY`; create branch from default SHA, commit proposal markdown under configurable path (default `.mobius/slack-agent/drafts/README.md`), open **draft** PR; refuses if `auto_merge_allowed` is ever true; logs structured payload via existing `publishToOaaAndLedger`.
- **run:** requires manifest allowlist **and** declaration in `mobius.yaml` `jobs.workflows` when that list is non-empty; dispatches `workflow_dispatch` to the mapped workflow filename; logs dispatch via `publishToOaaAndLedger`.
- **Dedupe:** `claimSlackEventId` uses `@vercel/kv` when `KV_REST_*` or `UPSTASH_REDIS_*` is set; otherwise bounded in-memory set (single-instance).
- **Docs / env:** `.env.example` documents `GITHUB_TOKEN`, `SLACK_AGENT_GITHUB_*`; `mobius-slack-agent.md` updated.

## Tests

- `pnpm exec tsc --noEmit` — pass
- `pnpm build` — pass
- `pnpm lint` — not configured (interactive Next wizard per AGENTS.md)

## Operator notes

- Set production `slack_agent.allowed_channel_ids` to your real Slack channel IDs when ready (still empty = accept all).
- `GITHUB_TOKEN` needs appropriate scopes for this repo (`contents`, `pull_requests`, `actions:write` for dispatch).
- Stub workflows are intentional placeholders until HIVE/mesh/world pipelines are implemented.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://mobius-substrate.slack.com/archives/D0AU7DJDL9W/p1776709153359049?thread_ts=1776709153.359049&cid=D0AU7DJDL9W)

<div><a href="https://cursor.com/agents/bc-40babc9e-c6c9-5071-a8af-121ab5b7123f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40babc9e-c6c9-5071-a8af-121ab5b7123f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

