### PR TITLE
refactor(terminal): render chamber previews from snapshot before enrichment

### DIFF
--- a/app/terminal/GlobePageClient.tsx
+++ b/app/terminal/GlobePageClient.tsx
@@ -9,7 +9,7 @@ import type { MicroAgentSweepResult } from '@/lib/agents/micro';
 import type { EpiconItem } from '@/lib/terminal/types';
 
 export default function GlobePageClient() {
-  const { data, loading } = useGlobeChamber(true);
+  const { data, loading, preview, full, error } = useGlobeChamber(true);
 
   const micro = (data?.micro && typeof data.micro === 'object' ? data.micro : null) as MicroAgentSweepResult | null;
   const echo = (data?.echo && typeof data.echo === 'object' ? data.echo : {}) as { epicon?: EpiconItem[] };
@@ -38,15 +38,27 @@ export default function GlobePageClient() {
   if (loading && !data) return <ChamberSkeleton blocks={4} />;
 
   return (
-    <GlobeChamber
-      micro={micro}
-      echoEpicon={echoEpicon}
-      domains={[]}
-      cycleId={cycle}
-      clockLabel={`${new Date().toISOString().slice(11, 16)} UTC`}
-      giScore={Number(gi)}
-      miiScore={null}
-      globeDashboard={globeDashboard}
-    />
+    <div className="h-full">
+      {preview && !full ? (
+        <div className="mx-4 mt-3 rounded border border-cyan-800/40 bg-cyan-950/20 px-3 py-1 text-[10px] text-cyan-200">
+          Globe preview from snapshot · enriching in background
+        </div>
+      ) : null}
+      {error ? (
+        <div className="mx-4 mt-2 rounded border border-amber-800/40 bg-amber-950/20 px-3 py-1 text-[10px] text-amber-200">
+          Globe chamber degraded · showing preview state
+        </div>
+      ) : null}
+      <GlobeChamber
+        micro={micro}
+        echoEpicon={echoEpicon}
+        domains={[]}
+        cycleId={cycle}
+        clockLabel={`${new Date().toISOString().slice(11, 16)} UTC`}
+        giScore={Number(gi)}
+        miiScore={null}
+        globeDashboard={globeDashboard}
+      />
+    </div>
   );
 }

--- a/app/terminal/journal/JournalPageClient.tsx
+++ b/app/terminal/journal/JournalPageClient.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import JournalEntryCard from '@/components/terminal/journal/JournalEntryCard';
 import ChamberEmptyState from '@/components/terminal/ChamberEmptyState';
 import ChamberSkeleton from '@/components/terminal/ChamberSkeleton';
+import { useJournalChamber } from '@/hooks/useJournalChamber';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import type { JournalDisplayEntry, JournalDisplaySeverity, JournalDisplayStatus } from '@/lib/journal/types';
 
@@ -22,8 +23,6 @@ const AGENT_PILL_STYLE: Record<string, { border: string; activeBg: string; text:
   DAEDALUS: { border: 'border-amber-900/60', activeBg: 'bg-amber-950/40', text: 'text-amber-200' },
   ECHO: { border: 'border-slate-500/50', activeBg: 'bg-slate-600/20', text: 'text-slate-100' },
 };
-
-type JournalResponse = { count?: number; mode?: 'hot' | 'canon' | 'merged'; entries?: JournalDisplayEntry[] };
 
 type EpiconItem = {
   id: string;
@@ -128,6 +127,7 @@ export default function JournalPageClient() {
   const [cycleTab, setCycleTab] = useState<string>(() => currentCycleId());
   const [derivedMode, setDerivedMode] = useState(false);
   const [readMode, setReadMode] = useState<'hot' | 'canon' | 'merged'>('hot');
+  const journal = useJournalChamber(true, readMode, 100);
   const [missingRelatedId, setMissingRelatedId] = useState<string | null>(null);
   const anchorsRef = useRef<Map<string, HTMLElement>>(new Map());
 
@@ -151,13 +151,7 @@ export default function JournalPageClient() {
     let mounted = true;
     void (async () => {
       let journalEntries: JournalDisplayEntry[] = [];
-      try {
-        const res = await fetch(`/api/chambers/journal?limit=100&mode=${readMode}`, { cache: 'no-store' });
-        const data = (await res.json()) as JournalResponse;
-        journalEntries = data.entries ?? [];
-      } catch {
-        // network failure — fall through to epicon fallback
-      }
+      journalEntries = (journal.data?.entries ?? []) as JournalDisplayEntry[];
 
       if (!mounted) return;
 
@@ -189,7 +183,7 @@ export default function JournalPageClient() {
     return () => {
       mounted = false;
     };
-  }, [readMode]);
+  }, [journal.data]);
 
   const agentCounts = useMemo(() => {
     const m = new Map<string, number>();
@@ -252,6 +246,16 @@ export default function JournalPageClient() {
       {derivedMode ? (
         <div className="mb-3 rounded border border-amber-500/40 bg-amber-950/20 px-3 py-2 text-xs text-amber-100">
           Derived from EPICON feed · Native journals pending SUBSTRATE_GITHUB_TOKEN
+        </div>
+      ) : null}
+      {journal.preview && !journal.full ? (
+        <div className="mb-3 rounded border border-cyan-500/40 bg-cyan-950/20 px-3 py-2 text-xs text-cyan-100">
+          Preview from snapshot · chamber enrichment in progress
+        </div>
+      ) : null}
+      {journal.error ? (
+        <div className="mb-3 rounded border border-amber-500/40 bg-amber-950/20 px-3 py-2 text-xs text-amber-100">
+          Journal chamber degraded · showing snapshot/derived preview
         </div>
       ) : null}
 

--- a/app/terminal/ledger/LedgerPageClient.tsx
+++ b/app/terminal/ledger/LedgerPageClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import ChamberSkeleton from '@/components/terminal/ChamberSkeleton';
+import { useLedgerChamber } from '@/hooks/useLedgerChamber';
 import type { LedgerEntry } from '@/lib/terminal/types';
 
 type EchoFeedResponse = {
@@ -67,17 +68,10 @@ function sortRows(rows: LedgerEntry[], key: SortKey, dir: SortDir): LedgerEntry[
 }
 
 export default function LedgerPageClient() {
-  const [feed, setFeed] = useState<EchoFeedResponse | null>(null);
+  const { data, preview, full, error } = useLedgerChamber(true);
   const [sortKey, setSortKey] = useState<SortKey>('timestamp');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
-
-  useEffect(() => {
-    fetch('/api/chambers/ledger', { cache: 'no-store' })
-      .then((r) => r.json())
-      .then((json) => setFeed(json as EchoFeedResponse))
-      .catch(() => setFeed({ events: [] }));
-  }, []);
-
+  const feed = useMemo(() => (data ? ({ events: data.events, status: { cycleId: 'C-—' } } as EchoFeedResponse) : null), [data]);
   const rows = useMemo(() => feed?.events ?? [], [feed]);
   const sorted = useMemo(() => sortRows(rows, sortKey, sortDir), [rows, sortKey, sortDir]);
   const totalDelta = useMemo(() => rows.reduce((sum, row) => sum + (row.integrityDelta ?? 0), 0), [rows]);
@@ -101,6 +95,9 @@ export default function LedgerPageClient() {
         <span className="text-slate-400">
           {feed.status?.cycleId ?? 'C-—'} · {rows.length} ledger rows
         </span>
+        {preview && !full ? (
+          <span className="rounded border border-cyan-700/40 bg-cyan-950/20 px-2 py-1 text-[10px] text-cyan-200">preview</span>
+        ) : null}
         <div className="flex gap-1">
           {(['timestamp', 'agent', 'delta', 'status'] as SortKey[]).map((k) => (
             <button
@@ -114,6 +111,7 @@ export default function LedgerPageClient() {
           ))}
         </div>
       </div>
+      {error ? <div className="mb-2 rounded border border-amber-700/40 bg-amber-950/20 px-2 py-1 text-[11px] text-amber-200">Ledger chamber degraded · showing snapshot preview</div> : null}
       {rows.length === 0 ? (
         <div className="rounded border border-slate-800 bg-slate-900/60 p-4 text-slate-400">
           No ledger rows available yet.

--- a/app/terminal/signals/SignalsPageClient.tsx
+++ b/app/terminal/signals/SignalsPageClient.tsx
@@ -177,7 +177,7 @@ function PostureBadge({ posture, laneStale }: { posture: AgentPosture; laneStale
 }
 
 export default function SignalsPageClient() {
-  const { data, loading, error } = useSignalsChamber(true);
+  const { data, loading, error, preview, full } = useSignalsChamber(true);
 
   const payload = ((data?.raw && typeof data.raw === 'object') ? data.raw : {}) as MicroSweepPayload;
   const agents = useMemo(() => resolveAgents(payload), [payload]);
@@ -247,6 +247,11 @@ export default function SignalsPageClient() {
 
       {error ? (
         <div className="rounded border border-rose-900/50 bg-rose-950/20 px-3 py-2 text-[11px] text-rose-200">{error}</div>
+      ) : null}
+      {preview && !full ? (
+        <div className="rounded border border-cyan-900/50 bg-cyan-950/20 px-3 py-2 text-[11px] text-cyan-200">
+          Snapshot preview active · loading full chamber
+        </div>
       ) : null}
 
       {!signalsLeaf?.ok && signalsLeaf?.error ? (

--- a/hooks/useChamberHydration.ts
+++ b/hooks/useChamberHydration.ts
@@ -1,15 +1,24 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+
+type UseChamberHydrationOptions<T> = {
+  previewData?: T | null;
+  pollMs?: number;
+};
 
 type UseChamberHydrationResult<T> = {
+  preview: T | null;
+  full: T | null;
   data: T | null;
   loading: boolean;
   error: string | null;
+  degraded: boolean;
 };
 
-export function useChamberHydration<T>(url: string, enabled: boolean, pollMs = 30_000): UseChamberHydrationResult<T> {
-  const [data, setData] = useState<T | null>(null);
+export function useChamberHydration<T>(url: string, enabled: boolean, options: UseChamberHydrationOptions<T> = {}): UseChamberHydrationResult<T> {
+  const { previewData = null, pollMs = 30_000 } = options;
+  const [full, setFull] = useState<T | null>(null);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<string | null>(null);
 
@@ -28,7 +37,7 @@ export function useChamberHydration<T>(url: string, enabled: boolean, pollMs = 3
         const res = await fetch(url, { cache: 'no-store' });
         const json = (await res.json()) as T;
         if (!mounted) return;
-        setData(json);
+        setFull(json);
         setError(null);
       } catch (err) {
         if (!mounted) return;
@@ -47,5 +56,14 @@ export function useChamberHydration<T>(url: string, enabled: boolean, pollMs = 3
     };
   }, [enabled, url, pollMs]);
 
-  return { data, loading, error };
+  const data = useMemo(() => full ?? previewData ?? null, [full, previewData]);
+
+  return {
+    preview: previewData,
+    full,
+    data,
+    loading,
+    error,
+    degraded: Boolean(error),
+  };
 }

--- a/hooks/useGlobeChamber.ts
+++ b/hooks/useGlobeChamber.ts
@@ -1,6 +1,8 @@
 'use client';
 
+import { useMemo } from 'react';
 import { useChamberHydration } from '@/hooks/useChamberHydration';
+import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
 
 export type GlobeChamberPayload = {
   ok: boolean;
@@ -13,5 +15,16 @@ export type GlobeChamberPayload = {
 };
 
 export function useGlobeChamber(enabled: boolean) {
-  return useChamberHydration<GlobeChamberPayload>('/api/chambers/globe', enabled);
+  const { snapshot } = useTerminalSnapshot();
+  const preview = useMemo(() => ({
+    ok: true,
+    fallback: true,
+    cycle: snapshot?.cycle ?? 'C-—',
+    micro: snapshot?.signals?.data ?? null,
+    echo: snapshot?.echo?.data ?? null,
+    sentiment: snapshot?.sentiment?.data ?? null,
+    timestamp: snapshot?.timestamp ?? new Date().toISOString(),
+  } satisfies GlobeChamberPayload), [snapshot]);
+
+  return useChamberHydration<GlobeChamberPayload>('/api/chambers/globe', enabled, { previewData: preview });
 }

--- a/hooks/useJournalChamber.ts
+++ b/hooks/useJournalChamber.ts
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import { useChamberHydration } from '@/hooks/useChamberHydration';
+import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
 
 export type JournalChamberPayload = {
   ok: boolean;
@@ -13,6 +14,22 @@ export type JournalChamberPayload = {
 };
 
 export function useJournalChamber(enabled: boolean, mode: 'hot' | 'canon' | 'merged', limit = 100) {
+  const { snapshot } = useTerminalSnapshot();
   const url = useMemo(() => `/api/chambers/journal?mode=${mode}&limit=${limit}`, [mode, limit]);
-  return useChamberHydration<JournalChamberPayload>(url, enabled);
+  const preview = useMemo(() => {
+    const summary = snapshot?.journal_summary;
+    if (!summary || typeof summary !== 'object') return null;
+    const latest = (summary as { latest_agent_entries?: unknown[] }).latest_agent_entries;
+    if (!Array.isArray(latest)) return null;
+    return {
+      ok: true,
+      mode,
+      entries: latest,
+      canonical_available: false,
+      fallback: true,
+      timestamp: snapshot?.timestamp ?? new Date().toISOString(),
+    } satisfies JournalChamberPayload;
+  }, [mode, snapshot]);
+
+  return useChamberHydration<JournalChamberPayload>(url, enabled, { previewData: preview });
 }

--- a/hooks/useLaneDiagnosticsChamber.ts
+++ b/hooks/useLaneDiagnosticsChamber.ts
@@ -13,5 +13,5 @@ export type LaneDiagnosticsPayload = {
 };
 
 export function useLaneDiagnosticsChamber(enabled: boolean) {
-  return useChamberHydration<LaneDiagnosticsPayload>('/api/chambers/lane-diagnostics', enabled, 20_000);
+  return useChamberHydration<LaneDiagnosticsPayload>('/api/chambers/lane-diagnostics', enabled, { pollMs: 20_000 });
 }

--- a/hooks/useLedgerChamber.ts
+++ b/hooks/useLedgerChamber.ts
@@ -1,15 +1,46 @@
 'use client';
 
+import { useMemo } from 'react';
 import { useChamberHydration } from '@/hooks/useChamberHydration';
+import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
+import type { LedgerEntry } from '@/lib/terminal/types';
 
 export type LedgerChamberPayload = {
   ok: boolean;
-  events: unknown[];
+  events: LedgerEntry[];
   candidates: { pending: number; confirmed: number; contested: number };
   fallback: boolean;
   timestamp: string;
 };
 
 export function useLedgerChamber(enabled: boolean) {
-  return useChamberHydration<LedgerChamberPayload>('/api/chambers/ledger', enabled);
+  const { snapshot } = useTerminalSnapshot();
+  const preview = useMemo(() => {
+    const epicon = snapshot?.epicon?.data as { items?: Array<Record<string, unknown>> } | undefined;
+    const items = Array.isArray(epicon?.items) ? epicon.items : [];
+    const events: LedgerEntry[] = items.slice(0, 20).map((item, idx) => ({
+      id: typeof item.id === 'string' ? item.id : `snapshot-${idx}`,
+      cycleId: snapshot?.cycle ?? 'C-—',
+      type: 'epicon',
+      agentOrigin: typeof item.agentOrigin === 'string' ? item.agentOrigin : 'ECHO',
+      timestamp: typeof item.timestamp === 'string' ? item.timestamp : (snapshot?.timestamp ?? new Date().toISOString()),
+      title: typeof item.title === 'string' ? item.title : undefined,
+      summary: typeof item.summary === 'string' ? item.summary : 'Snapshot preview event',
+      integrityDelta: 0,
+      status: 'pending',
+      category: undefined,
+      confidenceTier: typeof item.confidenceTier === 'number' ? item.confidenceTier : undefined,
+      source: 'echo',
+    }));
+
+    return {
+      ok: true,
+      events,
+      candidates: { pending: events.length, confirmed: 0, contested: 0 },
+      fallback: true,
+      timestamp: snapshot?.timestamp ?? new Date().toISOString(),
+    } satisfies LedgerChamberPayload;
+  }, [snapshot]);
+
+  return useChamberHydration<LedgerChamberPayload>('/api/chambers/ledger', enabled, { previewData: preview });
 }

--- a/hooks/useSignalsChamber.ts
+++ b/hooks/useSignalsChamber.ts
@@ -1,6 +1,8 @@
 'use client';
 
+import { useMemo } from 'react';
 import { useChamberHydration } from '@/hooks/useChamberHydration';
+import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
 
 export type SignalsChamberPayload = {
   ok: boolean;
@@ -14,5 +16,22 @@ export type SignalsChamberPayload = {
 };
 
 export function useSignalsChamber(enabled: boolean) {
-  return useChamberHydration<SignalsChamberPayload>('/api/chambers/signals', enabled);
+  const { snapshot } = useTerminalSnapshot();
+  const preview = useMemo(() => {
+    const raw = snapshot?.signals?.data;
+    if (!raw || typeof raw !== 'object') return null;
+    const asPayload = raw as Partial<SignalsChamberPayload>;
+    return {
+      ok: true,
+      fallback: true,
+      families: Array.isArray(asPayload.families) ? asPayload.families : [],
+      anomalies: Array.isArray(asPayload.anomalies) ? asPayload.anomalies : [],
+      composite: typeof asPayload.composite === 'number' ? asPayload.composite : null,
+      last_sweep: typeof asPayload.timestamp === 'string' ? asPayload.timestamp : null,
+      raw,
+      timestamp: typeof asPayload.timestamp === 'string' ? asPayload.timestamp : (snapshot?.timestamp ?? new Date().toISOString()),
+    } satisfies SignalsChamberPayload;
+  }, [snapshot]);
+
+  return useChamberHydration<SignalsChamberPayload>('/api/chambers/signals', enabled, { previewData: preview });
 }

--- a/hooks/useTerminalSnapshot.ts
+++ b/hooks/useTerminalSnapshot.ts
@@ -30,6 +30,8 @@ export type TerminalSnapshot = {
   memory_mode?: MemoryModePayload;
   meta?: { total_ms?: number };
   lanes?: SnapshotLaneState[];
+  journal_summary?: { latest_agent_entries?: unknown[] };
+  agent_liveness?: unknown[];
   integrity?: SnapshotLeaf;
   signals?: SnapshotLeaf;
   kvHealth?: SnapshotLeaf;


### PR DESCRIPTION
### Motivation
- Fix C-290 symptom where `/api/terminal/snapshot` is healthy but chamber panels remain blank or lag because chamber hydration routes gate first paint. 
- Ensure operator truth (snapshot) is rendered immediately while chamber routes act as non-blocking enrichment, so the Terminal never shows blank chambers when backend truth exists.

### Description
- Implemented a snapshot-first chamber hydration contract by refactoring `useChamberHydration` to accept `previewData` and `pollMs` and to return `{ preview, full, data, loading, error, degraded }` so components can render preview immediately and replace with full data when available. 
- Wired snapshot-derived previews into chamber hooks (`useSignalsChamber`, `useJournalChamber`, `useLedgerChamber`, `useGlobeChamber`) that derive lightweight preview payloads from `useTerminalSnapshot`. 
- Updated chamber clients (Globe, Signals, Journal, Ledger) to show preview / enrichment in-progress banners and explicit degraded messaging instead of blank states. 
- Added minimal snapshot typing for `journal_summary` and `agent_liveness` and updated lane-diagnostics hook to use the new hydration options signature. 

### Testing
- Ran typecheck with `pnpm exec tsc --noEmit` and it passed. 
- Built the app with `pnpm build` and the production build completed successfully. 
- Ran `pnpm lint` but the repo is not ESLint-configured so the Next.js interactive setup prompt blocks non-interactive runs (lint reported as not configured).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea599bb808832d8a12cd5cdfc04bb6)