### PR TITLE
C-291 Ledger EPICON Bridge

### DIFF
--- a/app/api/chambers/ledger/route.ts
+++ b/app/api/chambers/ledger/route.ts
@@ -1,41 +1,157 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getEchoLedger } from '@/lib/echo/store';
+import type { LedgerEntry } from '@/lib/terminal/types';
 
 export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
-export async function GET() {
+type EpiconFeedItem = {
+  id?: string;
+  cycle?: string;
+  timestamp?: string;
+  author?: string;
+  title?: string;
+  body?: string;
+  type?: string;
+  category?: string;
+  status?: string;
+  severity?: string;
+  source?: string;
+  tags?: string[];
+  agentOrigin?: string;
+  verified?: boolean;
+  confidenceTier?: number;
+  gi?: number | null;
+};
+
+function normalizeCycle(input: unknown): string {
+  return typeof input === 'string' && input.trim().length > 0 ? input.trim() : 'C-—';
+}
+
+function normalizeTimestamp(input: unknown): string {
+  return typeof input === 'string' && input.trim().length > 0 ? input.trim() : new Date().toISOString();
+}
+
+function normalizeAgent(item: EpiconFeedItem): string {
+  return (item.agentOrigin ?? item.author ?? 'ECHO').trim().toUpperCase();
+}
+
+function normalizeStatus(item: EpiconFeedItem): LedgerEntry['status'] {
+  if (item.status === 'committed' || item.verified === true) return 'committed';
+  if (item.status === 'failed' || item.status === 'reverted') return 'reverted';
+  return 'pending';
+}
+
+function normalizeCategory(input: unknown): LedgerEntry['category'] | undefined {
+  if (
+    input === 'geopolitical' ||
+    input === 'market' ||
+    input === 'governance' ||
+    input === 'infrastructure' ||
+    input === 'narrative' ||
+    input === 'ethics' ||
+    input === 'civic-risk'
+  ) {
+    return input;
+  }
+  return undefined;
+}
+
+function normalizeSource(input: unknown): LedgerEntry['source'] {
+  if (input === 'eve-synthesis' || input === 'agent_commit' || input === 'backfill') return input;
+  return 'echo';
+}
+
+function epiconToLedgerEntry(item: EpiconFeedItem, idx: number): LedgerEntry {
+  const timestamp = normalizeTimestamp(item.timestamp);
+  return {
+    id: item.id?.trim() || `epicon-feed-${idx}-${timestamp}`,
+    cycleId: normalizeCycle(item.cycle),
+    type: 'epicon',
+    agentOrigin: normalizeAgent(item),
+    timestamp,
+    title: item.title,
+    summary: item.body ?? item.title ?? 'EPICON feed event',
+    integrityDelta: 0,
+    status: normalizeStatus(item),
+    category: normalizeCategory(item.category),
+    confidenceTier: typeof item.confidenceTier === 'number' ? item.confidenceTier : undefined,
+    tags: item.tags,
+    source: normalizeSource(item.source),
+  };
+}
+
+function dedupeSort(entries: LedgerEntry[]): LedgerEntry[] {
+  const seen = new Set<string>();
+  return entries
+    .filter((entry) => {
+      if (seen.has(entry.id)) return false;
+      seen.add(entry.id);
+      return true;
+    })
+    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+}
+
+async function fetchEpiconLedgerFallback(request: NextRequest): Promise<LedgerEntry[]> {
   try {
-    const events = getEchoLedger();
+    const url = new URL('/api/epicon/feed?limit=100&include_catalog=false', request.nextUrl.origin);
+    const res = await fetch(url, { cache: 'no-store' });
+    if (!res.ok) return [];
+    const data = (await res.json()) as { items?: EpiconFeedItem[] };
+    const items = Array.isArray(data.items) ? data.items : [];
+    return items.map(epiconToLedgerEntry);
+  } catch {
+    return [];
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const echoEvents = getEchoLedger();
+    const epiconEvents = await fetchEpiconLedgerFallback(request);
+    const events = dedupeSort([...echoEvents, ...epiconEvents]).slice(0, 100);
     const pending = events.filter((e) => e.status === 'pending').length;
     const confirmed = events.filter((e) => e.status === 'committed').length;
     const contested = events.filter((e) => e.status === 'reverted').length;
 
-    return NextResponse.json({
-      ok: true,
-      events,
-      candidates: { pending, confirmed, contested },
-      dva: {
-        primaryAgent: 'ECHO',
-        tier: 't1',
-        chambers: ['ledger'],
-        promotionGate: 'ZEUS',
+    return NextResponse.json(
+      {
+        ok: true,
+        events,
+        candidates: { pending, confirmed, contested },
+        sources: {
+          echoMemory: echoEvents.length,
+          epiconFeed: epiconEvents.length,
+          merged: events.length,
+        },
+        dva: {
+          primaryAgent: 'ECHO',
+          tier: 't1',
+          chambers: ['ledger'],
+          promotionGate: 'ZEUS',
+        },
+        fallback: echoEvents.length === 0 && epiconEvents.length > 0,
+        timestamp: new Date().toISOString(),
       },
-      fallback: false,
-      timestamp: new Date().toISOString(),
-    });
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
   } catch {
-    return NextResponse.json({
-      ok: true,
-      events: [],
-      candidates: { pending: 0, confirmed: 0, contested: 0 },
-      dva: {
-        primaryAgent: 'ECHO',
-        tier: 't1',
-        chambers: ['ledger'],
-        promotionGate: 'ZEUS',
+    return NextResponse.json(
+      {
+        ok: true,
+        events: [],
+        candidates: { pending: 0, confirmed: 0, contested: 0 },
+        sources: { echoMemory: 0, epiconFeed: 0, merged: 0 },
+        dva: {
+          primaryAgent: 'ECHO',
+          tier: 't1',
+          chambers: ['ledger'],
+          promotionGate: 'ZEUS',
+        },
+        fallback: true,
+        timestamp: new Date().toISOString(),
       },
-      fallback: true,
-      timestamp: new Date().toISOString(),
-    });
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
   }
 }

--- a/docs/pr-bundles/C-291-journal-ledger-epicon-sort.md
+++ b/docs/pr-bundles/C-291-journal-ledger-epicon-sort.md
@@ -1,0 +1,58 @@
+# C-291 — Journal Sorting + Ledger EPICON Bridge
+
+## Purpose
+
+Improve the Terminal operations lanes so Journal and Ledger reflect the live system more clearly.
+
+## Problem
+
+The Journal lane can become noisy when entries are sorted mostly by recency. Operators need the current cycle, canon state, verification status, agent role, severity, confidence, and timestamp to drive ordering.
+
+The Ledger chamber was reading only from ECHO in-memory ledger state. On Vercel serverless, that memory can be empty after a cold start, even while the EPICON feed is alive. This made Ledger look empty while `/api/epicon/feed` had valid entries.
+
+## Runtime change in this PR
+
+- `app/api/chambers/ledger/route.ts` now hydrates from both ECHO memory and `/api/epicon/feed`.
+- EPICON feed items are mapped into `LedgerEntry` rows.
+- The route merges, dedupes, sorts newest-first, and exposes source diagnostics.
+- The route returns `Cache-Control: no-store`.
+
+## Ledger source diagnostics
+
+The Ledger chamber now returns:
+
+```json
+{
+  "sources": {
+    "echoMemory": 0,
+    "epiconFeed": 42,
+    "merged": 42
+  }
+}
+```
+
+This makes it clear whether Ledger is empty because there are no events, or because one source lane is empty.
+
+## Journal sorting policy
+
+The desired Journal lane ordering is:
+
+1. Current cycle first
+2. Newer cycle numbers before older cycle numbers
+3. Canon state: CANON WRITTEN, CANON PENDING, HOT ONLY, CANON FAILED
+4. Journal status: verified, committed, contested, draft
+5. Agent lane priority: ZEUS, ATLAS, JADE, EVE, AUREA, HERMES, DAEDALUS, ECHO
+6. Severity: critical, elevated, nominal
+7. Confidence
+8. Timestamp newest-first
+
+The current Journal page already uses an operator-first sorter for cycle, status, severity, confidence, and recency. The next runtime patch should extend that sorter with canon state and agent lane priority once the UI type surface for `storage.canonStatus` is finalized.
+
+## Acceptance criteria
+
+- [x] Ledger chamber no longer depends only on warm ECHO memory.
+- [x] Ledger chamber can display EPICON entries when ECHO memory is empty.
+- [x] Ledger response includes source counts.
+- [x] Ledger response is no-store.
+- [ ] Follow-up: add canon-aware Journal sorting in the UI.
+- [ ] Follow-up: expose Journal sorting mode in the UI.


### PR DESCRIPTION
## Summary

Updates the Ledger chamber so it can display EPICON feed entries when the in-memory ECHO ledger is empty after a serverless cold start.

## Changes

- Updates `app/api/chambers/ledger/route.ts`.
- Reads ECHO memory and `/api/epicon/feed`.
- Maps EPICON feed items into `LedgerEntry` rows.
- Merges, dedupes, and sorts events newest-first.
- Adds source diagnostics for `echoMemory`, `epiconFeed`, and `merged`.
- Adds `Cache-Control: no-store`.
- Adds `docs/pr-bundles/C-291-journal-ledger-epicon-sort.md` with the Journal sorting policy and Ledger bridge notes.

## Validation

- Branch is 2 commits ahead of `main` and 0 behind.
- Changed files: 2.
- Local build was not run here; CI/Vercel should validate build and types.