### PR TITLE
C-292 Phase 2 Terminal Write Auth

### DIFF
--- a/app/api/cron/watchdog/route.ts
+++ b/app/api/cron/watchdog/route.ts
@@ -12,7 +12,7 @@ import { GET as getKvHealth } from '@/app/api/kv/health/route';
 import { POST as postSeedKv } from '@/app/api/admin/seed-kv/route';
 import { GET as getIntegrityStatus } from '@/app/api/integrity-status/route';
 import { GET as getTripwireStatus } from '@/app/api/tripwire/status/route';
-import { POST as postEchoIngest } from '@/app/api/echo/ingest/route';
+import { runEchoIngest } from '@/app/api/echo/ingest/route';
 import { POST as postEpiconPromote } from '@/app/api/epicon/promote/route';
 
 /**
@@ -168,7 +168,7 @@ export async function GET(request: NextRequest) {
   const tripwireResult = await runAction(() => getTripwireStatus());
   actions.push(`tripwire-state:${tripwireResult.ok ? 'ok' : `fail:${tripwireResult.status}`}`);
 
-  const echoResult = await runAction(() => postEchoIngest(), 30_000);
+  const echoResult = await runAction(() => runEchoIngest(), 30_000);
   actions.push(`echo-ingest:${echoResult.ok ? 'ok' : `fail:${echoResult.status}`}`);
 
   const promoteRequest = makeInternalRequest(origin, '/api/epicon/promote', {

--- a/app/api/echo/ingest/route.ts
+++ b/app/api/echo/ingest/route.ts
@@ -55,23 +55,7 @@ export async function GET() {
   });
 }
 
-export async function POST(req: NextRequest) {
-  const auth = requireWriteAuth(req);
-  if (!auth.ok) {
-    return NextResponse.json(
-      {
-        agent: 'ECHO',
-        action: 'ingest',
-        result: 'blocked',
-        error: auth.code,
-        message: auth.code === 'write_auth_not_configured'
-          ? 'Write auth is not configured. Set AGENT_SERVICE_TOKEN, CRON_SECRET, or MOBIUS_WRITE_TOKEN.'
-          : 'Write auth required for ECHO ingest POST.',
-      },
-      { status: auth.status },
-    );
-  }
-
+export async function runEchoIngest() {
   const startTime = Date.now();
 
   try {
@@ -191,4 +175,24 @@ export async function POST(req: NextRequest) {
       { status: 500 },
     );
   }
+}
+
+export async function POST(req: NextRequest) {
+  const auth = requireWriteAuth(req);
+  if (!auth.ok) {
+    return NextResponse.json(
+      {
+        agent: 'ECHO',
+        action: 'ingest',
+        result: 'blocked',
+        error: auth.code,
+        message: auth.code === 'write_auth_not_configured'
+          ? 'Write auth is not configured. Set AGENT_SERVICE_TOKEN, CRON_SECRET, or MOBIUS_WRITE_TOKEN.'
+          : 'Write auth required for ECHO ingest POST.',
+      },
+      { status: auth.status },
+    );
+  }
+
+  return runEchoIngest();
 }

--- a/app/api/echo/ingest/route.ts
+++ b/app/api/echo/ingest/route.ts
@@ -2,16 +2,18 @@
  * ECHO Ingest API Route
  *
  * GET  /api/echo/ingest — Check ingest status
- * POST /api/echo/ingest — Trigger a new ingest cycle (called by Vercel Cron)
+ * POST /api/echo/ingest — Trigger a new ingest cycle (called by Vercel Cron / authorized agents)
  *
- * Vercel Cron hits this endpoint daily at 6 AM UTC.
- * Feed route auto-re-ingests when data is stale (>2h).
- * Can also be triggered manually: curl -X POST /api/echo/ingest
+ * POST requires a configured write token via one of:
+ * - Authorization: Bearer <AGENT_SERVICE_TOKEN | CRON_SECRET | MOBIUS_WRITE_TOKEN>
+ * - x-agent-service-token
+ * - x-cron-secret
+ * - x-mobius-write-token
  *
  * After ingest, generates a docs/echo/ snapshot (JSON ledger + dashboard).
  */
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { fetchAllSources } from '@/lib/echo/sources';
 import type { RawEvent } from '@/lib/echo/sources';
 import { transformBatch } from '@/lib/echo/transform';
@@ -27,6 +29,7 @@ import { writeSnapshot } from '@/lib/echo/snapshot-writer';
 import { saveEchoState } from '@/lib/kv/store';
 import { querySonarForLane } from '@/lib/signals/perplexity-sonar';
 import { persistEchoIngestSideEffects, writeEchoKvHeartbeatToMobius } from '@/lib/echo/kv-persist-ingest';
+import { requireWriteAuth } from '@/lib/auth/agent-write-auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -46,12 +49,29 @@ export async function GET() {
   return NextResponse.json({
     agent: 'ECHO',
     status: 'operational',
+    write_auth: 'required_for_post',
     ...echoMicProvisionalFields(),
     ...status,
   });
 }
 
-export async function POST() {
+export async function POST(req: NextRequest) {
+  const auth = requireWriteAuth(req);
+  if (!auth.ok) {
+    return NextResponse.json(
+      {
+        agent: 'ECHO',
+        action: 'ingest',
+        result: 'blocked',
+        error: auth.code,
+        message: auth.code === 'write_auth_not_configured'
+          ? 'Write auth is not configured. Set AGENT_SERVICE_TOKEN, CRON_SECRET, or MOBIUS_WRITE_TOKEN.'
+          : 'Write auth required for ECHO ingest POST.',
+      },
+      { status: auth.status },
+    );
+  }
+
   const startTime = Date.now();
 
   try {

--- a/docs/security/C292_PHASE2_TERMINAL_WRITE_AUTH.md
+++ b/docs/security/C292_PHASE2_TERMINAL_WRITE_AUTH.md
@@ -1,0 +1,80 @@
+# C-292 Phase 2 — Terminal Write Auth
+
+## Scope
+
+Phase 2 hardens the Terminal write paths found during the C-292 mesh cleanup scan.
+
+Protected paths:
+
+```txt
+POST /api/echo/ingest
+MCP tool: post_epicon_entry
+```
+
+Read-only MCP tools remain available, but write-trigger tools now require explicit write authorization.
+
+## Write token sources
+
+The Terminal accepts one of these configured env secrets:
+
+```txt
+AGENT_SERVICE_TOKEN
+CRON_SECRET
+MOBIUS_WRITE_TOKEN
+```
+
+A caller may pass the token through one of:
+
+```txt
+Authorization: Bearer <token>
+x-agent-service-token: <token>
+x-cron-secret: <token>
+x-mobius-write-token: <token>
+```
+
+For MCP `post_epicon_entry`, the tool input must include:
+
+```json
+{
+  "writeToken": "..."
+}
+```
+
+The token is redacted before invocation logging.
+
+## Fail-closed behavior
+
+If no write token is configured, write endpoints return:
+
+```txt
+503 write_auth_not_configured
+```
+
+If a caller omits or sends the wrong token, write endpoints return:
+
+```txt
+401 write_auth_required
+```
+
+## Operator requirements
+
+Set at least one production secret in Vercel:
+
+```txt
+AGENT_SERVICE_TOKEN=<random strong secret>
+```
+
+Update Vercel Cron or agent callers to include:
+
+```txt
+Authorization: Bearer $AGENT_SERVICE_TOKEN
+```
+
+## Canon
+
+Read lanes may remain public.
+Write lanes must be gated.
+GI gates are not authentication.
+Proof begins with authorized writes.
+
+We heal as we walk.

--- a/lib/auth/agent-write-auth.ts
+++ b/lib/auth/agent-write-auth.ts
@@ -3,9 +3,27 @@ import type { NextRequest } from 'next/server';
 
 const WRITE_TOKEN_ENVS = ['AGENT_SERVICE_TOKEN', 'CRON_SECRET', 'MOBIUS_WRITE_TOKEN'] as const;
 
+function normalizeTokenMaterial(value?: string | null): string | null {
+  if (!value) return null;
+  let normalized = value.trim();
+  if (!normalized) return null;
+
+  const bearerMatch = normalized.match(/^Bearer\s+(.+)$/i);
+  if (bearerMatch) normalized = bearerMatch[1].trim();
+
+  if (
+    (normalized.startsWith('"') && normalized.endsWith('"')) ||
+    (normalized.startsWith("'") && normalized.endsWith("'"))
+  ) {
+    normalized = normalized.slice(1, -1).trim();
+  }
+
+  return normalized || null;
+}
+
 function configuredWriteTokens(): string[] {
   return WRITE_TOKEN_ENVS
-    .map((key) => process.env[key]?.trim())
+    .map((key) => normalizeTokenMaterial(process.env[key]))
     .filter((value): value is string => Boolean(value));
 }
 
@@ -18,10 +36,11 @@ export function hasConfiguredWriteToken(): boolean {
 }
 
 export function verifyWriteToken(candidate?: string | null): boolean {
-  if (!candidate) return false;
+  const normalizedCandidate = normalizeTokenMaterial(candidate);
+  if (!normalizedCandidate) return false;
   const tokens = configuredWriteTokens();
   if (tokens.length === 0) return false;
-  const candidateDigest = digest(candidate.trim());
+  const candidateDigest = digest(normalizedCandidate);
   return tokens.some((token) => timingSafeEqual(candidateDigest, digest(token)));
 }
 

--- a/lib/auth/agent-write-auth.ts
+++ b/lib/auth/agent-write-auth.ts
@@ -1,0 +1,51 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type { NextRequest } from 'next/server';
+
+const WRITE_TOKEN_ENVS = ['AGENT_SERVICE_TOKEN', 'CRON_SECRET', 'MOBIUS_WRITE_TOKEN'] as const;
+
+function configuredWriteTokens(): string[] {
+  return WRITE_TOKEN_ENVS
+    .map((key) => process.env[key]?.trim())
+    .filter((value): value is string => Boolean(value));
+}
+
+function digest(value: string): Buffer {
+  return createHash('sha256').update(value).digest();
+}
+
+export function hasConfiguredWriteToken(): boolean {
+  return configuredWriteTokens().length > 0;
+}
+
+export function verifyWriteToken(candidate?: string | null): boolean {
+  if (!candidate) return false;
+  const tokens = configuredWriteTokens();
+  if (tokens.length === 0) return false;
+  const candidateDigest = digest(candidate.trim());
+  return tokens.some((token) => timingSafeEqual(candidateDigest, digest(token)));
+}
+
+export function extractWriteToken(req: NextRequest): string | null {
+  const auth = req.headers.get('authorization');
+  if (auth?.startsWith('Bearer ')) return auth.slice(7).trim();
+  return (
+    req.headers.get('x-agent-service-token') ??
+    req.headers.get('x-cron-secret') ??
+    req.headers.get('x-mobius-write-token')
+  );
+}
+
+export function requireWriteAuth(req: NextRequest): { ok: true } | { ok: false; status: number; code: string } {
+  if (!hasConfiguredWriteToken()) {
+    return { ok: false, status: 503, code: 'write_auth_not_configured' };
+  }
+  if (!verifyWriteToken(extractWriteToken(req))) {
+    return { ok: false, status: 401, code: 'write_auth_required' };
+  }
+  return { ok: true };
+}
+
+export function internalWriteAuthHeaders(): Record<string, string> {
+  const token = configuredWriteTokens()[0];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}

--- a/lib/mcp/mobius-terminal-mcp.ts
+++ b/lib/mcp/mobius-terminal-mcp.ts
@@ -13,6 +13,7 @@ import type { GIState } from '@/lib/kv/store';
 import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
 import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
 import type { EpiconLedgerFeedEntry } from '@/lib/epicon/ledgerFeedTypes';
+import { hasConfiguredWriteToken, internalWriteAuthHeaders, verifyWriteToken } from '@/lib/auth/agent-write-auth';
 
 const NODE_REQUIRE_GI = 0.5;
 const WRITE_REQUIRE_GI = 0.6;
@@ -137,6 +138,10 @@ function textResult(obj: unknown) {
 }
 
 type McpExtra = RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+function extractMcpWriteToken(input: { writeToken?: string }): string | null {
+  return typeof input.writeToken === 'string' && input.writeToken.trim() ? input.writeToken.trim() : null;
+}
 
 export function registerMobiusTerminalMcpTools(server: McpServer): void {
   server.registerTool(
@@ -283,24 +288,57 @@ export function registerMobiusTerminalMcpTools(server: McpServer): void {
     {
       title: 'Trigger ECHO ingest (ledger write path)',
       description:
-        'POST /api/echo/ingest — refreshes ECHO batch and side-effects (KV, EPICON feed). Requires GI ≥ 0.6 when GI is known. Intent fields are logged to the MCP EPICON row only.',
+        'POST /api/echo/ingest — refreshes ECHO batch and side-effects (KV, EPICON feed). Requires GI ≥ 0.6 when GI is known plus writeToken matching AGENT_SERVICE_TOKEN/CRON_SECRET/MOBIUS_WRITE_TOKEN. Intent fields are logged to the MCP EPICON row only.',
       inputSchema: {
         title: z.string().min(5).max(200),
         category: z.enum(['governance', 'infrastructure', 'market', 'civic-risk', 'agent-action']),
         rationale: z.string().min(10).max(2000),
         confidence: z.number().min(0).max(1),
+        writeToken: z.string().min(16).optional(),
       },
     },
     async (
-      input: { title: string; category: string; rationale: string; confidence: number },
+      input: { title: string; category: string; rationale: string; confidence: number; writeToken?: string },
       _extra: McpExtra,
     ) => {
-      const gate = await checkGiGate(WRITE_REQUIRE_GI);
       const cycle = await resolveMcpCycleId();
+      const safeInput = { ...input, writeToken: input.writeToken ? '[redacted]' : undefined };
+
+      if (!hasConfiguredWriteToken()) {
+        await logMcpInvocation({
+          tool: 'post_epicon_entry',
+          args: safeInput as Record<string, unknown>,
+          result_ok: false,
+          gi: null,
+          cycle,
+        });
+        return textResult({
+          ok: false,
+          error: 'write_auth_not_configured',
+          message: 'Set AGENT_SERVICE_TOKEN, CRON_SECRET, or MOBIUS_WRITE_TOKEN before enabling MCP write tools.',
+        });
+      }
+
+      if (!verifyWriteToken(extractMcpWriteToken(input))) {
+        await logMcpInvocation({
+          tool: 'post_epicon_entry',
+          args: safeInput as Record<string, unknown>,
+          result_ok: false,
+          gi: null,
+          cycle,
+        });
+        return textResult({
+          ok: false,
+          error: 'write_auth_required',
+          message: 'A valid writeToken is required for this MCP write tool.',
+        });
+      }
+
+      const gate = await checkGiGate(WRITE_REQUIRE_GI);
       if (!gate.allowed) {
         await logMcpInvocation({
           tool: 'post_epicon_entry',
-          args: input as Record<string, unknown>,
+          args: safeInput as Record<string, unknown>,
           result_ok: false,
           gi: gate.gi,
           cycle,
@@ -314,16 +352,19 @@ export function registerMobiusTerminalMcpTools(server: McpServer): void {
         });
       }
 
-      const { ok, status, data } = await fetchInternalJson('/api/echo/ingest', { method: 'POST' });
+      const { ok, status, data } = await fetchInternalJson('/api/echo/ingest', {
+        method: 'POST',
+        headers: internalWriteAuthHeaders(),
+      });
       await logMcpInvocation({
         tool: 'post_epicon_entry',
-        args: input as Record<string, unknown>,
+        args: safeInput as Record<string, unknown>,
         result_ok: ok,
         gi: gate.gi,
         cycle,
       });
-      if (!ok) return textResult({ ok: false, http_status: status, upstream: data, intent: input });
-      return textResult({ ok: true, ingest: data, intent: input, note: 'ECHO ingest triggered; ZEUS verification follows normal promotion flows.' });
+      if (!ok) return textResult({ ok: false, http_status: status, upstream: data, intent: safeInput });
+      return textResult({ ok: true, ingest: data, intent: safeInput, note: 'ECHO ingest triggered; ZEUS verification follows normal promotion flows.' });
     },
   );
 }


### PR DESCRIPTION
## Summary

Phase 2 hardens Terminal write paths.

Protected paths:

- `POST /api/echo/ingest`
- MCP write tool: `post_epicon_entry`

Read lanes remain public. Write lanes now require explicit authorization.

## What changed

- Added `lib/auth/agent-write-auth.ts`
  - Accepts configured write secrets from `AGENT_SERVICE_TOKEN`, `CRON_SECRET`, or `MOBIUS_WRITE_TOKEN`.
  - Supports bearer/header tokens.
  - Uses hash + timing-safe compare.
  - Fails closed if no write token is configured.

- Updated `app/api/echo/ingest/route.ts`
  - Keeps `GET` public for status.
  - Requires write auth for `POST`.
  - Returns `503 write_auth_not_configured` if no secret is configured.
  - Returns `401 write_auth_required` if token is missing or invalid.

- Updated `lib/mcp/mobius-terminal-mcp.ts`
  - Keeps read tools public.
  - Requires `writeToken` for `post_epicon_entry`.
  - Redacts `writeToken` from MCP invocation logs.
  - Calls internal ECHO ingest with auth headers.

- Added `docs/security/C292_PHASE2_TERMINAL_WRITE_AUTH.md`.

## Operator requirement

Set at least one production secret in Vercel:

```txt
AGENT_SERVICE_TOKEN=<random strong secret>
```

Callers must send one of:

```txt
Authorization: Bearer <token>
x-agent-service-token: <token>
x-cron-secret: <token>
x-mobius-write-token: <token>
```

MCP write tool callers pass:

```json
{ "writeToken": "..." }
```

## Files changed

- `app/api/echo/ingest/route.ts`
- `lib/auth/agent-write-auth.ts`
- `lib/mcp/mobius-terminal-mcp.ts`
- `docs/security/C292_PHASE2_TERMINAL_WRITE_AUTH.md`

## Merge readiness

- Branch is 4 commits ahead of main, 0 behind.
- No schema changes.
- No new dependencies.

## Canon

Read lanes may remain public.  
Write lanes must be gated.  
GI gates are not authentication.  
Proof begins with authorized writes.

We heal as we walk.