### PR TITLE
feat(C-288): operator hardening + Globe chapter dashboards

### DIFF
--- a/app/terminal/GlobePageClient.tsx
+++ b/app/terminal/GlobePageClient.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useMemo } from 'react';
 import GlobeChamber from '@/components/terminal/chambers/GlobeChamber';
 import ChamberSkeleton from '@/components/terminal/ChamberSkeleton';
+import { buildEveEscalationStrip } from '@/components/terminal/chambers/globeDashboardExtras';
 import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
 import type { MicroAgentSweepResult } from '@/lib/agents/micro';
 import type { EpiconItem } from '@/lib/terminal/types';
@@ -45,6 +47,20 @@ export default function GlobePageClient() {
   const cycle = integrity.cycle ?? (snapshot as Record<string, unknown> | null)?.cycle as string | undefined ?? 'C-271';
   const gi = integrity.global_integrity ?? (snapshot as Record<string, unknown> | null)?.gi as number | undefined ?? 0;
 
+  const globeDashboard = useMemo(() => {
+    if (!snapshot) return null;
+    const eveStrip = buildEveEscalationStrip(echoEpicon);
+    return {
+      eveStrip,
+      kvHealth: snapshot.kvHealth?.data ?? null,
+      runtime: snapshot.runtime?.data ?? null,
+      tripwire: snapshot.tripwire?.data ?? null,
+      vault: snapshot.vault?.data ?? null,
+      micReadiness: snapshot.micReadiness?.data ?? null,
+      miiFeed: snapshot.mii?.data ?? null,
+    };
+  }, [snapshot, echoEpicon]);
+
   return (
     <GlobeChamber
       micro={micro}
@@ -54,6 +70,7 @@ export default function GlobePageClient() {
       clockLabel={`${new Date().toISOString().slice(11, 16)} UTC`}
       giScore={Number(gi)}
       miiScore={null}
+      globeDashboard={globeDashboard}
     />
   );
 }

--- a/components/terminal/chambers/GlobeChamber.tsx
+++ b/components/terminal/chambers/GlobeChamber.tsx
@@ -2,27 +2,8 @@
 
 import dynamic from 'next/dynamic';
 import { useEffect, useState } from 'react';
-import type { MicroAgentSweepResult } from '@/lib/agents/micro';
-import type { EpiconItem } from '@/lib/terminal/types';
-import type { SentimentDomainKey } from '@/lib/terminal/globePins';
-
-type SentimentDomain = {
-  key: SentimentDomainKey;
-  label: string;
-  agent: string;
-  score: number | null;
-  status: 'nominal' | 'stressed' | 'critical' | 'unknown';
-};
-
-export type GlobeChamberProps = {
-  micro: (MicroAgentSweepResult & { ok?: boolean }) | null;
-  echoEpicon: EpiconItem[];
-  domains: SentimentDomain[];
-  cycleId: string;
-  clockLabel: string;
-  giScore: number;
-  miiScore: number | null;
-};
+import GlobeChapterDashboards from '@/components/terminal/chambers/GlobeChapterDashboards';
+import type { GlobeChamberProps } from '@/components/terminal/chambers/types';
 
 const GlobeView = dynamic(() => import('./GlobeView3D'), {
   ssr: false,
@@ -73,7 +54,7 @@ export default function GlobeChamber(props: GlobeChamberProps) {
   const show3D = isDesktop && !prefer2D;
 
   return (
-    <div className="relative">
+    <div className="relative space-y-0">
       {isDesktop ? (
         <button
           type="button"
@@ -84,6 +65,7 @@ export default function GlobeChamber(props: GlobeChamberProps) {
         </button>
       ) : null}
       {show3D ? <GlobeView {...props} /> : <WorldMapView {...props} />}
+      <GlobeChapterDashboards micro={props.micro} domains={props.domains} dashboard={props.globeDashboard ?? null} />
     </div>
   );
 }

--- a/components/terminal/chambers/GlobeChapterDashboards.tsx
+++ b/components/terminal/chambers/GlobeChapterDashboards.tsx
@@ -1,0 +1,305 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import type { MicroSignal } from '@/lib/agents/micro/core';
+import type { SentimentDomainKey } from '@/lib/terminal/globePins';
+import {
+  GLOBE_DOMAIN_ORDER,
+  domainBarColor,
+  extractUsgsSamples,
+  gdeltDeadLane,
+  partitionMicroSignals,
+  pickLatestMiiByAgent,
+  type GlobeDashboardBundle,
+  type MiiAgentScore,
+  type SeismicRow,
+} from '@/components/terminal/chambers/globeDashboardExtras';
+
+type SentimentDomain = {
+  key: SentimentDomainKey;
+  label: string;
+  agent: string;
+  score: number | null;
+  status: 'nominal' | 'stressed' | 'critical' | 'unknown';
+};
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  if (!v || typeof v !== 'object') return null;
+  return v as Record<string, unknown>;
+}
+
+function fmtTime(ms: number): string {
+  const d = new Date(ms);
+  return `${d.getUTCHours().toString().padStart(2, '0')}:${d.getUTCMinutes().toString().padStart(2, '0')}Z`;
+}
+
+function magPillClass(m: number): string {
+  if (m >= 5) return 'border-amber-500/60 bg-amber-500/15 text-amber-200';
+  if (m >= 4) return 'border-amber-500/40 bg-amber-500/10 text-amber-100';
+  return 'border-slate-600 bg-slate-800/80 text-slate-400';
+}
+
+function panelShell(title: string, subtitle: string | null, children: ReactNode) {
+  return (
+    <section className="rounded-md border border-white/[0.08] bg-[#020408]/90 p-3 shadow-sm backdrop-blur-sm">
+      <div className="mb-2 border-b border-white/[0.06] pb-1.5">
+        <h3 className="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400">{title}</h3>
+        {subtitle ? <p className="mt-0.5 text-[9px] leading-snug text-slate-600">{subtitle}</p> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+const MII_ORDER = ['ATLAS', 'ZEUS', 'EVE', 'JADE', 'AUREA', 'HERMES', 'ECHO', 'DAEDALUS'] as const;
+
+export default function GlobeChapterDashboards(props: {
+  micro: { allSignals?: MicroSignal[]; composite?: number; instrumentCount?: number } | null;
+  domains: SentimentDomain[];
+  dashboard: GlobeDashboardBundle | null;
+}) {
+  const { micro, domains, dashboard } = props;
+  const domainByKey = Object.fromEntries(domains.map((d) => [d.key, d])) as Record<string, SentimentDomain>;
+
+  const eveStrip = dashboard?.eveStrip ?? null;
+  const seismic = extractUsgsSamples(micro);
+  const { environmental, markets, governance } = partitionMicroSignals(micro);
+  const gdeltDead = gdeltDeadLane(micro);
+  const miiMap = pickLatestMiiByAgent(dashboard?.miiFeed ?? null);
+
+  const kv = asRecord(dashboard?.kvHealth);
+  const rt = asRecord(dashboard?.runtime);
+  const twRoot = asRecord(dashboard?.tripwire);
+  const tw = asRecord(twRoot?.tripwire) ?? twRoot;
+  const vault = asRecord(dashboard?.vault);
+  const mic = asRecord(dashboard?.micReadiness);
+
+  const inProg = typeof vault?.in_progress_balance === 'number' ? vault.in_progress_balance : null;
+  const thr = typeof vault?.activation_threshold === 'number' ? vault.activation_threshold : 50;
+  const tranchePct = inProg != null && thr > 0 ? Math.min(100, (inProg / thr) * 100) : null;
+  const hashCov = typeof vault?.hash_coverage_pct === 'number' ? vault.hash_coverage_pct : null;
+  const fountain = vault?.fountain_status != null ? String(vault.fountain_status) : null;
+  const sustainMet = vault?.sustain_cycles_met === true;
+  const sustainReq = typeof vault?.sustain_cycles_required === 'number' ? vault.sustain_cycles_required : 5;
+
+  const pulseInstr = typeof rt?.pulse === 'object' && rt.pulse !== null ? (rt.pulse as Record<string, unknown>).instruments : null;
+
+  const apod = (micro?.allSignals ?? []).find((s) => s.source.toLowerCase().includes('apod'));
+
+  return (
+    <div className="border-t border-white/[0.08] bg-[#020408]/98 px-2 py-3 sm:px-3">
+      {eveStrip ? (
+        <div className="mb-3 rounded border border-amber-500/35 bg-amber-950/40 px-3 py-2 text-[10px] leading-snug text-amber-100/95">
+          <span className="font-semibold text-amber-200/90">EVE · </span>
+          {eveStrip}
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-2 lg:grid-cols-2 xl:grid-cols-3">
+        {panelShell(
+          'Sentiment domains',
+          'From /api/sentiment/composite · same six keys as Pulse',
+          <div className="space-y-2">
+            {GLOBE_DOMAIN_ORDER.map((key) => {
+              const d = domainByKey[key];
+              const score = d?.score ?? null;
+              const w = score != null ? `${Math.round(score * 100)}%` : '0%';
+              const bg = domainBarColor(key, score);
+              return (
+                <div key={key} className="flex items-center gap-2">
+                  <div className="w-24 shrink-0 text-[9px] uppercase tracking-wide text-slate-500">{d?.label ?? key}</div>
+                  <div className="relative h-2 flex-1 overflow-hidden rounded bg-white/[0.06]">
+                    <div className="absolute left-0 top-0 h-full rounded transition-all" style={{ width: w, background: bg }} />
+                  </div>
+                  <div className="w-10 shrink-0 text-right font-mono text-[11px] text-slate-200">{score != null ? score.toFixed(2) : '—'}</div>
+                </div>
+              );
+            })}
+          </div>,
+        )}
+
+        {panelShell(
+          'Seismic · USGS (M2.5+ day)',
+          'Rows from GAIA micro-signal raw.samples',
+          seismic.length === 0 ? (
+            <p className="text-[10px] text-slate-500">No USGS samples in current micro sweep.</p>
+          ) : (
+            <ul className="max-h-40 space-y-1 overflow-y-auto font-mono text-[10px] text-slate-300">
+              {seismic.map((r, i) => (
+                <li key={`${r.mag}-${i}`} className="flex items-center gap-2">
+                  <span className={`shrink-0 rounded border px-1.5 py-0.5 font-bold ${magPillClass(r.mag)}`}>M{r.mag.toFixed(1)}</span>
+                  <span className="min-w-0 flex-1 truncate text-slate-400">{r.place}</span>
+                  <span className="shrink-0 text-slate-600">{fmtTime(r.timeMs)}</span>
+                </li>
+              ))}
+            </ul>
+          ),
+        )}
+
+        {panelShell(
+          'Environmental · ECHO lane',
+          'GAIA / ECHO micro instruments (non-seismic)',
+          environmental.length === 0 ? (
+            <p className="text-[10px] text-slate-500">No environmental instruments in sweep.</p>
+          ) : (
+            <ul className="max-h-44 space-y-1 overflow-y-auto text-[10px] leading-snug text-slate-400">
+              {environmental.map((s) => (
+                <li key={`${s.agentName}-${s.source}-${s.label}`}>
+                  <span className="text-slate-500">{s.agentName}</span> · {s.label}
+                </li>
+              ))}
+            </ul>
+          ),
+        )}
+
+        {panelShell(
+          'Markets · governance',
+          'CoinGecko / FX + Federal Register, USAspending, FDA, CrossRef, arXiv',
+          <div className="grid max-h-52 grid-cols-1 gap-2 overflow-y-auto sm:grid-cols-2">
+            <div>
+              <div className="mb-1 text-[9px] uppercase tracking-wide text-slate-600">Markets</div>
+              <ul className="space-y-1 text-[10px] text-slate-400">
+                {markets.length === 0 ? <li className="text-slate-600">—</li> : null}
+                {markets.map((s) => (
+                  <li key={`m-${s.source}-${s.label}`}>{s.label}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <div className="mb-1 text-[9px] uppercase tracking-wide text-slate-600">Governance</div>
+              <ul className="space-y-1 text-[10px] text-slate-400">
+                {governance.length === 0 ? <li className="text-slate-600">—</li> : null}
+                {governance.map((s) => (
+                  <li key={`g-${s.source}-${s.label}`}>
+                    {s.label}
+                    {gdeltDead && s.source.toLowerCase().includes('gdelt') ? (
+                      <span className="ml-1 text-rose-400/90">· dead lane</span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>,
+        )}
+
+        {panelShell(
+          'Agent MII',
+          'Latest per agent from mii:feed (snapshot lane)',
+          <div className="space-y-1.5">
+            {MII_ORDER.map((agent) => {
+              const row: MiiAgentScore | undefined = miiMap[agent];
+              const v = row?.mii ?? null;
+              return (
+                <div key={agent} className="flex items-center gap-2">
+                  <div className="w-20 shrink-0 font-mono text-[9px] uppercase tracking-wide text-slate-500">{agent}</div>
+                  <div className="relative h-1.5 flex-1 overflow-hidden rounded bg-white/[0.06]">
+                    {v != null ? (
+                      <div
+                        className="absolute left-0 top-0 h-full rounded bg-sky-500/80"
+                        style={{ width: `${Math.round(v * 100)}%` }}
+                      />
+                    ) : null}
+                  </div>
+                  <div className="w-9 shrink-0 text-right font-mono text-[10px] text-slate-200">{v != null ? v.toFixed(2) : '—'}</div>
+                </div>
+              );
+            })}
+          </div>,
+        )}
+
+        {panelShell(
+          'Vault · tranche',
+          'From /api/vault/status',
+          <div className="space-y-2 text-[10px] text-slate-400">
+            {inProg != null ? (
+              <>
+                <div className="flex justify-between font-mono text-slate-300">
+                  <span>In progress</span>
+                  <span>
+                    {inProg.toFixed(2)} / {thr.toFixed(2)}
+                  </span>
+                </div>
+                {tranchePct != null ? (
+                  <div className="relative h-2 overflow-hidden rounded bg-white/[0.06]">
+                    <div
+                      className="absolute left-0 top-0 h-full rounded bg-emerald-500/75"
+                      style={{ width: `${tranchePct.toFixed(1)}%` }}
+                    />
+                  </div>
+                ) : null}
+              </>
+            ) : (
+              <p className="text-slate-600">Vault lane unavailable or empty.</p>
+            )}
+            {hashCov != null ? (
+              <div>
+                Hash coverage: <span className="text-emerald-300/90">{hashCov}%</span>
+              </div>
+            ) : null}
+            {fountain ? (
+              <div>
+                Fountain: <span className="text-slate-200">{fountain}</span>
+              </div>
+            ) : null}
+            <div>
+              Sustain:{' '}
+              <span className={sustainMet ? 'text-emerald-300' : 'text-rose-300/90'}>
+                {sustainMet ? `met (${sustainReq} required)` : `pending · ${sustainReq} consecutive required`}
+              </span>
+            </div>
+          </div>,
+        )}
+
+        {panelShell(
+          'Infrastructure pulse',
+          'KV / backup Redis / runtime pulse',
+          <ul className="space-y-1 font-mono text-[10px] text-slate-400">
+            <li>
+              KV primary:{' '}
+              <span className={kv?.available === false ? 'text-rose-300' : 'text-emerald-300'}>
+                {kv?.available === false ? 'offline' : 'ok'}
+              </span>
+              {typeof kv?.latencyMs === 'number' ? <span className="text-slate-600"> · {kv.latencyMs}ms</span> : null}
+            </li>
+            <li>
+              Backup Redis:{' '}
+              <span className={asRecord(kv?.backup_redis)?.available === false ? 'text-rose-300' : 'text-emerald-300'}>
+                {asRecord(kv?.backup_redis)?.available === false ? 'offline' : 'ok'}
+              </span>
+            </li>
+            {typeof pulseInstr === 'number' ? (
+              <li>
+                System pulse instruments: <span className="text-slate-200">{pulseInstr}</span>
+              </li>
+            ) : null}
+            {tw ? (
+              <li>
+                Tripwire: <span className="text-slate-200">{String(tw.level ?? tw.elevated ?? '')}</span>
+              </li>
+            ) : null}
+          </ul>,
+        )}
+      </div>
+
+      {mic && typeof mic.replay === 'object' && mic.replay !== null ? (
+        <div className="mt-2 border-t border-white/[0.06] pt-2 text-center font-mono text-[9px] uppercase tracking-[0.12em] text-slate-600">
+          MIC readiness · replay {(mic.replay as Record<string, unknown>).replayPressure != null
+            ? Number((mic.replay as Record<string, unknown>).replayPressure).toFixed(3)
+            : '—'}{' '}
+          · sustain {String((mic.sustain as Record<string, unknown> | undefined)?.status ?? '—')}
+        </div>
+      ) : null}
+
+      {micro?.composite != null ? (
+        <div className="mt-1 text-center font-mono text-[9px] text-slate-600">
+          {apod ? (
+            <>
+              APOD · {apod.label.replace(/^APOD:\s*/i, '')} ·{' '}
+            </>
+          ) : null}
+          {micro.instrumentCount ?? '—'} instruments · composite {micro.composite.toFixed(3)}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/terminal/chambers/globeDashboardExtras.ts
+++ b/components/terminal/chambers/globeDashboardExtras.ts
@@ -1,0 +1,169 @@
+import type { MicroSignal } from '@/lib/agents/micro/core';
+import type { EpiconItem } from '@/lib/terminal/types';
+import type { SentimentDomainKey } from '@/lib/terminal/globePins';
+import { GLOBE_DOMAIN_ORDER } from '@/lib/terminal/globePins';
+
+export type GlobeDashboardBundle = {
+  eveStrip: string | null;
+  kvHealth: unknown;
+  runtime: unknown;
+  tripwire: unknown;
+  vault: unknown;
+  micReadiness: unknown;
+  miiFeed: unknown;
+};
+
+export type SeismicRow = { mag: number; place: string; timeMs: number };
+
+export type MiiAgentScore = { agent: string; mii: number; timestamp: string };
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  if (!v || typeof v !== 'object') return null;
+  return v as Record<string, unknown>;
+}
+
+export function pickLatestMiiByAgent(miiLeafData: unknown): Record<string, MiiAgentScore> {
+  const row = asRecord(miiLeafData);
+  const entries = row?.entries;
+  if (!Array.isArray(entries)) return {};
+  const out: Record<string, MiiAgentScore> = {};
+  for (const e of entries) {
+    const o = asRecord(e);
+    if (!o) continue;
+    const agent = typeof o.agent === 'string' ? o.agent.toUpperCase().trim() : '';
+    const mii = typeof o.mii === 'number' && Number.isFinite(o.mii) ? o.mii : null;
+    const ts = typeof o.timestamp === 'string' ? o.timestamp : '';
+    if (!agent || mii === null) continue;
+    const prev = out[agent];
+    if (!prev || ts > prev.timestamp) {
+      out[agent] = { agent, mii, timestamp: ts };
+    }
+  }
+  return out;
+}
+
+export function extractUsgsSamples(micro: { allSignals?: MicroSignal[] } | null): SeismicRow[] {
+  const all = micro?.allSignals ?? [];
+  const usgs = all.filter((s) => typeof s.source === 'string' && s.source.toLowerCase().includes('usgs'));
+  const rows: SeismicRow[] = [];
+  for (const s of usgs) {
+    const raw = s.raw && typeof s.raw === 'object' ? (s.raw as Record<string, unknown>) : null;
+    const samples = raw?.samples;
+    if (!Array.isArray(samples)) continue;
+    for (const row of samples) {
+      const o = row && typeof row === 'object' ? (row as Record<string, unknown>) : null;
+      if (!o) continue;
+      const mag = typeof o.mag === 'number' && Number.isFinite(o.mag) ? o.mag : null;
+      const place = typeof o.place === 'string' ? o.place : '';
+      const lat = typeof o.lat === 'number' ? o.lat : null;
+      const lng = typeof o.lng === 'number' ? o.lng : null;
+      if (mag === null) continue;
+      rows.push({
+        mag,
+        place: place || (lat != null && lng != null ? `${lat.toFixed(2)}, ${lng.toFixed(2)}` : 'unknown'),
+        timeMs: typeof s.timestamp === 'string' ? new Date(s.timestamp).getTime() : Date.now(),
+      });
+    }
+  }
+  rows.sort((a, b) => b.mag - a.mag);
+  return rows.slice(0, 16);
+}
+
+function sourceLower(s: MicroSignal): string {
+  return `${s.source} ${s.label}`.toLowerCase();
+}
+
+export function partitionMicroSignals(micro: { allSignals?: MicroSignal[] } | null): {
+  environmental: MicroSignal[];
+  markets: MicroSignal[];
+  governance: MicroSignal[];
+} {
+  const all = micro?.allSignals ?? [];
+  const environmental: MicroSignal[] = [];
+  const markets: MicroSignal[] = [];
+  const governance: MicroSignal[] = [];
+  for (const s of all) {
+    const sl = sourceLower(s);
+    const agent = (s.agentName ?? '').toUpperCase();
+    if (sl.includes('usgs') || sl.includes('earthquake')) continue;
+    if (
+      agent === 'GAIA' ||
+      sl.includes('eonet') ||
+      sl.includes('nasa') ||
+      sl.includes('open-meteo') ||
+      sl.includes('meteo') ||
+      sl.includes('nws') ||
+      sl.includes('relief') ||
+      sl.includes('iss') ||
+      sl.includes('weather')
+    ) {
+      environmental.push(s);
+      continue;
+    }
+    if (
+      sl.includes('coingecko') ||
+      sl.includes('bitcoin') ||
+      sl.includes('ethereum') ||
+      sl.includes('solana') ||
+      sl.includes('frankfurter') ||
+      sl.includes('eur/usd') ||
+      sl.includes('fx')
+    ) {
+      markets.push(s);
+      continue;
+    }
+    if (
+      sl.includes('federal register') ||
+      sl.includes('usaspending') ||
+      sl.includes('openfda') ||
+      sl.includes('crossref') ||
+      sl.includes('arxiv') ||
+      sl.includes('data.gov')
+    ) {
+      governance.push(s);
+      continue;
+    }
+  }
+  return { environmental, markets, governance };
+}
+
+export function gdeltDeadLane(micro: { allSignals?: MicroSignal[] } | null): boolean {
+  for (const s of micro?.allSignals ?? []) {
+    const sl = sourceLower(s);
+    if (!sl.includes('gdelt')) continue;
+    if (sl.includes('dead-instrument') || sl.includes('dead lane') || sl.includes('neutral baseline')) return true;
+    const raw = s.raw && typeof s.raw === 'object' ? (s.raw as Record<string, unknown>) : null;
+    if (raw?.structuralEmpty === true) return true;
+  }
+  return false;
+}
+
+export function buildEveEscalationStrip(epicon: EpiconItem[]): string | null {
+  const scored = epicon
+    .filter((row) => {
+      const t = (row.title ?? '').toLowerCase();
+      const o = (row.ownerAgent ?? '').toUpperCase();
+      const origin = (row.agentOrigin ?? '').toUpperCase();
+      return o === 'EVE' || origin === 'EVE' || t.includes('eve review') || t.includes('eve escalation');
+    })
+    .sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1));
+  const top = scored[0];
+  if (!top) return null;
+  const parts: string[] = [];
+  const title = top.title?.trim() ?? '';
+  if (title) parts.push(title.slice(0, 120));
+  const trace = Array.isArray(top.trace) ? top.trace : [];
+  const tagHints = [...trace].filter((x) => typeof x === 'string' && /gi_critical|ethics:|civic-risk|escalation/i.test(x)).slice(0, 4);
+  parts.push(...tagHints);
+  return parts.length > 0 ? parts.join(' · ') : null;
+}
+
+export function domainBarColor(key: SentimentDomainKey, score: number | null): string {
+  if (score == null) return '#64748b';
+  if (score >= 0.8) return '#34d399';
+  if (score >= 0.65) return '#38bdf8';
+  if (score >= 0.55) return '#fbbf24';
+  return '#fb7185';
+}
+
+export { GLOBE_DOMAIN_ORDER };

--- a/components/terminal/chambers/types.ts
+++ b/components/terminal/chambers/types.ts
@@ -1,6 +1,7 @@
 import type { MicroAgentSweepResult } from '@/lib/agents/micro';
 import type { EpiconItem } from '@/lib/terminal/types';
 import type { SentimentDomainKey } from '@/lib/terminal/globePins';
+import type { GlobeDashboardBundle } from '@/components/terminal/chambers/globeDashboardExtras';
 
 export type MicroSweepResponse = MicroAgentSweepResult & { ok?: boolean };
 
@@ -20,4 +21,6 @@ export type GlobeChamberProps = {
   clockLabel: string;
   giScore: number;
   miiScore: number | null;
+  /** Extra snapshot lanes for Globe chapter dashboards (same fetch as globe). */
+  globeDashboard?: GlobeDashboardBundle | null;
 };

--- a/hooks/useTerminalSnapshot.ts
+++ b/hooks/useTerminalSnapshot.ts
@@ -42,6 +42,8 @@ export type TerminalSnapshot = {
   promotion?: SnapshotLeaf;
   eve?: SnapshotLeaf;
   mii?: SnapshotLeaf;
+  vault?: SnapshotLeaf;
+  micReadiness?: SnapshotLeaf;
   tripwire?: SnapshotLeaf;
   lite?: boolean;
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Delivers C-288 operator priorities (MIC KV echo, readiness hydrate, Sentinel seal notifications, HERMES dead-lane handling, EVE ethics review queue) and adds **Globe chapter dashboards** that render below the 3D globe / 2D map using the **same** full terminal snapshot as the globe (`useTerminalSnapshot` — shared ~60s cache with no extra polling).

## Key changes

- **Globe:** `GlobeChapterDashboards` + `globeDashboardExtras` — EVE strip from EPICON, six sentiment bars, USGS rows from GAIA samples, environmental / markets / governance micro lanes (GDELT dead lane), MII bars from `mii` lane, vault tranche + sustain, infra pulse (KV / backup / pulse / tripwire), MIC replay footer, APOD + composite line.
- **MIC / vault / EVE / HERMES:** (see prior commits on branch) replay KV snapshot, local readiness hydrate when no upstream snapshot, Sentinel draft journals on seal candidate formation, HERMES µ3/µ4 structural empty handling, `ethicsReviewQueue` + ledger tags.

## Verification

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- ESLint not configured for non-interactive `pnpm lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://mobius-substrate.slack.com/archives/D0AU7DJDL9W/p1776709153359049?thread_ts=1776709153.359049&cid=D0AU7DJDL9W)

<div><a href="https://cursor.com/agents/bc-749f75ef-d3e1-5bff-9b9a-4962d732b9b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-749f75ef-d3e1-5bff-9b9a-4962d732b9b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

