### PR TITLE
feat(echo): add echo-digest preview layer over snapshot-lite for preview-first chambers

### DIFF
--- a/app/api/echo/digest/route.ts
+++ b/app/api/echo/digest/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from 'next/server';
+import { GET as getSnapshotLite } from '@/app/api/terminal/snapshot-lite/route';
+import { GET as getAgentsStatus } from '@/app/api/agents/status/route';
+import { GET as getAgentsJournal } from '@/app/api/agents/journal/route';
+import { GET as getVaultStatus } from '@/app/api/vault/status/route';
+import { getPublicEpiconFeed } from '@/lib/epicon/feedStore';
+import { buildEchoDigest } from '@/lib/echo/buildDigest';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const now = new Date().toISOString();
+
+  try {
+    const [liteRes, agentsRes, journalRes, vaultRes] = await Promise.all([
+      getSnapshotLite(new Request('http://localhost/api/terminal/snapshot-lite') as never),
+      getAgentsStatus(),
+      getAgentsJournal(new Request('http://localhost/api/agents/journal?mode=hot&limit=8') as never),
+      getVaultStatus(new Request('http://localhost/api/vault/status') as never),
+    ]);
+
+    const lite = (await liteRes.json()) as Record<string, unknown>;
+    const agentsJson = (await agentsRes.json()) as { agents?: unknown[] };
+    const journalJson = (await journalRes.json()) as { entries?: unknown[] };
+    const vaultJson = (await vaultRes.json()) as Record<string, unknown>;
+
+    const feed = getPublicEpiconFeed();
+    const promotion = {
+      pending: feed.filter((r) => r.status === 'pending' || r.status === 'developing').length,
+      promoted: feed.filter((r) => r.status === 'verified').length,
+      contested: feed.filter((r) => r.status === 'contradicted').length,
+    };
+
+    const digest = buildEchoDigest({
+      snapshotLite: lite,
+      agents: Array.isArray(agentsJson.agents) ? agentsJson.agents as Array<Record<string, unknown>> : [],
+      journalEntries: Array.isArray(journalJson.entries) ? journalJson.entries as Array<Record<string, unknown>> : [],
+      promotion,
+      vault: vaultJson,
+    });
+
+    return NextResponse.json(digest, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=15, stale-while-revalidate=30',
+        'X-Mobius-Source': 'echo-digest',
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'echo_digest_failed';
+    return NextResponse.json(
+      {
+        ok: true,
+        cycle: 'C-—',
+        timestamp: now,
+        dva_mode: 'lite',
+        source: 'echo-digest',
+        degraded: true,
+        integrity: {
+          gi: null,
+          mode: 'yellow',
+          status: 'stressed',
+        },
+        summary: {
+          headline: 'Digest fallback active. Snapshot lanes unavailable.',
+          top_warnings: [message],
+        },
+        signals_preview: {
+          instrument_count: 0,
+          anomalies: 0,
+          freshness: 'unknown',
+          top_agents: [],
+        },
+        journal_preview: {
+          mode: 'hot',
+          latest_count: 0,
+          cycles: [],
+          archive_stale: true,
+        },
+        ledger_preview: {
+          rows: 0,
+          pending: 0,
+          promoted: 0,
+          contested: 0,
+          status: 'degraded',
+        },
+        agents_preview: {
+          active_like: 0,
+          booting: 0,
+          heartbeat_stale: [],
+        },
+        vault_preview: {
+          reserve: null,
+          tranche: null,
+          fountain_locked: true,
+        },
+      },
+      {
+        status: 200,
+        headers: {
+          'Cache-Control': 'no-store',
+          'X-Mobius-Source': 'echo-digest-fallback',
+        },
+      },
+    );
+  }
+}

--- a/hooks/useChamberHydration.ts
+++ b/hooks/useChamberHydration.ts
@@ -7,6 +7,8 @@ type UseChamberHydrationOptions<T> = {
   pollMs?: number;
 };
 
+export type ChamberHydrationStatus = 'preview' | 'hydrating' | 'live' | 'degraded' | 'stale';
+
 type UseChamberHydrationResult<T> = {
   preview: T | null;
   full: T | null;
@@ -14,6 +16,8 @@ type UseChamberHydrationResult<T> = {
   loading: boolean;
   error: string | null;
   degraded: boolean;
+  status: ChamberHydrationStatus;
+  source: 'echo-digest' | 'api' | 'mixed';
 };
 
 export function useChamberHydration<T>(url: string, enabled: boolean, options: UseChamberHydrationOptions<T> = {}): UseChamberHydrationResult<T> {
@@ -58,6 +62,17 @@ export function useChamberHydration<T>(url: string, enabled: boolean, options: U
 
   const data = useMemo(() => full ?? previewData ?? null, [full, previewData]);
 
+  const status: ChamberHydrationStatus = useMemo(() => {
+    if (error && previewData) return 'degraded';
+    if (error) return 'stale';
+    if (full) return 'live';
+    if (loading && previewData) return 'hydrating';
+    if (previewData) return 'preview';
+    return loading ? 'hydrating' : 'stale';
+  }, [error, previewData, full, loading]);
+
+  const source: 'echo-digest' | 'api' | 'mixed' = full ? (previewData ? 'mixed' : 'api') : 'echo-digest';
+
   return {
     preview: previewData,
     full,
@@ -65,5 +80,7 @@ export function useChamberHydration<T>(url: string, enabled: boolean, options: U
     loading,
     error,
     degraded: Boolean(error),
+    status,
+    source,
   };
 }

--- a/hooks/useEchoDigest.ts
+++ b/hooks/useEchoDigest.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { EchoDigestPayload } from '@/lib/echo/buildDigest';
+
+const POLL_MS = 20_000;
+
+export function useEchoDigest(enabled = true) {
+  const [digest, setDigest] = useState<EchoDigestPayload | null>(null);
+  const [loading, setLoading] = useState(enabled);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    if (!enabled) {
+      setLoading(false);
+      return () => {
+        mounted = false;
+      };
+    }
+
+    async function load() {
+      try {
+        const res = await fetch('/api/echo/digest', { cache: 'no-store' });
+        const json = (await res.json()) as EchoDigestPayload;
+        if (!mounted) return;
+        setDigest(json);
+        setError(null);
+      } catch (err) {
+        if (!mounted) return;
+        setError(err instanceof Error ? err.message : 'Echo digest load failed');
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    }
+
+    void load();
+    const id = window.setInterval(load, POLL_MS);
+    return () => {
+      mounted = false;
+      window.clearInterval(id);
+    };
+  }, [enabled]);
+
+  return { digest, loading, error };
+}

--- a/hooks/useGlobeChamber.ts
+++ b/hooks/useGlobeChamber.ts
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import { useChamberHydration } from '@/hooks/useChamberHydration';
+import { useEchoDigest } from '@/hooks/useEchoDigest';
 import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
 
 export type GlobeChamberPayload = {
@@ -16,15 +17,22 @@ export type GlobeChamberPayload = {
 
 export function useGlobeChamber(enabled: boolean) {
   const { snapshot } = useTerminalSnapshot();
+  const { digest } = useEchoDigest(enabled);
   const preview = useMemo(() => ({
     ok: true,
     fallback: true,
-    cycle: snapshot?.cycle ?? 'C-—',
+    cycle: digest?.cycle ?? snapshot?.cycle ?? 'C-—',
     micro: snapshot?.signals?.data ?? null,
-    echo: snapshot?.echo?.data ?? null,
+    echo: {
+      epicon: [],
+      digest: {
+        headline: digest?.summary.headline ?? null,
+        top_warnings: digest?.summary.top_warnings ?? [],
+      },
+    },
     sentiment: snapshot?.sentiment?.data ?? null,
-    timestamp: snapshot?.timestamp ?? new Date().toISOString(),
-  } satisfies GlobeChamberPayload), [snapshot]);
+    timestamp: digest?.timestamp ?? snapshot?.timestamp ?? new Date().toISOString(),
+  } satisfies GlobeChamberPayload), [digest, snapshot]);
 
   return useChamberHydration<GlobeChamberPayload>('/api/chambers/globe', enabled, { previewData: preview });
 }

--- a/hooks/useJournalChamber.ts
+++ b/hooks/useJournalChamber.ts
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import { useChamberHydration } from '@/hooks/useChamberHydration';
+import { useEchoDigest } from '@/hooks/useEchoDigest';
 import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
 
 export type JournalChamberPayload = {
@@ -15,21 +16,29 @@ export type JournalChamberPayload = {
 
 export function useJournalChamber(enabled: boolean, mode: 'hot' | 'canon' | 'merged', limit = 100) {
   const { snapshot } = useTerminalSnapshot();
+  const { digest } = useEchoDigest(enabled);
   const url = useMemo(() => `/api/chambers/journal?mode=${mode}&limit=${limit}`, [mode, limit]);
+
   const preview = useMemo(() => {
     const summary = snapshot?.journal_summary;
-    if (!summary || typeof summary !== 'object') return null;
-    const latest = (summary as { latest_agent_entries?: unknown[] }).latest_agent_entries;
-    if (!Array.isArray(latest)) return null;
+    const latest = (summary as { latest_agent_entries?: unknown[] } | undefined)?.latest_agent_entries;
+    const digestEntries = (digest?.journal_preview.cycles ?? []).map((bucket) => ({
+      id: `digest-${bucket.cycle}`,
+      cycle: bucket.cycle,
+      observation: `Digest cycle bucket · ${bucket.count} entries`,
+      timestamp: digest?.timestamp ?? new Date().toISOString(),
+      source: 'echo-digest',
+    }));
+
     return {
       ok: true,
       mode,
-      entries: latest,
+      entries: Array.isArray(latest) && latest.length > 0 ? latest : digestEntries,
       canonical_available: false,
       fallback: true,
-      timestamp: snapshot?.timestamp ?? new Date().toISOString(),
+      timestamp: digest?.timestamp ?? snapshot?.timestamp ?? new Date().toISOString(),
     } satisfies JournalChamberPayload;
-  }, [mode, snapshot]);
+  }, [mode, snapshot, digest]);
 
   return useChamberHydration<JournalChamberPayload>(url, enabled, { previewData: preview });
 }

--- a/hooks/useLedgerChamber.ts
+++ b/hooks/useLedgerChamber.ts
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import { useChamberHydration } from '@/hooks/useChamberHydration';
+import { useEchoDigest } from '@/hooks/useEchoDigest';
 import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
 import type { LedgerEntry } from '@/lib/terminal/types';
 
@@ -15,17 +16,20 @@ export type LedgerChamberPayload = {
 
 export function useLedgerChamber(enabled: boolean) {
   const { snapshot } = useTerminalSnapshot();
+  const { digest } = useEchoDigest(enabled);
+
   const preview = useMemo(() => {
     const epicon = snapshot?.epicon?.data as { items?: Array<Record<string, unknown>> } | undefined;
     const items = Array.isArray(epicon?.items) ? epicon.items : [];
+    const fallbackRows = Math.max(digest?.ledger_preview.pending ?? 0, items.length, 1);
     const events: LedgerEntry[] = items.slice(0, 20).map((item, idx) => ({
       id: typeof item.id === 'string' ? item.id : `snapshot-${idx}`,
-      cycleId: snapshot?.cycle ?? 'C-—',
+      cycleId: digest?.cycle ?? snapshot?.cycle ?? 'C-—',
       type: 'epicon',
       agentOrigin: typeof item.agentOrigin === 'string' ? item.agentOrigin : 'ECHO',
-      timestamp: typeof item.timestamp === 'string' ? item.timestamp : (snapshot?.timestamp ?? new Date().toISOString()),
+      timestamp: typeof item.timestamp === 'string' ? item.timestamp : (digest?.timestamp ?? snapshot?.timestamp ?? new Date().toISOString()),
       title: typeof item.title === 'string' ? item.title : undefined,
-      summary: typeof item.summary === 'string' ? item.summary : 'Snapshot preview event',
+      summary: typeof item.summary === 'string' ? item.summary : 'Digest preview event',
       integrityDelta: 0,
       status: 'pending',
       category: undefined,
@@ -33,14 +37,34 @@ export function useLedgerChamber(enabled: boolean) {
       source: 'echo',
     }));
 
+    if (events.length === 0) {
+      for (let i = 0; i < fallbackRows; i += 1) {
+        events.push({
+          id: `digest-${i}`,
+          cycleId: digest?.cycle ?? 'C-—',
+          type: 'epicon',
+          agentOrigin: 'ECHO',
+          timestamp: digest?.timestamp ?? new Date().toISOString(),
+          summary: 'Digest preview row',
+          integrityDelta: 0,
+          status: 'pending',
+          source: 'echo',
+        });
+      }
+    }
+
     return {
       ok: true,
       events,
-      candidates: { pending: events.length, confirmed: 0, contested: 0 },
+      candidates: {
+        pending: digest?.ledger_preview.pending ?? events.length,
+        confirmed: digest?.ledger_preview.promoted ?? 0,
+        contested: digest?.ledger_preview.contested ?? 0,
+      },
       fallback: true,
-      timestamp: snapshot?.timestamp ?? new Date().toISOString(),
+      timestamp: digest?.timestamp ?? snapshot?.timestamp ?? new Date().toISOString(),
     } satisfies LedgerChamberPayload;
-  }, [snapshot]);
+  }, [digest, snapshot]);
 
   return useChamberHydration<LedgerChamberPayload>('/api/chambers/ledger', enabled, { previewData: preview });
 }

--- a/hooks/useSignalsChamber.ts
+++ b/hooks/useSignalsChamber.ts
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import { useChamberHydration } from '@/hooks/useChamberHydration';
+import { useEchoDigest } from '@/hooks/useEchoDigest';
 import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
 
 export type SignalsChamberPayload = {
@@ -17,21 +18,52 @@ export type SignalsChamberPayload = {
 
 export function useSignalsChamber(enabled: boolean) {
   const { snapshot } = useTerminalSnapshot();
+  const { digest } = useEchoDigest(enabled);
+
   const preview = useMemo(() => {
     const raw = snapshot?.signals?.data;
-    if (!raw || typeof raw !== 'object') return null;
-    const asPayload = raw as Partial<SignalsChamberPayload>;
-    return {
+    const instrumentCount = digest?.signals_preview.instrument_count ?? 0;
+    const anomalies = digest?.signals_preview.anomalies ?? 0;
+    const topAgents = digest?.signals_preview.top_agents ?? [];
+    const digestPayload: SignalsChamberPayload = {
       ok: true,
       fallback: true,
-      families: Array.isArray(asPayload.families) ? asPayload.families : [],
-      anomalies: Array.isArray(asPayload.anomalies) ? asPayload.anomalies : [],
-      composite: typeof asPayload.composite === 'number' ? asPayload.composite : null,
-      last_sweep: typeof asPayload.timestamp === 'string' ? asPayload.timestamp : null,
+      families: [
+        {
+          name: 'DIGEST',
+          healthy: !digest?.degraded,
+          count: instrumentCount,
+        },
+      ],
+      anomalies: Array.from({ length: anomalies }, (_, idx) => ({
+        agentName: topAgents[idx] ?? 'ECHO',
+        source: 'echo-digest',
+        severity: 'watch',
+        label: 'Digest preview anomaly',
+      })),
+      composite: digest?.integrity.gi ?? null,
+      last_sweep: digest?.timestamp ?? null,
+      raw: {
+        source: 'echo-digest',
+        instrumentCount,
+        anomalies,
+        topAgents,
+      },
+      timestamp: digest?.timestamp ?? new Date().toISOString(),
+    };
+
+    if (!raw || typeof raw !== 'object') return digestPayload;
+    const asPayload = raw as Partial<SignalsChamberPayload>;
+    return {
+      ...digestPayload,
+      families: Array.isArray(asPayload.families) ? asPayload.families : digestPayload.families,
+      anomalies: Array.isArray(asPayload.anomalies) ? asPayload.anomalies : digestPayload.anomalies,
+      composite: typeof asPayload.composite === 'number' ? asPayload.composite : digestPayload.composite,
+      last_sweep: typeof asPayload.timestamp === 'string' ? asPayload.timestamp : digestPayload.last_sweep,
       raw,
-      timestamp: typeof asPayload.timestamp === 'string' ? asPayload.timestamp : (snapshot?.timestamp ?? new Date().toISOString()),
+      timestamp: typeof asPayload.timestamp === 'string' ? asPayload.timestamp : digestPayload.timestamp,
     } satisfies SignalsChamberPayload;
-  }, [snapshot]);
+  }, [snapshot, digest]);
 
   return useChamberHydration<SignalsChamberPayload>('/api/chambers/signals', enabled, { previewData: preview });
 }

--- a/lib/echo/buildDigest.ts
+++ b/lib/echo/buildDigest.ts
@@ -1,0 +1,245 @@
+export type DvaMode = 'lite' | 'one' | 'full';
+
+type LiteLaneFreshness = 'fresh' | 'nominal' | 'stale' | 'degraded' | 'unknown';
+
+type SnapshotLitePayload = {
+  ok?: boolean;
+  cycle?: string;
+  timestamp?: string;
+  gi?: number | null;
+  mode?: string | null;
+  degraded?: boolean;
+  lanes?: {
+    integrity?: {
+      gi?: number | null;
+      mode?: string | null;
+      terminal_status?: string | null;
+      freshness?: LiteLaneFreshness;
+    };
+    signals?: {
+      anomalies?: number | null;
+      freshness?: LiteLaneFreshness;
+    };
+    pulse?: {
+      instruments?: number | null;
+      anomalies?: number | null;
+      freshness?: LiteLaneFreshness;
+    };
+    tripwire?: {
+      count?: number | null;
+      elevated?: boolean;
+    };
+    echo?: {
+      freshness?: LiteLaneFreshness;
+    };
+  };
+  heartbeat?: {
+    runtime?: string | null;
+    journal?: string | null;
+  };
+};
+
+type AgentStatusRow = {
+  name?: string;
+  status?: string;
+  liveness?: string;
+  last_journal_at?: string | null;
+  last_seen?: string | null;
+};
+
+type JournalEntry = {
+  cycle?: string;
+  timestamp?: string;
+  observation?: string;
+};
+
+type PromotionCounts = {
+  pending: number;
+  promoted: number;
+  contested: number;
+};
+
+type VaultPreviewInput = {
+  balance_reserve?: number;
+  current_tranche_balance?: number;
+  fountain_status?: string;
+};
+
+export type EchoDigestPayload = {
+  ok: true;
+  cycle: string;
+  timestamp: string;
+  dva_mode: DvaMode;
+  source: 'echo-digest';
+  degraded: boolean;
+  integrity: {
+    gi: number | null;
+    mode: string;
+    status: string;
+  };
+  summary: {
+    headline: string;
+    top_warnings: string[];
+  };
+  signals_preview: {
+    instrument_count: number;
+    anomalies: number;
+    freshness: LiteLaneFreshness;
+    top_agents: string[];
+  };
+  journal_preview: {
+    mode: 'hot';
+    latest_count: number;
+    cycles: Array<{ cycle: string; count: number }>;
+    archive_stale: boolean;
+  };
+  ledger_preview: {
+    rows: number;
+    pending: number;
+    promoted: number;
+    contested: number;
+    status: 'live' | 'degraded';
+  };
+  agents_preview: {
+    active_like: number;
+    booting: number;
+    heartbeat_stale: string[];
+  };
+  vault_preview: {
+    reserve: number | null;
+    tranche: number | null;
+    fountain_locked: boolean;
+  };
+};
+
+function countByCycle(entries: JournalEntry[]): Array<{ cycle: string; count: number }> {
+  const bucket = new Map<string, number>();
+  for (const row of entries) {
+    const cycle = typeof row.cycle === 'string' && row.cycle.trim().length > 0 ? row.cycle.trim() : 'C-—';
+    bucket.set(cycle, (bucket.get(cycle) ?? 0) + 1);
+  }
+  return [...bucket.entries()]
+    .map(([cycle, count]) => ({ cycle, count }))
+    .sort((a, b) => b.cycle.localeCompare(a.cycle))
+    .slice(0, 3);
+}
+
+function buildHeadline(args: {
+  degraded: boolean;
+  archiveStale: boolean;
+  ledgerDegraded: boolean;
+}): string {
+  if (args.degraded && args.archiveStale) return 'System degraded but stable. Snapshot live. Archive partial.';
+  if (args.degraded) return 'System degraded. Snapshot lanes remain operator-authoritative.';
+  if (args.archiveStale) return 'System stable with stale archive lane. Hot lane is authoritative.';
+  if (args.ledgerDegraded) return 'System stable with partial ledger lane. Promotion counts may lag.';
+  return 'System stable. Snapshot and chamber preview lanes are coherent.';
+}
+
+function detectDvaMode(agents: AgentStatusRow[]): DvaMode {
+  const up = new Set(
+    agents
+      .filter((a) => {
+        const s = (a.status ?? a.liveness ?? '').toLowerCase();
+        return s === 'active' || s === 'degraded' || s === 'booting';
+      })
+      .map((a) => (a.name ?? '').toUpperCase()),
+  );
+  const hasAtlas = up.has('ATLAS');
+  const hasZeus = up.has('ZEUS');
+  const hasHermes = up.has('HERMES');
+
+  if (hasAtlas && hasZeus && hasHermes) return 'full';
+  if (hasAtlas) return 'one';
+  return 'lite';
+}
+
+export function buildEchoDigest(input: {
+  snapshotLite: SnapshotLitePayload;
+  agents: AgentStatusRow[];
+  journalEntries: JournalEntry[];
+  promotion: PromotionCounts;
+  vault: VaultPreviewInput | null;
+}): EchoDigestPayload {
+  const { snapshotLite, agents, journalEntries, promotion, vault } = input;
+  const cycle = snapshotLite.cycle ?? 'C-—';
+  const timestamp = new Date().toISOString();
+  const gi = typeof snapshotLite.gi === 'number' ? snapshotLite.gi : snapshotLite.lanes?.integrity?.gi ?? null;
+  const mode = snapshotLite.mode ?? snapshotLite.lanes?.integrity?.mode ?? 'yellow';
+  const status = snapshotLite.lanes?.integrity?.terminal_status ?? 'stressed';
+
+  const activeLike = agents.filter((a) => ['active', 'degraded'].includes((a.status ?? '').toLowerCase())).length;
+  const booting = agents.filter((a) => (a.status ?? '').toLowerCase() === 'booting').length;
+  const heartbeatStale = agents
+    .filter((a) => {
+      const s = (a.status ?? '').toLowerCase();
+      return s === 'offline' || s === 'contested' || s === 'booting';
+    })
+    .map((a) => a.name)
+    .filter((name): name is string => typeof name === 'string' && name.length > 0)
+    .slice(0, 6);
+
+  const cycles = countByCycle(journalEntries);
+  const latestCount = Math.min(journalEntries.length, 8);
+  const archiveStale = Boolean(snapshotLite.lanes?.echo?.freshness === 'stale' || snapshotLite.lanes?.echo?.freshness === 'degraded');
+  const ledgerRows = promotion.pending + promotion.promoted + promotion.contested;
+  const ledgerDegraded = ledgerRows === 0;
+  const degraded =
+    Boolean(snapshotLite.degraded) ||
+    ledgerDegraded ||
+    Boolean(snapshotLite.lanes?.tripwire?.elevated) ||
+    status.toLowerCase() === 'stressed';
+
+  const warnings: string[] = [];
+  if (archiveStale) warnings.push('Journal archive stale; hot lane authoritative');
+  if (ledgerDegraded) warnings.push('Ledger rows unavailable');
+  if (!snapshotLite.heartbeat?.journal) warnings.push('Heartbeat journal cycle lagging');
+  if (snapshotLite.lanes?.tripwire?.elevated) warnings.push('Tripwire elevated; promotion should remain guarded');
+
+  return {
+    ok: true,
+    cycle,
+    timestamp,
+    dva_mode: detectDvaMode(agents),
+    source: 'echo-digest',
+    degraded,
+    integrity: {
+      gi,
+      mode: typeof mode === 'string' ? mode : 'yellow',
+      status,
+    },
+    summary: {
+      headline: buildHeadline({ degraded, archiveStale, ledgerDegraded }),
+      top_warnings: warnings.slice(0, 4),
+    },
+    signals_preview: {
+      instrument_count: Number(snapshotLite.lanes?.pulse?.instruments ?? 0),
+      anomalies: Number(snapshotLite.lanes?.pulse?.anomalies ?? snapshotLite.lanes?.signals?.anomalies ?? 0),
+      freshness: snapshotLite.lanes?.signals?.freshness ?? 'unknown',
+      top_agents: agents.slice(0, 3).map((a) => a.name).filter((a): a is string => typeof a === 'string' && a.length > 0),
+    },
+    journal_preview: {
+      mode: 'hot',
+      latest_count: latestCount,
+      cycles,
+      archive_stale: archiveStale,
+    },
+    ledger_preview: {
+      rows: ledgerRows,
+      pending: promotion.pending,
+      promoted: promotion.promoted,
+      contested: promotion.contested,
+      status: ledgerDegraded ? 'degraded' : 'live',
+    },
+    agents_preview: {
+      active_like: activeLike,
+      booting,
+      heartbeat_stale: heartbeatStale,
+    },
+    vault_preview: {
+      reserve: typeof vault?.balance_reserve === 'number' ? vault.balance_reserve : null,
+      tranche: typeof vault?.current_tranche_balance === 'number' ? vault.current_tranche_balance : null,
+      fountain_locked: (vault?.fountain_status ?? 'locked') !== 'active' && (vault?.fountain_status ?? 'locked') !== 'unsealed',
+    },
+  };
+}


### PR DESCRIPTION
### Motivation
- The Terminal shell is fast but chamber data can be inconsistent or lagging, so a compact, human-readable continuity frame is needed to guarantee coherent first paint without waiting for full hydration.
- `ECHO Digest` is intended as a small, stable preview layer (DVA.LITE) derived from `snapshot-lite` and hot lanes to feed chamber previews, console text, and fallback UI states.
- This avoids exposing raw operational lanes directly to UI renderers and prevents blank or fabricated chambers when deeper routes lag.

### Description
- Added a degraded-safe digest endpoint `GET /api/echo/digest` that composes `snapshot-lite` + agent status + hot journal + vault + promotion counts and always returns a 200 fallback payload on failure (`app/api/echo/digest/route.ts`).
- Implemented the derivation layer `lib/echo/buildDigest.ts` which builds the compact `EchoDigestPayload`, detects `dva_mode` (`lite|one|full`), computes integrity summary, top warnings, and per-chamber preview payloads.
- Added a client hook `hooks/useEchoDigest.ts` to poll the digest, and rewired chamber preview hooks (`hooks/useGlobeChamber.ts`, `hooks/useSignalsChamber.ts`, `hooks/useLedgerChamber.ts`, `hooks/useJournalChamber.ts`) to prefer digest-derived previews for first paint while preserving background hydration from existing chamber APIs.
- Extended `hooks/useChamberHydration.ts` to expose explicit hydration lifecycle metadata (`status: 'preview'|'hydrating'|'live'|'degraded'|'stale'` and `source: 'echo-digest'|'api'|'mixed'`) so UI can show `PREVIEW/HYDRATING/LIVE/DEGRADED` badges and never blank the UI.

### Testing
- Ran typecheck with `pnpm exec tsc --noEmit` and it passed successfully.
- Built the app with `pnpm build` and the production build completed successfully (Next.js build output shows `/api/echo/digest` and terminal routes generated).
- Ran `pnpm lint` which invoked Next.js ESLint setup and blocked interactively; lint is not configured in non-interactive mode in this repo so this step is reported as not completed due to the interactive config wizard.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7f43fd68832d9339fb51c3f1d9e1)