### PR TITLE
docs: add Mobius Trust Tripwires v1 specification

### DIFF
--- a/MOBIUS_TRUST_TRIPWIRES_V1.md
+++ b/MOBIUS_TRUST_TRIPWIRES_V1.md
@@ -1,0 +1,310 @@
+# Mobius Trust Tripwires — Integrity of Meaning Layer
+
+## 0. Purpose
+
+Define the second-generation tripwire system that protects:
+
+- truth continuity
+- archive quality
+- verification discipline
+- emergence awareness
+
+These tripwires go beyond system uptime and integrity metrics.
+
+They answer:
+
+**Is the system still trustworthy over time?**
+
+## 1. Core Principle
+
+Mobius must protect not just whether the system is running,
+but whether the system is still believable.
+
+## 2. Tripwire Taxonomy
+
+### T1 — Runtime Tripwires
+
+Detect:
+
+- system failures
+- KV outages
+- API failures
+- ingestion failures
+
+### T2 — Integrity Tripwires
+
+Detect:
+
+- GI drops
+- anomaly spikes
+- lane degradation
+- signal divergence
+
+### T3 — Provenance Tripwires
+
+Detect:
+
+- broken lineage
+- missing source attribution
+- unresolved references
+
+### T4 — Journal Quality Tripwires
+
+Detect:
+
+- cognitive degradation
+- shallow analysis
+- repetition / hallucination drift
+
+### T5 — Archive Health Tripwires
+
+Detect:
+
+- archive inflation
+- signal dilution
+- structural inconsistencies
+
+### T6 — Emergence Tripwires
+
+Detect:
+
+- cross-signal clustering
+- regime shifts
+- weak-signal aggregation
+
+## 3. Trust Tripwires (v1 Implementation Set)
+
+### 3.1 Provenance Break Tripwire
+
+- **Type:** T3  
+- **Purpose:** Ensure data lineage is intact
+
+**Trigger Conditions**
+
+- Missing `source` field
+- Missing `derivedFrom`
+- Broken file path / hash mismatch
+- Unresolvable EPICON reference
+
+**Severity**
+
+- elevated → critical if persistent
+
+**Impact**
+
+- Reduce GI confidence weighting
+- Flag data as unverifiable
+
+### 3.2 Verification Dilution Tripwire
+
+- **Type:** T3 / T5  
+- **Purpose:** Detect weakening of verification discipline
+
+**Trigger Conditions**
+
+- % of low-confidence EPICON entries > threshold
+- Increase in unverified events
+- Contested events unresolved over cycles
+
+**Severity**
+
+- elevated
+
+**Impact**
+
+- Lower system-wide confidence multiplier
+- Require stricter EPICON verification thresholds
+
+### 3.3 Journal Quality Drift Tripwire
+
+- **Type:** T4  
+- **Purpose:** Detect degradation in agent cognition
+
+**Trigger Conditions**
+
+- Drop in journal length / detail
+- Repetition frequency increases
+- Generic or templated responses spike
+- `derivedFrom` fields become sparse
+
+**Severity**
+
+- elevated → critical if persistent
+
+**Impact**
+
+- Reduce agent confidence scores
+- Flag agent as `DEGRADED`
+- Trigger agent review
+
+### 3.4 Temporal Coherence Tripwire
+
+- **Type:** T5  
+- **Purpose:** Protect timeline integrity
+
+**Trigger Conditions**
+
+- Out-of-order timestamps
+- Future references in journals
+- Missing cycle linkage
+- Inconsistent event ordering
+
+**Severity**
+
+- critical
+
+**Impact**
+
+- Invalidate affected time window
+- Flag replay reliability compromised
+
+### 3.5 Trust Concentration Tripwire
+
+- **Type:** T3 / T6  
+- **Purpose:** Prevent monoculture of truth
+
+**Trigger Conditions**
+
+- One agent dominates confirmations
+- One signal source dominates > X%
+- Disagreement rate approaches zero
+
+**Severity**
+
+- elevated
+
+**Impact**
+
+- Reduce trust weighting for dominant agent/source
+- Encourage cross-agent validation
+
+### 3.6 Archive Inflation Tripwire
+
+- **Type:** T5  
+- **Purpose:** Prevent low-value data accumulation
+
+**Trigger Conditions**
+
+- Event volume increases but verified density decreases
+- Journal count rises without unique signal increase
+- Repeated low-information entries detected
+
+**Severity**
+
+- elevated
+
+**Impact**
+
+- Trigger compression review
+- Lower weight of redundant entries
+
+### 3.7 Integrity–Narrative Divergence Tripwire
+
+- **Type:** T4 / T2  
+- **Purpose:** Align system narrative with real state
+
+**Trigger Conditions**
+
+- GI stable but journals signal instability
+- GI unstable but journals remain overly calm
+- Synthesis vs raw signal mismatch
+
+**Severity**
+
+- critical
+
+**Impact**
+
+- Flag synthesis layer
+- Trigger agent reconciliation
+
+### 3.8 Emergence Pressure Tripwire
+
+- **Type:** T6  
+- **Purpose:** Detect early regime shifts
+
+**Trigger Conditions**
+
+- Multiple anomaly families rise together
+- Cross-lane signal correlation increases
+- Journal tone shifts across agents
+- Unusual clustering patterns
+
+**Severity**
+
+- elevated → critical if compounded
+
+**Impact**
+
+- Raise early warning flag
+- Increase monitoring frequency
+- Trigger ZEUS/ATLAS deeper analysis
+
+## 4. Severity Model
+
+- `nominal` = informational drift
+- `elevated` = attention required
+- `critical` = trust at risk
+
+## 5. Integration with GI
+
+Each tripwire affects:
+
+```text
+GI = base_integrity × trust_multipliers
+```
+
+Where trust multipliers include:
+
+- provenance score
+- verification strength
+- journal quality score
+- temporal coherence score
+
+## 6. Agent-Level Effects
+
+Tripwires should propagate to agent state:
+
+```python
+if JournalQualityTripwire triggered:
+    agent.status = DEGRADED
+if ProvenanceBreakTripwire triggered:
+    agent.confidence -= delta
+if TrustConcentrationTripwire triggered:
+    agent.weighting reduced
+```
+
+## 7. Operator Visibility
+
+Terminal must display:
+
+- active tripwires
+- category (T1–T6)
+- severity
+- affected agents
+- affected time windows
+
+## 8. Minimal v1 Activation Set
+
+Implement first:
+
+1. Provenance Break
+2. Verification Dilution
+3. Journal Quality Drift
+4. Temporal Coherence
+5. Trust Concentration
+
+These five establish baseline trust protection.
+
+## 9. Future Expansion
+
+Planned:
+
+- adaptive thresholds
+- ML-based drift detection
+- cross-cycle anomaly clustering
+- predictive emergence scoring
+
+## 10. One-Line Definition
+
+Trust Tripwires ensure Mobius not only runs correctly, but continues to produce reliable, meaningful, and verifiable history over time.


### PR DESCRIPTION
### Motivation
- Add a formal v1 specification for a system of trust tripwires to protect the integrity-of-meaning layer and ensure the Mobius stack remains believable over time.
- Provide a canonical taxonomy, activation baseline, and operator visibility requirements so tripwires can be implemented consistently across GI, journals, and terminals.

### Description
- Add `MOBIUS_TRUST_TRIPWIRES_V1.md` containing the full v1 framework, including taxonomy T1–T6 and eight tripwire definitions with triggers, severities, and impacts.
- Document GI integration model, agent-level propagation rules, operator visibility requirements, minimal v1 activation set (five tripwires), and a roadmap for future expansion.
- This change is documentation-only and does not modify runtime code paths or UI behavior.

### Testing
- Ran typecheck with `pnpm exec tsc --noEmit` and it passed.
- Built the application with `pnpm build` and it completed successfully.
- Lint was not run because ESLint is not configured in this repository per project guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9369d840c832d85a407bad3cb4ac1)