### PR TITLE
docs(pr): journal → substrate canonical sync PR spec

### DIFF
--- a/docs/prs/journal-substrate-canon-sync.md
+++ b/docs/prs/journal-substrate-canon-sync.md
@@ -1,0 +1,200 @@
+# PR: Journal → Substrate Canon Sync
+
+## Title
+feat(journal): canonical substrate-backed journal sync with hot KV mirror
+
+---
+
+## Objective
+
+Make Mobius-Substrate the canonical journal memory layer and keep KV/Redis as the hot operational mirror.
+
+---
+
+## Architecture Rule
+
+### Write Path
+POST /api/agents/journal  
+→ validate payload  
+→ writeJournalToSubstrate()  
+→ KV mirror (optional)  
+→ return canonical result
+
+### Read Modes
+- HOT = KV / Redis
+- CANON = Substrate repo
+- MERGED = KV + Substrate fallback
+
+---
+
+## API Changes
+
+### POST /api/agents/journal
+
+#### Success Response
+```json
+{
+  "ok": true,
+  "canonical": true,
+  "path": "journals/zeus/2026-04-20T09-00-00Z-journal.json",
+  "mirrored_to_kv": true,
+  "timestamp": "2026-04-20T09:00:00Z"
+}
+```
+
+#### Failure Response
+```json
+{
+  "ok": false,
+  "canonical": false,
+  "error": "substrate_write_failed",
+  "mirrored_to_kv": false
+}
+```
+
+---
+
+### GET /api/agents/journal
+
+Query params:
+- mode=hot|canon|merged
+- agent=ZEUS
+- cycle=C-286
+- limit=10
+
+---
+
+## Schema Update
+
+Add fields:
+
+- verification_status?: "unverified" | "confirmed" | "contested"
+- tripwire_context?: string[]
+- canonical_path?: string
+- commit_sha?: string
+
+---
+
+## Snapshot Integration
+
+Add support:
+
+`/api/terminal/snapshot?include_substrate=true&journal_mode=merged`
+
+Response:
+
+```json
+{
+  "journal_mode": "merged",
+  "journal_summary": {
+    "latest_agent_entries": [
+      {
+        "agent": "zeus",
+        "source": "substrate",
+        "timestamp": "2026-04-20T09:00:00Z",
+        "severity": "elevated",
+        "summary": "Tripwire persistent; GI source live."
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Substrate File Layout
+
+```text
+Mobius-Substrate/
+  journals/
+    zeus/
+    atlas/
+    hermes/
+    eve/
+```
+
+File naming:
+
+`YYYY-MM-DDTHH-MM-SSZ-journal.json`
+
+---
+
+## Cycle Rollups
+
+```text
+Mobius-Substrate/
+  cycles/
+    C-286/
+      summary.json
+      timeline.json
+      journals-index.json
+```
+
+---
+
+## Integrity Rules
+
+- Substrate write failure = request fails
+- KV mirror failure = allowed, log only
+
+---
+
+## Environment Variables
+
+- SUBSTRATE_GITHUB_TOKEN=...
+- JOURNAL_DEFAULT_MODE=merged
+- JOURNAL_CANONICAL_REQUIRED=true
+- JOURNAL_KV_MIRROR=true
+
+---
+
+## UI Updates
+
+Add selector:
+
+`[ HOT ] [ CANON ] [ MERGED ]`
+
+Journal card:
+- agent
+- timestamp
+- severity
+- source badge (KV / SUBSTRATE)
+- canonical path link
+
+---
+
+## Tasks
+
+### Backend
+- enforce canonical write
+- add read modes
+- extend schema
+- snapshot integration
+
+### Frontend
+- journal mode selector
+- source badges
+- canonical link
+
+### Reliability
+- handle failure states
+- log KV mirror failures
+
+---
+
+## Acceptance Criteria
+
+- All journals written to Substrate
+- KV is mirror only
+- Read modes functional
+- Snapshot includes journal summary
+- UI shows source
+- Failures handled correctly
+
+---
+
+## Outcome
+
+Mobius becomes:
+
+A durable, replayable, substrate-backed system memory — not just a terminal feed.


### PR DESCRIPTION
### Motivation
- Formalize the journaling architecture so Substrate is the canonical archive and KV/Redis remains a hot operational mirror for previews and speed.
- Provide a concrete implementation spec for API behavior, snapshot integration, schema extensions, integrity rules, and UI expectations so the Terminal can read journals in HOT | CANON | MERGED modes.

### Description
- Add a new PR-spec artifact at `docs/prs/journal-substrate-canon-sync.md` that defines write/read rules, API contracts for `POST`/`GET /api/agents/journal`, schema additions, snapshot params, cycle rollups, integrity policy, env vars, UI changes, tasks, and acceptance criteria.
- Specify the canonical write flow (`writeJournalToSubstrate()` then best-effort KV mirror), read modes (`hot`, `canon`, `merged`), and example response shapes for success/failure.
- Include operational guidance for cycle rollups, ledger reference model, environment variables, and a checklist of backend/frontend/reliability tasks to implement the spec.

### Testing
- Ran `pnpm exec tsc --noEmit` which completed successfully (typecheck: pass).
- Ran `pnpm build` which completed successfully (build: pass).
- Ran `pnpm lint` which invoked Next.js ESLint setup and is interactive in this repo, so lint is reported as not configured rather than failing (lint: not configured / interactive prompt).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f168803c832d94ef31137e549223)