### PR TITLE
fix(epicon): add missing Candidate.source typing to unblock build

### DIFF
--- a/components/epicon/CandidateFeed.tsx
+++ b/components/epicon/CandidateFeed.tsx
@@ -12,6 +12,7 @@ type Candidate = {
   category: string;
   status: 'pending' | 'verified' | 'contradicted' | 'pending-verification' | 'contested';
   confidence_tier: number;
+  source?: string;
   external_source_system?: string;
   external_source_actor?: string;
   zeus_note?: string;


### PR DESCRIPTION
### Motivation
- Build on Vercel was failing with a TypeScript error because `CandidateFeed.tsx` references `item.source` but the local `Candidate` type did not declare `source`, causing the typecheck to fail.

### Description
- Add `source?: string` to the `Candidate` type in `components/epicon/CandidateFeed.tsx` to align the type with the API payload and the call to `isEveSynthesisFeedSource(item.source)`.

### Testing
- Ran `pnpm exec tsc --noEmit` and typecheck passed.
- Ran `pnpm build` and the build completed successfully.
- Ran `pnpm lint` which triggered an interactive ESLint setup prompt and exited non-zero in the non-interactive environment (lint did not complete cleanly).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaaf573fdc832d9ce043dd827c1d49)