### PR TITLE
C-291 Normalize Ledger Cycle and Status

### DIFF
--- a/app/api/chambers/ledger/route.ts
+++ b/app/api/chambers/ledger/route.ts
@@ -24,8 +24,26 @@ type EpiconFeedItem = {
   gi?: number | null;
 };
 
-function normalizeCycle(input: unknown): string {
-  return typeof input === 'string' && input.trim().length > 0 ? input.trim() : 'C-—';
+const CYCLE_PATTERN = /\bC-?(\d{1,5})\b/i;
+
+function cleanText(input: unknown): string {
+  return typeof input === 'string' ? input.trim() : '';
+}
+
+function inferCycleFromText(...inputs: unknown[]): string {
+  for (const input of inputs) {
+    const text = Array.isArray(input) ? input.join(' ') : cleanText(input);
+    if (!text) continue;
+    const match = text.match(CYCLE_PATTERN);
+    if (match?.[1]) return `C-${match[1]}`;
+  }
+  return 'C-—';
+}
+
+function normalizeCycle(item: EpiconFeedItem): string {
+  const explicit = cleanText(item.cycle);
+  if (explicit) return inferCycleFromText(explicit);
+  return inferCycleFromText(item.id, item.title, item.body, item.tags, item.source);
 }
 
 function normalizeTimestamp(input: unknown): string {
@@ -37,8 +55,22 @@ function normalizeAgent(item: EpiconFeedItem): string {
 }
 
 function normalizeStatus(item: EpiconFeedItem): LedgerEntry['status'] {
-  if (item.status === 'committed' || item.verified === true) return 'committed';
-  if (item.status === 'failed' || item.status === 'reverted') return 'reverted';
+  const status = cleanText(item.status).toLowerCase();
+  const title = cleanText(item.title).toLowerCase();
+  const type = cleanText(item.type).toLowerCase();
+  const source = cleanText(item.source).toLowerCase();
+  if (
+    status === 'committed' ||
+    status === 'verified' ||
+    item.verified === true ||
+    title.startsWith('merge pull request') ||
+    type === 'merge' ||
+    source === 'github' ||
+    source === 'github-commit'
+  ) {
+    return 'committed';
+  }
+  if (status === 'failed' || status === 'reverted' || status === 'contested') return 'reverted';
   return 'pending';
 }
 
@@ -66,7 +98,7 @@ function epiconToLedgerEntry(item: EpiconFeedItem, idx: number): LedgerEntry {
   const timestamp = normalizeTimestamp(item.timestamp);
   return {
     id: item.id?.trim() || `epicon-feed-${idx}-${timestamp}`,
-    cycleId: normalizeCycle(item.cycle),
+    cycleId: normalizeCycle(item),
     type: 'epicon',
     agentOrigin: normalizeAgent(item),
     timestamp,
@@ -113,6 +145,7 @@ export async function GET(request: NextRequest) {
     const pending = events.filter((e) => e.status === 'pending').length;
     const confirmed = events.filter((e) => e.status === 'committed').length;
     const contested = events.filter((e) => e.status === 'reverted').length;
+    const missingCycle = events.filter((e) => e.cycleId === 'C-—').length;
 
     return NextResponse.json(
       {
@@ -123,6 +156,7 @@ export async function GET(request: NextRequest) {
           echoMemory: echoEvents.length,
           epiconFeed: epiconEvents.length,
           merged: events.length,
+          missingCycle,
         },
         dva: {
           primaryAgent: 'ECHO',
@@ -141,7 +175,7 @@ export async function GET(request: NextRequest) {
         ok: true,
         events: [],
         candidates: { pending: 0, confirmed: 0, contested: 0 },
-        sources: { echoMemory: 0, epiconFeed: 0, merged: 0 },
+        sources: { echoMemory: 0, epiconFeed: 0, merged: 0, missingCycle: 0 },
         dva: {
           primaryAgent: 'ECHO',
           tier: 't1',

--- a/app/api/chambers/ledger/route.ts
+++ b/app/api/chambers/ledger/route.ts
@@ -54,20 +54,16 @@ function normalizeAgent(item: EpiconFeedItem): string {
   return (item.agentOrigin ?? item.author ?? 'ECHO').trim().toUpperCase();
 }
 
-function normalizeStatus(item: EpiconFeedItem): LedgerEntry['status'] {
-  const status = cleanText(item.status).toLowerCase();
+function isMergeEvent(item: EpiconFeedItem): boolean {
   const title = cleanText(item.title).toLowerCase();
   const type = cleanText(item.type).toLowerCase();
-  const source = cleanText(item.source).toLowerCase();
-  if (
-    status === 'committed' ||
-    status === 'verified' ||
-    item.verified === true ||
-    title.startsWith('merge pull request') ||
-    type === 'merge' ||
-    source === 'github' ||
-    source === 'github-commit'
-  ) {
+  const tags = (item.tags ?? []).map((tag) => tag.toLowerCase());
+  return title.startsWith('merge pull request') || type === 'merge' || tags.includes('merge');
+}
+
+function normalizeStatus(item: EpiconFeedItem): LedgerEntry['status'] {
+  const status = cleanText(item.status).toLowerCase();
+  if (status === 'committed' || status === 'verified' || item.verified === true || isMergeEvent(item)) {
     return 'committed';
   }
   if (status === 'failed' || status === 'reverted' || status === 'contested') return 'reverted';

--- a/docs/pr-bundles/C-291-ledger-cycle-status-normalize.md
+++ b/docs/pr-bundles/C-291-ledger-cycle-status-normalize.md
@@ -1,0 +1,50 @@
+# C-291 — Ledger Cycle + Status Normalization
+
+## Purpose
+
+Fix Ledger display labels after the EPICON bridge went live.
+
+## Problem
+
+Ledger rows were appearing as:
+
+- `C-—` when EPICON or GitHub-derived rows did not carry an explicit `cycle` field.
+- `pending` even when the event was clearly a merged GitHub pull request or verified EPICON row.
+
+This made the Ledger lane look less canonical than the data actually was.
+
+## Change
+
+`app/api/chambers/ledger/route.ts` now:
+
+- infers cycle IDs from `cycle`, `id`, `title`, `body`, `tags`, and `source`
+- normalizes `C291` and `C-291` to `C-291`
+- marks GitHub merge pull request rows as `committed`
+- marks verified EPICON rows as `committed`
+- keeps unknown rows as `pending`
+- adds `sources.missingCycle` diagnostics
+
+## Expected result
+
+Instead of:
+
+```txt
+C-— · 18 ledger rows
+Merge pull request #397... pending
+```
+
+Ledger should move toward:
+
+```txt
+C-291 · 18 ledger rows
+Merge pull request #397... committed
+```
+
+## Acceptance criteria
+
+- [x] Ledger can infer cycle from PR titles like `c291-*`.
+- [x] Ledger normalizes inferred cycle to `C-291`.
+- [x] GitHub merge pull request rows become `committed`.
+- [x] Verified EPICON rows become `committed`.
+- [x] Unknown rows remain `pending`.
+- [x] Response includes `sources.missingCycle`.


### PR DESCRIPTION
## Summary

C-291 cleanup for the Ledger lane after the EPICON bridge went live.

The Ledger was now receiving EPICON/GitHub-derived rows, but some displayed as `C-—` and `pending` even when the title/source clearly identified a C-291 merge or verified event.

## What changed

- Infers cycle IDs from `cycle`, `id`, `title`, `body`, `tags`, and `source`.
- Normalizes `C291` and `C-291` style strings to `C-291`.
- Marks GitHub merge pull request rows as `committed`.
- Marks verified EPICON rows as `committed`.
- Keeps unknown/unverified rows as `pending`.
- Adds `sources.missingCycle` diagnostics.
- Adds `docs/pr-bundles/C-291-ledger-cycle-status-normalize.md`.

## Expected result

Before:

```txt
C-— · 18 ledger rows
Merge pull request #397... pending
```

After:

```txt
C-291 · 18 ledger rows
Merge pull request #397... committed
```

## Files

- `app/api/chambers/ledger/route.ts`
- `docs/pr-bundles/C-291-ledger-cycle-status-normalize.md`

## Validation

- Branch is 2 commits ahead of `main`, 0 behind.
- Changed files: 2.
- CI/Vercel should validate build/types.