### PR TITLE
fix(api): add degraded-safe chamber compatibility routes

### DIFF
--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { GET as getAgentStatus } from '@/app/api/agents/status/route';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const response = await getAgentStatus();
+    const payload = (await response.json()) as Record<string, unknown>;
+    return NextResponse.json(
+      {
+        ...payload,
+        ok: payload.ok === false ? false : true,
+        degraded: payload.degraded === true || payload.fallback === true,
+        error: null,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        degraded: true,
+        fallback: true,
+        error: error instanceof Error ? error.message : 'agents_route_failed',
+        source: 'route-fallback',
+        cycle: 'unknown',
+        timestamp: new Date().toISOString(),
+        agents: [],
+      },
+      { status: 200 },
+    );
+  }
+}

--- a/app/api/agents/status/route.ts
+++ b/app/api/agents/status/route.ts
@@ -87,7 +87,11 @@ function deriveLiveness(input: {
   const actionFresh = isWithin(actionAge, ACTION_FRESH_MS);
   const journalFresh = isWithin(journalAge, JOURNAL_FRESH_MS);
 
-  if (hbFresh && actionFresh && journalFresh && input.confidence >= 0.6) return 'ACTIVE';
+  // C-290: ACTIVE should reflect runtime liveness first.
+  // Canon/journal freshness degrades health but should not freeze agents in BOOTING.
+  if (hbFresh && actionFresh && input.confidence >= 0.6) {
+    return journalFresh ? 'ACTIVE' : 'DEGRADED';
+  }
 
   const noHeartbeat = !Number.isFinite(hbAge) || hbAge > OFFLINE_AFTER_MS;
   const noAction = !Number.isFinite(actionAge) || actionAge > OFFLINE_AFTER_MS;

--- a/app/api/gi-state/route.ts
+++ b/app/api/gi-state/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { GET as getGlobe } from '@/app/api/chambers/globe/route';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const response = await getGlobe();
+    const payload = (await response.json()) as Record<string, unknown>;
+    return NextResponse.json(
+      {
+        ...payload,
+        ok: payload.ok === false ? false : true,
+        degraded: payload.fallback === true,
+        error: null,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        degraded: true,
+        fallback: true,
+        error: error instanceof Error ? error.message : 'gi_state_route_failed',
+        cycle: 'C-—',
+        micro: null,
+        echo: { epicon: [] },
+        sentiment: null,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }
+}

--- a/app/api/journal/route.ts
+++ b/app/api/journal/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { GET as getJournal } from '@/app/api/chambers/journal/route';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  try {
+    const response = await getJournal(request);
+    const payload = (await response.json()) as Record<string, unknown>;
+    return NextResponse.json(
+      {
+        ...payload,
+        ok: payload.ok === false ? false : true,
+        degraded: payload.fallback === true,
+        error: null,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    const mode = request.nextUrl.searchParams.get('mode') ?? 'merged';
+    return NextResponse.json(
+      {
+        ok: false,
+        degraded: true,
+        fallback: true,
+        error: error instanceof Error ? error.message : 'journal_route_failed',
+        mode,
+        entries: [],
+        canonical_available: false,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }
+}

--- a/app/api/ledger/route.ts
+++ b/app/api/ledger/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { GET as getLedger } from '@/app/api/chambers/ledger/route';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const response = await getLedger();
+    const payload = (await response.json()) as Record<string, unknown>;
+    return NextResponse.json(
+      {
+        ...payload,
+        ok: payload.ok === false ? false : true,
+        degraded: payload.fallback === true,
+        error: null,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        degraded: true,
+        fallback: true,
+        error: error instanceof Error ? error.message : 'ledger_route_failed',
+        events: [],
+        candidates: { pending: 0, confirmed: 0, contested: 0 },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }
+}

--- a/app/api/signals/route.ts
+++ b/app/api/signals/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { GET as getSignals } from '@/app/api/chambers/signals/route';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const response = await getSignals();
+    const payload = (await response.json()) as Record<string, unknown>;
+    return NextResponse.json(
+      {
+        ...payload,
+        ok: payload.ok === false ? false : true,
+        degraded: payload.fallback === true,
+        error: null,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        degraded: true,
+        fallback: true,
+        error: error instanceof Error ? error.message : 'signals_route_failed',
+        families: [],
+        anomalies: [],
+        composite: null,
+        last_sweep: null,
+        raw: null,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- Prevent individual chamber API routes from hard 500s so the Terminal chambers can render degraded data instead of blank shells when downstream services fail.
- Reduce agent roster fragility by decoupling ACTIVE liveness from stale journal/canon availability so agents do not remain stuck in `BOOTING` due to ledger/substrate outages.

### Description
- Added compatibility endpoints that wrap chamber handlers with resilient `try/catch` logic and always return HTTP 200 with explicit `ok`, `degraded`, and `error` fields for `/api/gi-state`, `/api/signals`, `/api/ledger`, `/api/journal`, and `/api/agents` (new files: `app/api/gi-state/route.ts`, `app/api/signals/route.ts`, `app/api/ledger/route.ts`, `app/api/journal/route.ts`, `app/api/agents/route.ts`).
- Updated runtime agent liveness logic in `app/api/agents/status/route.ts` so `ACTIVE` is driven by runtime heartbeat/action proof first and stale journal/canon evidence now maps to `DEGRADED` instead of forcing `BOOTING`.
- Kept operator-visible failure truth by exposing `degraded: true` and `error` text while ensuring chambers receive a renderable payload.

### Testing
- Ran typecheck with `pnpm exec tsc --noEmit` and it passed.
- Built the project with `pnpm build` and the Next.js production build completed successfully.
- Ran `pnpm lint` which invoked Next.js interactive ESLint setup; lint is not configured for non-interactive execution so it could not complete (interactive prompt reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea497c8028832d9c36a83625f86580)