### PR TITLE
Harden terminal snapshot fallback signaling

### DIFF
--- a/app/api/terminal/snapshot/route.ts
+++ b/app/api/terminal/snapshot/route.ts
@@ -183,7 +183,7 @@ export async function GET(request: NextRequest) {
   try {
     lanes = normalizeAllSnapshotLanes(leaves);
   } catch (error) {
-    console.error('[terminal/snapshot] lane normalization failed:', error);
+    console.error('[snapshot] lane normalize fail', error);
     lanes = [];
   }
   const laneByKey = new Map(lanes.map((lane) => [lane.key, lane]));
@@ -310,12 +310,13 @@ export async function GET(request: NextRequest) {
       headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'terminal-snapshot' },
     });
   } catch (error) {
-    console.error('[terminal/snapshot] fatal aggregation error:', error);
+    console.error('[snapshot] fatal', error);
     const msg = error instanceof Error ? error.message : 'snapshot_failed';
     const fallbackLeaf = { ok: false, status: 500, data: null, error: msg };
     return NextResponse.json({
       ok: false,
       fallback: true,
+      error: 'snapshot_failed',
       cycle: cycle ?? null,
       gi: null,
       effective_gi: null,


### PR DESCRIPTION
### Motivation
- Make the terminal snapshot route fail-safe and operator-truthful so aggregation errors degrade the UI without hiding failure cause and are easier to spot in logs.

### Description
- Align lane-normalization and fatal aggregation logging to the `[snapshot]` tag and add a top-level `error: 'snapshot_failed'` field to the fallback JSON while preserving the existing HTTP 200 degraded response and empty lanes/journal/agent lists.

### Testing
- Ran `pnpm exec tsc --noEmit` and `pnpm build`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea18120584832dadf01037346895c5)