### PR TITLE
C-290: Terminal hydration hardening and digest fallback normalization

### DIFF
--- a/app/api/echo/digest/route.ts
+++ b/app/api/echo/digest/route.ts
@@ -93,6 +93,12 @@ export async function GET() {
           tranche: null,
           fountain_locked: true,
         },
+
+        predictive: {
+          risk_level: 'critical',
+          signals: ['digest_unavailable'],
+          recommendation: 'maintain snapshot preview mode until digest recovers',
+        },
       },
       {
         status: 200,

--- a/app/terminal/GlobePageClient.tsx
+++ b/app/terminal/GlobePageClient.tsx
@@ -40,7 +40,7 @@ export default function GlobePageClient() {
   const micro = (data?.micro && typeof data.micro === 'object' ? data.micro : null) as MicroAgentSweepResult | null;
   const echo = (data?.echo && typeof data.echo === 'object' ? data.echo : {}) as { epicon?: EpiconItem[] };
   const echoEpicon = echo.epicon ?? [];
-  const cycle = data?.cycle ?? 'C-271';
+  const cycle = data?.cycle ?? preview?.cycle ?? 'C-—';
 
   // Prefer live sentiment from the chamber response, fall back to snapshot
   const chamberSentiment = (data?.sentiment && typeof data.sentiment === 'object')
@@ -62,11 +62,13 @@ export default function GlobePageClient() {
   }));
 
   // GI: prefer chamber data, then snapshot
-  const gi = typeof data?.gi === 'number'
+  const gi = typeof data?.gi === 'number' && data.gi > 0
     ? data.gi
-    : typeof snapshot?.gi === 'number'
-      ? snapshot.gi
-      : 0;
+    : typeof preview?.gi === 'number'
+      ? preview.gi
+      : typeof snapshot?.gi === 'number'
+        ? snapshot.gi
+        : 0;
 
   const miiScore = snapshotSentiment?.overall_sentiment ?? null;
 

--- a/app/terminal/layout.tsx
+++ b/app/terminal/layout.tsx
@@ -3,6 +3,7 @@ import { WalletProvider } from '@/contexts/WalletContext';
 import CommandSurface from '@/components/terminal/CommandSurface';
 import FooterStatusBar from '@/components/terminal/FooterStatusBar';
 import TerminalShell from '@/components/terminal/TerminalShell';
+import { EchoDigestProvider } from '@/components/terminal/EchoDigestProvider';
 
 type ShellSeed = {
   gi?: number | null;
@@ -50,7 +51,9 @@ export default async function TerminalLayout({ children }: { children: ReactNode
           }}
         />
       ) : null}
-      <TerminalShell>{children}</TerminalShell>
+      <EchoDigestProvider>
+        <TerminalShell>{children}</TerminalShell>
+      </EchoDigestProvider>
       <CommandSurface />
       <FooterStatusBar />
     </WalletProvider>

--- a/components/terminal/EchoDigestProvider.tsx
+++ b/components/terminal/EchoDigestProvider.tsx
@@ -1,19 +1,23 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import type { EchoDigestPayload } from '@/lib/echo/buildDigest';
-import { useEchoDigestContext } from '@/components/terminal/EchoDigestProvider';
+
+type EchoDigestContextValue = {
+  digest: EchoDigestPayload | null;
+  loading: boolean;
+  error: string | null;
+};
 
 const POLL_MS = 20_000;
+const EchoDigestContext = createContext<EchoDigestContextValue | null>(null);
 
-export function useEchoDigest(enabled = true) {
-  const context = useEchoDigestContext();
+export function EchoDigestProvider({ children }: { children: ReactNode }) {
   const [digest, setDigest] = useState<EchoDigestPayload | null>(null);
-  const [loading, setLoading] = useState(enabled);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (context || !enabled) return;
     let mounted = true;
 
     async function load() {
@@ -37,15 +41,13 @@ export function useEchoDigest(enabled = true) {
       mounted = false;
       window.clearInterval(id);
     };
-  }, [enabled, context]);
+  }, []);
 
-  if (!enabled) {
-    return { digest: null, loading: false, error: null };
-  }
+  const value = useMemo(() => ({ digest, loading, error }), [digest, loading, error]);
 
-  if (context) {
-    return context;
-  }
+  return <EchoDigestContext.Provider value={value}>{children}</EchoDigestContext.Provider>;
+}
 
-  return { digest, loading, error };
+export function useEchoDigestContext() {
+  return useContext(EchoDigestContext);
 }

--- a/hooks/useChamberHydration.ts
+++ b/hooks/useChamberHydration.ts
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from 'react';
 type UseChamberHydrationOptions<T> = {
   previewData?: T | null;
   pollMs?: number;
+  requestTimeoutMs?: number;
 };
 
 export type ChamberHydrationStatus = 'preview' | 'hydrating' | 'live' | 'degraded' | 'stale';
@@ -20,15 +21,37 @@ type UseChamberHydrationResult<T> = {
   source: 'echo-digest' | 'api' | 'mixed';
 };
 
+type ChamberEnvelope<T> = {
+  ok?: boolean;
+  degraded?: boolean;
+  fallback?: boolean;
+  data?: T;
+};
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object') return null;
+  return value as Record<string, unknown>;
+}
+
+function normalizeHydrationPayload<T>(json: unknown): { payload: T | null; envelopeDegraded: boolean } {
+  const record = asRecord(json);
+  if (!record) return { payload: null, envelopeDegraded: true };
+
+  const envelope = record as ChamberEnvelope<T>;
+  const payload = (envelope.data ?? json) as T;
+  const envelopeDegraded = envelope.ok === false || envelope.degraded === true;
+  return { payload, envelopeDegraded };
+}
+
 export function useChamberHydration<T>(url: string, enabled: boolean, options: UseChamberHydrationOptions<T> = {}): UseChamberHydrationResult<T> {
-  const { previewData = null, pollMs = 30_000 } = options;
+  const { previewData = null, pollMs = 30_000, requestTimeoutMs = DEFAULT_TIMEOUT_MS } = options;
   const [full, setFull] = useState<T | null>(null);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<string | null>(null);
-  // C-290 v2: track fetch completion separately from loading.
-  // !loading alone is unreliable — React 18 can render loading=false before
-  // setFull flushes, causing previewData to be promoted live prematurely.
   const [fetchedOnce, setFetchedOnce] = useState(false);
+  const [envelopeDegraded, setEnvelopeDegraded] = useState(false);
 
   useEffect(() => {
     let mounted = true;
@@ -41,11 +64,15 @@ export function useChamberHydration<T>(url: string, enabled: boolean, options: U
     }
 
     async function load() {
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(() => controller.abort(), requestTimeoutMs);
       try {
-        const res = await fetch(url, { cache: 'no-store' });
-        const json = (await res.json()) as T;
+        const res = await fetch(url, { cache: 'no-store', signal: controller.signal });
+        const json = (await res.json()) as unknown;
+        const normalized = normalizeHydrationPayload<T>(json);
         if (!mounted) return;
-        setFull(json);
+        setFull(normalized.payload);
+        setEnvelopeDegraded(normalized.envelopeDegraded || !res.ok);
         setFetchedOnce(true);
         setError(null);
       } catch (err) {
@@ -53,6 +80,7 @@ export function useChamberHydration<T>(url: string, enabled: boolean, options: U
         setError(err instanceof Error ? err.message : 'Chamber fetch failed');
         setFetchedOnce(true);
       } finally {
+        window.clearTimeout(timeoutId);
         if (mounted) setLoading(false);
       }
     }
@@ -64,22 +92,19 @@ export function useChamberHydration<T>(url: string, enabled: boolean, options: U
       mounted = false;
       window.clearInterval(id);
     };
-  }, [enabled, url, pollMs]);
+  }, [enabled, url, pollMs, requestTimeoutMs]);
 
   const data = useMemo(() => full ?? previewData ?? null, [full, previewData]);
 
   const status: ChamberHydrationStatus = useMemo(() => {
-    if (error && previewData) return 'degraded';
-    if (error) return 'stale';
+    if ((error || envelopeDegraded) && previewData) return 'degraded';
+    if (error || envelopeDegraded) return 'stale';
     if (full) return 'live';
-    // C-290 v2: promote previewData to 'live' only after fetchedOnce=true,
-    // not on !loading — setFull and setLoading are separate setState calls
-    // and !loading can be true one render before full populates.
     if (fetchedOnce && previewData) return 'live';
     if (loading && previewData) return 'hydrating';
     if (previewData) return 'preview';
     return loading ? 'hydrating' : 'stale';
-  }, [error, previewData, full, loading, fetchedOnce]);
+  }, [error, envelopeDegraded, previewData, full, loading, fetchedOnce]);
 
   const source: 'echo-digest' | 'api' | 'mixed' = full ? (previewData ? 'mixed' : 'api') : 'echo-digest';
 
@@ -89,7 +114,7 @@ export function useChamberHydration<T>(url: string, enabled: boolean, options: U
     data,
     loading,
     error,
-    degraded: Boolean(error),
+    degraded: Boolean(error || envelopeDegraded),
     status,
     source,
   };

--- a/hooks/useLaneDiagnosticsChamber.ts
+++ b/hooks/useLaneDiagnosticsChamber.ts
@@ -1,6 +1,9 @@
 'use client';
 
+import { useMemo } from 'react';
 import { useChamberHydration } from '@/hooks/useChamberHydration';
+import { useEchoDigest } from '@/hooks/useEchoDigest';
+import { useTerminalSnapshot } from '@/hooks/useTerminalSnapshot';
 
 export type LaneDiagnosticsPayload = {
   ok: boolean;
@@ -10,8 +13,53 @@ export type LaneDiagnosticsPayload = {
   heartbeat: { runtime: string | null; journal: string | null };
   reason: string | null;
   timestamp: string;
+  fallback?: boolean;
 };
 
+function laneFromDigest(digest: ReturnType<typeof useEchoDigest>['digest']) {
+  return {
+    kv: { freshness: 'unknown', state: 'unknown', message: 'KV lane status pending hydration' },
+    backup_redis: { freshness: 'unknown', state: 'unknown', message: 'BACKUP_REDIS lane status pending hydration' },
+    tripwire: {
+      freshness: digest?.degraded ? 'degraded' : 'nominal',
+      state: digest?.degraded ? 'degraded' : 'nominal',
+      message: digest?.signals_preview.anomalies ? 'Tripwire watch signals present' : 'Tripwire nominal',
+      count: digest?.signals_preview.anomalies ?? 0,
+      elevated: digest?.degraded ?? false,
+    },
+    integrity: {
+      freshness: digest?.degraded ? 'degraded' : 'fresh',
+      state: digest?.degraded ? 'degraded' : 'healthy',
+      message: `GI ${typeof digest?.integrity.gi === 'number' ? digest.integrity.gi.toFixed(2) : '—'} from digest`,
+    },
+    signals: {
+      freshness: digest?.signals_preview.freshness ?? 'unknown',
+      state: digest?.signals_preview.freshness ?? 'unknown',
+      message: `Signals preview instruments ${digest?.signals_preview.instrument_count ?? 0}`,
+    },
+  } as Record<string, unknown>;
+}
+
 export function useLaneDiagnosticsChamber(enabled: boolean) {
-  return useChamberHydration<LaneDiagnosticsPayload>('/api/chambers/lane-diagnostics', enabled, { pollMs: 20_000 });
+  const { snapshot } = useTerminalSnapshot();
+  const { digest } = useEchoDigest(enabled);
+
+  const preview = useMemo(() => ({
+    ok: true,
+    degraded: Boolean(digest?.degraded),
+    lanes: laneFromDigest(digest),
+    tripwire: {
+      count: digest?.signals_preview.anomalies ?? 0,
+      elevated: Boolean(digest?.degraded),
+    },
+    heartbeat: {
+      runtime: null,
+      journal: null,
+    },
+    reason: digest?.degraded ? 'digest indicates degraded state' : null,
+    timestamp: digest?.timestamp ?? snapshot?.timestamp ?? new Date().toISOString(),
+    fallback: true,
+  } satisfies LaneDiagnosticsPayload), [digest, snapshot]);
+
+  return useChamberHydration<LaneDiagnosticsPayload>('/api/chambers/lane-diagnostics', enabled, { pollMs: 20_000, previewData: preview });
 }

--- a/lib/echo/buildDigest.ts
+++ b/lib/echo/buildDigest.ts
@@ -110,6 +110,11 @@ export type EchoDigestPayload = {
     tranche: number | null;
     fountain_locked: boolean;
   };
+  predictive: {
+    risk_level: 'nominal' | 'watch' | 'elevated' | 'critical';
+    signals: string[];
+    recommendation: string;
+  };
 };
 
 function countByCycle(entries: JournalEntry[]): Array<{ cycle: string; count: number }> {
@@ -136,21 +141,22 @@ function buildHeadline(args: {
   return 'System stable. Snapshot and chamber preview lanes are coherent.';
 }
 
-function detectDvaMode(agents: AgentStatusRow[]): DvaMode {
-  const up = new Set(
-    agents
-      .filter((a) => {
-        const s = (a.status ?? a.liveness ?? '').toLowerCase();
-        return s === 'active' || s === 'degraded' || s === 'booting';
-      })
-      .map((a) => (a.name ?? '').toUpperCase()),
-  );
-  const hasAtlas = up.has('ATLAS');
-  const hasZeus = up.has('ZEUS');
-  const hasHermes = up.has('HERMES');
+function detectDvaMode(args: {
+  agents: AgentStatusRow[];
+  snapshotLite: SnapshotLitePayload;
+}): DvaMode {
+  const { agents, snapshotLite } = args;
+  const fresh = (v: LiteLaneFreshness | undefined) => v === 'fresh' || v === 'nominal';
+  const hasEcho = Boolean(snapshotLite.ok !== false);
+  const hasAtlas = agents.some((a) => (a.name ?? '').toUpperCase() === 'ATLAS' && (a.status ?? '').toLowerCase() === 'active');
+  const hasZeus = agents.some((a) => (a.name ?? '').toUpperCase() === 'ZEUS' && (a.status ?? '').toLowerCase() === 'active');
+  const hasHermes = agents.some((a) => (a.name ?? '').toUpperCase() === 'HERMES' && (a.status ?? '').toLowerCase() === 'active');
+  const atlasFresh = fresh(snapshotLite.lanes?.integrity?.freshness);
+  const zeusFresh = fresh(snapshotLite.lanes?.signals?.freshness);
+  const hermesFresh = fresh(snapshotLite.lanes?.echo?.freshness);
 
-  if (hasAtlas && hasZeus && hasHermes) return 'full';
-  if (hasAtlas) return 'one';
+  if (hasEcho && hasAtlas && hasZeus && hasHermes && atlasFresh && zeusFresh && hermesFresh) return 'full';
+  if (hasEcho && hasAtlas && atlasFresh) return 'one';
   return 'lite';
 }
 
@@ -190,6 +196,12 @@ export function buildEchoDigest(input: {
     Boolean(snapshotLite.lanes?.tripwire?.elevated) ||
     status.toLowerCase() === 'stressed';
 
+  const integrityLaneGi = typeof snapshotLite.lanes?.integrity?.gi === 'number' ? snapshotLite.lanes.integrity.gi : null;
+  const divergence = typeof snapshotLite.gi === 'number' && typeof integrityLaneGi === 'number'
+    ? Math.abs(snapshotLite.gi - integrityLaneGi)
+    : 0;
+  const hydrationDrift = snapshotLite.lanes?.signals?.freshness === 'stale' || snapshotLite.lanes?.signals?.freshness === 'degraded';
+
   const warnings: string[] = [];
   if (archiveStale) warnings.push('Journal archive stale; hot lane authoritative');
   if (ledgerDegraded) warnings.push('Ledger rows unavailable');
@@ -200,7 +212,7 @@ export function buildEchoDigest(input: {
     ok: true,
     cycle,
     timestamp,
-    dva_mode: detectDvaMode(agents),
+    dva_mode: detectDvaMode({ agents, snapshotLite }),
     source: 'echo-digest',
     degraded,
     integrity: {
@@ -240,6 +252,20 @@ export function buildEchoDigest(input: {
       reserve: typeof vault?.balance_reserve === 'number' ? vault.balance_reserve : null,
       tranche: typeof vault?.current_tranche_balance === 'number' ? vault.current_tranche_balance : null,
       fountain_locked: (vault?.fountain_status ?? 'locked') !== 'active' && (vault?.fountain_status ?? 'locked') !== 'unsealed',
+    },
+    predictive: {
+      risk_level: divergence > 0.2 || hydrationDrift ? 'elevated' : degraded ? 'watch' : 'nominal',
+      signals: [
+        divergence > 0.2 ? 'divergence_detected' : null,
+        hydrationDrift ? 'hydration_drift' : null,
+        degraded ? 'digest_instability' : null,
+      ].filter((v): v is string => Boolean(v)),
+      recommendation:
+        divergence > 0.2 || hydrationDrift
+          ? 'bias snapshot authority and delay chamber promotion'
+          : degraded
+            ? 'keep preview authority until chamber confirms'
+            : 'normal operation',
     },
   };
 }


### PR DESCRIPTION
### Motivation

- Prevent UI empty/"awaiting data" states when snapshot/digest preview exists but full chamber APIs are delayed or partial.  
- Centralize echo digest polling to eliminate multiple per-chamber pollers and reduce desync/API load.  
- Harden hydration lifecycle to be abortable, normalized, and envelope-aware so preview→hydrating→live transitions are deterministic.  

### Description

- Introduces a terminal-scoped `EchoDigestProvider` and wraps the terminal layout so digest polling is a single shared source of truth, and updates `useEchoDigest` to consume the provider when available.  
- Hardens `useChamberHydration` by normalizing envelopes (`json.data ?? json`), tracking degraded envelopes, adding an abortable fetch timeout (`AbortController` / `requestTimeoutMs`), and ensuring preview is promoted only after a reliable fetch signal.  
- Adds preview-backed lane diagnostics (`useLaneDiagnosticsChamber`) sourced from the digest so lane rows and tripwire/KV indicators render meaningful preview values while hydration completes.  
- Fixes Globe fallbacks and GI calculation to prefer valid preview GI (`data.gi > 0 ? data.gi : preview?.gi ?? snapshot?.gi ?? 0`) and remove stale `C-271` default cycle.  
- Extends the echo digest contract (`buildEchoDigest`) with `predictive` risk metadata and tightens DVA detection to require active+fresh lanes (booting no longer counts as live).  
- Ensures digest fallback response includes the new `predictive` shape so clients can make preview-versus-promote decisions consistently.  

### Testing

- Files changed: `app/terminal/layout.tsx`, `components/terminal/EchoDigestProvider.tsx`, `hooks/useEchoDigest.ts`, `hooks/useChamberHydration.ts`, `hooks/useLaneDiagnosticsChamber.ts`, `app/terminal/GlobePageClient.tsx`, `lib/echo/buildDigest.ts`, `app/api/echo/digest/route.ts`.  
- Commands run: `pnpm exec tsc --noEmit`, `pnpm build`, `pnpm lint`.  
- Results: `typecheck: pass` (`pnpm exec tsc --noEmit` succeeded), `build: pass` (`pnpm build` succeeded), `lint: not run cleanly` (`pnpm lint` exited due to Next.js ESLint interactive setup prompt in this repo).  
- Notes: build artifacts generated and routes validated by the Next build; lint requires interactive configuration in this environment and was not completed non-interactively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab6a69f48832da533500c08da2cc8)