### PR TITLE
C-289: fix React hook-order crash in Globe chamber

### DIFF
--- a/app/terminal/GlobePageClient.tsx
+++ b/app/terminal/GlobePageClient.tsx
@@ -10,7 +10,6 @@ import type { EpiconItem } from '@/lib/terminal/types';
 
 export default function GlobePageClient() {
   const { snapshot, loading } = useTerminalSnapshot();
-  if (loading && !snapshot) return <ChamberSkeleton blocks={4} />;
 
   const integrityData = snapshot?.integrity?.data;
   const integrity = (integrityData && typeof integrityData === 'object' ? integrityData : {}) as { cycle?: string; global_integrity?: number };
@@ -90,6 +89,8 @@ export default function GlobePageClient() {
       miiFeed: snapshot.mii?.data ?? null,
     };
   }, [snapshot, echoEpicon, loading, micro]);
+
+  if (loading && !snapshot) return <ChamberSkeleton blocks={4} />;
 
   return (
     <GlobeChamber


### PR DESCRIPTION
### Motivation
- Fix React error #310 caused by a hook-order mismatch when `GlobePageClient` returned early during snapshot loading, stabilizing the Terminal UI by ensuring hooks execute in the same order across renders.

### Description
- In `app/terminal/GlobePageClient.tsx` moved the `if (loading && !snapshot) return <ChamberSkeleton />` check to after the `useMemo` (and other hook evaluations) so all hooks (`useTerminalSnapshot`, `useMemo`) run on every render and the component no longer conditionally omits hooks.

### Testing
- Ran `pnpm exec tsc --noEmit` (typecheck) and `pnpm build`, and both completed successfully; lint was not run because repository linting is not configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96d1e0218832db2959d431aaa7f7d)