### PR TITLE
feat(tripwire): add trust tripwire engine and snapshot integration

### DIFF
--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -9,6 +9,8 @@ import {
   type SubstrateJournalWriteInput,
 } from '@/lib/substrate/github-journal';
 import { readAgentJournals } from '@/lib/substrate/github-reader';
+import { checkProvenanceBreak, checkTemporalCoherence } from '@/lib/tripwire/archiveChecks';
+import { checkJournalQualityDrift } from '@/lib/tripwire/journalQuality';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -464,6 +466,56 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       { ok: false, error: 'Required fields: agent, observation, inference, cycle' },
       { status: 400 },
+    );
+  }
+
+  const candidateEntry: SubstrateJournalEntry = {
+    ...entry,
+    tags: entry.tags ?? [],
+  };
+
+  const provenance = checkProvenanceBreak([candidateEntry]);
+  if (provenance.triggered) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'provenance_break',
+        message: 'PROVENANCE BREAK — trust chain incomplete',
+      },
+      { status: 422 },
+    );
+  }
+
+  let recentAgentEntries: SubstrateJournalEntry[] = [];
+  try {
+    recentAgentEntries = await Promise.race([
+      readAgentJournals(entry.agent.toLowerCase(), 5),
+      new Promise<SubstrateJournalEntry[]>((_, reject) => setTimeout(() => reject(new Error('journal_read_timeout')), 4000)),
+    ]);
+  } catch {
+    recentAgentEntries = [];
+  }
+  const temporal = checkTemporalCoherence([candidateEntry, ...recentAgentEntries]);
+  if (temporal.triggered) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'temporal_break',
+        message: 'TEMPORAL BREAK — replay integrity compromised',
+      },
+      { status: 422 },
+    );
+  }
+
+  const quality = checkJournalQualityDrift([candidateEntry, ...recentAgentEntries]);
+  if (quality.triggered && quality.affectedAgents.includes(entry.agent)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'journal_quality_drift',
+        message: 'JOURNAL DRIFT — agent cognition degrading',
+      },
+      { status: 422 },
     );
   }
 

--- a/app/api/agents/status/route.ts
+++ b/app/api/agents/status/route.ts
@@ -9,6 +9,8 @@ import {
 } from '@/lib/response-envelope';
 import { readAgentJournals } from '@/lib/substrate/github-reader';
 import type { SubstrateJournalEntry } from '@/lib/substrate/github-journal';
+import type { TrustTripwireSnapshot } from '@/lib/tripwire/types';
+import { applyTrustTripwiresToAgentStatus } from '@/lib/tripwire/trustTripwires';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -115,10 +117,11 @@ async function loadLatestJournalByAgent(): Promise<Record<string, SubstrateJourn
 
 export async function GET() {
   try {
-    const [rawHeartbeat, giState, journalByAgent] = await Promise.all([
+    const [rawHeartbeat, giState, journalByAgent, trustTripwire] = await Promise.all([
       kvGet<HeartbeatPayload | string>(KV_KEYS.HEARTBEAT),
       kvGet<GiStatePayload>(KV_KEYS.GI_STATE),
       loadLatestJournalByAgent(),
+      kvGet<TrustTripwireSnapshot>(KV_KEYS.TRIPWIRE_STATE_KV),
     ]);
 
     const heartbeat = parseHeartbeat(rawHeartbeat);
@@ -137,13 +140,23 @@ export async function GET() {
       const journal = journalByAgent[agent.name] ?? null;
       const lastJournalAt = journal?.timestamp ?? null;
       const confidence = journal?.confidence ?? (isFresh(timestamp, HEARTBEAT_FRESH_MS) ? 0.75 : 0.5);
-      const liveness = deriveLiveness({
+      const baseLiveness = deriveLiveness({
         lastSeen: lastSeen ?? undefined,
         lastActionAt: lastActionAt ?? undefined,
         lastJournalAt: lastJournalAt ?? undefined,
         confidence,
       });
-      const health = liveness === 'ACTIVE' ? 'nominal' : liveness === 'OFFLINE' ? 'critical' : 'degraded';
+      const trustStatus = applyTrustTripwiresToAgentStatus(agent.name, trustTripwire);
+      const liveness: LivenessState =
+        baseLiveness === 'OFFLINE' || baseLiveness === 'BOOTING' || baseLiveness === 'DECLARED'
+          ? baseLiveness
+          : trustStatus === 'CONTESTED'
+            ? 'CONTESTED'
+            : trustStatus === 'DEGRADED' && baseLiveness === 'ACTIVE'
+              ? 'DEGRADED'
+              : baseLiveness;
+
+      const health = liveness === 'ACTIVE' ? 'nominal' : liveness === 'OFFLINE' || liveness === 'CONTESTED' ? 'critical' : 'degraded';
       const sourceBadges = [
         ...(lastSeen ? ['HB'] : []),
         ...(lastAction ? ['ACT'] : []),

--- a/app/api/cron/watchdog/route.ts
+++ b/app/api/cron/watchdog/route.ts
@@ -4,6 +4,9 @@ import { appendAgentJournalEntry } from '@/lib/agents/journal';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
 import { kvSet, kvSetRawKey, KV_KEYS, isRedisAvailable, KV_TTL_SECONDS } from '@/lib/kv/store';
+import { readAllSubstrateJournals } from '@/lib/substrate/github-reader';
+import { evaluateTrustTripwires } from '@/lib/tripwire/trustTripwires';
+import type { TrustTripwireSnapshot } from '@/lib/tripwire/types';
 
 import { GET as getKvHealth } from '@/app/api/kv/health/route';
 import { POST as postSeedKv } from '@/app/api/admin/seed-kv/route';
@@ -39,6 +42,17 @@ import { POST as postEpiconPromote } from '@/app/api/epicon/promote/route';
  * verified by `getServiceAuthError` at the top of this handler).
  */
 export const dynamic = 'force-dynamic';
+
+function emptyTrustSnapshot(timestamp: string): TrustTripwireSnapshot {
+  return {
+    ok: true,
+    tripwireCount: 0,
+    elevated: false,
+    critical: false,
+    results: [],
+    timestamp,
+  };
+}
 
 type WatchdogActionResult = {
   ok: boolean;
@@ -164,6 +178,34 @@ export async function GET(request: NextRequest) {
   const promoteResult = await runAction(() => postEpiconPromote(promoteRequest), 30_000);
   actions.push(`promote:${promoteResult.ok ? 'ok' : `fail:${promoteResult.status}`}`);
 
+  const trustSnapshot = await (async (): Promise<TrustTripwireSnapshot> => {
+    try {
+      const substrateJournals = await Promise.race([
+        readAllSubstrateJournals(10),
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error('trust_journal_timeout')), 7000)),
+      ]);
+      const journals = Object.values(substrateJournals).flat();
+      const promoteBody = promoteResult.body as Record<string, unknown> | null;
+      const giBody = giResult.body as Record<string, unknown> | null;
+      const epiconRows = Array.isArray(promoteBody?.items)
+        ? (promoteBody.items as Array<Record<string, unknown>>)
+        : Array.isArray(giBody?.entries)
+          ? (giBody.entries as Array<Record<string, unknown>>)
+          : [];
+      return evaluateTrustTripwires({ journals, epiconRows });
+    } catch (error) {
+      console.error('[watchdog] trust tripwire evaluation failed:', error instanceof Error ? error.message : error);
+      return emptyTrustSnapshot(new Date().toISOString());
+    }
+  })();
+
+  await Promise.all([
+    kvSet(KV_KEYS.TRIPWIRE_STATE, trustSnapshot, KV_TTL_SECONDS.TRIPWIRE_STATE),
+    kvSet(KV_KEYS.TRIPWIRE_STATE_KV, trustSnapshot, KV_TTL_SECONDS.TRIPWIRE_STATE),
+    kvSetRawKey('TRUST_TRIPWIRE_STATE', JSON.stringify(trustSnapshot), KV_TTL_SECONDS.TRIPWIRE_STATE),
+  ]).catch(() => {});
+  actions.push(`trust-tripwire:${trustSnapshot.ok ? 'ok' : trustSnapshot.critical ? 'fail:critical' : 'fail:elevated'}`);
+
   const logResult = {
     seeded: seedResult.body,
     gi: giResult.body,
@@ -194,7 +236,9 @@ export async function GET(request: NextRequest) {
     agent: 'ATLAS',
     cycle: currentCycleId(),
     observation: `Sentinel watchdog ran checks: ${actions.join(', ')}.`,
-    inference: failed === 0 ? 'System integrity checks passed in this cycle.' : `${failed} watchdog checks failed and require operator review.`,
+    inference: failed === 0
+      ? 'System integrity checks passed in this cycle.'
+      : `${failed} watchdog checks failed and require operator review.`,
     recommendation: failed === 0
       ? 'Continue scheduled watch cadence.'
       : 'Inspect failed watchdog actions and confirm CRON_SECRET / KV health before next run.',
@@ -207,6 +251,26 @@ export async function GET(request: NextRequest) {
   }).catch((err) => {
     console.error('[watchdog] ATLAS journal append failed:', err instanceof Error ? err.message : err);
   });
+
+  if (trustSnapshot.elevated) {
+    void appendAgentJournalEntry({
+      agent: 'ATLAS',
+      cycle: currentCycleId(),
+      observation: `Trust tripwires triggered: ${trustSnapshot.results.filter((result) => result.triggered).map((result) => result.kind).join(', ')}.`,
+      inference: trustSnapshot.critical
+        ? 'Trust posture is critically degraded and requires immediate operator attention.'
+        : 'Trust posture is elevated; monitor affected agents and verification quality.',
+      recommendation: trustSnapshot.critical
+        ? 'Pause high-risk promotion decisions and inspect provenance/timeline violations before continuing.'
+        : 'Review trust tripwire panel and increase verification rigor on upcoming promotions.',
+      confidence: trustSnapshot.critical ? 0.52 : 0.68,
+      derivedFrom: ['watchdog:trust-tripwire', `watchdog:run:${timestamp}`],
+      relatedAgents: ['ZEUS', 'EVE'],
+      status: 'committed',
+      category: 'alert',
+      severity: trustSnapshot.critical ? 'critical' : 'elevated',
+    }).catch(() => {});
+  }
 
   const allOk = kvHealth.ok && seedResult.ok && giResult.ok && tripwireResult.ok && echoResult.ok && promoteResult.ok;
 

--- a/app/api/terminal/snapshot/route.ts
+++ b/app/api/terminal/snapshot/route.ts
@@ -13,6 +13,7 @@ import { GET as getMii } from '@/app/api/mii/feed/route';
 import { GET as getVault } from '@/app/api/vault/status/route';
 import { GET as getMicReadiness } from '@/app/api/mic/readiness/route';
 import { GET as getTripwire } from '@/app/api/tripwire/status/route';
+import { GET as getTrustTripwire } from '@/app/api/tripwire/trust/route';
 import { GET as getSnapshotLite } from '@/app/api/terminal/snapshot-lite/route';
 import { memoryModeFromIntegrityPayload, memoryModeFromSnapshotLiteBody } from '@/lib/terminal/memoryMode';
 import { loadSignalSnapshot, isRedisAvailable } from '@/lib/kv/store';
@@ -24,6 +25,8 @@ import {
 } from '@/lib/terminal/snapshotLanes';
 import type { SubstrateJournalEntry } from '@/lib/substrate/github-journal';
 import { readAllSubstrateJournals } from '@/lib/substrate/github-reader';
+import { trustMultiplier } from '@/lib/tripwire/trustTripwires';
+import type { TrustTripwireSnapshot } from '@/lib/tripwire/types';
 
 export const dynamic = 'force-dynamic';
 
@@ -96,6 +99,7 @@ export async function GET(request: NextRequest) {
     timedHandler(makeRequest(baseUrl, '/api/vault/status'), getVault),
     timedHandler(makeRequest(baseUrl, '/api/mic/readiness'), getMicReadiness),
     timedHandler(makeRequest(baseUrl, '/api/tripwire/status'), getTripwire),
+    timedHandler(makeRequest(baseUrl, '/api/tripwire/trust'), getTrustTripwire),
   ]);
 
   const litePromise = timedHandler(makeRequest(baseUrl, '/api/terminal/snapshot-lite'), getSnapshotLite);
@@ -113,7 +117,7 @@ export async function GET(request: NextRequest) {
     signalsDuration = Date.now() - signalsStart;
   }
 
-  const [integrity, kvHealth, agents, epicon, echo, journal, sentiment, runtime, promotion, eve, mii, vault, micReadiness, tripwire] =
+  const [integrity, kvHealth, agents, epicon, echo, journal, sentiment, runtime, promotion, eve, mii, vault, micReadiness, tripwire, trustTripwire] =
     results;
 
   const litePayload = liteResult.leaf.data as Record<string, unknown> | null;
@@ -135,6 +139,7 @@ export async function GET(request: NextRequest) {
     vault: vault.duration_ms,
     micReadiness: micReadiness.duration_ms,
     tripwire: tripwire.duration_ms,
+    trustTripwire: trustTripwire.duration_ms,
   };
 
   type SubstrateAgentRow = { agent: string; lastEntry: SubstrateJournalEntry | null; entryCount: number };
@@ -210,6 +215,9 @@ export async function GET(request: NextRequest) {
       : typeof integrityData?.global_integrity === 'number' && Number.isFinite(integrityData.global_integrity)
         ? integrityData.global_integrity
         : null;
+  const trustPayload = (trustTripwire.leaf.data ?? {}) as Record<string, unknown> | null;
+  const trustSnapshot = (trustPayload?.trust_tripwire ?? null) as TrustTripwireSnapshot | null;
+  const effectiveGi = typeof topGi === 'number' ? Number((topGi * trustMultiplier(trustSnapshot)).toFixed(4)) : null;
 
   const journalData = journal.leaf.data as Record<string, unknown> | null;
   const journalEntries = Array.isArray(journalData?.entries) ? journalData?.entries as Record<string, unknown>[] : [];
@@ -244,13 +252,32 @@ export async function GET(request: NextRequest) {
   const topDegraded =
     memoryMode?.degraded === true ||
     tripwireElevated ||
+    Boolean(trustSnapshot?.elevated) ||
     Boolean(integrityData?.gi_degraded ?? integrityData?.degraded) ||
     (typeof integrityData?.mode === 'string' && (integrityData.mode === 'red' || integrityData.mode === 'yellow'));
+
+  const trustSummary = trustSnapshot
+    ? {
+        elevated: trustSnapshot.elevated,
+        critical: trustSnapshot.critical,
+        tripwireCount: trustSnapshot.tripwireCount,
+        top: trustSnapshot.results
+          .filter((result) => result.triggered)
+          .slice(0, 5)
+          .map((result) => ({
+            kind: result.kind,
+            severity: result.severity,
+            message: result.message,
+            affectedAgents: result.affectedAgents ?? [],
+          })),
+      }
+    : { elevated: false, critical: false, tripwireCount: 0, top: [] };
 
   return NextResponse.json({
     ok: criticalOk && !criticalFail,
     cycle: eveCycle ?? cycle ?? null,
     gi: topGi,
+    effective_gi: effectiveGi,
     degraded: topDegraded,
     include_catalog: includeCatalog === 'true',
     journal_mode: journalMode === 'hot' || journalMode === 'canon' || journalMode === 'merged' ? journalMode : 'merged',
@@ -261,6 +288,7 @@ export async function GET(request: NextRequest) {
     },
     meta: { total_ms: totalMs, lane_ms: timings },
     memory_mode: memoryMode,
+    trust_tripwire: trustSummary,
     lanes,
     journal_summary: journalSummary,
     agent_liveness: agentLiveness,
@@ -269,6 +297,7 @@ export async function GET(request: NextRequest) {
     runtime: runtime.leaf, promotion: promotion.leaf, eve: eve.leaf, mii: mii.leaf, vault: vault.leaf,
     micReadiness: micReadiness.leaf,
     tripwire: tripwire.leaf,
+    trustTripwire: trustTripwire.leaf,
     substrate,
   }, {
     headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'terminal-snapshot' },

--- a/app/api/tripwire/trust/route.ts
+++ b/app/api/tripwire/trust/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { kvGet, KV_KEYS } from '@/lib/kv/store';
+import type { TrustTripwireSnapshot } from '@/lib/tripwire/types';
+
+export const dynamic = 'force-dynamic';
+
+function nominalTrustSnapshot(): TrustTripwireSnapshot {
+  return {
+    ok: true,
+    tripwireCount: 0,
+    elevated: false,
+    critical: false,
+    results: [],
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export async function GET() {
+  const state = await kvGet<TrustTripwireSnapshot>(KV_KEYS.TRIPWIRE_STATE_KV);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      trust_tripwire: state ?? nominalTrustSnapshot(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    },
+  );
+}

--- a/lib/tripwire/archiveChecks.ts
+++ b/lib/tripwire/archiveChecks.ts
@@ -1,0 +1,69 @@
+import type { SubstrateJournalEntry } from '@/lib/substrate/github-journal';
+import type { TripwireSeverity } from '@/lib/tripwire/types';
+
+type ProvenanceBreakCheck = {
+  triggered: boolean;
+  severity: TripwireSeverity;
+  missingCount: number;
+  affectedAgents: string[];
+};
+
+type TemporalCoherenceCheck = {
+  triggered: boolean;
+  severity: TripwireSeverity;
+  totalViolations: number;
+  affectedAgents: string[];
+};
+
+export function checkProvenanceBreak(entries: SubstrateJournalEntry[]): ProvenanceBreakCheck {
+  const bad = entries.filter((entry) => {
+    const source = typeof entry.source === 'string' ? entry.source.trim() : '';
+    const derived = Array.isArray(entry.derivedFrom) ? entry.derivedFrom.filter(Boolean) : [];
+    return source.length === 0 || derived.length === 0;
+  });
+
+  const affectedAgents = [...new Set(bad.map((entry) => entry.agent).filter(Boolean))];
+  const missingCount = bad.length;
+
+  return {
+    triggered: missingCount > 0,
+    severity: missingCount > 10 ? 'critical' : missingCount > 0 ? 'elevated' : 'nominal',
+    missingCount,
+    affectedAgents,
+  };
+}
+
+export function checkTemporalCoherence(entries: SubstrateJournalEntry[]): TemporalCoherenceCheck {
+  let outOfOrder = 0;
+  let invalidCycles = 0;
+  const affectedAgents = new Set<string>();
+
+  for (let index = 1; index < entries.length; index += 1) {
+    const current = entries[index];
+    const previous = entries[index - 1];
+    const currentTs = Date.parse(current.timestamp);
+    const previousTs = Date.parse(previous.timestamp);
+    if (Number.isFinite(currentTs) && Number.isFinite(previousTs) && currentTs > previousTs) {
+      outOfOrder += 1;
+      if (current.agent) affectedAgents.add(current.agent);
+      if (previous.agent) affectedAgents.add(previous.agent);
+    }
+  }
+
+  for (const entry of entries) {
+    const cycle = typeof entry.cycle === 'string' ? entry.cycle.trim() : '';
+    if (!/^C-\d+$/.test(cycle)) {
+      invalidCycles += 1;
+      if (entry.agent) affectedAgents.add(entry.agent);
+    }
+  }
+
+  const totalViolations = outOfOrder + invalidCycles;
+
+  return {
+    triggered: totalViolations > 0,
+    severity: totalViolations > 5 ? 'critical' : totalViolations > 0 ? 'elevated' : 'nominal',
+    totalViolations,
+    affectedAgents: [...affectedAgents],
+  };
+}

--- a/lib/tripwire/journalQuality.ts
+++ b/lib/tripwire/journalQuality.ts
@@ -1,0 +1,66 @@
+import type { SubstrateJournalEntry } from '@/lib/substrate/github-journal';
+import type { TripwireSeverity } from '@/lib/tripwire/types';
+
+type JournalQualityDriftCheck = {
+  triggered: boolean;
+  severity: TripwireSeverity;
+  weakCount: number;
+  affectedAgents: string[];
+};
+
+function wordCount(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function similarity(a: string, b: string): number {
+  if (!a || !b) return 0;
+  return a.trim().toLowerCase() === b.trim().toLowerCase() ? 1 : 0;
+}
+
+export function checkJournalQualityDrift(entries: SubstrateJournalEntry[]): JournalQualityDriftCheck {
+  const byAgent = new Map<string, SubstrateJournalEntry[]>();
+
+  for (const entry of entries) {
+    if (!entry.agent) continue;
+    const rows = byAgent.get(entry.agent) ?? [];
+    rows.push(entry);
+    byAgent.set(entry.agent, rows);
+  }
+
+  const weakAgents: string[] = [];
+
+  for (const [agent, rows] of byAgent.entries()) {
+    const recent = [...rows]
+      .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+      .slice(0, 5);
+
+    if (recent.length < 2) continue;
+
+    const tooShort = recent.filter((entry) => {
+      const totalWords =
+        wordCount(entry.observation ?? '') +
+        wordCount(entry.inference ?? '') +
+        wordCount(entry.recommendation ?? '');
+      return totalWords < 30;
+    }).length;
+
+    const repetitive = recent
+      .slice(1)
+      .filter((entry, index) => similarity(entry.observation ?? '', recent[index].observation ?? '') > 0.95).length;
+
+    const sparseDerived = recent.filter((entry) => !entry.derivedFrom || entry.derivedFrom.length < 1).length;
+
+    if (tooShort >= 3 || repetitive >= 2 || sparseDerived >= 3) {
+      weakAgents.push(agent);
+    }
+  }
+
+  const weakCount = weakAgents.length;
+
+  return {
+    triggered: weakCount > 0,
+    severity: weakCount > 2 ? 'critical' : weakCount > 0 ? 'elevated' : 'nominal',
+    weakCount,
+    affectedAgents: weakAgents,
+  };
+}

--- a/lib/tripwire/trustTripwires.ts
+++ b/lib/tripwire/trustTripwires.ts
@@ -1,0 +1,186 @@
+import type { SubstrateJournalEntry } from '@/lib/substrate/github-journal';
+import { checkProvenanceBreak, checkTemporalCoherence } from '@/lib/tripwire/archiveChecks';
+import { checkJournalQualityDrift } from '@/lib/tripwire/journalQuality';
+import type { TripwireSeverity, TrustTripwireResult, TrustTripwireSnapshot } from '@/lib/tripwire/types';
+
+type EvaluateArgs = {
+  journals: SubstrateJournalEntry[];
+  epiconRows: Array<Record<string, unknown>>;
+};
+
+type AgentLikeEntry = { agent?: string; source?: string };
+
+function checkVerificationDilution(epiconRows: Array<Record<string, unknown>>) {
+  const total = epiconRows.length;
+  if (total === 0) {
+    return {
+      triggered: false,
+      severity: 'nominal' as TripwireSeverity,
+      lowConfidenceRate: 0,
+      total,
+    };
+  }
+
+  const lowConfidence = epiconRows.filter((row) => {
+    const confidence = typeof row.confidence === 'number' ? row.confidence : 1;
+    const status = typeof row.status === 'string' ? row.status.toLowerCase() : '';
+    return confidence < 0.7 || status === 'unverified' || status === 'contested' || status === 'soft-confirmed';
+  }).length;
+
+  const lowConfidenceRate = lowConfidence / total;
+
+  return {
+    triggered: lowConfidenceRate > 0.25,
+    severity: lowConfidenceRate > 0.4 ? 'critical' as TripwireSeverity : lowConfidenceRate > 0.25 ? 'elevated' as TripwireSeverity : 'nominal' as TripwireSeverity,
+    lowConfidenceRate,
+    total,
+  };
+}
+
+function checkTrustConcentration(entries: AgentLikeEntry[]) {
+  const total = entries.length;
+  if (total === 0) {
+    return {
+      triggered: false,
+      severity: 'nominal' as TripwireSeverity,
+      dominantShare: 0,
+      dominantKey: null,
+      counts: {} as Record<string, number>,
+    };
+  }
+
+  const counts = new Map<string, number>();
+  for (const row of entries) {
+    const key = row.agent ?? row.source ?? 'unknown';
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  let dominantKey: string | null = null;
+  let dominantCount = 0;
+  for (const [key, count] of counts.entries()) {
+    if (count > dominantCount) {
+      dominantCount = count;
+      dominantKey = key;
+    }
+  }
+
+  const dominantShare = dominantCount / total;
+
+  return {
+    triggered: dominantShare > 0.7,
+    severity: dominantShare > 0.85 ? 'critical' as TripwireSeverity : dominantShare > 0.7 ? 'elevated' as TripwireSeverity : 'nominal' as TripwireSeverity,
+    dominantShare,
+    dominantKey,
+    counts: Object.fromEntries(counts),
+  };
+}
+
+export function evaluateTrustTripwires({ journals, epiconRows }: EvaluateArgs): TrustTripwireSnapshot {
+  const timestamp = new Date().toISOString();
+  const provenance = checkProvenanceBreak(journals);
+  const temporal = checkTemporalCoherence(journals);
+  const journalDrift = checkJournalQualityDrift(journals);
+  const dilution = checkVerificationDilution(epiconRows);
+  const concentration = checkTrustConcentration(
+    epiconRows.map((row) => ({
+      agent: typeof row.agentOrigin === 'string' ? row.agentOrigin : undefined,
+      source: typeof row.source === 'string' ? row.source : undefined,
+    })),
+  );
+
+  const results: TrustTripwireResult[] = [
+    {
+      kind: 'provenance_break',
+      ok: !provenance.triggered,
+      triggered: provenance.triggered,
+      severity: provenance.severity,
+      score: provenance.triggered ? 0.4 : 1,
+      message: provenance.triggered ? 'PROVENANCE BREAK — trust chain incomplete' : 'Provenance chain intact',
+      affectedAgents: provenance.affectedAgents,
+      evidence: provenance,
+      timestamp,
+    },
+    {
+      kind: 'temporal_coherence',
+      ok: !temporal.triggered,
+      triggered: temporal.triggered,
+      severity: temporal.severity,
+      score: temporal.triggered ? 0.2 : 1,
+      message: temporal.triggered ? 'TEMPORAL BREAK — replay integrity compromised' : 'Timeline coherence nominal',
+      affectedAgents: temporal.affectedAgents,
+      evidence: temporal,
+      timestamp,
+    },
+    {
+      kind: 'journal_quality_drift',
+      ok: !journalDrift.triggered,
+      triggered: journalDrift.triggered,
+      severity: journalDrift.severity,
+      score: journalDrift.triggered ? 0.5 : 1,
+      message: journalDrift.triggered ? 'JOURNAL DRIFT — agent cognition degrading' : 'Journal quality nominal',
+      affectedAgents: journalDrift.affectedAgents,
+      evidence: journalDrift,
+      timestamp,
+    },
+    {
+      kind: 'verification_dilution',
+      ok: !dilution.triggered,
+      triggered: dilution.triggered,
+      severity: dilution.severity,
+      score: dilution.triggered ? 0.45 : 1,
+      message: dilution.triggered ? 'VERIFICATION DILUTION — archive rigor weakening' : 'Verification density nominal',
+      evidence: dilution,
+      timestamp,
+    },
+    {
+      kind: 'trust_concentration',
+      ok: !concentration.triggered,
+      triggered: concentration.triggered,
+      severity: concentration.severity,
+      score: concentration.triggered ? 0.55 : 1,
+      message: concentration.triggered ? 'TRUST CONCENTRATION — monoculture detected' : 'Trust distribution healthy',
+      evidence: concentration,
+      timestamp,
+    },
+  ];
+
+  const tripwireCount = results.filter((result) => result.triggered).length;
+  const critical = results.some((result) => result.triggered && result.severity === 'critical');
+
+  return {
+    ok: tripwireCount === 0,
+    tripwireCount,
+    elevated: tripwireCount > 0,
+    critical,
+    results,
+    timestamp,
+  };
+}
+
+export function trustMultiplier(snapshot: TrustTripwireSnapshot | null | undefined): number {
+  if (!snapshot) return 1;
+  const penalties = snapshot.results
+    .filter((result) => result.triggered)
+    .reduce((sum, result) => {
+      if (result.severity === 'critical') return sum + 0.12;
+      if (result.severity === 'elevated') return sum + 0.05;
+      return sum;
+    }, 0);
+
+  return Math.max(0.5, 1 - penalties);
+}
+
+export function applyTrustTripwiresToAgentStatus(
+  agent: string,
+  snapshot: TrustTripwireSnapshot | null | undefined,
+): 'ACTIVE' | 'DEGRADED' | 'CONTESTED' {
+  if (!snapshot) return 'ACTIVE';
+
+  const hits = snapshot.results.filter(
+    (result) => result.triggered && (result.affectedAgents ?? []).includes(agent),
+  );
+
+  if (hits.some((result) => result.severity === 'critical')) return 'CONTESTED';
+  if (hits.length > 0) return 'DEGRADED';
+  return 'ACTIVE';
+}

--- a/lib/tripwire/types.ts
+++ b/lib/tripwire/types.ts
@@ -1,0 +1,30 @@
+export type TrustTripwireKind =
+  | 'provenance_break'
+  | 'journal_quality_drift'
+  | 'verification_dilution'
+  | 'temporal_coherence'
+  | 'trust_concentration';
+
+export type TripwireSeverity = 'nominal' | 'elevated' | 'critical';
+
+export type TrustTripwireResult = {
+  kind: TrustTripwireKind;
+  ok: boolean;
+  severity: TripwireSeverity;
+  score: number;
+  triggered: boolean;
+  message: string;
+  affectedAgents?: string[];
+  affectedPaths?: string[];
+  evidence?: Record<string, unknown>;
+  timestamp: string;
+};
+
+export type TrustTripwireSnapshot = {
+  ok: boolean;
+  tripwireCount: number;
+  elevated: boolean;
+  critical: boolean;
+  results: TrustTripwireResult[];
+  timestamp: string;
+};


### PR DESCRIPTION
### Motivation
- Introduce a deterministic v1 Trust Tripwire engine to detect silent archive degradation across provenance, time, verification, journal quality, and concentration risks. 
- Surface trust signals into existing watchdog/snapshot flows so operator-facing UI and agent liveness can respond to emerging trust issues. 
- Provide a minimal, implementable engine that persists snapshots to KV and can be iterated with ML/threshold tuning later.

### Description
- Add a new trust library under `lib/tripwire/` including `types.ts`, `archiveChecks.ts`, `journalQuality.ts`, and `trustTripwires.ts` implementing the five tripwires, `trustMultiplier`, and `applyTrustTripwiresToAgentStatus`.
- Add a read route `GET /api/tripwire/trust` that returns the current trust snapshot (nominal fallback when absent) and persist snapshots using `KV_KEYS.TRIPWIRE_STATE*` plus raw `TRUST_TRIPWIRE_STATE` for compatibility.
- Integrate evaluation into the watchdog (`app/api/cron/watchdog/route.ts`) which reads Substrate journals + promotion/epicon rows, stores the snapshot to KV, and appends an ATLAS alert journal entry when trust is elevated.
- Wire trust into runtime surfaces: include a `trust_tripwire` summary and `effective_gi` (via `trustMultiplier`) in `GET /api/terminal/snapshot`, couple trust hits into agent liveness computation (`GET /api/agents/status`), and add lightweight guard checks on `POST /api/agents/journal` to reject provenance/temporal/quality failures.

### Testing
- Ran typecheck with `pnpm exec tsc --noEmit`, which completed successfully (`pass`).
- Built the app with `pnpm build`, which completed successfully and produced a successful Next.js production build (`pass`).
- Ran `pnpm lint`, which invoked Next.js ESLint interactive setup in non-TTY mode and therefore is reported as "not configured" for non-interactive CI (`not configured`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9434d6a90832da6067a2683d4c221)