### PR TITLE
feat(C-288): vault seal council notify, MIC KV hydrate, HERMES dead-lane, EVE ethics queue

### DIFF
--- a/app/api/eve/governance-preview/route.ts
+++ b/app/api/eve/governance-preview/route.ts
@@ -27,6 +27,7 @@ export async function GET() {
       category: output.category,
       civicRiskLevel: output.civicRiskLevel,
       ethicsFlags: output.ethicsFlags,
+      ethicsReviewQueue: output.ethicsReviewQueue,
       externalDegraded: input.externalDegraded,
       derivedFromCount: output.derivedFrom.length,
       ...preview,

--- a/app/api/mic/readiness/route.ts
+++ b/app/api/mic/readiness/route.ts
@@ -13,6 +13,8 @@ import type { MicReadinessResponse } from '@/lib/mic/types';
 import { loadMicReadinessSnapshotRaw } from '@/lib/mic/loadReadinessSnapshot';
 import { kvSet, kvLpushCapped, KV_KEYS, kvGet, KV_TTL_SECONDS } from '@/lib/kv/store';
 import { scheduleKvBridgeDualWrite } from '@/lib/kv/kvBridgeClient';
+import { persistLocalMicReadinessSnapshot } from '@/lib/mic/persistReadinessKv';
+import { persistResolvedReplayPressureToKv } from '@/lib/mic/replayPressure';
 
 export const dynamic = 'force-dynamic';
 
@@ -30,8 +32,22 @@ function micReadinessPostAuth(req: NextRequest): boolean {
 export async function GET(req: NextRequest) {
   const cycleParam = req.nextUrl.searchParams.get('cycle')?.trim();
   const { raw: micSnapRaw, source: micSnapSource } = await loadMicReadinessSnapshotRaw();
+  const hadUpstreamKvSnapshot = micSnapSource === 'kv';
   const giMeta = await resolveGiForTerminal({ micReadinessSnapshotRaw: micSnapRaw });
   const readiness = await getMergedMicReadiness(cycleParam);
+
+  if (!hadUpstreamKvSnapshot) {
+    try {
+      await persistLocalMicReadinessSnapshot(readiness);
+    } catch (e) {
+      console.warn('[mic-readiness] local snapshot hydrate failed:', e instanceof Error ? e.message : e);
+    }
+  }
+  try {
+    await persistResolvedReplayPressureToKv(readiness.replay.replayPressure);
+  } catch (e) {
+    console.warn('[mic-readiness] replay pressure KV persist failed:', e instanceof Error ? e.message : e);
+  }
 
   return NextResponse.json(
     {
@@ -46,6 +62,7 @@ export async function GET(req: NextRequest) {
         timestamp: giMeta.timestamp,
         mic_readiness_snapshot_source: micSnapSource,
       },
+      mic_readiness_snapshot_hydrated: !hadUpstreamKvSnapshot,
     },
     {
       headers: {

--- a/lib/agents/micro/instrument-polls.ts
+++ b/lib/agents/micro/instrument-polls.ts
@@ -303,29 +303,33 @@ export async function pollHermesU2(): Promise<AgentPollResult> {
 
 export async function pollHermesU3(): Promise<AgentPollResult> {
   const queries = ['governance OR democracy OR civic', 'transparency OR regulation OR policy'];
+  const timespans = ['7d', '3d', '1d'];
   let n = 0;
   let lastMeta: Awaited<ReturnType<typeof safeFetchWithMeta<{ articles?: unknown[] }>>> | null = null;
-  for (const q of queries) {
-    const url =
-      `https://api.gdeltproject.org/api/v2/doc/doc?query=${encodeURIComponent(q)}&mode=artlist&maxrecords=8&format=json&timespan=1d`;
-    const meta = await safeFetchWithMeta<{ articles?: unknown[] }>(url, 12000);
-    lastMeta = meta;
-    if (meta.ok && meta.data) {
-      n += meta.data.articles?.length ?? 0;
+  outer: for (const span of timespans) {
+    for (const q of queries) {
+      const url =
+        `https://api.gdeltproject.org/api/v2/doc/doc?query=${encodeURIComponent(q)}&mode=artlist&maxrecords=8&format=json&timespan=${span}`;
+      const meta = await safeFetchWithMeta<{ articles?: unknown[] }>(url, 12000);
+      lastMeta = meta;
+      if (meta.ok && meta.data) {
+        n += meta.data.articles?.length ?? 0;
+      }
+      if (n > 0) break outer;
     }
-    if (n > 0) break;
   }
   const d = new Date();
   const weekend = d.getUTCDay() === 0 || d.getUTCDay() === 6;
   const quietHour = d.getUTCHours() >= 0 && d.getUTCHours() <= 8;
   const httpOk = Boolean(lastMeta?.ok);
   const quietContext = httpOk && n === 0 && (weekend || quietHour);
-  const value = Number((quietContext ? 0.5 : normalizeDirect(Math.min(n, 16), 0, 16)).toFixed(3));
-  const severity = quietContext
+  const structuralEmpty = httpOk && n === 0 && !quietContext;
+  const value = Number(
+    (quietContext || structuralEmpty ? 0.5 : normalizeDirect(Math.min(n, 16), 0, 16)).toFixed(3),
+  );
+  const severity = quietContext || structuralEmpty
     ? 'nominal'
-    : n === 0
-      ? 'watch'
-      : classifySeverity(value, { watch: 0.45, elevated: 0.3, critical: 0.15 });
+    : classifySeverity(value, { watch: 0.45, elevated: 0.3, critical: 0.15 });
   return wrap('HERMES-µ3', {
     agentName: 'HERMES-µ3',
     source: 'GDELT · governance artlist',
@@ -333,14 +337,16 @@ export async function pollHermesU3(): Promise<AgentPollResult> {
     value,
     label: quietContext
       ? `GDELT: 0 articles (quiet window — HTTP ${lastMeta?.status ?? 'ok'}, nominal)`
-      : `GDELT: ${n} articles (24h governance+civic)`,
+      : structuralEmpty
+        ? `GDELT: 0 articles across widened window — treating as dead-instrument neutral (HTTP ${lastMeta?.status ?? 'ok'})`
+        : `GDELT: ${n} articles (governance+civic sample)`,
     severity,
-    raw: { count: n, httpOk, quietContext },
+    raw: { count: n, httpOk, quietContext, structuralEmpty, timespansTried: timespans },
   });
 }
 
 export async function pollHermesU4(): Promise<AgentPollResult> {
-  const subs = ['worldnews', 'technology', 'civictech'];
+  const subs = ['worldnews', 'technology', 'civictech', 'news', 'politics'];
   let kids: Array<{ data?: { score?: number; title?: string } }> = [];
   let lastStatus: number | null = null;
   let lastOk = false;
@@ -364,9 +370,10 @@ export async function pollHermesU4(): Promise<AgentPollResult> {
   const weekend = d.getUTCDay() === 0 || d.getUTCDay() === 6;
   const quietHour = d.getUTCHours() >= 0 && d.getUTCHours() <= 8;
   const quietContext = lastOk && kids.length === 0 && (weekend || quietHour);
-  const value = Number((quietContext ? 0.5 : normalizeDirect(avg, 0, 2000)).toFixed(3));
+  const structuralEmpty = lastOk && kids.length === 0 && !quietContext;
+  const value = Number((quietContext || structuralEmpty ? 0.5 : normalizeDirect(avg, 0, 2000)).toFixed(3));
   const severity =
-    quietContext ? 'nominal' : kids.length === 0 ? 'watch' : classifySeverity(value, { watch: 0.4, elevated: 0.22, critical: 0.08 });
+    quietContext || structuralEmpty ? 'nominal' : classifySeverity(value, { watch: 0.4, elevated: 0.22, critical: 0.08 });
   return wrap('HERMES-µ4', {
     agentName: 'HERMES-µ4',
     source: 'Reddit · narrative feed',
@@ -374,9 +381,11 @@ export async function pollHermesU4(): Promise<AgentPollResult> {
     value,
     label: quietContext
       ? `Reddit: 0 posts in sample (quiet window — HTTP ${lastStatus ?? 'ok'}, nominal)`
-      : `Reddit narrative: avg score ${Math.round(avg)} on ${kids.length} posts`,
+      : structuralEmpty
+        ? `Reddit: 0 posts across expanded subs — dead-instrument neutral (HTTP ${lastStatus ?? 'ok'})`
+        : `Reddit narrative: avg score ${Math.round(avg)} on ${kids.length} posts`,
     severity,
-    raw: { count: kids.length, httpOk: lastOk, quietContext },
+    raw: { count: kids.length, httpOk: lastOk, quietContext, structuralEmpty, subsTried: subs },
   });
 }
 

--- a/lib/eve/governance-synthesis.ts
+++ b/lib/eve/governance-synthesis.ts
@@ -61,6 +61,8 @@ export type EveGovernanceSynthesisOutput = {
   confidenceTier: number;
   governancePosture: 'stable' | 'watch' | 'stressed' | 'critical';
   ethicsFlags: string[];
+  /** C-279 / C-288 — persistent ethics tags that need human governance review (not auto-cleared). */
+  ethicsReviewQueue: string[];
   civicRiskLevel: 'low' | 'medium' | 'high';
   derivedFrom: string[];
 };
@@ -439,6 +441,12 @@ export function buildEveGovernanceSynthesisOutput(input: EveGovernanceSynthesisI
   if (input.narrativeClusterCount >= NARRATIVE_CLUSTER_THRESHOLD) ethicsFlags.push('narrative-cluster-spike');
   if (input.externalDegraded) ethicsFlags.push('external-feed-degraded');
 
+  const ethicsReviewQueue: string[] = [];
+  if (input.tripwire.active) ethicsReviewQueue.push('ethics:active-tripwire');
+  if (input.narrativeClusterCount >= NARRATIVE_CLUSTER_THRESHOLD) {
+    ethicsReviewQueue.push('ethics:narrative-cluster-spike');
+  }
+
   const derivedFrom: string[] = [];
   for (const row of input.committedAgentRows.slice(0, 12)) {
     if (typeof row.id === 'string' && row.id) derivedFrom.push(row.id);
@@ -482,7 +490,12 @@ export function buildEveGovernanceSynthesisOutput(input: EveGovernanceSynthesisI
     `${governancePosture.toUpperCase()} posture · ${agentList.length} agent lane(s) · GI ${input.gi.toFixed(2)}`,
   );
 
-  const body = [governanceSummary, civicLine, ethicsLine, extLine.trim() ? extLine : null]
+  const reviewLine =
+    ethicsReviewQueue.length > 0
+      ? `Governance review queue (C-279): ${ethicsReviewQueue.join(', ')} — schedule operator acknowledgment before next cycle close; do not carry unresolved.`
+      : null;
+
+  const body = [governanceSummary, civicLine, ethicsLine, reviewLine, extLine.trim() ? extLine : null]
     .filter((p): p is string => typeof p === 'string')
     .join('\n\n');
 
@@ -500,6 +513,7 @@ export function buildEveGovernanceSynthesisOutput(input: EveGovernanceSynthesisI
     confidenceTier,
     governancePosture,
     ethicsFlags,
+    ethicsReviewQueue,
     civicRiskLevel,
     derivedFrom,
   };
@@ -670,6 +684,7 @@ export async function processEveCycleWindowSynthesis(
     category: output.category,
     civicRiskLevel: output.civicRiskLevel,
     ethicsFlags: output.ethicsFlags,
+    ethicsReviewQueue: output.ethicsReviewQueue,
     summary: output.summary,
     externalDegraded: input.externalDegraded,
     trace: buildSynthTrace(input),
@@ -758,6 +773,7 @@ export async function processEveEscalationSynthesis(
     category: output.category,
     civicRiskLevel: output.civicRiskLevel,
     ethicsFlags: output.ethicsFlags,
+    ethicsReviewQueue: output.ethicsReviewQueue,
     summary: output.summary,
     externalDegraded: input.externalDegraded,
     trace: {
@@ -784,13 +800,18 @@ export async function publishEveGovernanceSynthesis(
   const ledgerSeverity = ledgerSeverityFromSignals(output.severity);
 
   const sonarEnriched = Boolean(input.sonarCivic?.answer.trim());
+  const ethicsTagSet = new Set<string>();
+  for (const f of output.ethicsFlags) ethicsTagSet.add(`ethics:${f}`);
+  for (const q of output.ethicsReviewQueue) {
+    ethicsTagSet.add(q.startsWith('ethics:') ? q : `ethics:${q}`);
+  }
   const tags: string[] = [
     'eve',
     EVE_GOVERNANCE_SYNTH_TAG,
     idempotencyTag,
     output.category,
     ...(input.sonarCivic && input.sonarCivic.answer.trim() ? ['eve-sonar-enriched'] : []),
-    ...output.ethicsFlags.map((f) => `ethics:${f}`),
+    ...ethicsTagSet,
   ];
   if (sonarEnriched) {
     tags.push('external-sonar-enriched', 'eve:sonar-enriched');

--- a/lib/mic/persistReadinessKv.ts
+++ b/lib/mic/persistReadinessKv.ts
@@ -1,0 +1,35 @@
+/**
+ * Optional KV hydration for MIC readiness when no upstream Substrate snapshot is in KV.
+ * Keeps `MIC_READINESS_SNAPSHOT` warm for GI chain / probes without claiming external authority.
+ */
+
+import type { MicReadinessResponse } from '@/lib/mic/types';
+import { withHash } from '@/lib/mic/hash';
+import { kvSet, KV_KEYS, KV_TTL_SECONDS } from '@/lib/kv/store';
+import { scheduleKvBridgeDualWrite } from '@/lib/kv/kvBridgeClient';
+
+export async function persistLocalMicReadinessSnapshot(merged: MicReadinessResponse): Promise<void> {
+  const { readiness_proof: _readinessProofOmit, ...forHash } = merged;
+  void _readinessProofOmit;
+  const proof = withHash(forHash);
+  const body: MicReadinessResponse = {
+    ...merged,
+    readiness_proof: {
+      hash: proof.hash,
+      hash_algorithm: 'sha256',
+    },
+  };
+  const snapshot = {
+    snapshot: body,
+    received_at: new Date().toISOString(),
+    source: 'terminal-readiness-hydrate',
+  };
+  const snapStr = JSON.stringify(snapshot);
+  await kvSet(KV_KEYS.MIC_READINESS_SNAPSHOT, snapStr, KV_TTL_SECONDS.MIC_READINESS_SNAPSHOT);
+  scheduleKvBridgeDualWrite(
+    'MIC_READINESS_SNAPSHOT',
+    snapshot as unknown,
+    KV_TTL_SECONDS.MIC_READINESS_SNAPSHOT,
+    'mic-readiness-hydrate',
+  );
+}

--- a/lib/mic/replayPressure.ts
+++ b/lib/mic/replayPressure.ts
@@ -15,6 +15,12 @@ export type ReplayPressureKvV1 = {
   /** Accumulated pressure from ECHO duplicate suppression (decayed by time). */
   ingestPressure: number;
   lastUpdatedAt: string;
+  /**
+   * Last MIC readiness–resolved total (ingest decay + deposit-window ratio), RFC3339.
+   * Used so ops/catalog can see a fresh KV echo of replay without re-running deposit math.
+   */
+  snapshot_total?: number;
+  snapshot_at?: string;
 };
 
 type LegacyReplayKv = {
@@ -37,19 +43,44 @@ function decayValue(prev: number, lastIso: string, nowMs: number): number {
   return prev * decayFactor;
 }
 
-async function loadEnvelope(): Promise<{ ingestPressure: number; lastUpdatedAt: string }> {
+type LoadedEnvelope = {
+  ingestPressure: number;
+  lastUpdatedAt: string;
+  snapshotTotal: number | null;
+  snapshotAt: string | null;
+};
+
+async function loadEnvelope(): Promise<LoadedEnvelope> {
   const raw = await kvGet<ReplayPressureKvV1 | LegacyReplayKv>(KV_KEYS.MIC_REPLAY_PRESSURE);
   const now = new Date().toISOString();
   if (!raw || typeof raw !== 'object') {
-    return { ingestPressure: 0, lastUpdatedAt: now };
+    return { ingestPressure: 0, lastUpdatedAt: now, snapshotTotal: null, snapshotAt: null };
   }
+  const snapT =
+    'snapshot_total' in raw && typeof raw.snapshot_total === 'number' && Number.isFinite(raw.snapshot_total)
+      ? raw.snapshot_total
+      : null;
+  const snapA =
+    'snapshot_at' in raw && typeof raw.snapshot_at === 'string' && raw.snapshot_at.trim() !== ''
+      ? raw.snapshot_at.trim()
+      : null;
   if ('ingestPressure' in raw && typeof raw.ingestPressure === 'number' && Number.isFinite(raw.ingestPressure)) {
-    return { ingestPressure: raw.ingestPressure, lastUpdatedAt: raw.lastUpdatedAt ?? now };
+    return {
+      ingestPressure: raw.ingestPressure,
+      lastUpdatedAt: raw.lastUpdatedAt ?? now,
+      snapshotTotal: snapT,
+      snapshotAt: snapA,
+    };
   }
   if ('decayedPressure' in raw && typeof raw.decayedPressure === 'number' && Number.isFinite(raw.decayedPressure)) {
-    return { ingestPressure: raw.decayedPressure, lastUpdatedAt: raw.lastUpdatedAt ?? now };
+    return {
+      ingestPressure: raw.decayedPressure,
+      lastUpdatedAt: raw.lastUpdatedAt ?? now,
+      snapshotTotal: snapT,
+      snapshotAt: snapA,
+    };
   }
-  return { ingestPressure: 0, lastUpdatedAt: now };
+  return { ingestPressure: 0, lastUpdatedAt: now, snapshotTotal: null, snapshotAt: null };
 }
 
 /**
@@ -61,13 +92,16 @@ export async function recordReplayPressureFromIngest(duplicateSuppressedCount: n
 
   const nowMs = Date.now();
   const nowIso = new Date(nowMs).toISOString();
-  const { ingestPressure, lastUpdatedAt } = await loadEnvelope();
-  const decayed = decayValue(ingestPressure, lastUpdatedAt, nowMs);
+  const env = await loadEnvelope();
+  const decayed = decayValue(env.ingestPressure, env.lastUpdatedAt, nowMs);
   const bump = Math.min(dups * PER_DUPLICATE_SUPPRESSED, INGEST_BATCH_CAP);
   const next: ReplayPressureKvV1 = {
     schema: 'MIC_REPLAY_PRESSURE_V1',
     ingestPressure: Number(Math.min(decayed + bump, 1).toFixed(4)),
     lastUpdatedAt: nowIso,
+    ...(env.snapshotTotal !== null && env.snapshotAt !== null
+      ? { snapshot_total: env.snapshotTotal, snapshot_at: env.snapshotAt }
+      : {}),
   };
   await kvSet(KV_KEYS.MIC_REPLAY_PRESSURE, next, KV_TTL_SECONDS.MIC_REPLAY_PRESSURE);
 }
@@ -89,4 +123,23 @@ export async function resolveReplayPressureWithDecay(
     status: statusFromPressure(total),
     replay_decay_half_life_hours: REPLAY_HALF_LIFE_HOURS,
   };
+}
+
+/**
+ * Persist resolved replay total for KV visibility (catalog / probes). Echo ingest path
+ * continues to own `ingestPressure`; we add a short-TTL snapshot of the merged total.
+ */
+export async function persistResolvedReplayPressureToKv(resolvedTotal: number): Promise<void> {
+  const total = Number.isFinite(resolvedTotal) ? Math.max(0, Math.min(1, resolvedTotal)) : 0;
+  const nowIso = new Date().toISOString();
+  const env = await loadEnvelope();
+  /** Do not rewrite `lastUpdatedAt` — ECHO ingest uses it for ingest-side decay. */
+  const next: ReplayPressureKvV1 = {
+    schema: 'MIC_REPLAY_PRESSURE_V1',
+    ingestPressure: Number(env.ingestPressure.toFixed(4)),
+    lastUpdatedAt: env.lastUpdatedAt,
+    snapshot_total: Number(total.toFixed(4)),
+    snapshot_at: nowIso,
+  };
+  await kvSet(KV_KEYS.MIC_REPLAY_PRESSURE, next, KV_TTL_SECONDS.MIC_REPLAY_PRESSURE);
 }

--- a/lib/vault-v2/deposit.ts
+++ b/lib/vault-v2/deposit.ts
@@ -33,6 +33,7 @@ import {
 import { VAULT_RESERVE_PARCEL_UNITS } from '@/lib/vault-v2/constants';
 import { formCandidate } from '@/lib/vault-v2/seal';
 import type { Mode, SealCandidate } from '@/lib/vault-v2/types';
+import { notifySentinelCouncilSealFormation } from '@/lib/vault-v2/sentinelCouncilNotify';
 
 const THRESHOLD = VAULT_RESERVE_PARCEL_UNITS;
 
@@ -144,6 +145,10 @@ export async function accrueDepositV2(args: {
     overflow_carried: overflow,
   });
 
+  void notifySentinelCouncilSealFormation(candidate).catch((err) => {
+    console.warn('[vault-v2] sentinel council notify:', err instanceof Error ? err.message : err);
+  });
+
   return {
     balance_after: overflow,
     candidate_formed: candidate,
@@ -187,6 +192,9 @@ export async function tryFormNextCandidate(args: { cycle: string }): Promise<Sea
     console.info('[vault-v2] next candidate formed from queued reserve', {
       seal_id: candidate.seal_id,
       overflow_carried: overflow,
+    });
+    void notifySentinelCouncilSealFormation(candidate).catch((err) => {
+      console.warn('[vault-v2] sentinel council notify:', err instanceof Error ? err.message : err);
     });
   }
   return candidate;

--- a/lib/vault-v2/sentinelCouncilNotify.ts
+++ b/lib/vault-v2/sentinelCouncilNotify.ts
@@ -1,0 +1,38 @@
+/**
+ * C-288 — When a Seal candidate forms at the first tranche threshold, surface a
+ * Sentinel Council notification in agent journals (draft; no vault deposit).
+ */
+
+import { appendAgentJournalEntry } from '@/lib/agents/journal';
+import type { SealCandidate } from '@/lib/vault-v2/types';
+import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
+
+export async function notifySentinelCouncilSealFormation(candidate: SealCandidate): Promise<void> {
+  const cycle = candidate.cycle_at_seal?.trim() || 'unknown';
+  const obs =
+    `Seal candidate ${candidate.seal_id} formed (sequence ${candidate.sequence}). ` +
+    `Reserve parcel threshold reached; GI at seal ${candidate.gi_at_seal.toFixed(3)}, mode ${candidate.mode_at_seal}. ` +
+    `Source entries: ${candidate.source_entries}. Awaiting Sentinel attestations before quorum.`;
+
+  await Promise.all(
+    SENTINEL_AGENTS.map((agent) =>
+      appendAgentJournalEntry({
+        agent,
+        cycle,
+        observation: obs,
+        inference: `Sentinel Council: attestation window open for ${candidate.seal_id}. Post verdict via /api/vault/seal/attest.`,
+        recommendation:
+          'Review seal_hash and deposit_hashes; attest pass/flag/reject with rationale before timeout_at.',
+        confidence: 0.95,
+        status: 'draft',
+        category: 'alert',
+        severity: 'elevated',
+        derivedFrom: [candidate.seal_id, candidate.seal_hash],
+        relatedAgents: [...SENTINEL_AGENTS],
+        agentOrigin: 'TERMINAL',
+      }).catch((err) => {
+        console.warn(`[vault-v2] sentinel council journal notify failed for ${agent}:`, err instanceof Error ? err.message : err);
+      }),
+    ),
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the four C-288 operator priorities from the morning briefing as **repo-backed** behavior: Sentinel visibility when a seal candidate forms, **MIC replay + readiness** KV visibility without lying about upstream authority, **HERMES µ3/µ4** structural-zero handling, and an explicit **EVE governance review queue** for persistent ethics tags.

## Changes

1. **Vault / Sentinel Council** — When `formCandidate` succeeds (deposit path or `tryFormNextCandidate`), fire-and-forget `notifySentinelCouncilSealFormation`: **draft** `appendAgentJournalEntry` for each of `ATLAS`, `ZEUS`, `EVE`, `JADE`, `AUREA` with seal metadata and attestation instructions. No vault deposit (status `draft`).

2. **MIC replay pressure KV** — Extend `MIC_REPLAY_PRESSURE_V1` with optional `snapshot_total` / `snapshot_at`. `GET /api/mic/readiness` calls `persistResolvedReplayPressureToKv` after assembly. ECHO ingest preserves snapshot fields when bumping ingest pressure.

3. **MIC readiness snapshot** — When there is **no** upstream KV snapshot (`loadMicReadinessSnapshotRaw` not `kv`), persist local merged readiness to `MIC_READINESS_SNAPSHOT` with `source: terminal-readiness-hydrate` (no feed LPUSH spam). Response includes `mic_readiness_snapshot_hydrated`.

4. **HERMES µ3 / µ4** — Widen GDELT timespan retries (`7d`, `3d`, `1d`) and Reddit subs; if HTTP succeeds but sample is still empty outside quiet windows, emit **nominal 0.5** with explicit **dead-instrument** labeling (raw flags) instead of `watch`.

5. **EVE ethics / C-279** — `ethicsReviewQueue` on synthesis output (`ethics:active-tripwire`, `ethics:narrative-cluster-spike` when warranted), body line scheduling operator acknowledgment, ledger tags deduped with existing `ethics:*` tags; `GET /api/eve/governance-preview` exposes `ethicsReviewQueue`.

## Verification

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- ESLint not configured for non-interactive `pnpm lint` (per AGENTS.md)

## Notes

- Sentinel journals are **draft** so operators can promote after review; they intentionally skip committed-path side effects.  
- Readiness GET hydration runs only when Substrate/tokenomics has not populated KV; upstream POST path unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://mobius-substrate.slack.com/archives/D0AU7DJDL9W/p1776709153359049?thread_ts=1776709153.359049&cid=D0AU7DJDL9W)

<div><a href="https://cursor.com/agents/bc-749f75ef-d3e1-5bff-9b9a-4962d732b9b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-749f75ef-d3e1-5bff-9b9a-4962d732b9b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

