### PR TITLE
C-291 Fix Ledger Route Build

### DIFF
--- a/app/api/ledger/route.ts
+++ b/app/api/ledger/route.ts
@@ -1,11 +1,12 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { GET as getLedger } from '@/app/api/chambers/ledger/route';
 
 export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const response = await getLedger();
+    const response = await getLedger(request);
     const payload = (await response.json()) as Record<string, unknown>;
     return NextResponse.json(
       {
@@ -14,7 +15,10 @@ export async function GET() {
         degraded: payload.fallback === true,
         error: null,
       },
-      { status: 200 },
+      {
+        status: 200,
+        headers: { 'Cache-Control': 'no-store' },
+      },
     );
   } catch (error) {
     return NextResponse.json(
@@ -27,7 +31,10 @@ export async function GET() {
         candidates: { pending: 0, confirmed: 0, contested: 0 },
         timestamp: new Date().toISOString(),
       },
-      { status: 200 },
+      {
+        status: 200,
+        headers: { 'Cache-Control': 'no-store' },
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary

Fixes the production build failure after PR #394.

`app/api/chambers/ledger/route.ts` now expects a `NextRequest`, but `app/api/ledger/route.ts` was still calling `getLedger()` with no arguments.

## Change

- Updates `app/api/ledger/route.ts` to accept `NextRequest`.
- Passes that request into `getLedger(request)`.
- Adds `revalidate = 0` and `Cache-Control: no-store` to keep the ledger proxy dynamic.

## Validation

This directly addresses the Vercel TypeScript error:

`Type error: Expected 1 arguments, but got 0.`