### PR TITLE
fix(snapshot): harden snapshot and snapshot-lite fallbacks to prevent 500s and stale shell collapse

### DIFF
--- a/app/api/agents/journal/seed/route.ts
+++ b/app/api/agents/journal/seed/route.ts
@@ -38,7 +38,7 @@ function nowIso(): string {
 }
 
 function seedEntries(cycle = 'C-272'): SeedEntry[] {
-  return [
+  const entries: SeedEntry[] = [
     {
       agent: 'ATLAS',
       cycle,
@@ -153,6 +153,25 @@ function seedEntries(cycle = 'C-272'): SeedEntry[] {
       tags: ['genesis', 'c272'],
     },
   ];
+
+  if (cycle === 'C-289') {
+    entries.push({
+      agent: 'JADE',
+      cycle,
+      scope: 'Operator truth preservation under degraded snapshot state',
+      category: 'observation',
+      severity: 'elevated',
+      observation: 'Terminal health remained live while snapshot aggregation routes hard-failed, causing stale shell drift and operator ambiguity.',
+      inference: 'The system was not fully offline; the truth surface failed because aggregation lacked fallback discipline. Hardened degraded responses preserve truthful operator posture.',
+      recommendation: 'Treat snapshot and snapshot-lite as required degraded-safe contracts. Prefer explicit fallback payloads over HTTP 500 in operator surfaces.',
+      confidence: 0.92,
+      derivedFrom: ['terminal/snapshot', 'terminal/snapshot-lite', 'health', 'C-289'],
+      agentOrigin: 'JADE',
+      tags: ['jade', 'snapshot', 'fallback', 'degraded-mode', 'C-289'],
+    });
+  }
+
+  return entries;
 }
 
 export async function POST(request: NextRequest) {

--- a/app/api/terminal/snapshot-lite/route.ts
+++ b/app/api/terminal/snapshot-lite/route.ts
@@ -68,21 +68,74 @@ async function resolveMicRawWithBridge(micFromMget: string | null): Promise<{ ra
 export async function GET(req: NextRequest) {
   const start = Date.now();
   const cors = handbookCorsHeaders(req.headers.get('origin'));
+  try {
 
-  const { value: cached, fresh: cacheFresh } = await cachedByKey(SNAPSHOT_LITE_CACHE_KEY, async () => {
-    const bundle = await loadSnapshotLiteKvBundle();
-    const mic = await resolveMicRawWithBridge(bundle.micReadinessRaw);
-    return { bundle, mic };
-  });
+    let cached: Awaited<ReturnType<typeof cachedByKey<{ bundle: Awaited<ReturnType<typeof loadSnapshotLiteKvBundle>>; mic: { raw: string | null; source: 'kv' | 'oaa' | 'none' } }>>>['value'];
+    let cacheFresh = false;
+    try {
+      const cacheResult = await cachedByKey(SNAPSHOT_LITE_CACHE_KEY, async () => {
+        const bundle = await loadSnapshotLiteKvBundle();
+        const mic = await resolveMicRawWithBridge(bundle.micReadinessRaw);
+        return { bundle, mic };
+      });
+      cached = cacheResult.value;
+      cacheFresh = cacheResult.fresh;
+    } catch (error) {
+      console.error('[terminal/snapshot-lite] cache/bundle load failed:', error);
+      cached = {
+        bundle: {
+          giState: null,
+          giCarry: null,
+          pulse: null,
+          signals: null,
+          echo: null,
+          tripwire: null,
+          micReadinessRaw: null,
+          kvHealth: {
+            available: false,
+            configured: false,
+            latencyMs: null,
+            error: null,
+            backup_redis: {
+              configured: false,
+              available: false,
+              mirror_enabled: false,
+              read_fallback_enabled: false,
+              latency_ms: null,
+              error: null,
+            },
+          },
+        },
+        mic: { raw: null, source: 'none' },
+      };
+    }
 
-  const { bundle, mic } = cached;
-  const micSnapRaw = mic.raw;
-  const micSnapSource = mic.source;
+    const { bundle, mic } = cached;
+    const micSnapRaw = mic.raw;
+    const micSnapSource = mic.source;
 
-  const giResolved = await resolveGiForTerminal({
-    micReadinessSnapshotRaw: micSnapRaw,
-    preloadedGi: { primary: bundle.giState, carry: bundle.giCarry },
-  });
+    let giResolved: Awaited<ReturnType<typeof resolveGiForTerminal>>;
+    try {
+      giResolved = await resolveGiForTerminal({
+        micReadinessSnapshotRaw: micSnapRaw,
+        preloadedGi: { primary: bundle.giState, carry: bundle.giCarry },
+      });
+    } catch (error) {
+      console.error('[terminal/snapshot-lite] GI resolve failed:', error);
+      giResolved = {
+        gi: null,
+        mode: 'yellow',
+        source: 'null',
+        gi_provenance: 'unknown',
+        verified: false,
+        degraded: true,
+        terminal_status: 'stressed',
+        primary_driver: null,
+        timestamp: new Date().toISOString(),
+        age_seconds: null,
+        kv: null,
+      };
+    }
 
   const gi =
     giResolved.source === 'kv'
@@ -188,58 +241,151 @@ export async function GET(req: NextRequest) {
     modeStr === 'red' ||
     lanes.tripwire.elevated;
 
-  return NextResponse.json(
-    {
-      ok: true,
-      lite: true,
-      cycle,
-      timestamp: new Date().toISOString(),
-      deployment: {
-        commit_sha: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
-        environment: process.env.VERCEL_ENV ?? null,
+    return NextResponse.json(
+      {
+        ok: true,
+        lite: true,
+        cycle,
+        timestamp: new Date().toISOString(),
+        deployment: {
+          commit_sha: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+          environment: process.env.VERCEL_ENV ?? null,
+        },
+        gi: giResolved.gi ?? gi?.global_integrity ?? null,
+        mode: modeStr,
+        gi_source:
+          giResolved.source === 'kv' ||
+          giResolved.source === 'kv_carry_forward' ||
+          giResolved.source === 'oaa_verified'
+            ? 'kv'
+            : giResolved.source === 'live_compute'
+              ? 'live'
+              : giResolved.source === 'readiness_snapshot'
+                ? 'readiness_fallback'
+                : 'null',
+        gi_provenance: giResolved.gi_provenance,
+        gi_verified: giResolved.verified,
+        degraded,
+        lanes,
+        heartbeat: {
+          runtime: getHeartbeat(),
+          journal: getJournalHeartbeat(),
+        },
+        meta: {
+          total_ms: Date.now() - start,
+          kv_available: isRedisAvailable(),
+          kv_bundle_mget: true,
+          kv_cache_fresh: cacheFresh,
+          cycle_source:
+            typeof pulse?.cycle === 'string' && pulse.cycle.trim().length > 0
+              ? 'pulse'
+              : echo?.cycleId?.trim()
+                ? 'echo'
+                : tripwire?.cycleId?.trim()
+                  ? 'tripwire'
+                  : 'calendar',
+        },
       },
-      gi: giResolved.gi ?? gi?.global_integrity ?? null,
-      mode: modeStr,
-      gi_source:
-        giResolved.source === 'kv' ||
-        giResolved.source === 'kv_carry_forward' ||
-        giResolved.source === 'oaa_verified'
-          ? 'kv'
-          : giResolved.source === 'live_compute'
-            ? 'live'
-            : giResolved.source === 'readiness_snapshot'
-              ? 'readiness_fallback'
-              : 'null',
-      gi_provenance: giResolved.gi_provenance,
-      gi_verified: giResolved.verified,
-      degraded,
-      lanes,
-      heartbeat: {
-        runtime: getHeartbeat(),
-        journal: getJournalHeartbeat(),
+      {
+        headers: {
+          ...(cors ?? {}),
+          'Cache-Control': 'public, s-maxage=15, stale-while-revalidate=30',
+          'X-Cache-Strategy': 'edge-15s',
+          'X-Mobius-Source': 'terminal-snapshot-lite',
+        },
       },
-      meta: {
-        total_ms: Date.now() - start,
-        kv_available: isRedisAvailable(),
-        kv_bundle_mget: true,
-        kv_cache_fresh: cacheFresh,
-        cycle_source:
-          typeof pulse?.cycle === 'string' && pulse.cycle.trim().length > 0
-            ? 'pulse'
-            : echo?.cycleId?.trim()
-              ? 'echo'
-              : tripwire?.cycleId?.trim()
-                ? 'tripwire'
-                : 'calendar',
+    );
+  } catch (error) {
+    console.error('[terminal/snapshot-lite] fatal error:', error);
+    const msg = error instanceof Error ? error.message : 'snapshot_lite_failed';
+    return NextResponse.json(
+      {
+        ok: false,
+        lite: true,
+        fallback: true,
+        error: msg,
+        cycle: currentCycleId(),
+        timestamp: new Date().toISOString(),
+        deployment: {
+          commit_sha: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+          environment: process.env.VERCEL_ENV ?? null,
+        },
+        gi: null,
+        mode: 'yellow',
+        gi_source: 'null',
+        gi_provenance: null,
+        gi_verified: false,
+        degraded: true,
+        lanes: {
+          kv: { ok: false, latency_ms: null },
+          backup_redis: {
+            configured: false,
+            available: false,
+            mirror_enabled: false,
+            read_fallback_enabled: false,
+            latency_ms: null,
+          },
+          integrity: {
+            ok: false,
+            gi: null,
+            mode: null,
+            terminal_status: 'stressed',
+            source: 'null',
+            provenance: null,
+            verified: false,
+            mic_readiness_snapshot_source: 'none',
+            freshness: 'unknown',
+            age_seconds: null,
+          },
+          signals: {
+            ok: false,
+            composite: null,
+            anomalies: null,
+            healthy: null,
+            freshness: 'unknown',
+            age_seconds: null,
+          },
+          echo: {
+            ok: false,
+            cycle: null,
+            total_ingested: null,
+            healthy: null,
+            freshness: 'unknown',
+            age_seconds: null,
+          },
+          tripwire: {
+            ok: false,
+            elevated: false,
+            count: 0,
+          },
+          pulse: {
+            ok: false,
+            composite: null,
+            instruments: null,
+            anomalies: null,
+            freshness: 'unknown',
+          },
+        },
+        heartbeat: {
+          runtime: getHeartbeat(),
+          journal: getJournalHeartbeat(),
+        },
+        meta: {
+          total_ms: Date.now() - start,
+          kv_available: isRedisAvailable(),
+          kv_bundle_mget: false,
+          kv_cache_fresh: false,
+          cycle_source: 'calendar',
+        },
       },
-    },
-    {
-      headers: {
-        ...(cors ?? {}),
-        'Cache-Control': 'public, s-maxage=15, stale-while-revalidate=30',
-        'X-Cache-Strategy': 'edge-15s',
-        'X-Mobius-Source': 'terminal-snapshot-lite',
+      {
+        status: 200,
+        headers: {
+          ...(cors ?? {}),
+          'Cache-Control': 'no-store',
+          'X-Mobius-Source': 'terminal-snapshot-lite-fallback',
+        },
       },
-    },
-  );
+    );
+  }
 }

--- a/app/api/terminal/snapshot/route.ts
+++ b/app/api/terminal/snapshot/route.ts
@@ -74,6 +74,7 @@ export async function GET(request: NextRequest) {
   const journalMode = (request.nextUrl.searchParams.get('journal_mode')?.trim().toLowerCase() ?? 'merged');
   const journalLimit = request.nextUrl.searchParams.get('journal_limit')?.trim();
   const baseUrl = request.nextUrl.origin;
+  try {
 
   const journalQuery = new URLSearchParams();
   if (cycle) journalQuery.set('cycle', cycle);
@@ -83,7 +84,7 @@ export async function GET(request: NextRequest) {
   const epiconPath = includeCatalog === 'true' ? '/api/epicon/feed?include_catalog=true' : '/api/epicon/feed';
 
   const signalsStart = Date.now();
-  const cachedPromise = loadSignalSnapshot();
+  const cachedPromise = loadSignalSnapshot().catch(() => null);
   const lanesPromise = Promise.all([
     timedHandler(makeRequest(baseUrl, '/api/integrity-status'), getIntegrity),
     timedHandler(makeRequest(baseUrl, '/api/kv/health'), getKvHealth),
@@ -178,7 +179,13 @@ export async function GET(request: NextRequest) {
     micReadiness: micReadiness.leaf, tripwire: tripwire.leaf,
   };
 
-  const lanes: SnapshotLaneState[] = normalizeAllSnapshotLanes(leaves);
+  let lanes: SnapshotLaneState[] = [];
+  try {
+    lanes = normalizeAllSnapshotLanes(leaves);
+  } catch (error) {
+    console.error('[terminal/snapshot] lane normalization failed:', error);
+    lanes = [];
+  }
   const laneByKey = new Map(lanes.map((lane) => [lane.key, lane]));
   const criticalLaneKeys: SnapshotLaneKey[] = ['integrity', 'signals', 'kvHealth'];
   // C-283 (ATLAS audit): `stale` and `promotable` are legitimate operational
@@ -273,33 +280,79 @@ export async function GET(request: NextRequest) {
       }
     : { elevated: false, critical: false, tripwireCount: 0, top: [] };
 
-  return NextResponse.json({
-    ok: criticalOk && !criticalFail,
-    cycle: eveCycle ?? cycle ?? null,
-    gi: topGi,
-    effective_gi: effectiveGi,
-    degraded: topDegraded,
-    include_catalog: includeCatalog === 'true',
-    journal_mode: journalMode === 'hot' || journalMode === 'canon' || journalMode === 'merged' ? journalMode : 'merged',
-    timestamp: new Date().toISOString(),
-    deployment: {
-      commit_sha: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
-      environment: process.env.VERCEL_ENV ?? null,
-    },
-    meta: { total_ms: totalMs, lane_ms: timings },
-    memory_mode: memoryMode,
-    trust_tripwire: trustSummary,
-    lanes,
-    journal_summary: journalSummary,
-    agent_liveness: agentLiveness,
-    integrity: integrity.leaf, signals, kvHealth: kvHealth.leaf, agents: agents.leaf,
-    epicon: epicon.leaf, echo: echo.leaf, journal: journal.leaf, sentiment: sentiment.leaf,
-    runtime: runtime.leaf, promotion: promotion.leaf, eve: eve.leaf, mii: mii.leaf, vault: vault.leaf,
-    micReadiness: micReadiness.leaf,
-    tripwire: tripwire.leaf,
-    trustTripwire: trustTripwire.leaf,
-    substrate,
-  }, {
-    headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'terminal-snapshot' },
-  });
+    return NextResponse.json({
+      ok: criticalOk && !criticalFail,
+      cycle: eveCycle ?? cycle ?? null,
+      gi: topGi,
+      effective_gi: effectiveGi,
+      degraded: topDegraded,
+      include_catalog: includeCatalog === 'true',
+      journal_mode: journalMode === 'hot' || journalMode === 'canon' || journalMode === 'merged' ? journalMode : 'merged',
+      timestamp: new Date().toISOString(),
+      deployment: {
+        commit_sha: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+        environment: process.env.VERCEL_ENV ?? null,
+      },
+      meta: { total_ms: totalMs, lane_ms: timings },
+      memory_mode: memoryMode,
+      trust_tripwire: trustSummary,
+      lanes,
+      journal_summary: journalSummary,
+      agent_liveness: agentLiveness,
+      integrity: integrity.leaf, signals, kvHealth: kvHealth.leaf, agents: agents.leaf,
+      epicon: epicon.leaf, echo: echo.leaf, journal: journal.leaf, sentiment: sentiment.leaf,
+      runtime: runtime.leaf, promotion: promotion.leaf, eve: eve.leaf, mii: mii.leaf, vault: vault.leaf,
+      micReadiness: micReadiness.leaf,
+      tripwire: tripwire.leaf,
+      trustTripwire: trustTripwire.leaf,
+      substrate,
+    }, {
+      headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'terminal-snapshot' },
+    });
+  } catch (error) {
+    console.error('[terminal/snapshot] fatal aggregation error:', error);
+    const msg = error instanceof Error ? error.message : 'snapshot_failed';
+    const fallbackLeaf = { ok: false, status: 500, data: null, error: msg };
+    return NextResponse.json({
+      ok: false,
+      fallback: true,
+      cycle: cycle ?? null,
+      gi: null,
+      effective_gi: null,
+      degraded: true,
+      include_catalog: includeCatalog === 'true',
+      journal_mode: journalMode === 'hot' || journalMode === 'canon' || journalMode === 'merged' ? journalMode : 'merged',
+      timestamp: new Date().toISOString(),
+      deployment: {
+        commit_sha: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+        environment: process.env.VERCEL_ENV ?? null,
+      },
+      meta: { total_ms: Date.now() - totalStart, lane_ms: {} },
+      memory_mode: null,
+      trust_tripwire: { elevated: false, critical: false, tripwireCount: 0, top: [] },
+      lanes: [],
+      journal_summary: { latest_agent_entries: [] },
+      agent_liveness: [],
+      integrity: fallbackLeaf,
+      signals: fallbackLeaf,
+      kvHealth: fallbackLeaf,
+      agents: fallbackLeaf,
+      epicon: fallbackLeaf,
+      echo: fallbackLeaf,
+      journal: fallbackLeaf,
+      sentiment: fallbackLeaf,
+      runtime: fallbackLeaf,
+      promotion: fallbackLeaf,
+      eve: fallbackLeaf,
+      mii: fallbackLeaf,
+      vault: fallbackLeaf,
+      micReadiness: fallbackLeaf,
+      tripwire: fallbackLeaf,
+      trustTripwire: fallbackLeaf,
+      substrate: { ok: false, totalEntries: 0, agents: [], repoUrl: null, latest: [] },
+    }, {
+      status: 200,
+      headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'terminal-snapshot-fallback' },
+    });
+  }
 }


### PR DESCRIPTION
### Motivation
- The Terminal `/api/terminal/snapshot` and `/api/terminal/snapshot-lite` routes can hard-500 during partial lane or KV/cache failures, which starves the UI and surfaces stale/misleading shell defaults. 
- Ensure the backend always returns a truthful degraded payload so the operator surface remains honest and the UI can degrade gracefully.

### Description
- Wrap `GET` handlers in `app/api/terminal/snapshot/route.ts` and `app/api/terminal/snapshot-lite/route.ts` in top-level `try/catch` blocks that log the fatal error and return a shaped degraded JSON payload with `fallback: true` and HTTP 200 instead of throwing. 
- Harden fragile calls by changing `loadSignalSnapshot()` to `loadSignalSnapshot().catch(() => null)` and wrapping `normalizeAllSnapshotLanes(...)` in a `try/catch` in `snapshot`, and by guarding `cachedByKey(...)` bundle load and `resolveGiForTerminal(...)` in `snapshot-lite` with safe defaults and explicit `console.error` logs. 
- Add lane placeholders and consistent fallback leaf shapes (e.g. `{ ok:false, status:500, data:null, error: msg }`) to preserve the snapshot contract and add `X-Mobius-Source` headers identifying fallback responses. 
- Add a C-289 JADE journal seed entry to `app/api/agents/journal/seed/route.ts` to record the stabilization event when seeding cycle `C-289`.

### Testing
- Ran typecheck with `pnpm exec tsc --noEmit` and it passed successfully. 
- Built the app with `pnpm build` and the Next.js build completed successfully. 
- Ran `pnpm lint` which invoked Next.js ESLint interactive setup in this non-TTY environment, so lint is reported as not configured/interactive rather than failing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e978af1d08832da88377d317f175d8)