### PR TITLE
C-292 Open Lane Flow Control

### DIFF
--- a/components/terminal/DataflowCommandSpine.tsx
+++ b/components/terminal/DataflowCommandSpine.tsx
@@ -14,6 +14,14 @@ type DataflowStage = {
   detail: string;
 };
 
+type FlowBudget = {
+  label: string;
+  agent: string;
+  role: string;
+  metric: string;
+  state: StageState;
+};
+
 function normalizeState(value: unknown): StageState {
   const text = typeof value === 'string' ? value.toLowerCase() : '';
   if (text.includes('degraded') || text.includes('critical') || text.includes('failed')) return 'degraded';
@@ -78,6 +86,22 @@ function countLaneRows(lanes: Record<string, unknown> | undefined): number {
   return Object.keys(lanes).length;
 }
 
+function countProblemLanes(lanes: Record<string, unknown> | undefined): number {
+  if (!lanes) return 0;
+  return Object.values(lanes).filter((value) => {
+    const row = value as Record<string, unknown> | undefined;
+    const state = normalizeState(row?.freshness ?? row?.state ?? row?.status ?? row?.message);
+    return state === 'watch' || state === 'slow' || state === 'stale' || state === 'degraded' || state === 'offline';
+  }).length;
+}
+
+function flowBudgetClass(state: StageState): string {
+  if (state === 'fresh' || state === 'ok') return 'border-emerald-500/25 text-emerald-200';
+  if (state === 'watch' || state === 'slow' || state === 'stale') return 'border-amber-500/25 text-amber-200';
+  if (state === 'degraded' || state === 'offline') return 'border-rose-500/30 text-rose-200';
+  return 'border-slate-700 text-slate-400';
+}
+
 export default function DataflowCommandSpine({
   shell,
   diagnostics,
@@ -90,14 +114,19 @@ export default function DataflowCommandSpine({
   if (!visible) return null;
 
   const lanes = diagnostics?.lanes;
+  const laneCount = countLaneRows(lanes);
+  const problemLanes = countProblemLanes(lanes);
   const dataFreshness = shell?.timestamp ?? diagnostics?.timestamp ?? null;
+  const journalState = laneState(lanes, 'journal');
+  const ledgerState = laneState(lanes, 'ledger', 'epicon', 'integrity');
+  const verifyState = shell ? (shell.tripwire?.elevated ? 'watch' : 'ok') : 'unknown';
   const stages: DataflowStage[] = [
     {
       id: 'sources',
       label: 'Sources',
       agent: 'HERMES',
       state: laneState(lanes, 'kv', 'backup_redis', 'signals'),
-      detail: `${countLaneRows(lanes)} lanes`,
+      detail: `${laneCount} lanes open`,
     },
     {
       id: 'intake',
@@ -117,14 +146,14 @@ export default function DataflowCommandSpine({
       id: 'verify',
       label: 'Verify',
       agent: 'ZEUS',
-      state: shell ? (shell.tripwire?.elevated ? 'watch' : 'ok') : 'unknown',
+      state: verifyState,
       detail: `${shell?.tripwire?.count ?? 0} tripwires`,
     },
     {
       id: 'ledger',
       label: 'Ledger',
       agent: 'JADE',
-      state: laneState(lanes, 'ledger', 'epicon', 'integrity'),
+      state: ledgerState,
       detail: 'proof lane',
     },
     {
@@ -136,6 +165,44 @@ export default function DataflowCommandSpine({
     },
   ];
 
+  const budgets: FlowBudget[] = [
+    {
+      label: 'Open HOT',
+      agent: 'ECHO',
+      role: 'intake sampler',
+      metric: journalState === 'unknown' ? 'awaiting journal lane' : `journal ${badgeLabel(journalState)}`,
+      state: journalState,
+    },
+    {
+      label: 'Shape',
+      agent: 'HERMES',
+      role: 'dedupe / packet route',
+      metric: `${laneCount} lane${laneCount === 1 ? '' : 's'} visible`,
+      state: laneCount > 0 ? 'ok' : 'unknown',
+    },
+    {
+      label: 'Challenge',
+      agent: 'ZEUS',
+      role: 'contamination check',
+      metric: `${shell?.tripwire?.count ?? 0} tripwire${(shell?.tripwire?.count ?? 0) === 1 ? '' : 's'}`,
+      state: verifyState,
+    },
+    {
+      label: 'Gate Canon',
+      agent: 'JADE',
+      role: 'reservoir control',
+      metric: `ledger ${badgeLabel(ledgerState)}`,
+      state: ledgerState,
+    },
+    {
+      label: 'Overflow',
+      agent: 'AUREA',
+      role: 'pressure review',
+      metric: `${problemLanes} lane${problemLanes === 1 ? '' : 's'} need care`,
+      state: problemLanes > 0 ? 'watch' : laneCount > 0 ? 'ok' : 'unknown',
+    },
+  ];
+
   const packetMode = shell?.source === 'fallback' || diagnostics?.fallback ? 'preview/fallback' : shell ? 'live packet' : 'awaiting shell';
 
   return (
@@ -143,7 +210,7 @@ export default function DataflowCommandSpine({
       <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
         <div>
           <div className="text-[10px] font-mono uppercase tracking-[0.22em] text-cyan-300/80">Dataflow Command</div>
-          <div className="text-[11px] text-slate-500">Circulation before content · chamber packets over raw firehose</div>
+          <div className="text-[11px] text-slate-500">Open-lane flow · agents govern pressure before canon</div>
         </div>
         <div className="flex flex-wrap gap-1.5 text-[10px] font-mono uppercase tracking-[0.12em]">
           <span className="rounded border border-slate-700 bg-slate-900/70 px-2 py-1 text-slate-300">{shell?.cycle ?? 'C-—'}</span>
@@ -152,7 +219,7 @@ export default function DataflowCommandSpine({
         </div>
       </div>
 
-      <div className="grid gap-1.5 md:grid-cols-6">
+      <div className="mb-2 grid gap-1.5 md:grid-cols-6">
         {stages.map((stage, idx) => (
           <div key={stage.id} className={cn('relative rounded border px-2 py-2', stageClass(stage.state))}>
             {idx > 0 ? <span className="absolute -left-2 top-1/2 hidden -translate-y-1/2 text-slate-600 md:block">→</span> : null}
@@ -164,6 +231,25 @@ export default function DataflowCommandSpine({
             <div className="truncate text-[10px] text-slate-500">{stage.detail}</div>
           </div>
         ))}
+      </div>
+
+      <div className="rounded border border-slate-800/80 bg-slate-950/70 p-2">
+        <div className="mb-1.5 flex items-center justify-between gap-2">
+          <div className="text-[9px] font-mono uppercase tracking-[0.18em] text-slate-500">Agent flow budgets</div>
+          <div className="text-[9px] font-mono uppercase tracking-[0.12em] text-cyan-300/70">HOT open · CANON gated</div>
+        </div>
+        <div className="grid gap-1 md:grid-cols-5">
+          {budgets.map((budget) => (
+            <div key={`${budget.label}-${budget.agent}`} className={cn('rounded border bg-black/20 px-2 py-1.5', flowBudgetClass(budget.state))}>
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-[9px] font-mono uppercase tracking-[0.12em]">{budget.label}</span>
+                <span className="text-[9px] font-mono">{budget.agent}</span>
+              </div>
+              <div className="truncate text-[10px] text-slate-400">{budget.role}</div>
+              <div className="truncate text-[10px] text-slate-500">{budget.metric}</div>
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/components/terminal/TerminalShell.tsx
+++ b/components/terminal/TerminalShell.tsx
@@ -26,7 +26,8 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
   const [showDataflowCommand, setShowDataflowCommand] = useState(true);
   const [consoleCollapsed, setConsoleCollapsed] = useState(false);
   const { shell, loading } = useShellSnapshot();
-  const laneDiagnostics = useLaneDiagnosticsChamber(showLaneDiagnostics || showDataflowCommand);
+  const flowTelemetryEnabled = showDataflowCommand || showLaneDiagnostics;
+  const laneDiagnostics = useLaneDiagnosticsChamber(flowTelemetryEnabled);
 
   useEffect(() => {
     const tick = () => setClock(new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC');

--- a/docs/pr-bundles/C-292-open-lane-flow-control.md
+++ b/docs/pr-bundles/C-292-open-lane-flow-control.md
@@ -1,0 +1,39 @@
+# C-292 Open Lane Flow Control
+
+## Purpose
+
+Mobius should treat data as a river, not a dam. The HOT lane stays open. Agents handle pressure, routing, review, and canon gates.
+
+## Five optimizations
+
+1. The Dataflow Command copy now says: open-lane flow, agents govern pressure before canon.
+2. The Sources stage now reports how many lanes are open.
+3. A new Agent Flow Budget strip shows ECHO, HERMES, ZEUS, JADE, and AUREA responsibilities.
+4. The budget strip counts lanes that need care: watch, slow, stale, degraded, or offline.
+5. TerminalShell now names the diagnostics gate as flowTelemetryEnabled so Flow stays hydrated when visible while Lane Diagnostics remains an operator panel.
+
+## Agent flow roles
+
+- ECHO: intake sampler
+- HERMES: dedupe and packet route
+- ZEUS: trust review
+- JADE: canon gate
+- AUREA: pressure and architecture review
+
+## Rule
+
+All data may enter HOT. Not all HOT becomes priority. Not all priority becomes canon. Not all canon candidates become sealed.
+
+HOT can be messy. CANON must be earned. MERGED must explain the difference.
+
+## Next step
+
+Add API metrics for rows per minute, stale ratio, duplicate ratio, cycle mismatch count, canon candidate rate, blocked count, agent balance, and verification delay.
+
+## Canon
+
+The river should flow. The agents should govern pressure. The canon should remain protected.
+
+HOT is current. CANON is reservoir. MERGED is the map.
+
+We heal as we walk.


### PR DESCRIPTION
## Summary

Implements the C-292 open-lane flow control surface: HOT stays open, agents govern pressure, and JADE protects canon.

This shifts the Dataflow Command surface from a dam model to a river model. The Terminal now makes clear that Mobius should accept live data flow while agents sample, shape, challenge, gate, and review pressure.

## 5 optimizations

1. **Open-lane copy** — Dataflow Command now describes the operating model as `Open-lane flow · agents govern pressure before canon`.
2. **Lane count visibility** — Sources now reports `N lanes open` so operators can see circulation at a glance.
3. **Agent Flow Budget panel** — Adds a compact budget strip for ECHO, HERMES, ZEUS, JADE, and AUREA.
4. **Problem-lane counter** — Counts lanes in watch/slow/stale/degraded/offline states as early pressure signals.
5. **Telemetry gate naming** — TerminalShell now uses `flowTelemetryEnabled = showDataflowCommand || showLaneDiagnostics`, keeping Flow hydrated when visible while Lane Diagnostics remains opt-in.

## Files changed

- `components/terminal/DataflowCommandSpine.tsx`
- `components/terminal/TerminalShell.tsx`
- `docs/pr-bundles/C-292-open-lane-flow-control.md`

## Merge readiness

- Branch is 3 commits ahead of `main`, 0 behind.
- UI-focused change.
- No new API routes.

## Canon

The river should flow.  
The agents should govern pressure.  
The canon should remain protected.

HOT is current.  
CANON is reservoir.  
MERGED is the map.

We heal as we walk.