### PR TITLE
fix(flow): C-292 watermark blind spot + lane diagnostics + debug endp…

### DIFF
--- a/app/api/chambers/lane-diagnostics/route.ts
+++ b/app/api/chambers/lane-diagnostics/route.ts
@@ -1,14 +1,26 @@
 import { NextResponse } from 'next/server';
 import { GET as getSnapshotLite } from '@/app/api/terminal/snapshot-lite/route';
 import { getHeartbeat, getJournalHeartbeat } from '@/lib/runtime/heartbeat';
+import { readTerminalWatermark } from '@/lib/terminal/watermark';
+import { getJournalRedisClient } from '@/lib/agents/journalLane';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
   const now = new Date().toISOString();
+  // C-292: read watermark in parallel with snapshot-lite so the lane diagnostics
+  // panel can surface journal/ledger lane write recency from KV.
+  const [liteRes, watermarkResult] = await Promise.allSettled([
+    getSnapshotLite(new Request('http://localhost/api/terminal/snapshot-lite') as never),
+    readTerminalWatermark(getJournalRedisClient()),
+  ]);
+
+  const lite = liteRes.status === 'fulfilled'
+    ? ((await liteRes.value.json().catch(() => ({}))) as { degraded?: boolean; lanes?: Record<string, unknown> })
+    : { degraded: true, lanes: {} };
+  const wm = watermarkResult.status === 'fulfilled' ? watermarkResult.value : null;
+
   try {
-    const res = await getSnapshotLite(new Request('http://localhost/api/terminal/snapshot-lite') as never);
-    const lite = (await res.json()) as { degraded?: boolean; lanes?: Record<string, unknown> };
     const tripwireLane = (lite.lanes?.tripwire as { count?: number; elevated?: boolean } | undefined) ?? {};
     return NextResponse.json({
       ok: true,
@@ -22,6 +34,17 @@ export async function GET() {
         runtime: getHeartbeat(),
         journal: getJournalHeartbeat(),
       },
+      watermark: wm
+        ? {
+            version: wm.version,
+            cycle: wm.cycle ?? null,
+            updatedAt: wm.updatedAt,
+            journal: wm.lanes.journal ?? null,
+            ledger: wm.lanes.ledger ?? null,
+            snapshot: wm.lanes.snapshot ?? null,
+            signals: wm.lanes.signals ?? null,
+          }
+        : null,
       reason: lite.degraded ? 'one or more lanes degraded' : null,
       timestamp: now,
     });
@@ -32,6 +55,7 @@ export async function GET() {
       lanes: {},
       tripwire: { count: 0, elevated: false },
       heartbeat: { runtime: getHeartbeat(), journal: getJournalHeartbeat() },
+      watermark: null,
       reason: 'lane diagnostics unavailable',
       timestamp: now,
     });

--- a/app/api/debug/watermark/route.ts
+++ b/app/api/debug/watermark/route.ts
@@ -1,0 +1,63 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { readTerminalWatermark } from '@/lib/terminal/watermark';
+import { getJournalRedisClient } from '@/lib/agents/journalLane';
+import { getServiceAuthError } from '@/lib/security/serviceAuth';
+
+export const dynamic = 'force-dynamic';
+
+// C-292: operator endpoint for diagnosing journal/ledger lane flow stoppages.
+// Returns full terminal:watermark KV state with per-lane age in seconds.
+// Requires MOBIUS_SERVICE_SECRET or CRON_SECRET Bearer token.
+//
+// Usage:
+//   curl -H "Authorization: Bearer $MOBIUS_SERVICE_SECRET" \
+//     https://mobius-civic-ai-terminal.vercel.app/api/debug/watermark
+export async function GET(request: NextRequest) {
+  const authErr = getServiceAuthError(request);
+  if (authErr) return authErr;
+
+  const redis = getJournalRedisClient();
+  if (!redis) {
+    return NextResponse.json(
+      { ok: false, error: 'KV not configured', watermark: null },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const watermark = await readTerminalWatermark(redis);
+    const now = Date.now();
+
+    const laneAgeSeconds = Object.fromEntries(
+      Object.entries(watermark.lanes).map(([lane, lw]) => {
+        if (!lw?.updatedAt) return [lane, null];
+        const age = Math.floor((now - new Date(lw.updatedAt).getTime()) / 1000);
+        return [lane, Number.isFinite(age) ? age : null];
+      }),
+    );
+
+    return NextResponse.json({
+      ok: true,
+      watermark,
+      lane_age_seconds: laneAgeSeconds,
+      diagnostic: {
+        journal_last_write: watermark.lanes.journal?.updatedAt ?? null,
+        journal_cycle: watermark.cycle ?? null,
+        journal_status: watermark.lanes.journal?.status ?? null,
+        journal_age_seconds: laneAgeSeconds.journal ?? null,
+        ledger_last_write: watermark.lanes.ledger?.updatedAt ?? null,
+        signals_last_write: watermark.lanes.signals?.updatedAt ?? null,
+      },
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : 'watermark read failed',
+        watermark: null,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/agents/journal.ts
+++ b/lib/agents/journal.ts
@@ -5,6 +5,8 @@ import { scheduleVaultDepositForJournal } from '@/lib/vault/vault';
 import { writeToSubstrate } from '@/lib/substrate/client';
 import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
 import { setJournalHeartbeat } from '@/lib/runtime/heartbeat';
+import { bumpTerminalWatermark } from '@/lib/terminal/watermark';
+import { getJournalRedisClient } from '@/lib/agents/journalLane';
 
 const INDEX_KEY = 'journal:index';
 const MAX_ENTRIES_PER_AGENT = 100;
@@ -177,6 +179,16 @@ export async function appendAgentJournalEntry(input: NewJournalEntryInput): Prom
   const next = [...existing, entry].slice(-MAX_ENTRIES_PER_AGENT);
   await kvSet(key, next);
   await upsertIndex(agent, entry.cycle);
+  // C-292: bump watermark so the journal lane reflects Writer A (cron/synthesis)
+  // writes, not just Writer B (appendJournalLaneEntry / direct POST). Fire-and-forget
+  // so a watermark failure never blocks the journal write itself.
+  void bumpTerminalWatermark(getJournalRedisClient(), 'journal', {
+    cycle: entry.cycle,
+    status: 'hot',
+    hotCount: 1,
+  }).catch((err) => {
+    console.warn('[journal] watermark bump failed (non-blocking):', err instanceof Error ? err.message : err);
+  });
   if (entry.status === 'committed') {
     scheduleVaultDepositForJournal(entry);
 


### PR DESCRIPTION
…oint

Root cause: appendAgentJournalEntry (Writer A — used by EVE synthesis, ATLAS, ZEUS, and all 6 steward cron journals) never called bumpTerminalWatermark. Only appendJournalLaneEntry (Writer B — direct POST) bumped the watermark, so terminal:watermark showed the journal lane as perpetually stale even when all overnight cron writes succeeded.

lib/agents/journal.ts:
- Add fire-and-forget bumpTerminalWatermark call after every appendAgentJournalEntry write so Writer A cron journals register in the watermark. Failure is logged as a warning and never blocks the journal write.

app/api/chambers/lane-diagnostics/route.ts:
- Read watermark in parallel with snapshot-lite via Promise.allSettled.
- Surface watermark.journal, .ledger, .snapshot, .signals in the response so the lane diagnostics panel can show last KV write timestamps per lane.

app/api/debug/watermark/route.ts (new):
- Operator debug endpoint (service auth required) returning full watermark state with per-lane age in seconds and a diagnostic block covering journal_last_write, journal_cycle, journal_status, journal_age_seconds, ledger/signals timestamps.

https://claude.ai/code/session_01DjkbLW6kAyaYppCbCbbV2o

# Mobius Terminal PR — C-[CYCLE]

> Replace all `[PLACEHOLDERS]` before submitting. Incomplete PRs will not be merged.

---

## 1. Summary

- **Cycle:** C-
- **Type:** `fix` | `feat` | `chore` | `docs`
- **Primary area:** `journal` | `epicon` | `signals` | `echo` | `ledger` | `agents` | `ui` | `infra` | `docs`
- **Files changed:** (list every file modified)
- **Files deliberately NOT changed:** (list files in the same area you intentionally left alone)

**What changed?**
(One paragraph. Concrete. What the code does now that it didn't before.)

**Why?**
(Reference to CURRENT_CYCLE.md section, snapshot lane state, or specific broken behavior with evidence.)

---

## 2. Risk Tier

- [ ] **Tier 0** — Docs / comments / formatting only
- [ ] **Tier 1** — App logic, no auth/KV schema changes
- [ ] **Tier 2** — KV key schema, journal schema, EPICON shape, signal domain assignment
- [ ] **Tier 3** — MIC economy, identity, ledger integrity math, auth

> Tier 2+ requires operator review before merge. Do not self-merge Tier 2+.

---

## 3. EPICON Intent

```text
epicon_id: EPICON_C-[CYCLE]_[area]_[short-description]
scope: [area]
mode: normal
issued_at: [ISO timestamp]

justification:
  PROBLEM:
    [What is broken or missing? Be specific. Include snapshot lane state or error text.]

  CONTEXT:
    [Why does this matter now? Reference CURRENT_CYCLE.md if relevant.]

  DECISION:
    [What exactly is being changed and why this approach over alternatives.]

  BOUNDARIES:
    [What this PR does NOT touch. Be explicit about locked behaviors preserved.]

  TRADEOFFS:
    - Removed: [anything deleted or disabled]
    - Kept: [locked behaviors confirmed preserved]
    - Risk: [what could go wrong]

  COUNTERFACTUALS:
    - If [condition], then [corrective action]
    - If [condition], then [corrective action]
```

---

## 4. LOCKED BEHAVIOR AUDIT

I have read `CURRENT_CYCLE.md` and confirm the following:

**Journal KV key schema (`journal:{AGENT}:{CYCLE}`)**
- [ ] This PR does NOT change the key schema in `app/api/agents/journal/route.ts`
- [ ] OR: I am modifying this because: ___

**ECHO → `epicon:feed` LPUSH**
- [ ] This PR does NOT remove or bypass the LPUSH/LTRIM in `app/api/echo/ingest/route.ts`
- [ ] OR: I am modifying this because: ___

**Substrate GitHub auth header**
- [ ] This PR does NOT remove the `Authorization` header from `lib/substrate/github-reader.ts`
- [ ] OR: I am modifying this because: ___

**Signal domain ownership**
- [ ] This PR does NOT add crypto price sources to HERMES-µ
- [ ] This PR does NOT reassign domain ownership between agents
- [ ] OR: I am modifying this because: ___

**EXPECTED EMPTY states**
- [ ] This PR does NOT attempt to "fix" `sources.kv: 0` on epicon or journal
- [ ] This PR does NOT add seed/genesis data to mask empty KV state
- [ ] OR: I am modifying this because: ___

---

## 5. Integrity Impact

**What could go wrong if this PR is wrong?**

### Assessment
- **Estimated MII for this PR:** (0.00–1.00)
- **Risk level:** Low | Medium | High
- **Lanes affected:** (list terminal snapshot lanes this could impact)

### Checklist
- [ ] Does not change KV key schemas without operator approval
- [ ] Does not remove auth from any route
- [ ] Does not introduce duplicate signal sources across agents
- [ ] Does not add hardcoded cycle IDs, timestamps, or seed data
- [ ] pnpm build passes (or explain why it couldn't be run)

---

## 6. Verification

**Pre-merge:**
- [ ] `pnpm exec tsc --noEmit` — typecheck passes
- [ ] `pnpm build` — build passes (or document environment failure reason)
- [ ] Hit `/api/terminal/snapshot` on preview deployment
- [ ] Confirm affected lanes show expected state in snapshot

**Post-merge (operator to verify):**
- [ ] `/api/terminal/snapshot` checked on production
- [ ] No regressions in previously healthy lanes
- [ ] Snapshot `ok` field and lane states match expected outcome

**Evidence:**
(Paste relevant snapshot lane output or API response here)

---

## 7. Rollback Plan

```bash
git revert [commit-sha]
# If KV writes were involved, manually clean affected keys in Upstash console
# Verify /api/terminal/snapshot returns to pre-PR state
```

---

## 8. Stop Conditions Met

This PR was reviewed against the following stop conditions before submission:

- [ ] No stop condition triggered — scope is clean
- [ ] Stop condition triggered: ___ — resolved by: ___

> Stop conditions: touching a LOCKED file, "fixing" an EXPECTED EMPTY state,
> creating duplicate signal sources, changing KV key schema without Tier 2 review.

---

## 9. Final Checklist

- [ ] Risk tier correctly assessed
- [ ] EPICON intent block completed with BOUNDARIES field
- [ ] Locked behavior audit completed (all boxes checked or exceptions documented)
- [ ] Rollback plan provided
- [ ] I have read AGENTS.md, BUILD.md, and CURRENT_CYCLE.md before starting this PR
- [ ] I am okay with this appearing in the public cathedral

---

*"Let me update my consensus." — Mobius constitutional phrase for acknowledging new ground truth.*
