### PR TITLE
C-291 Normalize Journal Preview Rows

### DIFF
--- a/docs/pr-bundles/C-291-journal-preview-normalize.md
+++ b/docs/pr-bundles/C-291-journal-preview-normalize.md
@@ -1,0 +1,43 @@
+# C-291 — Journal Preview Normalization
+
+## Purpose
+
+Clean up the Journal lane when Predictive Stabilization locks the UI to preview data.
+
+## Problem
+
+During elevated integrity drift, `useChamberHydration` can lock the Journal chamber to preview rows. The snapshot preview rows may contain partial fields like `title`, `summary`, `body`, or `message` instead of canonical journal fields like `observation` and `inference`.
+
+That caused the UI to render cards with:
+
+- `Observed: —`
+- `Inferred: —`
+- lowercase / inconsistent agent labels
+- weak fallback source attribution
+
+## Change
+
+`hooks/useJournalChamber.ts` now normalizes preview rows before returning them to the Journal UI.
+
+Normalization includes:
+
+- agent resolution across `agentOrigin`, `agent`, `sourceAgent`, `author`, and `source`
+- uppercase agent and agent origin
+- observation fallback from `observation`, `summary`, `title`, `body`, then `message`
+- inference fallback from `inference`, then `recommendation`, then a clear preview placeholder
+- stable fallback id
+- normalized status
+- normalized severity
+- normalized source
+- default derivedFrom array
+
+## Why this helps
+
+The Journal lane now stays readable during preview/stabilization mode without pretending partial preview rows are fully canonical.
+
+## Acceptance criteria
+
+- [x] Preview rows no longer show blank observed/inferred fields when summary/title/body/message exists.
+- [x] Agent labels are normalized before card rendering.
+- [x] Tier scoping still applies before preview normalization.
+- [x] Stabilization mode can keep using preview state safely.

--- a/hooks/useJournalChamber.ts
+++ b/hooks/useJournalChamber.ts
@@ -28,15 +28,36 @@ const DVA_TIER_AGENTS: Record<Exclude<DvaTier, 'ALL'>, string[]> = {
 };
 
 type PreviewJournalCandidate = {
+  id?: string;
   agent?: string;
   agentOrigin?: string;
   author?: string;
   source?: string;
   sourceAgent?: string;
+  cycle?: string;
+  category?: string;
+  observation?: string;
+  inference?: string;
+  recommendation?: string;
+  summary?: string;
+  title?: string;
+  body?: string;
+  message?: string;
+  timestamp?: string;
+  status?: string;
+  severity?: string;
+  confidence?: number;
+  derivedFrom?: string[];
+  source_mode?: 'kv' | 'substrate';
+  canonical_path?: string;
 };
 
 function normalizeAgentName(value: unknown): string {
   return typeof value === 'string' ? value.trim().toUpperCase() : '';
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
 }
 
 function resolveTierAgents(tier: DvaTier): string[] {
@@ -55,12 +76,59 @@ function getPreviewEntryAgent(entry: unknown): string {
   );
 }
 
+function normalizePreviewStatus(value: unknown): 'draft' | 'committed' | 'contested' | 'verified' {
+  const status = normalizeText(value).toLowerCase();
+  if (status === 'draft' || status === 'contested' || status === 'verified') return status;
+  return 'committed';
+}
+
+function normalizePreviewSeverity(value: unknown): 'nominal' | 'elevated' | 'critical' {
+  const severity = normalizeText(value).toLowerCase();
+  if (severity === 'critical') return 'critical';
+  if (severity === 'elevated' || severity === 'high' || severity === 'medium') return 'elevated';
+  return 'nominal';
+}
+
+function normalizePreviewEntry(entry: unknown, idx: number, fallbackTimestamp: string) {
+  const candidate = entry as PreviewJournalCandidate;
+  const agent = getPreviewEntryAgent(entry) || 'ECHO';
+  const observation =
+    normalizeText(candidate.observation) ||
+    normalizeText(candidate.summary) ||
+    normalizeText(candidate.title) ||
+    normalizeText(candidate.body) ||
+    normalizeText(candidate.message) ||
+    'Preview journal row awaiting native observation payload.';
+  const inference =
+    normalizeText(candidate.inference) ||
+    normalizeText(candidate.recommendation) ||
+    'Preview source did not include a separate inference field.';
+
+  return {
+    ...candidate,
+    id: normalizeText(candidate.id) || `preview-${agent}-${idx}`,
+    agent,
+    agentOrigin: normalizeAgentName(candidate.agentOrigin) || agent,
+    sourceAgent: normalizeAgentName(candidate.sourceAgent) || agent,
+    cycle: normalizeText(candidate.cycle) || 'C-—',
+    category: normalizeText(candidate.category) || 'observation',
+    observation,
+    inference,
+    recommendation: normalizeText(candidate.recommendation),
+    timestamp: normalizeText(candidate.timestamp) || fallbackTimestamp,
+    source: normalizeText(candidate.source) || 'snapshot-preview',
+    status: normalizePreviewStatus(candidate.status),
+    severity: normalizePreviewSeverity(candidate.severity),
+    confidence: typeof candidate.confidence === 'number' ? candidate.confidence : undefined,
+    derivedFrom: Array.isArray(candidate.derivedFrom) ? candidate.derivedFrom : [],
+    source_mode: candidate.source_mode,
+    canonical_path: candidate.canonical_path,
+  };
+}
+
 function entryBelongsToTier(entry: unknown, tierAgents: Set<string>): boolean {
   if (tierAgents.size === 0) return true;
   const agent = getPreviewEntryAgent(entry);
-  // C-291 fix: unscoped preview rows must not bypass a non-ALL tier filter.
-  // If a fallback/digest row cannot prove an agent origin, it is excluded until
-  // the live chamber response returns canonical scoping metadata.
   return agent.length > 0 && tierAgents.has(agent);
 }
 
@@ -78,9 +146,7 @@ export function useJournalChamber(
   const url = useMemo(() => {
     const params = new URLSearchParams({ mode, limit: String(safeLimit) });
     params.set('tier', tier);
-    for (const agent of tierAgentsList) {
-      params.append('agent', agent);
-    }
+    for (const agent of tierAgentsList) params.append('agent', agent);
     return `/api/chambers/journal?${params.toString()}`;
   }, [mode, safeLimit, tier, tierAgentsList]);
 
@@ -106,7 +172,9 @@ export function useJournalChamber(
 
     const latestEntries = Array.isArray(latest) ? latest : digestEntries;
     const tierAgents = new Set(tierAgentsList);
-    const scopedEntries = latestEntries.filter((entry) => entryBelongsToTier(entry, tierAgents));
+    const scopedEntries = latestEntries
+      .filter((entry) => entryBelongsToTier(entry, tierAgents))
+      .map((entry, idx) => normalizePreviewEntry(entry, idx, timestamp));
 
     return {
       ok: true,


### PR DESCRIPTION
## Summary

Fixes the Journal cards showing blank `Observed` / `Inferred` fields during Predictive Stabilization preview lock.

## What changed

- Normalizes preview journal rows in `hooks/useJournalChamber.ts` before the UI renders them.
- Resolves agent identity across `agentOrigin`, `agent`, `sourceAgent`, `author`, and `source`.
- Uppercases agent and agent origin.
- Falls back observation text from `observation`, `summary`, `title`, `body`, then `message`.
- Falls back inference text from `inference`, then `recommendation`, then a clear preview placeholder.
- Normalizes preview status, severity, source, id, timestamp, and `derivedFrom`.
- Keeps tier scoping before normalization.
- Adds `docs/pr-bundles/C-291-journal-preview-normalize.md`.

## Why

The Journal lane can be locked to preview state during elevated integrity drift. Snapshot preview rows are not always canonical journal rows, so they may have summary/title/body fields instead of observation/inference. This made the UI look empty even though data existed.

## Validation

- Branch is 2 commits ahead of `main`, 0 behind.
- Changed files: 2.
- CI/Vercel should validate build/types.