### PR TITLE
feat(terminal): agent liveness contract + substrate-backed journal read/write modes

### DIFF
--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -16,6 +16,7 @@ export const revalidate = 0;
 type AgentJournalStatus = 'draft' | 'committed' | 'contested' | 'verified';
 type AgentJournalCategory = 'observation' | 'inference' | 'alert' | 'recommendation' | 'close';
 type AgentJournalSeverity = 'nominal' | 'elevated' | 'critical';
+type JournalReadMode = 'hot' | 'canon' | 'merged';
 
 interface AgentJournalEntry {
   id: string;
@@ -34,6 +35,8 @@ interface AgentJournalEntry {
   source: 'agent-journal';
   agentOrigin: string;
   tags?: string[];
+  source_mode?: 'kv' | 'substrate';
+  canonical_path?: string;
 }
 
 type AgentJournalCreateInput = Omit<AgentJournalEntry, 'id' | 'timestamp' | 'status' | 'source'> & {
@@ -48,17 +51,16 @@ type AgentJournalCreateInput = Omit<AgentJournalEntry, 'id' | 'timestamp' | 'sta
 };
 
 const MAX_READ = 100;
-/** When merging all agents from KV, cap per agent so one noisy writer cannot evict others from the global list. */
 const KV_JOURNAL_PER_AGENT_CAP = 50;
 const KV_JOURNAL_FAIR_MERGE_MAX = 600;
 const GENESIS_AGENTS = ['ATLAS', 'ZEUS', 'EVE', 'HERMES', 'AUREA', 'JADE', 'DAEDALUS', 'ECHO'] as const;
+const DEFAULT_READ_MODE = ((process.env.JOURNAL_DEFAULT_READ_MODE ?? 'merged').trim().toLowerCase() as JournalReadMode);
 
 function randomToken(length: number): string {
   const alphabet = '0123456789abcdefghijklmnopqrstuvwxyz';
   const bytes = crypto.getRandomValues(new Uint8Array(length));
   return Array.from(bytes, (byte) => alphabet[byte % alphabet.length]).join('');
 }
-
 
 function asRecord(input: unknown): Record<string, unknown> | null {
   if (!input || typeof input !== 'object') return null;
@@ -77,6 +79,18 @@ function asStringArray(input: unknown): string[] {
 function asOptionalTags(input: unknown): string[] | undefined {
   const tags = asStringArray(input);
   return tags.length > 0 ? tags : undefined;
+}
+
+function normalizeMode(input: string | null): JournalReadMode {
+  const raw = asString(input).toLowerCase();
+  if (raw === 'hot' || raw === 'canon' || raw === 'merged') return raw;
+  if (DEFAULT_READ_MODE === 'hot' || DEFAULT_READ_MODE === 'canon' || DEFAULT_READ_MODE === 'merged') return DEFAULT_READ_MODE;
+  return 'merged';
+}
+
+function canonicalPathFromTimestamp(agent: string, timestamp: string): string {
+  const fileStamp = timestamp.replace(/:/g, '-').replace(/\./g, '-');
+  return `journals/${agent.toLowerCase()}/${fileStamp}-journal.json`;
 }
 
 function substrateRecordToAgentEntry(row: SubstrateJournalEntry): AgentJournalEntry | null {
@@ -121,6 +135,8 @@ function substrateRecordToAgentEntry(row: SubstrateJournalEntry): AgentJournalEn
     source: 'agent-journal',
     agentOrigin,
     tags: asOptionalTags(row.tags),
+    source_mode: 'substrate',
+    canonical_path: canonicalPathFromTimestamp(agent, timestamp),
   };
 }
 
@@ -168,6 +184,7 @@ function parseEntry(input: unknown, fallbackAgent?: string, fallbackCycle?: stri
     source: 'agent-journal',
     agentOrigin,
     tags: asOptionalTags(row.tags),
+    source_mode: 'kv',
   };
 }
 
@@ -213,20 +230,12 @@ function buildEntry(input: AgentJournalCreateInput): AgentJournalEntry | null {
     source: 'agent-journal',
     agentOrigin: asString(input.agentOrigin).toUpperCase() || agent,
     tags: asOptionalTags(input.tags),
+    source_mode: 'kv',
   };
 
   return entry;
 }
 
-/**
- * Resolve logical agent + cycle from Redis key.
- * - Unprefixed: `journal:ZEUS:C-280` (legacy / journal-lane raw client)
- * - Mobius-prefixed: `mobius:journal:ZEUS:C-280` (appendAgentJournalEntry via kvSet)
- */
-/**
- * All-agents journal GET used to take only the newest MAX_READ rows globally; frequent EVE (or ZEUS)
- * runs could fill that window and hide ATLAS entirely. Take newest N per agent, then merge.
- */
 function mergeKvJournalFair(entries: AgentJournalEntry[], perAgent: number, maxTotal: number): AgentJournalEntry[] {
   const byAgent = new Map<string, AgentJournalEntry[]>();
   for (const e of entries) {
@@ -324,32 +333,12 @@ async function loadEntries(
   }
 }
 
-export async function GET(request: NextRequest) {
-  const redis = getJournalRedisClient();
-
-  const { searchParams } = request.nextUrl;
-  const agentFilters = Array.from(
-    new Set(
-      searchParams
-        .getAll('agent')
-        .map((agent) => asString(agent).toUpperCase())
-        .filter(Boolean),
-    ),
-  );
-  const agentFilterSet = new Set(agentFilters);
-  const cycleFilter = asString(searchParams.get('cycle'));
-  const limitRaw = Number(searchParams.get('limit') ?? '20');
-  const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(Math.floor(limitRaw), 100) : 20;
-
-  let kvEntries = await loadEntries(redis, agentFilters);
-  if (agentFilters.length === 0) {
-    kvEntries = mergeKvJournalFair(kvEntries, KV_JOURNAL_PER_AGENT_CAP, KV_JOURNAL_FAIR_MERGE_MAX);
-  }
-
+async function loadSubstrateEntries(agentFilters: string[], limit: number): Promise<{ entries: AgentJournalEntry[]; error: string | null }> {
   let substrateError: string | null = null;
-  let substrateEntries: AgentJournalEntry[] = [];
+  const substrateEntries: AgentJournalEntry[] = [];
   const substrateAgents = agentFilters.length > 0 ? agentFilters : [...GENESIS_AGENTS];
-  const substrateLimit = agentFilters.length === 1 ? 10 : Math.max(3, Math.ceil(limit / substrateAgents.length));
+  const substrateLimit = agentFilters.length === 1 ? Math.max(3, limit) : Math.max(3, Math.ceil(limit / substrateAgents.length));
+
   for (const agent of substrateAgents) {
     try {
       const substrateRead = readAgentJournals(agent.toLowerCase(), substrateLimit);
@@ -369,13 +358,46 @@ export async function GET(request: NextRequest) {
     }
   }
 
+  return { entries: substrateEntries, error: substrateError };
+}
+
+export async function GET(request: NextRequest) {
+  const redis = getJournalRedisClient();
+
+  const { searchParams } = request.nextUrl;
+  const mode = normalizeMode(searchParams.get('mode'));
+  const agentFilters = Array.from(
+    new Set(
+      searchParams
+        .getAll('agent')
+        .map((agent) => asString(agent).toUpperCase())
+        .filter(Boolean),
+    ),
+  );
+  const agentFilterSet = new Set(agentFilters);
+  const cycleFilter = asString(searchParams.get('cycle'));
+  const limitRaw = Number(searchParams.get('limit') ?? '20');
+  const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(Math.floor(limitRaw), MAX_READ) : 20;
+
+  const shouldReadKv = mode === 'hot' || mode === 'merged';
+  const shouldReadSubstrate = mode === 'canon' || mode === 'merged';
+
+  let kvEntries: AgentJournalEntry[] = shouldReadKv ? await loadEntries(redis, agentFilters) : [];
+  if (shouldReadKv && agentFilters.length === 0) {
+    kvEntries = mergeKvJournalFair(kvEntries, KV_JOURNAL_PER_AGENT_CAP, KV_JOURNAL_FAIR_MERGE_MAX);
+  }
+
+  const { entries: substrateEntries, error: substrateError } = shouldReadSubstrate
+    ? await loadSubstrateEntries(agentFilters, limit)
+    : { entries: [], error: null };
+
   const kvForSources = agentFilters.length > 0
     ? kvEntries.filter((e) => agentFilterSet.has(e.agentOrigin.toUpperCase()))
     : kvEntries;
 
-  const all = [...kvEntries, ...substrateEntries];
+  const combined = mode === 'hot' ? kvEntries : mode === 'canon' ? substrateEntries : [...kvEntries, ...substrateEntries];
   const seen = new Set<string>();
-  const merged = all
+  const merged = combined
     .filter((e) => {
       if (seen.has(e.id)) return false;
       seen.add(e.id);
@@ -400,6 +422,7 @@ export async function GET(request: NextRequest) {
   return NextResponse.json(
     {
       ok: true,
+      mode,
       count: filtered.length,
       entries: filtered,
       agents,
@@ -408,7 +431,8 @@ export async function GET(request: NextRequest) {
         kv: kvForSources.length,
         substrate: substrateEntries.length,
       },
-      merged_from_archive: substrateEntries.length > 0,
+      merged_from_archive: mode === 'merged' && substrateEntries.length > 0,
+      canonical_source: 'substrate',
       archive_error: substrateError,
       archive_fetched_count: substrateEntries.length,
       archive_stale: archiveStale,
@@ -443,37 +467,6 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const redis = getJournalRedisClient();
-  if (redis) {
-    const writeResult = await appendJournalLaneEntry(redis, {
-      ...entry,
-      id: entry.id,
-      timestamp: entry.timestamp,
-    });
-
-    if (!writeResult.written) {
-      return NextResponse.json({ ok: true, duplicate: true, token: writeResult.token, substrate: 'writing' });
-    }
-    entry.id = writeResult.entry.id;
-    entry.timestamp = writeResult.entry.timestamp;
-  }
-
-  void writeToSubstrate({
-    agent: entry.agent,
-    agentOrigin: entry.agentOrigin,
-    cycle: entry.cycle,
-    title: entry.inference,
-    summary: entry.observation,
-    category: entry.category,
-    severity: entry.severity,
-    source: 'agent-journal',
-    confidence: entry.confidence,
-    derivedFrom: entry.derivedFrom,
-    tags: entry.tags,
-  }).catch((error) => {
-    console.error('[ledger] journal attest error', error);
-  });
-
   const giAt =
     input && typeof input.gi_snapshot === 'number' && Number.isFinite(input.gi_snapshot)
       ? input.gi_snapshot
@@ -498,14 +491,52 @@ export async function POST(request: NextRequest) {
     status: entry.status,
   };
 
-  void writeJournalToSubstrate(substratePayload).catch((err) => {
-    console.error('[journal] substrate write failed:', err);
+  const substrateResult = await writeJournalToSubstrate(substratePayload);
+  if (!substrateResult.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        canonical: false,
+        error: substrateResult.error ?? 'substrate_write_failed',
+        mirrored_to_kv: false,
+      },
+      { status: 502 },
+    );
+  }
+
+  let mirroredToKv = false;
+  const redis = getJournalRedisClient();
+  if (redis) {
+    const writeResult = await appendJournalLaneEntry(redis, {
+      ...entry,
+      id: entry.id,
+      timestamp: entry.timestamp,
+    });
+    mirroredToKv = writeResult.written || writeResult.token === 'already_exists';
+  }
+
+  void writeToSubstrate({
+    agent: entry.agent,
+    agentOrigin: entry.agentOrigin,
+    cycle: entry.cycle,
+    title: entry.inference,
+    summary: entry.observation,
+    category: entry.category,
+    severity: entry.severity,
+    source: 'agent-journal',
+    confidence: entry.confidence,
+    derivedFrom: entry.derivedFrom,
+    tags: entry.tags,
+  }).catch((error) => {
+    console.error('[ledger] journal attest error', error);
   });
 
   return NextResponse.json({
     ok: true,
+    canonical: true,
+    path: substrateResult.path,
+    mirrored_to_kv: mirroredToKv,
     entryId: entry.id,
     timestamp: entry.timestamp,
-    substrate: 'writing',
   });
 }

--- a/app/api/agents/liveness/route.ts
+++ b/app/api/agents/liveness/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { GET as getAgentStatus } from '@/app/api/agents/status/route';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function GET(request: NextRequest) {
+  const statusResponse = await getAgentStatus();
+  const payload = await statusResponse.json().catch(() => null) as Record<string, unknown> | null;
+  const agents = Array.isArray(payload?.agents) ? payload?.agents as Record<string, unknown>[] : [];
+
+  return NextResponse.json({
+    ok: true,
+    timestamp: payload?.timestamp ?? new Date().toISOString(),
+    cycle: payload?.cycle ?? null,
+    agents: agents.map((agent) => ({
+      agent: agent.name,
+      status: agent.liveness ?? agent.status ?? 'DECLARED',
+      lane: agent.lane ?? null,
+      role: agent.role ?? null,
+      last_seen: agent.last_seen ?? null,
+      last_action: agent.last_action ?? null,
+      last_journal: agent.last_journal ?? null,
+      last_journal_at: agent.last_journal_at ?? null,
+      confidence: typeof agent.confidence === 'number' ? agent.confidence : null,
+      source_badges: Array.isArray(agent.source_badges) ? agent.source_badges : [],
+    })),
+  });
+}

--- a/app/api/agents/status/route.ts
+++ b/app/api/agents/status/route.ts
@@ -7,6 +7,8 @@ import {
   mockEnvelope,
   staleCacheEnvelope,
 } from '@/lib/response-envelope';
+import { readAgentJournals } from '@/lib/substrate/github-reader';
+import type { SubstrateJournalEntry } from '@/lib/substrate/github-journal';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -16,6 +18,7 @@ type HeartbeatPayload = {
   timestamp?: string;
   cycle?: string;
   cycleId?: string;
+  agents?: Array<{ id?: string; status?: string; last_action?: string }>;
 };
 
 type GiStatePayload = {
@@ -23,35 +26,25 @@ type GiStatePayload = {
   cycleId?: string;
 };
 
+type LivenessState = 'DECLARED' | 'BOOTING' | 'ACTIVE' | 'DEGRADED' | 'OFFLINE' | 'CONTESTED';
+
 const AGENT_BASE = [
-  { id: 'atlas', name: 'ATLAS', role: 'System Integrity Sentinel', tier: 'Sentinel', color: 'cerulean' },
-  { id: 'zeus', name: 'ZEUS', role: 'Verification Authority', tier: 'Sentinel', color: 'gold' },
-  { id: 'hermes', name: 'HERMES', role: 'Signal Routing & Prioritization', tier: 'Steward', color: 'coral' },
-  { id: 'aurea', name: 'AUREA', role: 'Strategic Synthesis', tier: 'Architect', color: 'amber' },
-  { id: 'jade', name: 'JADE', role: 'Constitutional Annotation', tier: 'Architect', color: 'jade' },
-  { id: 'daedalus', name: 'DAEDALUS', role: 'Infrastructure Health', tier: 'Architect', color: 'bronze' },
-  { id: 'echo', name: 'ECHO', role: 'Event Memory & Ingestion', tier: 'Steward', color: 'silver' },
-  { id: 'eve', name: 'EVE', role: 'Governance & Ethics Observer', tier: 'Observer', color: 'rose' },
+  { id: 'atlas', name: 'ATLAS', role: 'System Integrity Sentinel', tier: 'Sentinel', color: 'cerulean', lane: 'integrity', scope: 'Anomaly and integrity scans' },
+  { id: 'zeus', name: 'ZEUS', role: 'Verification Authority', tier: 'Sentinel', color: 'gold', lane: 'integrity', scope: 'Verification and contested claims' },
+  { id: 'hermes', name: 'HERMES', role: 'Signal Routing & Prioritization', tier: 'Steward', color: 'coral', lane: 'routing', scope: 'Routing and transport actions' },
+  { id: 'aurea', name: 'AUREA', role: 'Strategic Synthesis', tier: 'Architect', color: 'amber', lane: 'synthesis', scope: 'Synthesis and strategy events' },
+  { id: 'jade', name: 'JADE', role: 'Constitutional Annotation', tier: 'Architect', color: 'jade', lane: 'annotation', scope: 'Annotation and morale contributions' },
+  { id: 'daedalus', name: 'DAEDALUS', role: 'Infrastructure Health', tier: 'Architect', color: 'bronze', lane: 'infrastructure', scope: 'Build and research artifacts' },
+  { id: 'echo', name: 'ECHO', role: 'Event Memory & Ingestion', tier: 'Steward', color: 'silver', lane: 'ingest', scope: 'Ingest and ledger-facing events' },
+  { id: 'eve', name: 'EVE', role: 'Governance & Ethics Observer', tier: 'Observer', color: 'rose', lane: 'governance', scope: 'Ethics and governance review' },
 ] as const;
 
 let staleSnapshot: { cycle: string; timestamp: string } | null = null;
-const HEARTBEAT_STALE_MS = 15 * 60 * 1000;
 
-function toAgentStatus(status: 'alive' | 'idle') {
-  return AGENT_BASE.map((agent) => ({
-    ...agent,
-    status,
-    detail:
-      status === 'alive'
-        ? 'Live heartbeat observed from KV.'
-        : 'Heartbeat is stale; agent state is currently unknown.',
-    heartbeat_ok: status === 'alive',
-    last_action:
-      status === 'alive'
-        ? 'Live heartbeat received'
-        : 'Awaiting fresh runtime heartbeat',
-  }));
-}
+const HEARTBEAT_FRESH_MS = Number(process.env.AGENT_HEARTBEAT_FRESH_MS ?? 300000);
+const ACTION_FRESH_MS = Number(process.env.AGENT_ACTION_FRESH_MS ?? 900000);
+const JOURNAL_FRESH_MS = Number(process.env.AGENT_JOURNAL_FRESH_MS ?? 3600000);
+const OFFLINE_AFTER_MS = Number(process.env.AGENT_OFFLINE_AFTER_MS ?? 7200000);
 
 function parseHeartbeat(rawHeartbeat: HeartbeatPayload | string | null): HeartbeatPayload | null {
   if (!rawHeartbeat) return null;
@@ -64,11 +57,68 @@ function parseHeartbeat(rawHeartbeat: HeartbeatPayload | string | null): Heartbe
   }
 }
 
+function ageMs(iso?: string | null): number {
+  if (!iso) return Number.POSITIVE_INFINITY;
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return Number.POSITIVE_INFINITY;
+  return Date.now() - t;
+}
+
+function isWithin(ms: number, threshold: number): boolean {
+  return Number.isFinite(ms) && ms <= threshold;
+}
+
+function deriveLiveness(input: {
+  lastSeen?: string;
+  lastActionAt?: string;
+  lastJournalAt?: string;
+  confidence: number;
+  contested?: boolean;
+}): LivenessState {
+  if (input.contested) return 'CONTESTED';
+
+  const hbAge = ageMs(input.lastSeen);
+  const actionAge = ageMs(input.lastActionAt);
+  const journalAge = ageMs(input.lastJournalAt);
+
+  const hbFresh = isWithin(hbAge, HEARTBEAT_FRESH_MS);
+  const actionFresh = isWithin(actionAge, ACTION_FRESH_MS);
+  const journalFresh = isWithin(journalAge, JOURNAL_FRESH_MS);
+
+  if (hbFresh && actionFresh && journalFresh && input.confidence >= 0.6) return 'ACTIVE';
+
+  const noHeartbeat = !Number.isFinite(hbAge) || hbAge > OFFLINE_AFTER_MS;
+  const noAction = !Number.isFinite(actionAge) || actionAge > OFFLINE_AFTER_MS;
+  const noJournal = !Number.isFinite(journalAge) || journalAge > OFFLINE_AFTER_MS;
+  if (noHeartbeat && noAction && noJournal) return 'OFFLINE';
+
+  if (hbFresh && (!actionFresh || !journalFresh)) return 'BOOTING';
+
+  if (!Number.isFinite(hbAge) && Number.isFinite(actionAge)) return 'BOOTING';
+
+  return 'DEGRADED';
+}
+
+async function loadLatestJournalByAgent(): Promise<Record<string, SubstrateJournalEntry | null>> {
+  const pairs = await Promise.all(
+    AGENT_BASE.map(async (agent) => {
+      try {
+        const rows = await readAgentJournals(agent.id, 1);
+        return [agent.name, rows[0] ?? null] as const;
+      } catch {
+        return [agent.name, null] as const;
+      }
+    }),
+  );
+  return Object.fromEntries(pairs);
+}
+
 export async function GET() {
   try {
-    const [rawHeartbeat, giState] = await Promise.all([
+    const [rawHeartbeat, giState, journalByAgent] = await Promise.all([
       kvGet<HeartbeatPayload | string>(KV_KEYS.HEARTBEAT),
       kvGet<GiStatePayload>(KV_KEYS.GI_STATE),
+      loadLatestJournalByAgent(),
     ]);
 
     const heartbeat = parseHeartbeat(rawHeartbeat);
@@ -77,24 +127,61 @@ export async function GET() {
 
     staleSnapshot = { cycle, timestamp };
 
-    if (heartbeat?.timestamp && isFresh(heartbeat.timestamp, HEARTBEAT_STALE_MS)) {
-      return NextResponse.json({
-        ok: true,
-        ...liveEnvelope(timestamp),
-        source: 'kv-heartbeat',
-        cycle,
-        timestamp,
-        agents: toAgentStatus('alive'),
+    const hbAgents = new Map((heartbeat?.agents ?? []).map((a) => [String(a.id ?? '').toLowerCase(), a]));
+
+    const agents = AGENT_BASE.map((agent) => {
+      const hb = hbAgents.get(agent.id);
+      const lastSeen = heartbeat?.timestamp ?? null;
+      const lastActionAt = heartbeat?.timestamp ?? null;
+      const lastAction = hb?.last_action ?? (isFresh(timestamp, HEARTBEAT_FRESH_MS) ? 'heartbeat-refresh' : 'awaiting-runtime-proof');
+      const journal = journalByAgent[agent.name] ?? null;
+      const lastJournalAt = journal?.timestamp ?? null;
+      const confidence = journal?.confidence ?? (isFresh(timestamp, HEARTBEAT_FRESH_MS) ? 0.75 : 0.5);
+      const liveness = deriveLiveness({
+        lastSeen: lastSeen ?? undefined,
+        lastActionAt: lastActionAt ?? undefined,
+        lastJournalAt: lastJournalAt ?? undefined,
+        confidence,
       });
-    }
+      const health = liveness === 'ACTIVE' ? 'nominal' : liveness === 'OFFLINE' ? 'critical' : 'degraded';
+      const sourceBadges = [
+        ...(lastSeen ? ['HB'] : []),
+        ...(lastAction ? ['ACT'] : []),
+        ...(lastJournalAt ? ['JRN'] : []),
+      ];
+
+      return {
+        ...agent,
+        declared: true,
+        status: liveness.toLowerCase(),
+        liveness,
+        detail:
+          liveness === 'ACTIVE'
+            ? 'Live heartbeat/action/journal proof available.'
+            : liveness === 'OFFLINE'
+              ? 'No recent runtime evidence across heartbeat, action, and journal.'
+              : 'Partial runtime proof; inspect freshness and lane dependencies.',
+        heartbeat_ok: liveness === 'ACTIVE' || liveness === 'BOOTING' || liveness === 'DEGRADED',
+        last_action: lastAction,
+        last_seen: lastSeen,
+        last_action_at: lastActionAt,
+        last_journal: journal?.id ?? null,
+        last_journal_at: lastJournalAt,
+        confidence,
+        health,
+        source_badges: sourceBadges,
+      };
+    });
+
+    const fresh = Boolean(heartbeat?.timestamp && isFresh(heartbeat.timestamp, HEARTBEAT_FRESH_MS));
 
     return NextResponse.json({
       ok: true,
-      ...staleCacheEnvelope(timestamp, 'Heartbeat stale'),
-      source: 'stale-cache',
+      ...(fresh ? liveEnvelope(timestamp) : staleCacheEnvelope(timestamp, 'Heartbeat stale')),
+      source: fresh ? 'kv-heartbeat' : 'stale-cache',
       cycle,
       timestamp,
-      agents: toAgentStatus('idle'),
+      agents,
     });
   } catch (error) {
     const mock = mockAgentStatus();
@@ -107,7 +194,22 @@ export async function GET() {
         source: 'stale-cache',
         cycle: staleSnapshot.cycle,
         timestamp: staleSnapshot.timestamp,
-        agents: toAgentStatus('idle'),
+        agents: AGENT_BASE.map((agent) => ({
+          ...agent,
+          declared: true,
+          status: 'offline',
+          liveness: 'OFFLINE',
+          detail: 'Status unavailable: stale snapshot fallback.',
+          heartbeat_ok: false,
+          last_action: 'Awaiting fresh runtime heartbeat',
+          last_seen: null,
+          last_action_at: null,
+          last_journal: null,
+          last_journal_at: null,
+          confidence: 0,
+          health: 'critical',
+          source_badges: [],
+        })),
       });
     }
 

--- a/app/api/terminal/snapshot/route.ts
+++ b/app/api/terminal/snapshot/route.ts
@@ -68,9 +68,15 @@ export async function GET(request: NextRequest) {
   const cycle = request.nextUrl.searchParams.get('cycle')?.trim();
   const includeCatalog = request.nextUrl.searchParams.get('include_catalog')?.trim();
   const includeSubstrate = request.nextUrl.searchParams.get('include_substrate')?.trim();
+  const journalMode = (request.nextUrl.searchParams.get('journal_mode')?.trim().toLowerCase() ?? 'merged');
+  const journalLimit = request.nextUrl.searchParams.get('journal_limit')?.trim();
   const baseUrl = request.nextUrl.origin;
 
-  const journalPath = cycle ? `/api/agents/journal?cycle=${encodeURIComponent(cycle)}` : '/api/agents/journal';
+  const journalQuery = new URLSearchParams();
+  if (cycle) journalQuery.set('cycle', cycle);
+  if (journalMode === 'hot' || journalMode === 'canon' || journalMode === 'merged') journalQuery.set('mode', journalMode);
+  if (journalLimit) journalQuery.set('limit', journalLimit);
+  const journalPath = `/api/agents/journal${journalQuery.toString() ? `?${journalQuery.toString()}` : ''}`;
   const epiconPath = includeCatalog === 'true' ? '/api/epicon/feed?include_catalog=true' : '/api/epicon/feed';
 
   const signalsStart = Date.now();
@@ -204,6 +210,35 @@ export async function GET(request: NextRequest) {
       : typeof integrityData?.global_integrity === 'number' && Number.isFinite(integrityData.global_integrity)
         ? integrityData.global_integrity
         : null;
+
+  const journalData = journal.leaf.data as Record<string, unknown> | null;
+  const journalEntries = Array.isArray(journalData?.entries) ? journalData?.entries as Record<string, unknown>[] : [];
+  const journalSummary = {
+    latest_agent_entries: journalEntries.slice(0, 8).map((entry) => ({
+      agent: typeof entry.agent === 'string' ? entry.agent.toLowerCase() : 'unknown',
+      source: typeof entry.source_mode === 'string' ? entry.source_mode : 'unknown',
+      timestamp: typeof entry.timestamp === 'string' ? entry.timestamp : null,
+      severity: typeof entry.severity === 'string' ? entry.severity : 'nominal',
+      summary: typeof entry.observation === 'string' ? entry.observation : '—',
+      cycle: typeof entry.cycle === 'string' ? entry.cycle : null,
+      canonical_path: typeof entry.canonical_path === 'string' ? entry.canonical_path : null,
+    })),
+  };
+
+  const agentsData = agents.leaf.data as Record<string, unknown> | null;
+  const agentRows = Array.isArray(agentsData?.agents) ? agentsData?.agents as Record<string, unknown>[] : [];
+  const agentLiveness = agentRows.map((agent) => ({
+    agent: typeof agent.name === 'string' ? agent.name : 'UNKNOWN',
+    status: typeof agent.liveness === 'string' ? agent.liveness : typeof agent.status === 'string' ? agent.status : 'DECLARED',
+    lane: typeof agent.lane === 'string' ? agent.lane : null,
+    role: typeof agent.role === 'string' ? agent.role : null,
+    last_seen: typeof agent.last_seen === 'string' ? agent.last_seen : null,
+    last_action: typeof agent.last_action === 'string' ? agent.last_action : null,
+    last_journal_at: typeof agent.last_journal_at === 'string' ? agent.last_journal_at : null,
+    confidence: typeof agent.confidence === 'number' ? agent.confidence : null,
+    source_badges: Array.isArray(agent.source_badges) ? agent.source_badges : [],
+  }));
+
   const tripwireLaneState = laneByKey.get('tripwire');
   const tripwireElevated = tripwireLaneState?.state === 'degraded';
   const topDegraded =
@@ -218,6 +253,7 @@ export async function GET(request: NextRequest) {
     gi: topGi,
     degraded: topDegraded,
     include_catalog: includeCatalog === 'true',
+    journal_mode: journalMode === 'hot' || journalMode === 'canon' || journalMode === 'merged' ? journalMode : 'merged',
     timestamp: new Date().toISOString(),
     deployment: {
       commit_sha: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
@@ -226,6 +262,8 @@ export async function GET(request: NextRequest) {
     meta: { total_ms: totalMs, lane_ms: timings },
     memory_mode: memoryMode,
     lanes,
+    journal_summary: journalSummary,
+    agent_liveness: agentLiveness,
     integrity: integrity.leaf, signals, kvHealth: kvHealth.leaf, agents: agents.leaf,
     epicon: epicon.leaf, echo: echo.leaf, journal: journal.leaf, sentiment: sentiment.leaf,
     runtime: runtime.leaf, promotion: promotion.leaf, eve: eve.leaf, mii: mii.leaf, vault: vault.leaf,

--- a/app/terminal/journal/JournalPageClient.tsx
+++ b/app/terminal/journal/JournalPageClient.tsx
@@ -23,7 +23,7 @@ const AGENT_PILL_STYLE: Record<string, { border: string; activeBg: string; text:
   ECHO: { border: 'border-slate-500/50', activeBg: 'bg-slate-600/20', text: 'text-slate-100' },
 };
 
-type JournalResponse = { count?: number; entries?: JournalDisplayEntry[] };
+type JournalResponse = { count?: number; mode?: 'hot' | 'canon' | 'merged'; entries?: JournalDisplayEntry[] };
 
 type EpiconItem = {
   id: string;
@@ -127,6 +127,7 @@ export default function JournalPageClient() {
   const [agent, setAgent] = useState('ALL');
   const [cycleTab, setCycleTab] = useState<string>(() => currentCycleId());
   const [derivedMode, setDerivedMode] = useState(false);
+  const [readMode, setReadMode] = useState<'hot' | 'canon' | 'merged'>('merged');
   const [missingRelatedId, setMissingRelatedId] = useState<string | null>(null);
   const anchorsRef = useRef<Map<string, HTMLElement>>(new Map());
 
@@ -151,7 +152,7 @@ export default function JournalPageClient() {
     void (async () => {
       let journalEntries: JournalDisplayEntry[] = [];
       try {
-        const res = await fetch('/api/agents/journal?limit=100', { cache: 'no-store' });
+        const res = await fetch(`/api/agents/journal?limit=100&mode=${readMode}`, { cache: 'no-store' });
         const data = (await res.json()) as JournalResponse;
         journalEntries = data.entries ?? [];
       } catch {
@@ -188,7 +189,7 @@ export default function JournalPageClient() {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [readMode]);
 
   const agentCounts = useMemo(() => {
     const m = new Map<string, number>();
@@ -253,6 +254,19 @@ export default function JournalPageClient() {
           Derived from EPICON feed · Native journals pending SUBSTRATE_GITHUB_TOKEN
         </div>
       ) : null}
+
+      <div className="mb-3 flex items-center gap-2 text-[11px] font-mono">
+        <span className="text-slate-500">Journal mode</span>
+        {(['hot', 'canon', 'merged'] as const).map((mode) => (
+          <button
+            key={mode}
+            onClick={() => setReadMode(mode)}
+            className={`rounded border px-2 py-1 uppercase tracking-[0.14em] ${readMode === mode ? 'border-cyan-400/60 bg-cyan-500/10 text-cyan-200' : 'border-slate-700 text-slate-400 hover:border-slate-500'}`}
+          >
+            {mode}
+          </button>
+        ))}
+      </div>
 
       {entries.length === 0 ? (
         <div className="space-y-4">

--- a/app/terminal/sentinel/SentinelPageClient.tsx
+++ b/app/terminal/sentinel/SentinelPageClient.tsx
@@ -5,7 +5,7 @@ import ChamberSkeleton from '@/components/terminal/ChamberSkeleton';
 import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 
-type Agent = { id: string; name: string; role: string; status: string; lastAction?: string; tier?: string; mii_avg?: number };
+type Agent = { id: string; name: string; role: string; status: string; liveness?: string; lastAction?: string; last_action?: string; last_seen?: string | null; last_journal_at?: string | null; confidence?: number; source_badges?: string[]; tier?: string; mii_avg?: number };
 type JournalEntry = { id: string; observation?: string; cycle?: string };
 type MiiEntry = { agent: string; mii: number; timestamp: string };
 
@@ -222,7 +222,11 @@ export default function SentinelPageClient() {
               </div>
             </div>
             <div className="mt-1 text-xs text-slate-400">{agent.role} · {agent.tier ?? '—'}</div>
-            <div className="mt-2 text-xs text-slate-500">{agent.lastAction ?? 'Awaiting first action this cycle.'}</div>
+            <div className="mt-2 text-xs text-slate-500">{agent.lastAction ?? agent.last_action ?? 'Awaiting first action this cycle.'}</div>
+            <div className="mt-1 text-[10px] text-slate-500">
+              {(agent.source_badges ?? []).map((b) => `[${b}]`).join(' ') || '[HB][ACT][JRN] pending'}
+              {agent.confidence != null ? ` · conf ${agent.confidence.toFixed(2)}` : ''}
+            </div>
             <div className="mt-2 flex items-center gap-2">
               <span className="text-[10px] font-mono uppercase tracking-[0.1em] text-slate-500">MII trend</span>
               {miiData[agent.name]?.length ? (

--- a/components/terminal/journal/JournalEntryCard.tsx
+++ b/components/terminal/journal/JournalEntryCard.tsx
@@ -62,6 +62,11 @@ export default function JournalEntryCard({ entry, onRelatedClick, registerAnchor
           </span>
         ) : null}
         <span className="text-[10px] text-slate-600">source {entry.source ?? 'journal'}</span>
+        {entry.source_mode ? (
+          <span className={`rounded border px-1.5 py-0.5 text-[10px] ${entry.source_mode === 'substrate' ? 'border-cyan-500/40 bg-cyan-500/10 text-cyan-200' : 'border-violet-500/30 bg-violet-500/10 text-violet-200'}`}>
+            {entry.source_mode === 'substrate' ? 'SUBSTRATE' : 'KV'}
+          </span>
+        ) : null}
       </div>
 
       <div className="mt-2 text-slate-200">
@@ -77,6 +82,11 @@ export default function JournalEntryCard({ entry, onRelatedClick, registerAnchor
           <span className="font-medium text-slate-500">Recommends: </span>
           {entry.recommendation}
         </div>
+      ) : null}
+
+
+      {entry.canonical_path ? (
+        <div className="mt-1 text-[10px] text-cyan-300/80">canon: {entry.canonical_path}</div>
       ) : null}
 
       <DerivedFromChain items={entry.derivedFrom} onJournalRefClick={onRelatedClick} />

--- a/docs/prs/c289-terminal-journal-liveness.md
+++ b/docs/prs/c289-terminal-journal-liveness.md
@@ -1,0 +1,20 @@
+# C-289 — Terminal Journal Canon + Agent Liveness
+
+## Scope implemented
+
+- `/api/agents/journal` now supports `mode=hot|canon|merged` with `merged` as default.
+- Journal entries expose runtime source metadata (`source_mode`) and canonical path when substrate-backed.
+- `/api/agents/journal` POST now requires canonical substrate write success before returning success.
+- Canonical write response now returns `canonical`, `path`, and `mirrored_to_kv` flags.
+- `/api/agents/status` now derives liveness states (`DECLARED|BOOTING|ACTIVE|DEGRADED|OFFLINE|CONTESTED`) and proof fields.
+- Added `/api/agents/liveness` endpoint for liveness-focused payloads.
+- `/api/terminal/snapshot` accepts `journal_mode` and `journal_limit` and now emits `journal_summary` and `agent_liveness` blocks.
+- Journal chamber UI now includes `HOT/CANON/MERGED` mode selector.
+- Journal cards now expose `KV/SUBSTRATE` source badges and canonical path when available.
+- Sentinel agent cards now display proof badges and confidence.
+
+## Notes
+
+- Substrate remains canonical journal memory.
+- KV remains hot operational mirror.
+- Liveness remains explicit proof-based state, not cosmetic card presence.

--- a/lib/journal/types.ts
+++ b/lib/journal/types.ts
@@ -23,4 +23,6 @@ export type JournalDisplayEntry = {
   severity?: JournalDisplaySeverity;
   scope?: string;
   agentOrigin?: string;
+  source_mode?: 'kv' | 'substrate';
+  canonical_path?: string;
 };


### PR DESCRIPTION
### Motivation
- Make agent runtime proof explicit so the Terminal can distinguish declared agents from those with verifiable runtime evidence. 
- Treat Substrate as canonical journal memory and KV as a hot runtime mirror, surfacing source-of-truth to operators. 
- Provide snapshot-level and UI affordances so operators can inspect journal source, canonical path, and agent liveness at a glance. 

### Description
- Added journal read modes to `GET /api/agents/journal` (`mode=hot|canon|merged`) and annotated returned entries with `source_mode` and `canonical_path`, and made merging behavior and archive diagnostics explicit. 
- Enforced a canonical write contract on `POST /api/agents/journal` where Substrate write must succeed before returning success, then best-effort mirror to KV and return `canonical`, `path`, and `mirrored_to_kv` metadata. 
- Implemented proof-based liveness derivation in `GET /api/agents/status` (states `DECLARED|BOOTING|ACTIVE|DEGRADED|OFFLINE|CONTESTED`) using heartbeat/action/journal recency and confidence, and added a compact `GET /api/agents/liveness` endpoint. 
- Propagated journal mode and limits into `GET /api/terminal/snapshot`, and added `journal_summary` and `agent_liveness` blocks to snapshot payloads; updated journal UI to include a `HOT/CANON/MERGED` selector and journal cards to show `KV/SUBSTRATE` badges and canonical path; updated sentinel/agent cards to surface proof badges and confidence. 

### Testing
- Ran typecheck with `pnpm exec tsc --noEmit`, which passed. 
- Built the app with `pnpm build`, which produced a successful Next.js production build. 
- Ran `pnpm lint`, which triggered Next.js's interactive ESLint setup and therefore could not run non-interactively; report: lint not configured for non-interactive CI-style execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92fe7ff54832dbfed8b8304e1a4d9)