### PR TITLE
feat(echo): add predictive stabilization (C-291)

### DIFF
--- a/app/terminal/GlobePageClient.tsx
+++ b/app/terminal/GlobePageClient.tsx
@@ -32,7 +32,7 @@ function toStatus(score: number | null): SentimentDomain['status'] {
 }
 
 export default function GlobePageClient() {
-  const { data, loading, preview, full, error } = useGlobeChamber(true);
+  const { data, loading, preview, full, error, stabilizationActive } = useGlobeChamber(true);
   // C-290: the globe chamber API returns sentiment: null (it only runs the
   // micro sweep). Pull sentiment from the snapshot so domain rings populate.
   const { snapshot } = useTerminalSnapshot();
@@ -102,6 +102,11 @@ export default function GlobePageClient() {
       {error ? (
         <div className="mx-4 mt-2 rounded border border-amber-800/40 bg-amber-950/20 px-3 py-1 text-[10px] text-amber-200">
           Globe chamber degraded · showing preview state
+        </div>
+      ) : null}
+      {stabilizationActive ? (
+        <div className="mx-4 mt-2 rounded border border-amber-700/50 bg-amber-950/30 px-3 py-1 text-[10px] text-amber-100">
+          ⚠ Predictive Stabilization Active · Preview state prioritized due to integrity drift
         </div>
       ) : null}
       <GlobeChamber

--- a/app/terminal/journal/JournalPageClient.tsx
+++ b/app/terminal/journal/JournalPageClient.tsx
@@ -258,6 +258,11 @@ export default function JournalPageClient() {
           Journal chamber degraded · showing snapshot/derived preview
         </div>
       ) : null}
+      {journal.stabilizationActive ? (
+        <div className="mb-3 rounded border border-amber-700/50 bg-amber-950/30 px-3 py-2 text-xs text-amber-100">
+          ⚠ Predictive Stabilization Active · Preview state prioritized due to integrity drift
+        </div>
+      ) : null}
 
       <div className="mb-3 flex items-center gap-2 text-[11px] font-mono">
         <span className="text-slate-500">Journal mode</span>

--- a/app/terminal/ledger/LedgerPageClient.tsx
+++ b/app/terminal/ledger/LedgerPageClient.tsx
@@ -68,7 +68,7 @@ function sortRows(rows: LedgerEntry[], key: SortKey, dir: SortDir): LedgerEntry[
 }
 
 export default function LedgerPageClient() {
-  const { data, preview, full, error } = useLedgerChamber(true);
+  const { data, preview, full, error, stabilizationActive } = useLedgerChamber(true);
   const [sortKey, setSortKey] = useState<SortKey>('timestamp');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const feed = useMemo(() => (data ? ({ events: data.events, status: { cycleId: 'C-—' } } as EchoFeedResponse) : null), [data]);
@@ -112,6 +112,7 @@ export default function LedgerPageClient() {
         </div>
       </div>
       {error ? <div className="mb-2 rounded border border-amber-700/40 bg-amber-950/20 px-2 py-1 text-[11px] text-amber-200">Ledger chamber degraded · showing snapshot preview</div> : null}
+      {stabilizationActive ? <div className="mb-2 rounded border border-amber-700/50 bg-amber-950/30 px-2 py-1 text-[11px] text-amber-100">⚠ Predictive Stabilization Active · Preview state prioritized due to integrity drift</div> : null}
       {rows.length === 0 ? (
         <div className="rounded border border-slate-800 bg-slate-900/60 p-4 text-slate-400">
           No ledger rows available yet.

--- a/app/terminal/signals/SignalsPageClient.tsx
+++ b/app/terminal/signals/SignalsPageClient.tsx
@@ -177,7 +177,7 @@ function PostureBadge({ posture, laneStale }: { posture: AgentPosture; laneStale
 }
 
 export default function SignalsPageClient() {
-  const { data, loading, error, preview, full } = useSignalsChamber(true);
+  const { data, loading, error, preview, full, stabilizationActive } = useSignalsChamber(true);
 
   const payload = ((data?.raw && typeof data.raw === 'object') ? data.raw : {}) as MicroSweepPayload;
   const agents = useMemo(() => resolveAgents(payload), [payload]);
@@ -226,6 +226,11 @@ export default function SignalsPageClient() {
 
   return (
     <div className="flex h-full flex-col gap-3 overflow-hidden p-4">
+      {stabilizationActive ? (
+        <div className="rounded border border-amber-700/50 bg-amber-950/30 px-3 py-1 text-[10px] text-amber-100">
+          ⚠ Predictive Stabilization Active · Preview state prioritized due to integrity drift
+        </div>
+      ) : null}
       <div className="flex shrink-0 flex-wrap items-center justify-between gap-2">
         <div className="text-[11px] text-slate-400">
           <span className="font-mono text-slate-200">{agents.length}</span>

--- a/hooks/useChamberHydration.ts
+++ b/hooks/useChamberHydration.ts
@@ -6,6 +6,7 @@ type UseChamberHydrationOptions<T> = {
   previewData?: T | null;
   pollMs?: number;
   requestTimeoutMs?: number;
+  lockToPreview?: boolean;
 };
 
 export type ChamberHydrationStatus = 'preview' | 'hydrating' | 'live' | 'degraded' | 'stale';
@@ -19,6 +20,7 @@ type UseChamberHydrationResult<T> = {
   degraded: boolean;
   status: ChamberHydrationStatus;
   source: 'echo-digest' | 'api' | 'mixed';
+  stabilizationActive: boolean;
 };
 
 type ChamberEnvelope<T> = {
@@ -46,7 +48,7 @@ function normalizeHydrationPayload<T>(json: unknown): { payload: T | null; envel
 }
 
 export function useChamberHydration<T>(url: string, enabled: boolean, options: UseChamberHydrationOptions<T> = {}): UseChamberHydrationResult<T> {
-  const { previewData = null, pollMs = 30_000, requestTimeoutMs = DEFAULT_TIMEOUT_MS } = options;
+  const { previewData = null, pollMs = 30_000, requestTimeoutMs = DEFAULT_TIMEOUT_MS, lockToPreview = false } = options;
   const [full, setFull] = useState<T | null>(null);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<string | null>(null);
@@ -94,9 +96,13 @@ export function useChamberHydration<T>(url: string, enabled: boolean, options: U
     };
   }, [enabled, url, pollMs, requestTimeoutMs]);
 
-  const data = useMemo(() => full ?? previewData ?? null, [full, previewData]);
+  const data = useMemo(() => {
+    if (lockToPreview && previewData) return previewData;
+    return full ?? previewData ?? null;
+  }, [full, previewData, lockToPreview]);
 
   const status: ChamberHydrationStatus = useMemo(() => {
+    if (lockToPreview && previewData) return 'preview';
     if ((error || envelopeDegraded) && previewData) return 'degraded';
     if (error || envelopeDegraded) return 'stale';
     if (full) return 'live';
@@ -104,9 +110,13 @@ export function useChamberHydration<T>(url: string, enabled: boolean, options: U
     if (loading && previewData) return 'hydrating';
     if (previewData) return 'preview';
     return loading ? 'hydrating' : 'stale';
-  }, [error, envelopeDegraded, previewData, full, loading, fetchedOnce]);
+  }, [error, envelopeDegraded, previewData, full, loading, fetchedOnce, lockToPreview]);
 
-  const source: 'echo-digest' | 'api' | 'mixed' = full ? (previewData ? 'mixed' : 'api') : 'echo-digest';
+  const source: 'echo-digest' | 'api' | 'mixed' = lockToPreview && previewData
+    ? 'echo-digest'
+    : full
+      ? (previewData ? 'mixed' : 'api')
+      : 'echo-digest';
 
   return {
     preview: previewData,
@@ -117,5 +127,6 @@ export function useChamberHydration<T>(url: string, enabled: boolean, options: U
     degraded: Boolean(error || envelopeDegraded),
     status,
     source,
+    stabilizationActive: lockToPreview,
   };
 }

--- a/hooks/useGlobeChamber.ts
+++ b/hooks/useGlobeChamber.ts
@@ -19,6 +19,7 @@ export type GlobeChamberPayload = {
 export function useGlobeChamber(enabled: boolean) {
   const { snapshot } = useTerminalSnapshot();
   const { digest } = useEchoDigest(enabled);
+  const stabilizationActive = digest?.predictive.risk_level === 'elevated' || digest?.predictive.risk_level === 'critical';
   const preview = useMemo(() => ({
     ok: true,
     fallback: true,
@@ -36,5 +37,8 @@ export function useGlobeChamber(enabled: boolean) {
     timestamp: digest?.timestamp ?? snapshot?.timestamp ?? new Date().toISOString(),
   } satisfies GlobeChamberPayload), [digest, snapshot]);
 
-  return useChamberHydration<GlobeChamberPayload>('/api/chambers/globe', enabled, { previewData: preview });
+  return useChamberHydration<GlobeChamberPayload>('/api/chambers/globe', enabled, {
+    previewData: preview,
+    lockToPreview: stabilizationActive,
+  });
 }

--- a/hooks/useJournalChamber.ts
+++ b/hooks/useJournalChamber.ts
@@ -17,6 +17,7 @@ export type JournalChamberPayload = {
 export function useJournalChamber(enabled: boolean, mode: 'hot' | 'canon' | 'merged', limit = 100) {
   const { snapshot } = useTerminalSnapshot();
   const { digest } = useEchoDigest(enabled);
+  const stabilizationActive = digest?.predictive.risk_level === 'elevated' || digest?.predictive.risk_level === 'critical';
   const url = useMemo(() => `/api/chambers/journal?mode=${mode}&limit=${limit}`, [mode, limit]);
 
   const preview = useMemo(() => {
@@ -40,5 +41,8 @@ export function useJournalChamber(enabled: boolean, mode: 'hot' | 'canon' | 'mer
     } satisfies JournalChamberPayload;
   }, [mode, snapshot, digest]);
 
-  return useChamberHydration<JournalChamberPayload>(url, enabled, { previewData: preview });
+  return useChamberHydration<JournalChamberPayload>(url, enabled, {
+    previewData: preview,
+    lockToPreview: stabilizationActive,
+  });
 }

--- a/hooks/useLaneDiagnosticsChamber.ts
+++ b/hooks/useLaneDiagnosticsChamber.ts
@@ -43,6 +43,7 @@ function laneFromDigest(digest: ReturnType<typeof useEchoDigest>['digest']) {
 export function useLaneDiagnosticsChamber(enabled: boolean) {
   const { snapshot } = useTerminalSnapshot();
   const { digest } = useEchoDigest(enabled);
+  const stabilizationActive = digest?.predictive.risk_level === 'elevated' || digest?.predictive.risk_level === 'critical';
 
   const preview = useMemo(() => ({
     ok: true,
@@ -61,5 +62,9 @@ export function useLaneDiagnosticsChamber(enabled: boolean) {
     fallback: true,
   } satisfies LaneDiagnosticsPayload), [digest, snapshot]);
 
-  return useChamberHydration<LaneDiagnosticsPayload>('/api/chambers/lane-diagnostics', enabled, { pollMs: 20_000, previewData: preview });
+  return useChamberHydration<LaneDiagnosticsPayload>('/api/chambers/lane-diagnostics', enabled, {
+    pollMs: 20_000,
+    previewData: preview,
+    lockToPreview: stabilizationActive,
+  });
 }

--- a/hooks/useLedgerChamber.ts
+++ b/hooks/useLedgerChamber.ts
@@ -17,6 +17,7 @@ export type LedgerChamberPayload = {
 export function useLedgerChamber(enabled: boolean) {
   const { snapshot } = useTerminalSnapshot();
   const { digest } = useEchoDigest(enabled);
+  const stabilizationActive = digest?.predictive.risk_level === 'elevated' || digest?.predictive.risk_level === 'critical';
 
   const preview = useMemo(() => {
     const epicon = snapshot?.epicon?.data as { items?: Array<Record<string, unknown>> } | undefined;
@@ -66,5 +67,8 @@ export function useLedgerChamber(enabled: boolean) {
     } satisfies LedgerChamberPayload;
   }, [digest, snapshot]);
 
-  return useChamberHydration<LedgerChamberPayload>('/api/chambers/ledger', enabled, { previewData: preview });
+  return useChamberHydration<LedgerChamberPayload>('/api/chambers/ledger', enabled, {
+    previewData: preview,
+    lockToPreview: stabilizationActive,
+  });
 }

--- a/hooks/useSignalsChamber.ts
+++ b/hooks/useSignalsChamber.ts
@@ -22,6 +22,7 @@ type RawSnapshotSignals = { allSignals?: RawSignal[]; composite?: number; timest
 export function useSignalsChamber(enabled: boolean) {
   const { snapshot } = useTerminalSnapshot();
   const { digest } = useEchoDigest(enabled);
+  const stabilizationActive = digest?.predictive.risk_level === 'elevated' || digest?.predictive.risk_level === 'critical';
 
   const preview = useMemo(() => {
     const raw = snapshot?.signals?.data;
@@ -96,5 +97,8 @@ export function useSignalsChamber(enabled: boolean) {
     } satisfies SignalsChamberPayload;
   }, [snapshot, digest]);
 
-  return useChamberHydration<SignalsChamberPayload>('/api/chambers/signals', enabled, { previewData: preview });
+  return useChamberHydration<SignalsChamberPayload>('/api/chambers/signals', enabled, {
+    previewData: preview,
+    lockToPreview: stabilizationActive,
+  });
 }

--- a/lib/echo/buildDigest.ts
+++ b/lib/echo/buildDigest.ts
@@ -201,6 +201,24 @@ export function buildEchoDigest(input: {
     ? Math.abs(snapshotLite.gi - integrityLaneGi)
     : 0;
   const hydrationDrift = snapshotLite.lanes?.signals?.freshness === 'stale' || snapshotLite.lanes?.signals?.freshness === 'degraded';
+  const anomalyCount = Number(snapshotLite.lanes?.signals?.anomalies ?? 0);
+  const digestInstabilityScore = [
+    degraded,
+    ledgerDegraded,
+    anomalyCount >= 5,
+    booting > activeLike,
+    archiveStale,
+  ].filter(Boolean).length;
+  const atlasStalled = agents.some((a) => (a.name ?? '').toUpperCase() === 'ATLAS' && (a.status ?? '').toLowerCase() === 'booting');
+  const zeusStalled = agents.some((a) => (a.name ?? '').toUpperCase() === 'ZEUS' && (a.status ?? '').toLowerCase() === 'booting');
+  const agentStallDetected = atlasStalled || zeusStalled || booting > activeLike;
+  const riskLevel: EchoDigestPayload['predictive']['risk_level'] = divergence > 0.35 || digestInstabilityScore >= 4
+    ? 'critical'
+    : divergence > 0.2 || hydrationDrift || digestInstabilityScore >= 2 || agentStallDetected
+      ? 'elevated'
+      : digestInstabilityScore >= 1
+        ? 'watch'
+        : 'nominal';
 
   const warnings: string[] = [];
   if (archiveStale) warnings.push('Journal archive stale; hot lane authoritative');
@@ -254,18 +272,22 @@ export function buildEchoDigest(input: {
       fountain_locked: (vault?.fountain_status ?? 'locked') !== 'active' && (vault?.fountain_status ?? 'locked') !== 'unsealed',
     },
     predictive: {
-      risk_level: divergence > 0.2 || hydrationDrift ? 'elevated' : degraded ? 'watch' : 'nominal',
+      risk_level: riskLevel,
       signals: [
         divergence > 0.2 ? 'divergence_detected' : null,
         hydrationDrift ? 'hydration_drift' : null,
-        degraded ? 'digest_instability' : null,
+        digestInstabilityScore >= 2 ? 'digest_instability' : null,
+        ledgerDegraded ? 'ledger_stall' : null,
+        agentStallDetected ? 'agent_stall_detected' : null,
       ].filter((v): v is string => Boolean(v)),
       recommendation:
-        divergence > 0.2 || hydrationDrift
-          ? 'bias snapshot authority and delay chamber promotion'
-          : degraded
-            ? 'keep preview authority until chamber confirms'
-            : 'normal operation',
+        riskLevel === 'critical'
+          ? 'lock preview, pause chamber promotion, and prioritize lane recovery'
+          : riskLevel === 'elevated'
+            ? 'lock preview, delay hydration promotion'
+            : riskLevel === 'watch'
+              ? 'bias snapshot authority and monitor lane freshness'
+              : 'normal operation',
     },
   };
 }


### PR DESCRIPTION
### Motivation
- Prevent visible chamber desyncs by detecting early integrity drift and holding snapshot previews before full hydration promotes stale or divergent data.
- Synthesize multiple early signals (divergence, hydration drift, digest instability, ledger/agent stalls) into a predictive risk decision that can govern preemptive stabilization.

### Description
- Extended `buildEchoDigest` to compute `predictive` output including `risk_level`, detected `signals`, and an actionable `recommendation` by scoring divergence, hydration drift, anomaly counts, ledger stall, and agent lifecycle stalls (files changed: `lib/echo/buildDigest.ts`).
- Added `lockToPreview` / `stabilizationActive` to `useChamberHydration` so a chamber can remain in preview authority when predictive risk is elevated/critical (file changed: `hooks/useChamberHydration.ts`).
- Wired chamber hooks to respect PIE signals by enabling `lockToPreview` when `digest.predictive.risk_level` is `elevated` or `critical` for Globe, Signals, Ledger, Journal, and Lane Diagnostics (files changed: `hooks/useGlobeChamber.ts`, `hooks/useSignalsChamber.ts`, `hooks/useLedgerChamber.ts`, `hooks/useJournalChamber.ts`, `hooks/useLaneDiagnosticsChamber.ts`).
- Surface operator-facing banners in Globe, Signals, Ledger, and Journal pages to indicate when predictive stabilization is active (files changed: `app/terminal/GlobePageClient.tsx`, `app/terminal/signals/SignalsPageClient.tsx`, `app/terminal/ledger/LedgerPageClient.tsx`, `app/terminal/journal/JournalPageClient.tsx`).

### Testing
- Ran typecheck with `pnpm exec tsc --noEmit` and it passed.
- Built the app with `pnpm build` and the production build completed successfully.
- Ran `pnpm lint` which invoked Next.js ESLint setup and produced an interactive prompt, so linting was not completed in this non-interactive environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5a5f1834832d95f71e8a134eafba)