### PR TITLE
C-292 Ledger Cycle + EPICON Bridge Fix

### DIFF
--- a/app/api/chambers/ledger/route.ts
+++ b/app/api/chambers/ledger/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getEchoLedger } from '@/lib/echo/store';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
 import type { LedgerEntry } from '@/lib/terminal/types';
 
 export const dynamic = 'force-dynamic';
@@ -8,10 +9,12 @@ export const revalidate = 0;
 type EpiconFeedItem = {
   id?: string;
   cycle?: string;
+  cycleId?: string;
   timestamp?: string;
   author?: string;
   title?: string;
   body?: string;
+  summary?: string;
   type?: string;
   category?: string;
   status?: string;
@@ -32,20 +35,19 @@ function cleanText(input: unknown): string {
   return typeof input === 'string' ? input.trim() : '';
 }
 
-function inferCycleFromText(...inputs: unknown[]): string {
+function inferCycleFromText(...inputs: unknown[]): string | null {
   for (const input of inputs) {
     const text = Array.isArray(input) ? input.join(' ') : cleanText(input);
     if (!text) continue;
     const match = text.match(CYCLE_PATTERN);
     if (match?.[1]) return `C-${match[1]}`;
   }
-  return 'C-—';
+  return null;
 }
 
-function normalizeCycle(item: EpiconFeedItem): string {
-  const explicit = cleanText(item.cycle);
-  if (explicit) return inferCycleFromText(explicit);
-  return inferCycleFromText(item.id, item.title, item.body, item.tags, item.source);
+function normalizeCycle(item: EpiconFeedItem, fallbackCycle: string): string {
+  const explicit = cleanText(item.cycle ?? item.cycleId);
+  return inferCycleFromText(explicit, item.id, item.title, item.body, item.summary, item.tags, item.source) ?? fallbackCycle;
 }
 
 function normalizeTimestamp(input: unknown): string {
@@ -132,17 +134,17 @@ function normalizeSource(input: unknown): LedgerEntry['source'] {
   return 'echo';
 }
 
-function epiconToLedgerEntry(item: EpiconFeedItem, idx: number): LedgerEntry {
+function epiconToLedgerEntry(item: EpiconFeedItem, idx: number, fallbackCycle: string): LedgerEntry {
   const timestamp = normalizeTimestamp(item.timestamp);
   const proofState = normalizeProofState(item);
   return {
     id: item.id?.trim() || `epicon-feed-${idx}-${timestamp}`,
-    cycleId: normalizeCycle(item),
+    cycleId: normalizeCycle(item, fallbackCycle),
     type: 'epicon',
     agentOrigin: normalizeAgent(item),
     timestamp,
     title: item.title,
-    summary: item.body ?? item.title ?? 'EPICON feed event',
+    summary: item.body ?? item.summary ?? item.title ?? 'EPICON feed event',
     integrityDelta: 0,
     ...proofState,
     category: normalizeCategory(item.category),
@@ -152,12 +154,13 @@ function epiconToLedgerEntry(item: EpiconFeedItem, idx: number): LedgerEntry {
   };
 }
 
-function annotateEchoEntry(entry: LedgerEntry): LedgerEntry {
-  if (entry.statusReason && entry.proofSource && entry.canonState) return entry;
+function annotateEchoEntry(entry: LedgerEntry, fallbackCycle: string): LedgerEntry {
   const committed = entry.status === 'committed';
   const reverted = entry.status === 'reverted';
+  const inferredCycle = inferCycleFromText(entry.cycleId, entry.id, entry.title, entry.summary, entry.tags, entry.source) ?? fallbackCycle;
   return {
     ...entry,
+    cycleId: inferredCycle,
     statusReason: entry.statusReason ?? (reverted ? 'echo_memory_reverted' : committed ? 'echo_memory_committed' : 'echo_memory_pending'),
     proofSource: entry.proofSource ?? 'echo_memory',
     canonState: entry.canonState ?? (reverted ? 'blocked' : committed ? 'candidate' : 'hot'),
@@ -175,23 +178,24 @@ function dedupeSort(entries: LedgerEntry[]): LedgerEntry[] {
     .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
 }
 
-async function fetchEpiconLedgerFallback(request: NextRequest): Promise<LedgerEntry[]> {
+async function fetchEpiconLedgerFallback(request: NextRequest, fallbackCycle: string): Promise<LedgerEntry[]> {
   try {
     const url = new URL('/api/epicon/feed?limit=100&include_catalog=false', request.nextUrl.origin);
     const res = await fetch(url, { cache: 'no-store' });
     if (!res.ok) return [];
     const data = (await res.json()) as { items?: EpiconFeedItem[] };
     const items = Array.isArray(data.items) ? data.items : [];
-    return items.map(epiconToLedgerEntry);
+    return items.map((item, idx) => epiconToLedgerEntry(item, idx, fallbackCycle));
   } catch {
     return [];
   }
 }
 
 export async function GET(request: NextRequest) {
+  const activeCycle = currentCycleId();
   try {
-    const echoEvents = getEchoLedger().map(annotateEchoEntry);
-    const epiconEvents = await fetchEpiconLedgerFallback(request);
+    const echoEvents = getEchoLedger().map((entry) => annotateEchoEntry(entry, activeCycle));
+    const epiconEvents = await fetchEpiconLedgerFallback(request, activeCycle);
     const events = dedupeSort([...echoEvents, ...epiconEvents]).slice(0, 100);
     const pending = events.filter((e) => e.status === 'pending').length;
     const confirmed = events.filter((e) => e.status === 'committed').length;
@@ -208,6 +212,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       {
         ok: true,
+        cycleId: activeCycle,
         events,
         candidates: { pending, confirmed, contested },
         canon,
@@ -232,6 +237,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       {
         ok: true,
+        cycleId: activeCycle,
         events: [],
         candidates: { pending: 0, confirmed: 0, contested: 0 },
         canon: { hot: 0, candidate: 0, attested: 0, sealed: 0, blocked: 0 },

--- a/app/terminal/ledger/LedgerPageClient.tsx
+++ b/app/terminal/ledger/LedgerPageClient.tsx
@@ -78,8 +78,9 @@ export default function LedgerPageClient() {
   const { data, preview, full, error, stabilizationActive } = useLedgerChamber(true);
   const [sortKey, setSortKey] = useState<SortKey>('timestamp');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
-  const feed = useMemo(() => (data ? ({ events: data.events, status: { cycleId: 'C-—' } } as EchoFeedResponse) : null), [data]);
+  const feed = useMemo(() => (data ? ({ events: data.events, status: { cycleId: data.cycleId ?? data.events[0]?.cycleId ?? 'C-—' } } as EchoFeedResponse) : null), [data]);
   const rows = useMemo(() => feed?.events ?? [], [feed]);
+  const activeCycle = data?.cycleId ?? feed?.status?.cycleId ?? rows.find((row) => row.cycleId !== 'C-—')?.cycleId ?? 'C-—';
   const sorted = useMemo(() => sortRows(rows, sortKey, sortDir), [rows, sortKey, sortDir]);
   const totalDelta = useMemo(() => rows.reduce((sum, row) => sum + (row.integrityDelta ?? 0), 0), [rows]);
   const canon = data?.canon;
@@ -103,7 +104,7 @@ export default function LedgerPageClient() {
     <div className="flex h-full flex-col overflow-hidden p-4 text-xs">
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
         <span className="text-slate-400">
-          {feed.status?.cycleId ?? 'C-—'} · {rows.length} ledger rows
+          {activeCycle} · {rows.length} ledger rows
         </span>
         {preview && !full ? (
           <span className="rounded border border-cyan-700/40 bg-cyan-950/20 px-2 py-1 text-[10px] text-cyan-200">preview</span>
@@ -134,9 +135,6 @@ export default function LedgerPageClient() {
         ) : null}
       </div>
       {error ? <div className="mb-2 rounded border border-amber-700/40 bg-amber-950/20 px-2 py-1 text-[11px] text-amber-200">Ledger chamber degraded · showing snapshot preview</div> : null}
-      {/* OPT-15 / Bug-1 (C-291): surface LEDGER_CIRCUIT_OPEN state with recovery guidance.
-          When the ledger circuit breaker is open, EPICON candidates can't be promoted.
-          This was previously silent — operators had no indication or recovery path. */}
       {(data as { degraded?: boolean; ledgerError?: string } | null)?.ledgerError === 'ledger_circuit_open' ? (
         <div className="mb-2 rounded border border-rose-700/50 bg-rose-950/20 px-3 py-2 text-[11px] text-rose-200">
           <span className="font-semibold">LEDGER CIRCUIT OPEN</span>
@@ -152,7 +150,6 @@ export default function LedgerPageClient() {
         </div>
       ) : (
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-slate-800">
-          {/* Desktop header — hidden on mobile */}
           <div className="hidden md:grid grid-cols-[90px_70px_1fr_90px_50px_80px_70px] bg-slate-950/80 px-3 py-2 text-[10px] uppercase tracking-wide text-slate-400">
             <button type="button" onClick={() => toggleSort('timestamp')} className="text-left hover:text-slate-200">
               Time{arrow('timestamp')}
@@ -181,7 +178,6 @@ export default function LedgerPageClient() {
               const hasDelta = Math.abs(delta) > 0.0001;
               return (
                 <div key={row.id}>
-                  {/* Desktop row */}
                   <div className="hidden md:grid grid-cols-[90px_70px_1fr_90px_50px_80px_70px] items-center gap-1 px-3 py-1.5 text-slate-200">
                     <span className="font-mono text-[10px] text-slate-500">{row.timestamp.slice(11, 19)}Z</span>
                     <span className={`truncate font-mono text-[10px] ${agentColor(row.agentOrigin)}`} title={row.agentOrigin}>
@@ -197,7 +193,6 @@ export default function LedgerPageClient() {
                     </span>
                     <span className={`inline-flex w-fit rounded border px-1.5 py-0.5 text-[9px] ${statusBadge(row.status)}`}>{row.status}</span>
                   </div>
-                  {/* Mobile card */}
                   <div className="md:hidden px-3 py-2.5 space-y-1">
                     <div className="flex items-center justify-between gap-2">
                       <span className={`font-mono text-[11px] font-semibold ${agentColor(row.agentOrigin)}`}>

--- a/docs/pr-bundles/C-292-ledger-cycle-epicon-bridge.md
+++ b/docs/pr-bundles/C-292-ledger-cycle-epicon-bridge.md
@@ -1,0 +1,60 @@
+# C-292 Ledger Cycle + EPICON Bridge
+
+## Issue
+
+The Ledger chamber was showing:
+
+```txt
+C-— · ledger rows
+```
+
+instead of the active cycle, even while the Terminal header showed `C-292`.
+
+This made it look like EPICON feed rows were not posting into the Ledger or that Ledger did not understand the current cycle.
+
+## Root cause
+
+The Ledger page client wrapped chamber data with a hardcoded fallback:
+
+```ts
+status: { cycleId: 'C-—' }
+```
+
+The Ledger chamber API also normalized missing feed cycles to `C-—` instead of using the active deterministic cycle.
+
+## Fix
+
+- `app/api/chambers/ledger/route.ts`
+  - imports `currentCycleId()`
+  - returns `cycleId` at top-level
+  - uses active cycle as fallback when EPICON feed rows lack cycle metadata
+  - preserves inferred cycles when rows include `C-###` in id/title/body/tags
+
+- `hooks/useLedgerChamber.ts`
+  - adds `cycleId` to `LedgerChamberPayload`
+  - preview rows inherit active cycle from digest/snapshot
+
+- `app/terminal/ledger/LedgerPageClient.tsx`
+  - renders active cycle from chamber payload instead of hardcoded `C-—`
+
+## Expected result
+
+Ledger chamber should display:
+
+```txt
+C-292 · 11 ledger rows
+```
+
+or the current deterministic cycle for the day.
+
+EPICON feed bridge rows will still be visible as candidates/committed rows, but now they carry an active cycle when the source does not include explicit cycle metadata.
+
+## Canon
+
+Ledger rows without explicit cycle metadata should inherit the active cycle, not lose cycle awareness.
+
+EPICON feeds the Ledger chamber.
+Ledger chamber shows the current cycle.
+Proof remains human-merge aware.
+
+We heal as we walk.

--- a/hooks/useLedgerChamber.ts
+++ b/hooks/useLedgerChamber.ts
@@ -16,6 +16,7 @@ export type LedgerCanonCounts = {
 
 export type LedgerChamberPayload = {
   ok: boolean;
+  cycleId?: string;
   events: LedgerEntry[];
   candidates: { pending: number; confirmed: number; contested: number };
   canon?: LedgerCanonCounts;
@@ -33,10 +34,11 @@ export function useLedgerChamber(enabled: boolean) {
   const preview = useMemo(() => {
     const epicon = snapshot?.epicon?.data as { items?: Array<Record<string, unknown>> } | undefined;
     const items = Array.isArray(epicon?.items) ? epicon.items : [];
+    const activeCycle = digest?.cycle ?? snapshot?.cycle ?? 'C-—';
     const fallbackRows = Math.max(digest?.ledger_preview.pending ?? 0, items.length, 1);
     const events: LedgerEntry[] = items.slice(0, 20).map((item, idx) => ({
       id: typeof item.id === 'string' ? item.id : `snapshot-${idx}`,
-      cycleId: digest?.cycle ?? snapshot?.cycle ?? 'C-—',
+      cycleId: typeof item.cycle === 'string' ? item.cycle : activeCycle,
       type: 'epicon',
       agentOrigin: typeof item.agentOrigin === 'string' ? item.agentOrigin : 'ECHO',
       timestamp: typeof item.timestamp === 'string' ? item.timestamp : (digest?.timestamp ?? snapshot?.timestamp ?? new Date().toISOString()),
@@ -56,7 +58,7 @@ export function useLedgerChamber(enabled: boolean) {
       for (let i = 0; i < fallbackRows; i += 1) {
         events.push({
           id: `digest-${i}`,
-          cycleId: digest?.cycle ?? 'C-—',
+          cycleId: activeCycle,
           type: 'epicon',
           agentOrigin: 'ECHO',
           timestamp: digest?.timestamp ?? new Date().toISOString(),
@@ -73,6 +75,7 @@ export function useLedgerChamber(enabled: boolean) {
 
     return {
       ok: true,
+      cycleId: activeCycle,
       events,
       candidates: {
         pending: digest?.ledger_preview.pending ?? events.length,


### PR DESCRIPTION
## Summary

Fixes the Ledger chamber showing `C-—` while Terminal header shows the active cycle, and makes EPICON feed bridge rows inherit the active cycle when source rows lack explicit cycle metadata.

## Issue observed

Ledger page showed:

```txt
C-— · 11 ledger rows
```

while Terminal header showed:

```txt
C-292
```

That made it look like EPICON feed was not posting into Ledger or Ledger was not tracking the current cycle.

## Root cause

- `LedgerPageClient` hardcoded `status: { cycleId: 'C-—' }` when wrapping chamber data.
- `/api/chambers/ledger` normalized missing feed cycles to `C-—` instead of using the deterministic active cycle.

## What changed

- `app/api/chambers/ledger/route.ts`
  - imports `currentCycleId()`
  - returns top-level `cycleId`
  - uses active cycle as fallback for EPICON feed rows missing cycle metadata
  - still preserves explicit cycles found in `id`, `title`, `body`, `summary`, `tags`, or `source`

- `hooks/useLedgerChamber.ts`
  - adds `cycleId` to `LedgerChamberPayload`
  - preview rows inherit active cycle from digest/snapshot

- `app/terminal/ledger/LedgerPageClient.tsx`
  - renders active cycle from chamber payload instead of hardcoded `C-—`

- `docs/pr-bundles/C-292-ledger-cycle-epicon-bridge.md`
  - documents issue, root cause, and expected behavior

## Expected result

Ledger page should render:

```txt
C-292 · 11 ledger rows
```

or the current deterministic cycle for the day.

## Files changed

- `app/api/chambers/ledger/route.ts`
- `hooks/useLedgerChamber.ts`
- `app/terminal/ledger/LedgerPageClient.tsx`
- `docs/pr-bundles/C-292-ledger-cycle-epicon-bridge.md`

## Merge readiness

- Branch is 4 commits ahead of main, 0 behind.
- No new dependencies.
- No schema changes.

## Canon

Ledger rows without explicit cycle metadata should inherit the active cycle, not lose cycle awareness.

EPICON feeds the Ledger chamber.  
Ledger chamber shows the current cycle.  
Proof remains human-merge aware.

We heal as we walk.