### PR TITLE
C-292 Predictive Stabilization Sub-50 Threshold

### DIFF
--- a/docs/pr-bundles/C-292-stabilization-sub50-threshold.md
+++ b/docs/pr-bundles/C-292-stabilization-sub50-threshold.md
@@ -1,0 +1,46 @@
+# C-292 Predictive Stabilization Sub-50 Threshold
+
+## Diagnosis
+
+Predictive Stabilization was activating while GI was in the 0.60 to 0.70 operating range. That made the Terminal lock chambers to preview data even though the system was degraded but still operating normally for the current cycle baseline.
+
+This caused stale preview state to override fresh HOT lane data.
+
+## Rule
+
+Predictive Stabilization should only lock preview when GI is below 0.50.
+
+GI in the 0.60 range is degraded, but normalized for the present operating baseline. It should warn, monitor, and keep lanes flowing. It should not freeze HOT.
+
+## Change
+
+The ECHO digest risk model now treats GI below 0.50 as the stabilization threshold.
+
+- GI below 0.50 can produce elevated or critical predictive risk.
+- GI above or equal to 0.50 can still produce watch risk.
+- Watch risk does not lock chambers to preview.
+- HOT lane remains authoritative during degraded-but-operating state.
+
+## Expected Behavior
+
+At GI 0.60 to 0.70:
+
+- Terminal may show DEGRADED.
+- Dataflow may show watch/degraded lanes.
+- Predictive Stabilization should not lock preview.
+- Journal HOT should fetch native HOT rows.
+- Fresh API/chamber data should override stale preview data.
+
+At GI below 0.50:
+
+- Predictive Stabilization may lock preview.
+- Promotion should slow down.
+- Operators should prioritize lane recovery.
+
+## Canon
+
+GI 60 is degraded, not emergency.
+HOT should continue to flow.
+Predictive Stabilization is a sub-50 safety brake, not a normal-state dam.
+
+We heal as we walk.

--- a/lib/echo/buildDigest.ts
+++ b/lib/echo/buildDigest.ts
@@ -117,6 +117,8 @@ export type EchoDigestPayload = {
   };
 };
 
+const STABILIZATION_GI_THRESHOLD = 0.5;
+
 function countByCycle(entries: JournalEntry[]): Array<{ cycle: string; count: number }> {
   const bucket = new Map<string, number>();
   for (const row of entries) {
@@ -212,19 +214,19 @@ export function buildEchoDigest(input: {
   const atlasStalled = agents.some((a) => (a.name ?? '').toUpperCase() === 'ATLAS' && (a.status ?? '').toLowerCase() === 'booting');
   const zeusStalled = agents.some((a) => (a.name ?? '').toUpperCase() === 'ZEUS' && (a.status ?? '').toLowerCase() === 'booting');
   const agentStallDetected = atlasStalled || zeusStalled || booting > activeLike;
-  const riskLevel: EchoDigestPayload['predictive']['risk_level'] = divergence > 0.35 || digestInstabilityScore >= 4
-    ? 'critical'
-    : divergence > 0.2 || hydrationDrift || digestInstabilityScore >= 2 || agentStallDetected
-      ? 'elevated'
-      : digestInstabilityScore >= 1
-        ? 'watch'
-        : 'nominal';
+  const sub50Gi = typeof gi === 'number' && gi < STABILIZATION_GI_THRESHOLD;
+  const riskLevel: EchoDigestPayload['predictive']['risk_level'] = sub50Gi
+    ? (divergence > 0.35 || digestInstabilityScore >= 4 ? 'critical' : 'elevated')
+    : digestInstabilityScore >= 1 || hydrationDrift || agentStallDetected || divergence > 0.2
+      ? 'watch'
+      : 'nominal';
 
   const warnings: string[] = [];
   if (archiveStale) warnings.push('Journal archive stale; hot lane authoritative');
   if (ledgerDegraded) warnings.push('Ledger rows unavailable');
   if (!snapshotLite.heartbeat?.journal) warnings.push('Heartbeat journal cycle lagging');
   if (snapshotLite.lanes?.tripwire?.elevated) warnings.push('Tripwire elevated; promotion should remain guarded');
+  if (sub50Gi) warnings.push('GI below 0.50; predictive stabilization may prioritize preview');
 
   return {
     ok: true,
@@ -279,14 +281,15 @@ export function buildEchoDigest(input: {
         digestInstabilityScore >= 2 ? 'digest_instability' : null,
         ledgerDegraded ? 'ledger_stall' : null,
         agentStallDetected ? 'agent_stall_detected' : null,
+        sub50Gi ? 'sub50_gi_stabilization_threshold' : null,
       ].filter((v): v is string => Boolean(v)),
       recommendation:
-        riskLevel === 'critical'
+        sub50Gi && riskLevel === 'critical'
           ? 'lock preview, pause chamber promotion, and prioritize lane recovery'
-          : riskLevel === 'elevated'
+          : sub50Gi
             ? 'lock preview, delay hydration promotion'
             : riskLevel === 'watch'
-              ? 'bias snapshot authority and monitor lane freshness'
+              ? 'normal operation; monitor lane freshness without preview lock'
               : 'normal operation',
     },
   };


### PR DESCRIPTION
## Summary

Updates the ECHO predictive risk model so Predictive Stabilization only locks preview when GI is below 0.50.

At GI 0.60–0.70, Mobius is degraded but normalized for the current operating baseline. It should warn and monitor, but it should not freeze HOT/native chamber data behind stale preview state.

## What changed

- Adds `STABILIZATION_GI_THRESHOLD = 0.5`.
- Treats GI `< 0.50` as the only condition that can raise predictive risk to `elevated` / `critical` for preview-lock behavior.
- Keeps GI `>= 0.50` risk at `watch` when there are lane issues, drift, ledger stalls, or agent stalls.
- Updates recommendations so watch means: `normal operation; monitor lane freshness without preview lock`.
- Adds notes in `docs/pr-bundles/C-292-stabilization-sub50-threshold.md`.

## Expected behavior

At GI 0.60–0.70:

- Terminal may still show `DEGRADED`.
- Dataflow may still show watch/degraded lanes.
- Predictive Stabilization should not lock preview.
- Journal HOT should fetch native HOT rows.
- Fresh API/chamber data should override stale preview data.

At GI below 0.50:

- Predictive Stabilization may lock preview.
- Promotion should slow down.
- Operators should prioritize lane recovery.

## Files changed

- `lib/echo/buildDigest.ts`
- `docs/pr-bundles/C-292-stabilization-sub50-threshold.md`

## Merge readiness

- Branch is 2 commits ahead of current `main`, 0 behind.
- Runtime change is scoped to ECHO digest predictive risk classification.
- No new API routes.

## Canon

GI 60 is degraded, not emergency.  
HOT should continue to flow.  
Predictive Stabilization is a sub-50 safety brake, not a normal-state dam.

We heal as we walk.