### PR TITLE
perf(kv): reduce Upstash command burn — MGET snapshot-lite, cache, selective mirror

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,8 @@ REDIS_URL=
 # When REDIS_URL is set, mirror + read fallback default to ON (C-286 close). Set explicitly to false to disable.
 MOBIUS_KV_BACKUP_MIRROR=
 MOBIUS_KV_READ_FALLBACK=
+# When true, every `saveGIState` also refreshes `gi:latest_carry` (default: hourly refresh to reduce KV writes).
+MOBIUS_KV_GI_CARRY_ALWAYS=
 
 # Mobius Slack Agent v1 — Events API bridge (`POST /api/slack/agent`)
 # Signing secret from Slack app "Basic Information" (verify inbound requests).

--- a/app/api/terminal/snapshot-lite/route.ts
+++ b/app/api/terminal/snapshot-lite/route.ts
@@ -1,21 +1,17 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { handbookCorsHeaders } from '@/lib/http/handbook-cors';
-import {
-  isRedisAvailable,
-  kvGet,
-  kvHealth,
-  KV_KEYS,
-  loadSignalSnapshot,
-  loadEchoState,
-  loadTripwireState,
-} from '@/lib/kv/store';
+import { isRedisAvailable } from '@/lib/kv/store';
+import { loadSnapshotLiteKvBundle } from '@/lib/kv/snapshotLiteKvBundle';
+import { cachedByKey } from '@/lib/kv/snapshotLiteCache';
+import { kvBridgeConfigured, kvBridgeRead } from '@/lib/kv/kvBridgeClient';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { getHeartbeat, getJournalHeartbeat } from '@/lib/runtime/heartbeat';
 import { resolveGiForTerminal } from '@/lib/integrity/resolveGi';
-import { loadMicReadinessSnapshotRaw } from '@/lib/mic/loadReadinessSnapshot';
 
 export const dynamic = 'force-dynamic';
+
+const SNAPSHOT_LITE_CACHE_KEY = 'terminal:snapshot-lite:v1';
 
 export async function OPTIONS(req: NextRequest) {
   const cors = handbookCorsHeaders(req.headers.get('origin'));
@@ -48,20 +44,46 @@ function freshness(sec: number | null): 'fresh' | 'nominal' | 'stale' | 'degrade
   return 'degraded';
 }
 
+async function resolveMicRawWithBridge(micFromMget: string | null): Promise<{ raw: string | null; source: 'kv' | 'oaa' | 'none' }> {
+  if (micFromMget !== null && micFromMget.trim() !== '') {
+    return { raw: micFromMget, source: 'kv' };
+  }
+  if (!kvBridgeConfigured()) {
+    return { raw: null, source: 'none' };
+  }
+  const row = await kvBridgeRead('MIC_READINESS_SNAPSHOT');
+  if (!row?.ok || row.value == null) {
+    return { raw: null, source: 'none' };
+  }
+  if (typeof row.value === 'string') {
+    return { raw: row.value, source: 'oaa' };
+  }
+  try {
+    return { raw: JSON.stringify(row.value), source: 'oaa' };
+  } catch {
+    return { raw: null, source: 'none' };
+  }
+}
+
 export async function GET(req: NextRequest) {
   const start = Date.now();
   const cors = handbookCorsHeaders(req.headers.get('origin'));
 
-  const [kv, micSnap, signals, echo, tripwire, pulse] = await Promise.all([
-    kvHealth(),
-    loadMicReadinessSnapshotRaw(),
-    loadSignalSnapshot(),
-    loadEchoState(),
-    loadTripwireState(),
-    kvGet<SystemPulse>(KV_KEYS.SYSTEM_PULSE),
-  ]);
-  const micSnapRaw = micSnap.raw;
-  const giResolved = await resolveGiForTerminal({ micReadinessSnapshotRaw: micSnapRaw });
+  const { value: cached, fresh: cacheFresh } = await cachedByKey(SNAPSHOT_LITE_CACHE_KEY, async () => {
+    const bundle = await loadSnapshotLiteKvBundle();
+    const mic = await resolveMicRawWithBridge(bundle.micReadinessRaw);
+    return { bundle, mic };
+  });
+
+  const { bundle, mic } = cached;
+  const micSnapRaw = mic.raw;
+  const micSnapSource = mic.source;
+
+  const giResolved = await resolveGiForTerminal({
+    micReadinessSnapshotRaw: micSnapRaw,
+    preloadedGi: { primary: bundle.giState, carry: bundle.giCarry },
+  });
+
   const gi =
     giResolved.source === 'kv'
       ? giResolved.kv
@@ -81,6 +103,12 @@ export async function GET(req: NextRequest) {
             timestamp: giResolved.timestamp ?? new Date().toISOString(),
           }
         : null;
+
+  const pulse = bundle.pulse as SystemPulse | null;
+  const signals = bundle.signals;
+  const echo = bundle.echo;
+  const tripwire = bundle.tripwire;
+  const kv = bundle.kvHealth;
 
   const cycle =
     (typeof pulse?.cycle === 'string' && pulse.cycle.trim().length > 0 ? pulse.cycle.trim() : null) ??
@@ -117,7 +145,7 @@ export async function GET(req: NextRequest) {
               : 'null',
       provenance: giResolved.gi_provenance,
       verified: giResolved.verified,
-      mic_readiness_snapshot_source: micSnap.source,
+      mic_readiness_snapshot_source: micSnapSource,
       freshness: freshness(giAge),
       age_seconds: giAge,
     },
@@ -160,52 +188,57 @@ export async function GET(req: NextRequest) {
     modeStr === 'red' ||
     lanes.tripwire.elevated;
 
-  return NextResponse.json({
-    ok: true,
-    lite: true,
-    cycle,
-    timestamp: new Date().toISOString(),
-    deployment: {
-      commit_sha: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
-      environment: process.env.VERCEL_ENV ?? null,
+  return NextResponse.json(
+    {
+      ok: true,
+      lite: true,
+      cycle,
+      timestamp: new Date().toISOString(),
+      deployment: {
+        commit_sha: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+        environment: process.env.VERCEL_ENV ?? null,
+      },
+      gi: giResolved.gi ?? gi?.global_integrity ?? null,
+      mode: modeStr,
+      gi_source:
+        giResolved.source === 'kv' ||
+        giResolved.source === 'kv_carry_forward' ||
+        giResolved.source === 'oaa_verified'
+          ? 'kv'
+          : giResolved.source === 'live_compute'
+            ? 'live'
+            : giResolved.source === 'readiness_snapshot'
+              ? 'readiness_fallback'
+              : 'null',
+      gi_provenance: giResolved.gi_provenance,
+      gi_verified: giResolved.verified,
+      degraded,
+      lanes,
+      heartbeat: {
+        runtime: getHeartbeat(),
+        journal: getJournalHeartbeat(),
+      },
+      meta: {
+        total_ms: Date.now() - start,
+        kv_available: isRedisAvailable(),
+        kv_bundle_mget: true,
+        kv_cache_fresh: cacheFresh,
+        cycle_source:
+          typeof pulse?.cycle === 'string' && pulse.cycle.trim().length > 0
+            ? 'pulse'
+            : echo?.cycleId?.trim()
+              ? 'echo'
+              : tripwire?.cycleId?.trim()
+                ? 'tripwire'
+                : 'calendar',
+      },
     },
-    gi: giResolved.gi ?? gi?.global_integrity ?? null,
-    mode: modeStr,
-    gi_source:
-      giResolved.source === 'kv' ||
-      giResolved.source === 'kv_carry_forward' ||
-      giResolved.source === 'oaa_verified'
-        ? 'kv'
-        : giResolved.source === 'live_compute'
-          ? 'live'
-          : giResolved.source === 'readiness_snapshot'
-            ? 'readiness_fallback'
-            : 'null',
-    gi_provenance: giResolved.gi_provenance,
-    gi_verified: giResolved.verified,
-    degraded,
-    lanes,
-    heartbeat: {
-      runtime: getHeartbeat(),
-      journal: getJournalHeartbeat(),
+    {
+      headers: {
+        ...(cors ?? {}),
+        'Cache-Control': 'public, s-maxage=10, stale-while-revalidate=30',
+        'X-Mobius-Source': 'terminal-snapshot-lite',
+      },
     },
-    meta: {
-      total_ms: Date.now() - start,
-      kv_available: isRedisAvailable(),
-      cycle_source:
-        typeof pulse?.cycle === 'string' && pulse.cycle.trim().length > 0
-          ? 'pulse'
-          : echo?.cycleId?.trim()
-            ? 'echo'
-            : tripwire?.cycleId?.trim()
-              ? 'tripwire'
-              : 'calendar',
-    },
-  }, {
-    headers: {
-      ...(cors ?? {}),
-      'Cache-Control': 'public, s-maxage=10, stale-while-revalidate=30',
-      'X-Mobius-Source': 'terminal-snapshot-lite',
-    },
-  });
+  );
 }

--- a/lib/echo/kv-persist-ingest.ts
+++ b/lib/echo/kv-persist-ingest.ts
@@ -9,7 +9,7 @@ import type { IntegrityRating } from '@/lib/echo/integrity-engine';
 import { getEchoStatus } from '@/lib/echo/store';
 import { saveEchoState, loadGIState, kvSet, KV_KEYS, KV_TTL_SECONDS } from '@/lib/kv/store';
 import { recordReplayPressureFromIngest } from '@/lib/mic/replayPressure';
-import { readMiiFeed, type MiiEntry } from '@/lib/kv/mii';
+import { filterMiiEntriesNeedingWrite, readMiiFeed, type MiiEntry } from '@/lib/kv/mii';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 
 type KvEpiconEntry = {
@@ -177,7 +177,10 @@ export async function persistEchoIngestSideEffects(result: IngestResult): Promis
       timestamp: miiTimestamp,
       source: 'live',
     }));
-    await writeMiiFeedBatch(batch);
+    const toWrite = filterMiiEntriesNeedingWrite(batch, lastKnown);
+    if (toWrite.length > 0) {
+      await writeMiiFeedBatch(toWrite);
+    }
   } catch (err) {
     console.error('[echo] mii write failed:', err instanceof Error ? err.message : err);
   }

--- a/lib/gi/resolveGiChain.ts
+++ b/lib/gi/resolveGiChain.ts
@@ -86,8 +86,10 @@ function parseGiStateValue(value: unknown): GIState | null {
 
 export async function resolveGiChain(opts?: {
   micReadinessSnapshotRaw?: string | null;
+  /** When provided (e.g. snapshot-lite MGET), avoids duplicate KV GETs for GI rows. */
+  preloadedGi?: { primary: GIState | null; carry: GIState | null };
 }): Promise<GiChainResolution> {
-  const st = await loadGIState();
+  const st = opts?.preloadedGi?.primary ?? (await loadGIState());
   if (st && typeof st.global_integrity === 'number' && Number.isFinite(st.global_integrity)) {
     const ageMs = Date.now() - new Date(st.timestamp).getTime();
     const maxAgeMs =
@@ -129,7 +131,7 @@ export async function resolveGiChain(opts?: {
     // continue
   }
 
-  const carry = await loadGIStateCarry();
+  const carry = opts?.preloadedGi?.carry ?? (await loadGIStateCarry());
   if (carry && typeof carry.global_integrity === 'number' && Number.isFinite(carry.global_integrity)) {
     const gi = Math.max(0, Math.min(1, carry.global_integrity));
     return {

--- a/lib/integrity/resolveGi.ts
+++ b/lib/integrity/resolveGi.ts
@@ -52,8 +52,12 @@ function mapProvenanceToLegacy(p: GISourceDisplay): GiResolutionSource {
  */
 export async function resolveGiForTerminal(opts?: {
   micReadinessSnapshotRaw?: string | null;
+  preloadedGi?: { primary: GIState | null; carry: GIState | null };
 }): Promise<ResolvedGi> {
-  const chain = await resolveGiChain({ micReadinessSnapshotRaw: opts?.micReadinessSnapshotRaw });
+  const chain = await resolveGiChain({
+    micReadinessSnapshotRaw: opts?.micReadinessSnapshotRaw,
+    preloadedGi: opts?.preloadedGi,
+  });
   return {
     gi: chain.gi,
     mode: chain.mode,

--- a/lib/kv/backup-redis.ts
+++ b/lib/kv/backup-redis.ts
@@ -2,12 +2,13 @@
  * Optional TCP Redis (`REDIS_URL`) alongside primary Upstash REST KV.
  *
  * - **Health**: `getBackupRedisHealth()` for `/api/kv/health`.
- * - **Write mirror**: `MOBIUS_KV_BACKUP_MIRROR=true` duplicates string SETs and list writes.
+ * - **Write mirror**: `MOBIUS_KV_BACKUP_MIRROR=true` mirrors continuity-critical keys only (see `backupMirrorPolicy.ts`).
  * - **Read fallback**: `MOBIUS_KV_READ_FALLBACK=true` uses `REDIS_URL` when primary GET misses
  *   or primary KV is unavailable / errors (best-effort DR read path).
  */
 
 import Redis from 'ioredis';
+import { shouldMirrorPrefixedFullKey, shouldMirrorRawKey } from '@/lib/kv/backupMirrorPolicy';
 
 let _backup: Redis | null | undefined;
 
@@ -210,6 +211,7 @@ export function scheduleBackupMirrorPrefixedKey(
   value: unknown,
   ttlSeconds?: number,
 ): void {
+  if (!shouldMirrorPrefixedFullKey(prefixedKey)) return;
   scheduleMirror(async (client) => {
     const payload = serializeValue(value);
     if (ttlSeconds && ttlSeconds > 0) {
@@ -225,6 +227,7 @@ export function scheduleBackupMirrorRawKey(
   value: unknown,
   ttlSeconds?: number,
 ): void {
+  if (!shouldMirrorRawKey(rawKey)) return;
   scheduleMirror(async (client) => {
     const payload = serializeValue(value);
     if (ttlSeconds && ttlSeconds > 0) {

--- a/lib/kv/backupMirrorPolicy.ts
+++ b/lib/kv/backupMirrorPolicy.ts
@@ -1,0 +1,33 @@
+/**
+ * Selective backup Redis mirror (C-287 KV burn reduction).
+ * Only continuity-critical keys are mirrored when MOBIUS_KV_BACKUP_MIRROR is on.
+ *
+ * Key strings must stay aligned with `KV_KEYS` in `store.ts` (no import — avoids circular deps).
+ */
+
+const MIRROR_LOGICAL_KEYS = new Set<string>([
+  'mic:readiness:snapshot',
+  'signals:latest',
+  'gi:latest',
+  'heartbeat:last',
+  'system:pulse',
+  'operator:current_cycle',
+  'vault:global:balance',
+  'vault:global:meta',
+  'tripwire:state',
+  'echo:state',
+]);
+
+const MIRROR_RAW_KEYS = new Set<string>(['TRIPWIRE_STATE']);
+
+const PREFIX = 'mobius:';
+
+export function shouldMirrorPrefixedFullKey(fullKey: string): boolean {
+  if (!fullKey.startsWith(PREFIX)) return MIRROR_RAW_KEYS.has(fullKey);
+  const logical = fullKey.slice(PREFIX.length);
+  return MIRROR_LOGICAL_KEYS.has(logical);
+}
+
+export function shouldMirrorRawKey(rawKey: string): boolean {
+  return MIRROR_RAW_KEYS.has(rawKey);
+}

--- a/lib/kv/batchRead.ts
+++ b/lib/kv/batchRead.ts
@@ -1,0 +1,45 @@
+/**
+ * Single-round-trip reads for Upstash REST (reduces command count vs N× GET).
+ */
+
+import { Redis } from '@upstash/redis';
+
+let _redis: Redis | null = null;
+
+function getRedis(): Redis | null {
+  if (_redis) return _redis;
+  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  try {
+    _redis = new Redis({ url, token });
+    return _redis;
+  } catch {
+    return null;
+  }
+}
+
+const PREFIX = 'mobius:';
+
+function fullKey(logical: string): string {
+  return `${PREFIX}${logical}`;
+}
+
+/**
+ * MGET for prefixed Mobius keys. One REST command for all keys.
+ * Returns null entries for missing keys; order matches input.
+ */
+export async function kvMgetPrefixedLogicalKeys(logicalKeys: readonly string[]): Promise<unknown[]> {
+  const redis = getRedis();
+  if (!redis || logicalKeys.length === 0) {
+    return logicalKeys.map(() => null);
+  }
+  const keys = logicalKeys.map(fullKey);
+  try {
+    const values = await redis.mget(...keys);
+    return Array.isArray(values) ? values : logicalKeys.map(() => null);
+  } catch (err) {
+    console.warn('[mobius-kv] mget failed:', err instanceof Error ? err.message : err);
+    return logicalKeys.map(() => null);
+  }
+}

--- a/lib/kv/mii.ts
+++ b/lib/kv/mii.ts
@@ -56,6 +56,17 @@ function isMiiEntry(value: unknown): value is MiiEntry {
  * - Sets mii:{AGENT}:{CYCLE} to the entry (latest score for that agent/cycle pair)
  * - LPUSHes to mii:feed and LTRIMs to FEED_MAX
  */
+const MII_DELTA_SKIP = 0.01;
+
+/** Skip MII rows when score barely moved vs last known per agent (echo ingest batch path). */
+export function filterMiiEntriesNeedingWrite(entries: MiiEntry[], lastMiiByAgent: Record<string, number>): MiiEntry[] {
+  return entries.filter((e) => {
+    const prev = lastMiiByAgent[e.agent];
+    if (prev === undefined || !Number.isFinite(prev)) return true;
+    return Math.abs(e.mii - prev) >= MII_DELTA_SKIP;
+  });
+}
+
 export async function writeMiiState(entry: MiiEntry): Promise<void> {
   const redis = getMiiRedisClient();
   if (!redis) return;
@@ -64,6 +75,19 @@ export async function writeMiiState(entry: MiiEntry): Promise<void> {
   const packed = JSON.stringify(entry);
 
   try {
+    const prevRaw = await redis.get<string>(key);
+    if (prevRaw) {
+      try {
+        const prev = JSON.parse(prevRaw) as { mii?: number };
+        if (typeof prev.mii === 'number' && Number.isFinite(prev.mii)) {
+          if (Math.abs(prev.mii - entry.mii) < MII_DELTA_SKIP) {
+            return;
+          }
+        }
+      } catch {
+        /* fall through to write */
+      }
+    }
     await redis.set(key, packed);
     await redis.lpush(FEED_KEY, packed);
     await redis.ltrim(FEED_KEY, 0, FEED_MAX - 1);

--- a/lib/kv/snapshotLiteCache.ts
+++ b/lib/kv/snapshotLiteCache.ts
@@ -1,0 +1,43 @@
+/**
+ * In-process cache for snapshot-lite hot path (30s fresh, 60s SWR).
+ * Cuts repeated MGET + ping traffic for warm Vercel instances / multi-tab users.
+ */
+
+type CacheEntry<T> = {
+  value: T;
+  fetchedAt: number;
+  revalidating: boolean;
+};
+
+const FRESH_MS = 30_000;
+const SWR_MS = 60_000;
+
+const store = new Map<string, CacheEntry<unknown>>();
+
+export async function cachedByKey<T>(key: string, fetcher: () => Promise<T>): Promise<{ value: T; fresh: boolean }> {
+  const now = Date.now();
+  const entry = store.get(key) as CacheEntry<T> | undefined;
+
+  if (entry) {
+    const age = now - entry.fetchedAt;
+    if (age < FRESH_MS) {
+      return { value: entry.value, fresh: true };
+    }
+    if (age < SWR_MS && !entry.revalidating) {
+      entry.revalidating = true;
+      void fetcher()
+        .then((value) => {
+          store.set(key, { value, fetchedAt: Date.now(), revalidating: false } as CacheEntry<unknown>);
+        })
+        .catch(() => {
+          const cur = store.get(key) as CacheEntry<T> | undefined;
+          if (cur === entry) entry.revalidating = false;
+        });
+      return { value: entry.value, fresh: false };
+    }
+  }
+
+  const value = await fetcher();
+  store.set(key, { value, fetchedAt: now, revalidating: false } as CacheEntry<unknown>);
+  return { value, fresh: true };
+}

--- a/lib/kv/snapshotLiteKvBundle.ts
+++ b/lib/kv/snapshotLiteKvBundle.ts
@@ -1,0 +1,80 @@
+/**
+ * Single MGET bundle for `/api/terminal/snapshot-lite` hot KV reads.
+ */
+
+import { kvHealth, KV_KEYS, type EchoKVState, type GIState, type SignalSnapshot, type TripwireKVState } from '@/lib/kv/store';
+import { kvMgetPrefixedLogicalKeys } from '@/lib/kv/batchRead';
+
+export const SNAPSHOT_LITE_MGET_KEYS = [
+  KV_KEYS.MIC_READINESS_SNAPSHOT,
+  KV_KEYS.SIGNAL_SNAPSHOT,
+  KV_KEYS.ECHO_STATE,
+  KV_KEYS.TRIPWIRE_STATE,
+  KV_KEYS.SYSTEM_PULSE,
+  KV_KEYS.GI_STATE,
+  KV_KEYS.GI_STATE_CARRY,
+] as const;
+
+type SystemPulse = {
+  ok?: boolean;
+  composite?: number;
+  cycle?: string;
+  instruments?: number;
+  anomalies?: number;
+  timestamp?: string;
+};
+
+export type SnapshotLiteKvBundle = {
+  kvHealth: Awaited<ReturnType<typeof kvHealth>>;
+  micReadinessRaw: string | null;
+  signals: SignalSnapshot | null;
+  echo: EchoKVState | null;
+  tripwire: TripwireKVState | null;
+  pulse: SystemPulse | null;
+  giState: GIState | null;
+  giCarry: GIState | null;
+};
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  if (!v || typeof v !== 'object') return null;
+  return v as Record<string, unknown>;
+}
+
+function parseMicRaw(v: unknown): string | null {
+  if (v === null || v === undefined) return null;
+  if (typeof v === 'string') return v.trim() !== '' ? v : null;
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return null;
+  }
+}
+
+export async function loadSnapshotLiteKvBundle(): Promise<SnapshotLiteKvBundle> {
+  const [kv, raw] = await Promise.all([kvHealth(), kvMgetPrefixedLogicalKeys([...SNAPSHOT_LITE_MGET_KEYS])]);
+
+  const micReadinessRaw = parseMicRaw(raw[0]);
+  const signals = asRecord(raw[1]) as SignalSnapshot | null;
+  const echo = asRecord(raw[2]) as EchoKVState | null;
+  const tripwire = asRecord(raw[3]) as TripwireKVState | null;
+  const pulse = asRecord(raw[4]) as SystemPulse | null;
+  const giState =
+    raw[5] != null && typeof raw[5] === 'object' && typeof (raw[5] as GIState).global_integrity === 'number'
+      ? (raw[5] as GIState)
+      : null;
+  const giCarry =
+    raw[6] != null && typeof raw[6] === 'object' && typeof (raw[6] as GIState).global_integrity === 'number'
+      ? (raw[6] as GIState)
+      : null;
+
+  return {
+    kvHealth: kv,
+    micReadinessRaw,
+    signals: signals && typeof signals.timestamp === 'string' ? signals : null,
+    echo: echo && typeof echo.timestamp === 'string' ? echo : null,
+    tripwire: tripwire && typeof tripwire.timestamp === 'string' ? tripwire : null,
+    pulse,
+    giState,
+    giCarry,
+  };
+}

--- a/lib/kv/store.ts
+++ b/lib/kv/store.ts
@@ -18,8 +18,8 @@
  *
  * Optional secondary Redis (TCP `redis://` or `rediss://`):
  *   REDIS_URL — classic Redis URL; health-checked via `/api/kv/health` as `backup_redis`
- *   MOBIUS_KV_BACKUP_MIRROR — mirror successful `kvSet` / `kvSetRawKey` / vault raw writes (when `REDIS_URL` set,
- *     defaults to enabled unless explicitly `false`)
+ *   MOBIUS_KV_BACKUP_MIRROR — mirror continuity-critical keys only (see `lib/kv/backupMirrorPolicy.ts`) when `REDIS_URL` set
+ *     (defaults to enabled unless explicitly `false`)
  *   MOBIUS_KV_READ_FALLBACK — read from backup when primary GET misses or errors (defaults on when `REDIS_URL` set)
  *
  *   OAA KV bridge (C-286) — warm tier on Render when Upstash hits monthly limits:
@@ -451,7 +451,13 @@ export type GIState = {
  */
 export async function saveGIState(state: GIState): Promise<void> {
   await kvSet(KV_KEYS.GI_STATE, state, KV_TTL_SECONDS.GI_STATE);
-  await kvSet(KV_KEYS.GI_STATE_CARRY, state, 604800);
+  // Carry-forward row: long TTL DR path — hourly cadence by default to cut KV writes (override with MOBIUS_KV_GI_CARRY_ALWAYS=true).
+  const alwaysCarry = process.env.MOBIUS_KV_GI_CARRY_ALWAYS?.trim().toLowerCase() === 'true';
+  const fiveMinSlot = Math.floor(Date.now() / 300_000);
+  const hourlyCarryTick = fiveMinSlot % 12 === 0;
+  if (alwaysCarry || hourlyCarryTick) {
+    await kvSet(KV_KEYS.GI_STATE_CARRY, state, 604800);
+  }
   scheduleKvBridgeDualWrite('GI_STATE', state, KV_TTL_SECONDS.GI_STATE, 'c287-dual-write');
 }
 
@@ -541,7 +547,19 @@ export type TripwireKVState = {
 /**
  * Save tripwire state. TTL: 30 minutes.
  */
+let _lastTripwireSemanticJson: string | null = null;
+
 export async function saveTripwireState(state: TripwireKVState): Promise<void> {
+  // Dedupe on semantic fields only — callers often pass a fresh `timestamp` per poll.
+  const semantic = JSON.stringify({
+    cycleId: state.cycleId,
+    tripwireCount: state.tripwireCount,
+    elevated: state.elevated,
+  });
+  if (_lastTripwireSemanticJson === semantic) {
+    return;
+  }
+  _lastTripwireSemanticJson = semantic;
   await kvSet(KV_KEYS.TRIPWIRE_STATE, state, KV_TTL_SECONDS.TRIPWIRE_STATE);
 }
 

--- a/lib/runtime/agent-heartbeat-kv.ts
+++ b/lib/runtime/agent-heartbeat-kv.ts
@@ -3,7 +3,7 @@
  */
 
 import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
-import { isRedisAvailable, kvSet, KV_KEYS, KV_TTL_SECONDS } from '@/lib/kv/store';
+import { isRedisAvailable, kvGet, kvSet, KV_KEYS, KV_TTL_SECONDS } from '@/lib/kv/store';
 import { scheduleKvBridgeDualWrite } from '@/lib/kv/kvBridgeClient';
 
 /** Canonical Terminal fleet IDs (lowercase) — matches `app/api/agents/status/route.ts` roster order. */
@@ -56,12 +56,16 @@ export async function writeFleetHeartbeatKV(source: AgentHeartbeatFleetPayload['
       heartbeat_ok: true,
     })),
   };
-  const ok =
-    (await kvSet(KV_KEYS.HEARTBEAT, JSON.stringify(payload), KV_TTL_SECONDS.HEARTBEAT)) &&
-    (await kvSet(KV_KEYS.CURRENT_CYCLE, payload.cycle, KV_TTL_SECONDS.HEARTBEAT));
+  const prevCycle = await kvGet<string>(KV_KEYS.CURRENT_CYCLE);
+  const cycleChanged = prevCycle !== payload.cycle;
+  const hbOk = await kvSet(KV_KEYS.HEARTBEAT, JSON.stringify(payload), KV_TTL_SECONDS.HEARTBEAT);
+  const cycleOk = cycleChanged ? await kvSet(KV_KEYS.CURRENT_CYCLE, payload.cycle, KV_TTL_SECONDS.HEARTBEAT) : true;
+  const ok = hbOk && cycleOk;
   if (ok) {
     scheduleKvBridgeDualWrite('HEARTBEAT', payload, KV_TTL_SECONDS.HEARTBEAT, 'heartbeat-dual-write');
-    scheduleKvBridgeDualWrite('CURRENT_CYCLE', payload.cycle, KV_TTL_SECONDS.HEARTBEAT, 'heartbeat-dual-write');
+    if (cycleChanged) {
+      scheduleKvBridgeDualWrite('CURRENT_CYCLE', payload.cycle, KV_TTL_SECONDS.HEARTBEAT, 'heartbeat-dual-write');
+    }
   }
   return ok;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses C-287 KV request ceiling as a **code-side** problem: snapshot-lite no longer issues many independent `GET`s, warm instances reuse a short-lived in-memory bundle, backup Redis mirroring is **selective** (continuity keys only), and several cron-adjacent write paths skip redundant work.

## Changes

### Snapshot-lite (`GET /api/terminal/snapshot-lite`)

- **MGET bundle** (`lib/kv/snapshotLiteKvBundle.ts` + `lib/kv/batchRead.ts`): one `redis.mget` for MIC readiness, signals, echo, tripwire, system pulse, GI primary + carry (plus existing `kvHealth()` ping).
- **In-process cache** (`lib/kv/snapshotLiteCache.ts`): 30s fresh / 60s stale-while-revalidate for the bundled read + MIC bridge resolution path. Response `meta.kv_bundle_mget` + `meta.kv_cache_fresh`.
- **GI chain**: `resolveGiChain` / `resolveGiForTerminal` accept optional `preloadedGi` so GI resolution does not re-fetch rows already in the MGET.

### Backup Redis mirror

- **`backupMirrorPolicy.ts`**: only mirror prefixed keys needed for continuity (GI, heartbeat, signals, system pulse, current cycle, vault balance/meta, tripwire, echo state, MIC readiness snapshot) + legacy raw `TRIPWIRE_STATE`.
- `scheduleBackupMirrorPrefixedKey` / `scheduleBackupMirrorRawKey` no-op for non-allowlisted keys (primary Upstash writes unchanged).

### Write cadence / dedupe

- **`saveGIState`**: `gi:latest_carry` refresh **hourly** by default (12×5min slots); opt back to every run with `MOBIUS_KV_GI_CARRY_ALWAYS=true` (documented in `.env.example`).
- **`saveTripwireState`**: skip KV `SET` when semantic payload unchanged (cycle/count/elevated), ignoring per-poll timestamp churn.
- **Fleet heartbeat**: skip `CURRENT_CYCLE` write when value unchanged (one `GET` vs redundant `SET` each cron).
- **MII**: `writeMiiState` skips when |Δmii| < 0.01; echo ingest batch uses `filterMiiEntriesNeedingWrite` before pipeline.

## Testing

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- `pnpm lint` — not configured (interactive Next wizard)

## Operator notes

- After deploy, confirm Upstash dashboard: snapshot-lite traffic should show **far fewer commands** per warm instance.
- If you require carry-forward row to refresh on **every** GI write, set `MOBIUS_KV_GI_CARRY_ALWAYS=true`.
- Full `/api/terminal/snapshot` aggregation is unchanged in this PR (separate follow-up if we want MGET there too).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://mobius-substrate.slack.com/archives/D0AU7DJDL9W/p1776709153359049?thread_ts=1776709153.359049&cid=D0AU7DJDL9W)

<div><a href="https://cursor.com/agents/bc-40babc9e-c6c9-5071-a8af-121ab5b7123f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40babc9e-c6c9-5071-a8af-121ab5b7123f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

