### PR TITLE
feat(dva): tier-based journal filtering and chamber ownership metadata (C-291)

### DIFF
--- a/app/api/chambers/globe/route.ts
+++ b/app/api/chambers/globe/route.ts
@@ -40,6 +40,11 @@ export async function GET() {
       fallback: false,
       cycle: integrity.cycle,
       gi: integrity.global_integrity ?? null,
+      dva: {
+        primaryAgent: 'ECHO',
+        tier: 't1',
+        chambers: ['globe', 'ledger', 'pulse'],
+      },
       micro,
       echo: { epicon: getEchoEpicon() },
       sentiment,
@@ -51,6 +56,11 @@ export async function GET() {
       fallback: true,
       cycle: 'C-—',
       gi: null,
+      dva: {
+        primaryAgent: 'ECHO',
+        tier: 't1',
+        chambers: ['globe', 'ledger', 'pulse'],
+      },
       micro: null,
       echo: { epicon: [] },
       sentiment: null,

--- a/app/api/chambers/journal/route.ts
+++ b/app/api/chambers/journal/route.ts
@@ -3,13 +3,36 @@ import { GET as getJournal } from '@/app/api/agents/journal/route';
 
 export const dynamic = 'force-dynamic';
 
+type DvaTier = 'ALL' | 't1' | 't2' | 't3' | 'sentinel' | 'architects';
+
+const DVA_TIER_AGENTS: Record<Exclude<DvaTier, 'ALL'>, string[]> = {
+  t1: ['ECHO'],
+  t2: ['ATLAS', 'ZEUS'],
+  t3: ['EVE', 'JADE', 'HERMES'],
+  sentinel: ['ATLAS', 'ZEUS', 'EVE'],
+  architects: ['AUREA', 'DAEDALUS'],
+};
+
+function normalizeTier(input: string | null): DvaTier {
+  const value = (input ?? '').trim();
+  if (value === 't1' || value === 't2' || value === 't3' || value === 'sentinel' || value === 'architects') {
+    return value;
+  }
+  return 'ALL';
+}
+
 export async function GET(request: NextRequest) {
   const mode = request.nextUrl.searchParams.get('mode') ?? 'merged';
   const limit = request.nextUrl.searchParams.get('limit') ?? '100';
-  const agent = request.nextUrl.searchParams.get('agent');
+  const tier = normalizeTier(request.nextUrl.searchParams.get('tier'));
+  const explicitAgents = request.nextUrl.searchParams.getAll('agent').map((agent) => agent.trim()).filter(Boolean);
+  const tierAgents = tier === 'ALL' ? [] : (DVA_TIER_AGENTS[tier] ?? []);
+  const requestedAgents = explicitAgents.length > 0 ? explicitAgents : tierAgents;
   const cycle = request.nextUrl.searchParams.get('cycle');
   const q = new URLSearchParams({ mode, limit });
-  if (agent) q.set('agent', agent);
+  for (const agent of requestedAgents) {
+    q.append('agent', agent);
+  }
   if (cycle) q.set('cycle', cycle);
 
   const forwarded = new NextRequest(`${request.nextUrl.origin}/api/agents/journal?${q.toString()}`, {
@@ -23,6 +46,7 @@ export async function GET(request: NextRequest) {
       ok: true,
       mode: json.mode ?? (mode as 'hot' | 'canon' | 'merged'),
       entries: json.entries ?? [],
+      tier,
       canonical_available: true,
       fallback: false,
       timestamp: new Date().toISOString(),
@@ -32,6 +56,7 @@ export async function GET(request: NextRequest) {
       ok: true,
       mode: mode as 'hot' | 'canon' | 'merged',
       entries: [],
+      tier,
       canonical_available: false,
       fallback: true,
       timestamp: new Date().toISOString(),

--- a/app/api/chambers/ledger/route.ts
+++ b/app/api/chambers/ledger/route.ts
@@ -14,6 +14,12 @@ export async function GET() {
       ok: true,
       events,
       candidates: { pending, confirmed, contested },
+      dva: {
+        primaryAgent: 'ECHO',
+        tier: 't1',
+        chambers: ['ledger'],
+        promotionGate: 'ZEUS',
+      },
       fallback: false,
       timestamp: new Date().toISOString(),
     });
@@ -22,6 +28,12 @@ export async function GET() {
       ok: true,
       events: [],
       candidates: { pending: 0, confirmed: 0, contested: 0 },
+      dva: {
+        primaryAgent: 'ECHO',
+        tier: 't1',
+        chambers: ['ledger'],
+        promotionGate: 'ZEUS',
+      },
       fallback: true,
       timestamp: new Date().toISOString(),
     });

--- a/app/terminal/journal/JournalPageClient.tsx
+++ b/app/terminal/journal/JournalPageClient.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import JournalEntryCard from '@/components/terminal/journal/JournalEntryCard';
 import ChamberEmptyState from '@/components/terminal/ChamberEmptyState';
 import ChamberSkeleton from '@/components/terminal/ChamberSkeleton';
-import { useJournalChamber } from '@/hooks/useJournalChamber';
+import { useJournalChamber, type DvaTier } from '@/hooks/useJournalChamber';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import type { JournalDisplayEntry, JournalDisplaySeverity, JournalDisplayStatus } from '@/lib/journal/types';
 
@@ -23,6 +23,22 @@ const AGENT_PILL_STYLE: Record<string, { border: string; activeBg: string; text:
   DAEDALUS: { border: 'border-amber-900/60', activeBg: 'bg-amber-950/40', text: 'text-amber-200' },
   ECHO: { border: 'border-slate-500/50', activeBg: 'bg-slate-600/20', text: 'text-slate-100' },
 };
+
+const DVA_TIERS: Array<{
+  id: DvaTier;
+  label: string;
+  desc: string;
+  color: string;
+  border: string;
+  activeBg: string;
+}> = [
+  { id: 'ALL', label: 'ALL', desc: 'All agents', color: 'text-slate-100', border: 'border-slate-600', activeBg: 'bg-slate-700/40' },
+  { id: 't2', label: 'SENTINEL', desc: 'ATLAS + ZEUS · Verification', color: 'text-cyan-100', border: 'border-cyan-600/50', activeBg: 'bg-cyan-500/15' },
+  { id: 'sentinel', label: 'COUNCIL', desc: 'ATLAS + ZEUS + EVE · Council', color: 'text-amber-100', border: 'border-amber-600/50', activeBg: 'bg-amber-500/15' },
+  { id: 't3', label: 'STABILIZE', desc: 'EVE + JADE + HERMES · Flow', color: 'text-emerald-100', border: 'border-emerald-600/50', activeBg: 'bg-emerald-500/15' },
+  { id: 'architects', label: 'ARCHITECTS', desc: 'AUREA + DAEDALUS · Synthesis', color: 'text-violet-100', border: 'border-violet-600/50', activeBg: 'bg-violet-500/15' },
+  { id: 't1', label: 'SUBSTRATE', desc: 'ECHO · Event memory', color: 'text-slate-300', border: 'border-slate-500/50', activeBg: 'bg-slate-600/20' },
+];
 
 type EpiconItem = {
   id: string;
@@ -127,7 +143,8 @@ export default function JournalPageClient() {
   const [cycleTab, setCycleTab] = useState<string>(() => currentCycleId());
   const [derivedMode, setDerivedMode] = useState(false);
   const [readMode, setReadMode] = useState<'hot' | 'canon' | 'merged'>('hot');
-  const journal = useJournalChamber(true, readMode, 100);
+  const [dvaTier, setDvaTier] = useState<DvaTier>('t2');
+  const journal = useJournalChamber(true, readMode, 100, dvaTier);
   const [missingRelatedId, setMissingRelatedId] = useState<string | null>(null);
   const anchorsRef = useRef<Map<string, HTMLElement>>(new Map());
 
@@ -263,6 +280,35 @@ export default function JournalPageClient() {
           ⚠ Predictive Stabilization Active · Preview state prioritized due to integrity drift
         </div>
       ) : null}
+
+      <div className="mb-3 rounded border border-slate-800/60 bg-slate-950/40 p-2">
+        <div className="mb-1.5 flex items-center justify-between">
+          <span className="text-[9px] font-mono uppercase tracking-[0.18em] text-slate-500">DVA Tier · Agent Layer</span>
+          <span className="text-[9px] text-slate-600">{DVA_TIERS.find((tier) => tier.id === dvaTier)?.desc ?? ''}</span>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {DVA_TIERS.map((tier) => {
+            const active = dvaTier === tier.id;
+            return (
+              <button
+                key={tier.id}
+                type="button"
+                onClick={() => {
+                  setDvaTier(tier.id);
+                  setAgent('ALL');
+                }}
+                className={`rounded border px-2 py-1 text-[10px] font-mono tracking-[0.12em] transition ${
+                  active
+                    ? `${tier.border} ${tier.activeBg} ${tier.color}`
+                    : 'border-slate-800 text-slate-500 hover:border-slate-600 hover:text-slate-400'
+                }`}
+              >
+                {tier.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
 
       <div className="mb-3 flex items-center gap-2 text-[11px] font-mono">
         <span className="text-slate-500">Journal mode</span>

--- a/app/terminal/pulse/PulsePageClient.tsx
+++ b/app/terminal/pulse/PulsePageClient.tsx
@@ -544,6 +544,28 @@ export default function PulsePageClient() {
             <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-400">Settings / data provenance</div>
             <p>Synthesis freshness: {synthesisFresh.line}</p>
             <p className="mt-1">Journal lane status: {journalLane?.state ?? 'unknown'}.</p>
+            <div className="mt-3 rounded border border-slate-800 bg-slate-950/50 p-2.5">
+              <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-500">DVA Tier · Chamber Routing</div>
+              <div className="space-y-1.5">
+                {([
+                  { tier: 'T1 · Substrate', agents: 'ECHO', chambers: 'Globe · Ledger · Pulse', color: 'text-slate-300', dot: 'bg-slate-400' },
+                  { tier: 'T2 · Sentinel Council', agents: 'ATLAS + ZEUS', chambers: 'Journal · EPICON', color: 'text-cyan-300', dot: 'bg-cyan-400' },
+                  { tier: 'T3 · Stabilizers', agents: 'EVE + JADE + HERMES', chambers: 'KV Flow · Substrate Sync', color: 'text-emerald-300', dot: 'bg-emerald-400' },
+                  { tier: 'Architects', agents: 'AUREA + DAEDALUS', chambers: 'Pulse synthesis · Lane Diagnostics', color: 'text-violet-300', dot: 'bg-violet-400' },
+                ] as const).map(({ tier, agents, chambers, color, dot }) => (
+                  <div key={tier} className="flex items-start gap-2 text-[10px]">
+                    <span className={`mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full ${dot}`} />
+                    <div>
+                      <span className={`font-semibold ${color}`}>{tier}</span>
+                      <span className="mx-1 text-slate-600">·</span>
+                      <span className="text-slate-400">{agents}</span>
+                      <span className="mx-1 text-slate-700">→</span>
+                      <span className="text-slate-500">{chambers}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
           </section>
         </div>
       </div>

--- a/hooks/useJournalChamber.ts
+++ b/hooks/useJournalChamber.ts
@@ -14,11 +14,38 @@ export type JournalChamberPayload = {
   timestamp: string;
 };
 
-export function useJournalChamber(enabled: boolean, mode: 'hot' | 'canon' | 'merged', limit = 100) {
+export type DvaTier = 'ALL' | 't1' | 't2' | 't3' | 'sentinel' | 'architects';
+
+const DVA_TIER_AGENTS: Record<Exclude<DvaTier, 'ALL'>, string[]> = {
+  t1: ['ECHO'],
+  t2: ['ATLAS', 'ZEUS'],
+  t3: ['EVE', 'JADE', 'HERMES'],
+  sentinel: ['ATLAS', 'ZEUS', 'EVE'],
+  architects: ['AUREA', 'DAEDALUS'],
+};
+
+function resolveTierAgents(tier: DvaTier): string[] {
+  if (tier === 'ALL') return [];
+  return DVA_TIER_AGENTS[tier] ?? [];
+}
+
+export function useJournalChamber(
+  enabled: boolean,
+  mode: 'hot' | 'canon' | 'merged',
+  limit = 100,
+  tier: DvaTier = 'ALL',
+) {
   const { snapshot } = useTerminalSnapshot();
   const { digest } = useEchoDigest(enabled);
   const stabilizationActive = digest?.predictive.risk_level === 'elevated' || digest?.predictive.risk_level === 'critical';
-  const url = useMemo(() => `/api/chambers/journal?mode=${mode}&limit=${limit}`, [mode, limit]);
+  const url = useMemo(() => {
+    const params = new URLSearchParams({ mode, limit: String(limit) });
+    params.set('tier', tier);
+    for (const agent of resolveTierAgents(tier)) {
+      params.append('agent', agent);
+    }
+    return `/api/chambers/journal?${params.toString()}`;
+  }, [mode, limit, tier]);
 
   const preview = useMemo(() => {
     const summary = snapshot?.journal_summary;
@@ -31,15 +58,25 @@ export function useJournalChamber(enabled: boolean, mode: 'hot' | 'canon' | 'mer
       source: 'echo-digest',
     }));
 
+    const latestEntries = Array.isArray(latest) ? latest : digestEntries;
+    const tierAgents = new Set(resolveTierAgents(tier));
+    const scopedEntries = tierAgents.size === 0
+      ? latestEntries
+      : latestEntries.filter((entry) => {
+          const candidate = entry as { agent?: string; agentOrigin?: string };
+          const agent = (candidate.agentOrigin ?? candidate.agent ?? '').toUpperCase();
+          return agent.length > 0 ? tierAgents.has(agent) : true;
+        });
+
     return {
       ok: true,
       mode,
-      entries: Array.isArray(latest) && latest.length > 0 ? latest : digestEntries,
+      entries: scopedEntries,
       canonical_available: false,
       fallback: true,
       timestamp: digest?.timestamp ?? snapshot?.timestamp ?? new Date().toISOString(),
     } satisfies JournalChamberPayload;
-  }, [mode, snapshot, digest]);
+  }, [mode, snapshot, digest, tier]);
 
   return useChamberHydration<JournalChamberPayload>(url, enabled, {
     previewData: preview,


### PR DESCRIPTION
### Motivation
- Reduce journal UI noise by surfacing high-signal agent output (ATLAS/ZEUS) and limiting KV/substrate reads via tiered agent grouping.
- Make chamber ownership and promotion gating explicit so Lane Diagnostics and operator workflows can rely on authoritative routing metadata.
- Provide an operator-facing way to inspect tier→agent→chamber routing without changing existing chamber/page boundaries.

### Description
- Add DVA tier support to the journal hook: `useJournalChamber` now accepts a `tier` (`DvaTier`) and resolves tier→agent lists for requests and preview scoping. (`hooks/useJournalChamber.ts`)
- Accept a `?tier=` query param in `/api/chambers/journal` and resolve it server-side to a list of agent `agent=` params forwarded to `/api/agents/journal` to reduce payload and KV reads. (`app/api/chambers/journal/route.ts`)
- Add a DVA tier selector UI to the Journal page with default first paint set to Tier 2 (`t2`, ATLAS+ZEUS) and ensure tier changes reset the agent pill filter to avoid conflicting filters. (`app/terminal/journal/JournalPageClient.tsx`)
- Surface explicit DVA metadata in chamber responses and operator UI: Globe and Ledger responses now include `dva` ownership metadata (`primaryAgent`, `tier`, `chambers`) and Ledger includes `promotionGate: 'ZEUS'`, and Pulse Settings shows a DVA Tier Routing Map for operator reference. (`app/api/chambers/globe/route.ts`, `app/api/chambers/ledger/route.ts`, `app/terminal/pulse/PulsePageClient.tsx`)
- Files changed: `hooks/useJournalChamber.ts`, `app/api/chambers/journal/route.ts`, `app/terminal/journal/JournalPageClient.tsx`, `app/api/chambers/globe/route.ts`, `app/api/chambers/ledger/route.ts`, `app/terminal/pulse/PulsePageClient.tsx`.

### Testing
- Ran typecheck with `pnpm exec tsc --noEmit` and it passed. 
- Ran full build with `pnpm build` (Next build) and it completed successfully. 
- Ran linter with `pnpm lint` which failed in this non-interactive environment because Next.js prompted for interactive ESLint configuration; lint did not complete. 
- Summary: `typecheck: pass`, `build: pass`, `lint: fail (interactive prompt)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb81002fd0832dafc57bfcfc1c3168)