### PR TITLE
C-292 KV Permission Healthcheck

### DIFF
--- a/app/api/health/kv-permissions/route.ts
+++ b/app/api/health/kv-permissions/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+import { Redis } from '@upstash/redis';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type ProbeStatus = {
+  ok: boolean;
+  read: boolean;
+  write: boolean;
+  counter: boolean;
+  list: boolean;
+  configured: boolean;
+  errors: string[];
+  timestamp: string;
+};
+
+function getRedisClient(): Redis | null {
+  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  return new Redis({ url, token });
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+export async function GET() {
+  const redis = getRedisClient();
+  const now = new Date().toISOString();
+  const keyToken = crypto.randomUUID();
+  const baseKey = `health:kv-permissions:${keyToken}`;
+  const errors: string[] = [];
+
+  const status: ProbeStatus = {
+    ok: false,
+    read: false,
+    write: false,
+    counter: false,
+    list: false,
+    configured: Boolean(redis),
+    errors,
+    timestamp: now,
+  };
+
+  if (!redis) {
+    errors.push('kv_env_missing');
+    return NextResponse.json(status, { status: 503, headers: { 'Cache-Control': 'no-store' } });
+  }
+
+  try {
+    await redis.set(`${baseKey}:string`, now, { ex: 60 });
+    status.write = true;
+  } catch (error) {
+    errors.push(`set_failed: ${errorMessage(error)}`);
+  }
+
+  try {
+    const value = await redis.get<string>(`${baseKey}:string`);
+    status.read = value === now || typeof value === 'string';
+  } catch (error) {
+    errors.push(`get_failed: ${errorMessage(error)}`);
+  }
+
+  try {
+    const value = await redis.incr(`${baseKey}:counter`);
+    status.counter = typeof value === 'number' && value >= 1;
+    await redis.expire(`${baseKey}:counter`, 60);
+  } catch (error) {
+    errors.push(`incr_failed: ${errorMessage(error)}`);
+  }
+
+  try {
+    await redis.lpush(`${baseKey}:list`, 'probe');
+    const rows = await redis.lrange<string>(`${baseKey}:list`, 0, 0);
+    await redis.ltrim(`${baseKey}:list`, 0, 0);
+    await redis.expire(`${baseKey}:list`, 60);
+    status.list = Array.isArray(rows) && rows.length > 0;
+  } catch (error) {
+    errors.push(`list_failed: ${errorMessage(error)}`);
+  }
+
+  status.ok = status.configured && status.read && status.write && status.counter && status.list;
+
+  return NextResponse.json(status, {
+    status: status.ok ? 200 : 503,
+    headers: { 'Cache-Control': 'no-store' },
+  });
+}

--- a/docs/pr-bundles/C-292-kv-permission-healthcheck.md
+++ b/docs/pr-bundles/C-292-kv-permission-healthcheck.md
@@ -1,0 +1,101 @@
+# C-292 — KV Permission Healthcheck
+
+## Purpose
+
+After the April security incident and production key rotation, Mobius needs a direct runtime check that confirms the active Upstash / Vercel KV credentials can do more than read.
+
+The Vercel logs showed repeated `NOPERM` failures for `SET`, which means routes could return HTTP 200 while failing to refresh hot state.
+
+## Problem
+
+The Terminal can appear alive while data freshness is degraded:
+
+- API reads return 200
+- cached/stale payloads continue serving
+- write-path refreshes fail
+- UI keeps showing stale state
+
+Observed failing operations included:
+
+- `SET echo:kv:heartbeat`
+- `SET TRIPWIRE_STATE`
+- `SET SENTIMENT_SNAPSHOT`
+- MII batch writes
+
+## Change
+
+Add:
+
+```txt
+GET /api/health/kv-permissions
+```
+
+The route checks whether the production KV token supports:
+
+- `SET`
+- `GET`
+- `INCR`
+- `LPUSH`
+- `LRANGE`
+- `LTRIM`
+- `EXPIRE`
+
+## Expected response
+
+Healthy:
+
+```json
+{
+  "ok": true,
+  "read": true,
+  "write": true,
+  "counter": true,
+  "list": true,
+  "configured": true,
+  "errors": [],
+  "timestamp": "..."
+}
+```
+
+Degraded:
+
+```json
+{
+  "ok": false,
+  "read": true,
+  "write": false,
+  "counter": false,
+  "list": false,
+  "configured": true,
+  "errors": ["set_failed: NOPERM ..."],
+  "timestamp": "..."
+}
+```
+
+## Why this helps
+
+This gives Mobius a fast way to distinguish between:
+
+- UI bug
+- stale cache
+- missing env vars
+- read-only KV token
+- rotated token with insufficient permissions
+
+## Acceptance criteria
+
+- [ ] Route returns 200 when all KV operations pass.
+- [ ] Route returns 503 when env vars are missing or any required operation fails.
+- [ ] Response never exposes token values.
+- [ ] Response uses `Cache-Control: no-store`.
+- [ ] Probe keys expire quickly.
+
+## Operator checklist
+
+After rotating Vercel / Upstash keys:
+
+1. Redeploy production.
+2. Open `/api/health/kv-permissions`.
+3. Confirm `ok: true`.
+4. Confirm no `NOPERM` messages appear in Vercel runtime logs.
+5. Recheck `/api/terminal/snapshot`, `/api/terminal/snapshot-lite`, `/api/terminal/watermark`, and `/api/agents/journal`.


### PR DESCRIPTION
## Summary

Adds a production KV permission probe after the April security incident/key rotation.

The Vercel logs showed repeated Upstash `NOPERM` failures on `SET`, meaning routes could return 200 while hot state writes failed and the Terminal kept reading stale/fallback state.

## What changed

- Adds `GET /api/health/kv-permissions`.
- Probes KV config and permissions without exposing token values.
- Checks required runtime operations:
  - `SET`
  - `GET`
  - `INCR`
  - `LPUSH`
  - `LRANGE`
  - `LTRIM`
  - `EXPIRE`
- Returns 200 only when all checks pass.
- Returns 503 with safe error summaries when env vars are missing or operations fail.
- Adds `docs/pr-bundles/C-292-kv-permission-healthcheck.md` with operator checklist.

## Why

This makes it immediately visible whether the rotated Vercel/Upstash credentials are read-only or missing write/list/counter permissions.

## Files

- `app/api/health/kv-permissions/route.ts`
- `docs/pr-bundles/C-292-kv-permission-healthcheck.md`

## Validation

- Branch compare shows 2 files added.
- No token values are logged or returned.
- Probe keys use short expiration.

## Merge note

The branch contains only the KV healthcheck files relative to the previous branch tip, but `main` moved after the reused branch was merged. If GitHub marks it behind, update the branch before merge.