### PR TITLE
C-292 Journal HOT Lane Read Fix

### DIFF
--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -55,6 +55,7 @@ type AgentJournalCreateInput = Omit<AgentJournalEntry, 'id' | 'timestamp' | 'sta
 const MAX_READ = 100;
 const KV_JOURNAL_PER_AGENT_CAP = 50;
 const KV_JOURNAL_FAIR_MERGE_MAX = 600;
+const KV_JOURNAL_LIST_READ_MAX = 200;
 const GENESIS_AGENTS = ['ATLAS', 'ZEUS', 'EVE', 'HERMES', 'AUREA', 'JADE', 'DAEDALUS', 'ECHO'] as const;
 const DEFAULT_READ_MODE = ((process.env.JOURNAL_DEFAULT_READ_MODE ?? 'merged').trim().toLowerCase() as JournalReadMode);
 
@@ -263,22 +264,39 @@ function mergeKvJournalFair(entries: AgentJournalEntry[], perAgent: number, maxT
     .slice(0, maxTotal);
 }
 
-function parseJournalStorageKey(key: string): { agent: string; cycle: string } | null {
-  if (key.startsWith('mobius:')) {
-    const rest = key.slice('mobius:'.length);
-    const segments = rest.split(':');
-    if (segments.length !== 3 || segments[0] !== 'journal') return null;
-    const keyAgent = asString(segments[1]).toUpperCase();
-    const keyCycle = asString(segments[2]);
-    if (!keyAgent || !keyCycle) return null;
-    return { agent: keyAgent, cycle: keyCycle };
+function parseJournalStorageKey(key: string): { agent?: string; cycle?: string; kind: 'list' | 'legacy' } | null {
+  const normalizedKey = key.startsWith('mobius:') ? key.slice('mobius:'.length) : key;
+  const segments = normalizedKey.split(':');
+  if (segments[0] !== 'journal') return null;
+  if (segments.length === 2 && segments[1] === 'all') return { kind: 'list' };
+  if (segments.length === 2 && segments[1]) return { kind: 'list', agent: asString(segments[1]).toUpperCase() };
+  if (segments.length === 3 && segments[1] && segments[2]) {
+    return { kind: 'legacy', agent: asString(segments[1]).toUpperCase(), cycle: asString(segments[2]) };
   }
-  const segments = key.split(':');
-  if (segments.length !== 3 || segments[0] !== 'journal') return null;
-  const keyAgent = asString(segments[1]).toUpperCase();
-  const keyCycle = asString(segments[2]);
-  if (!keyAgent || !keyCycle) return null;
-  return { agent: keyAgent, cycle: keyCycle };
+  return null;
+}
+
+function parseMaybeJson(row: unknown): unknown | null {
+  if (typeof row !== 'string') return row ?? null;
+  try {
+    return JSON.parse(row) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+async function readJournalRows(redis: ReturnType<typeof getJournalRedisClient>, key: string, kind: 'list' | 'legacy'): Promise<unknown[]> {
+  if (!redis) return [];
+  try {
+    if (kind === 'list') {
+      const rows = await redis.lrange<unknown>(key, 0, KV_JOURNAL_LIST_READ_MAX - 1);
+      return Array.isArray(rows) ? rows : [];
+    }
+    const raw = await redis.get<unknown>(key);
+    return Array.isArray(raw) ? raw : [raw];
+  } catch {
+    return [];
+  }
 }
 
 async function loadEntries(
@@ -289,36 +307,28 @@ async function loadEntries(
 
   try {
     const normalized = new Set((agentFilters ?? []).map((agent) => agent.trim().toUpperCase()).filter(Boolean));
+    const listKeys = normalized.size > 0
+      ? Array.from(normalized).map((agent) => `journal:${agent.toLowerCase()}`)
+      : ['journal:all'];
     const [keysUnprefixed, keysPrefixed] = await Promise.all([
       redis.keys('journal:*'),
       redis.keys('mobius:journal:*'),
     ]);
-    const keys = [...new Set([...keysUnprefixed, ...keysPrefixed])];
+    const keys = [...new Set([...listKeys, ...keysUnprefixed, ...keysPrefixed])];
     const seen = new Set<string>();
     const out: AgentJournalEntry[] = [];
 
     for (const key of keys) {
       const parsedKey = parseJournalStorageKey(key);
       if (!parsedKey) continue;
-      const { agent: keyAgent, cycle: keyCycle } = parsedKey;
-      if (normalized.size > 0 && !normalized.has(keyAgent)) continue;
+      if (parsedKey.agent && normalized.size > 0 && !normalized.has(parsedKey.agent)) continue;
 
-      const raw = await redis.get<unknown>(key);
-      const rows = Array.isArray(raw) ? raw : [raw];
+      const rows = await readJournalRows(redis, key, parsedKey.kind);
       for (const row of rows) {
-        const candidate =
-          typeof row === 'string'
-            ? (() => {
-                try {
-                  return JSON.parse(row) as unknown;
-                } catch {
-                  return null;
-                }
-              })()
-            : row;
+        const candidate = parseMaybeJson(row);
         if (!candidate) continue;
 
-        const parsed = parseEntry(candidate, keyAgent, keyCycle);
+        const parsed = parseEntry(candidate, parsedKey.agent, parsedKey.cycle);
         if (!parsed) continue;
         if (parsed.source !== 'agent-journal') continue;
         if (!asString(parsed.agentOrigin)) continue;

--- a/docs/pr-bundles/C-292-journal-hot-lane-read-fix.md
+++ b/docs/pr-bundles/C-292-journal-hot-lane-read-fix.md
@@ -1,0 +1,68 @@
+# C-292 — Journal HOT Lane Read Fix
+
+## Issue
+
+The C-292 Journal chamber showed:
+
+```txt
+No journal entries yet for this cycle
+```
+
+But the runtime logs showed `/api/chambers/journal` returning `200`, and prior writes were expected to exist in Upstash.
+
+## Root Cause
+
+The Journal write path now writes HOT entries into Redis lists:
+
+```txt
+journal:all
+journal:<agent>
+```
+
+But the Journal read path was still treating `journal:*` keys as legacy value keys and reading them with `GET`.
+
+That means list-backed HOT rows could exist in Upstash while the read path returned no parsed journal entries.
+
+## Fix
+
+Update `/api/agents/journal` HOT reader to understand both formats:
+
+```txt
+journal:all              → Redis list, read with LRANGE
+journal:<agent>          → Redis list, read with LRANGE
+journal:<agent>:<cycle>  → legacy value, read with GET
+mobius:journal:*         → legacy/prefixed compatibility
+```
+
+## Why this matters
+
+HOT is fast, but the reader must speak the same storage dialect as the writer.
+
+This fix restores the HOT → Journal UI path without changing the canon/Substrate path.
+
+## Validation Signal
+
+Expected after deploy:
+
+```txt
+/api/chambers/journal?mode=hot&cycle=C-292
+```
+
+should show HOT rows when `journal:all` contains C-292 entries.
+
+Agent filters should read per-agent list keys first:
+
+```txt
+/api/chambers/journal?mode=hot&cycle=C-292&agent=JADE
+```
+
+## Canon
+
+The lane was not empty.
+The reader was looking in the wrong shape.
+
+HOT is fast.
+CANON is earned.
+MERGED is the operator view.
+
+We heal as we walk.


### PR DESCRIPTION
## Summary

Fixes the empty C-292 Journal lane by teaching `/api/agents/journal` to read the current HOT lane Redis list keys.

The write path stores HOT entries in Redis lists:

```txt
journal:all
journal:<agent>
```

The read path was still treating `journal:*` keys as legacy value keys and using `GET`, so HOT rows could exist in Upstash while the Journal chamber rendered empty.

## What changed

- Adds list-aware Redis reads using `LRANGE` for:
  - `journal:all`
  - `journal:<agent>`
- Keeps compatibility with legacy keys:
  - `journal:<agent>:<cycle>`
  - `mobius:journal:*`
- Prefers `journal:all` when no agent filter is provided.
- Prefers per-agent list keys when an agent filter is provided.
- Adds PR notes documenting the storage-shape mismatch.

## Files changed

- `app/api/agents/journal/route.ts`
- `docs/pr-bundles/C-292-journal-hot-lane-read-fix.md`

## Expected validation

After deploy, if Upstash contains C-292 rows in `journal:all`, this should return entries:

```txt
/api/chambers/journal?mode=hot&cycle=C-292
```

Agent-scoped reads should also work:

```txt
/api/chambers/journal?mode=hot&cycle=C-292&agent=JADE
```

## Canon

The lane was not empty.
The reader was looking in the wrong shape.

HOT is fast.  
CANON is earned.  
MERGED is the operator view.

We heal as we walk.