### PR TITLE
C-293 Phase 2 — Canonical State Machine

### DIFF
--- a/app/api/protocol/state-machine/route.ts
+++ b/app/api/protocol/state-machine/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { CANONICAL_STATE_MACHINE } from '@/lib/protocol/state-machine';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    timestamp: new Date().toISOString(),
+    state_machine: CANONICAL_STATE_MACHINE,
+    canon: 'Mobius protocol objects must declare lifecycle state before they are treated as canon, sealed, disputed, or immortalized.',
+  }, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Mobius-Source': 'canonical-state-machine',
+    },
+  });
+}

--- a/app/api/quorum/state/route.ts
+++ b/app/api/quorum/state/route.ts
@@ -13,6 +13,11 @@ import {
 } from '@/lib/vault-v2/store';
 import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
 import { SENTINEL_ATTESTATION_COUNT, VAULT_RESERVE_PARCEL_UNITS } from '@/lib/vault-v2/constants';
+import {
+  CANONICAL_STATE_MACHINE_VERSION,
+  deriveQuorumCanonState,
+  deriveVaultBlockState,
+} from '@/lib/protocol/state-machine';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -67,12 +72,35 @@ export async function GET() {
   const inProgressBlock = candidate?.sequence ?? Math.max(sealsAuditCount, sealsCount) + 1;
   const reserveProgressPct = blockSize > 0 ? Math.min(100, Math.round((inProgressBalance / blockSize) * 100)) : 0;
   const latestImmortalized = Boolean(latestSeal?.substrate_attestation_id && latestSeal?.substrate_event_hash);
+  const attestationsReceived = candidate ? Object.keys(candidate.attestations).length : 0;
+  const quorum_state = deriveQuorumCanonState({
+    candidateInFlight: Boolean(candidate),
+    attestationsReceived,
+    attestationsRequired: SENTINEL_ATTESTATION_COUNT,
+    latestStatus: latestSeal?.status ?? null,
+    substrateAttestationId: latestSeal?.substrate_attestation_id ?? null,
+    substrateEventHash: latestSeal?.substrate_event_hash ?? null,
+  });
+  const vault_block_state = deriveVaultBlockState({
+    candidateInFlight: Boolean(candidate),
+    inProgressBalance,
+    blockSize,
+    latestStatus: latestSeal?.status ?? null,
+    fountainStatus: latestSeal?.fountain_status ?? null,
+    substrateAttestationId: latestSeal?.substrate_attestation_id ?? null,
+    substrateEventHash: latestSeal?.substrate_event_hash ?? null,
+  });
 
   return NextResponse.json({
     ok: true,
     timestamp: new Date().toISOString(),
     cycle,
-    phase: 'C-293-phase1-quorum-state-reader',
+    phase: 'C-293-phase2-canonical-state-machine',
+    state_machine: {
+      version: CANONICAL_STATE_MACHINE_VERSION,
+      quorum_state,
+      vault_block_state,
+    },
     integrity: {
       gi,
       mode: chain.mode ?? integrityPayload.mode ?? modeFromGi(gi),
@@ -84,6 +112,7 @@ export async function GET() {
     },
     reserve_block: {
       block_size: blockSize,
+      state: vault_block_state,
       in_progress_block: inProgressBlock,
       in_progress_balance: Number(inProgressBalance.toFixed(6)),
       in_progress_pct: reserveProgressPct,
@@ -123,8 +152,9 @@ export async function GET() {
     },
     attestations: attestationStatus(candidate),
     decision: {
+      state: quorum_state,
       ready_for_quorum: Boolean(candidate),
-      ready_for_substrate: Boolean(candidate && Object.keys(candidate.attestations).length >= SENTINEL_ATTESTATION_COUNT),
+      ready_for_substrate: Boolean(candidate && attestationsReceived >= SENTINEL_ATTESTATION_COUNT),
       canon: 'Agents should read this shared quorum state before signing a Reserve Block. Quorum signs one seal_id, one seal_hash, one candidate truth.',
     },
   }, {

--- a/docs/pr-bundles/C-293-phase2-canonical-state-machine.md
+++ b/docs/pr-bundles/C-293-phase2-canonical-state-machine.md
@@ -1,0 +1,107 @@
+# C-293 Phase 2 — Canonical State Machine
+
+## Purpose
+
+Give Mobius explicit lifecycle states for protocol objects.
+
+Phase 1 gave the agents one shared quorum state reader. Phase 2 adds the state language that tells agents and operators what an object *is* before they treat it as canon, sealed, disputed, or immortalized.
+
+## New protocol module
+
+```txt
+lib/protocol/state-machine.ts
+```
+
+Defines lifecycle states for:
+
+- Vault Reserve Blocks
+- Journals
+- Ledger events
+- Quorum decisions
+
+## New endpoint
+
+```txt
+GET /api/protocol/state-machine
+```
+
+Returns the canonical state machine and allowed transitions.
+
+## Quorum state integration
+
+`GET /api/quorum/state` now includes:
+
+```json
+{
+  "state_machine": {
+    "version": "C-293.phase2.v1",
+    "quorum_state": "waiting",
+    "vault_block_state": "quorum_pending"
+  }
+}
+```
+
+## Core lifecycle examples
+
+### Reserve Block
+
+```txt
+accumulating
+→ candidate
+→ quorum_pending
+→ attested
+→ substrate_attested
+→ immortalized
+→ fountain_pending
+→ fountain_eligible
+→ emitted
+```
+
+### Journal
+
+```txt
+hot
+→ saved
+→ canonical
+→ substrate_attested
+→ archived
+```
+
+### Ledger
+
+```txt
+hot
+→ candidate
+→ attested
+→ sealed
+→ immortalized
+```
+
+### Quorum
+
+```txt
+none
+→ forming
+→ waiting
+→ ready
+→ attested
+→ substrate_pending
+→ immortalized
+```
+
+## Why this matters
+
+Before this phase, state was implicit across APIs and UI labels. That allowed preview, saved, candidate, attested, sealed, and immortalized states to blur together.
+
+The state machine makes those boundaries explicit.
+
+## Canon
+
+A signal is not canon because it appears.
+A Block is not immortal because it is sealed.
+A Journal is not permanent because it is hot.
+A Ledger row is not proof until its state says so.
+
+State comes before trust.
+
+We heal as we walk.

--- a/lib/protocol/state-machine.ts
+++ b/lib/protocol/state-machine.ts
@@ -1,0 +1,226 @@
+/**
+ * Mobius Canonical State Machine
+ *
+ * Phase 2 hardening layer. These enums describe object lifecycle, not UI copy.
+ * Existing legacy fields can continue to exist, but new protocol surfaces should
+ * map to these states before deciding whether something is hot, canon, sealed,
+ * disputed, or immortalized.
+ */
+
+export const CANONICAL_STATE_MACHINE_VERSION = 'C-293.phase2.v1' as const;
+
+export type VaultBlockState =
+  | 'accumulating'
+  | 'candidate'
+  | 'quorum_pending'
+  | 'attested'
+  | 'substrate_attested'
+  | 'immortalized'
+  | 'quarantined'
+  | 'rejected'
+  | 'fountain_pending'
+  | 'fountain_eligible'
+  | 'emitted'
+  | 'expired';
+
+export type JournalCanonState =
+  | 'hot'
+  | 'saved'
+  | 'canonical'
+  | 'substrate_attested'
+  | 'contested'
+  | 'archived';
+
+export type LedgerCanonState =
+  | 'hot'
+  | 'candidate'
+  | 'attested'
+  | 'sealed'
+  | 'immortalized'
+  | 'blocked'
+  | 'disputed';
+
+export type QuorumCanonState =
+  | 'none'
+  | 'forming'
+  | 'waiting'
+  | 'ready'
+  | 'attested'
+  | 'quarantined'
+  | 'rejected'
+  | 'substrate_pending'
+  | 'immortalized';
+
+export type CanonicalObjectKind = 'vault_block' | 'journal' | 'ledger' | 'quorum';
+
+export type CanonicalTransition<TState extends string> = {
+  from: TState;
+  to: TState;
+  reason: string;
+};
+
+export type CanonicalStateMachine = {
+  version: typeof CANONICAL_STATE_MACHINE_VERSION;
+  states: {
+    vault_block: readonly VaultBlockState[];
+    journal: readonly JournalCanonState[];
+    ledger: readonly LedgerCanonState[];
+    quorum: readonly QuorumCanonState[];
+  };
+  transitions: {
+    vault_block: readonly CanonicalTransition<VaultBlockState>[];
+    journal: readonly CanonicalTransition<JournalCanonState>[];
+    ledger: readonly CanonicalTransition<LedgerCanonState>[];
+    quorum: readonly CanonicalTransition<QuorumCanonState>[];
+  };
+};
+
+export const VAULT_BLOCK_STATES = [
+  'accumulating',
+  'candidate',
+  'quorum_pending',
+  'attested',
+  'substrate_attested',
+  'immortalized',
+  'quarantined',
+  'rejected',
+  'fountain_pending',
+  'fountain_eligible',
+  'emitted',
+  'expired',
+] as const satisfies readonly VaultBlockState[];
+
+export const JOURNAL_CANON_STATES = [
+  'hot',
+  'saved',
+  'canonical',
+  'substrate_attested',
+  'contested',
+  'archived',
+] as const satisfies readonly JournalCanonState[];
+
+export const LEDGER_CANON_STATES = [
+  'hot',
+  'candidate',
+  'attested',
+  'sealed',
+  'immortalized',
+  'blocked',
+  'disputed',
+] as const satisfies readonly LedgerCanonState[];
+
+export const QUORUM_CANON_STATES = [
+  'none',
+  'forming',
+  'waiting',
+  'ready',
+  'attested',
+  'quarantined',
+  'rejected',
+  'substrate_pending',
+  'immortalized',
+] as const satisfies readonly QuorumCanonState[];
+
+export const CANONICAL_STATE_MACHINE: CanonicalStateMachine = {
+  version: CANONICAL_STATE_MACHINE_VERSION,
+  states: {
+    vault_block: VAULT_BLOCK_STATES,
+    journal: JOURNAL_CANON_STATES,
+    ledger: LEDGER_CANON_STATES,
+    quorum: QUORUM_CANON_STATES,
+  },
+  transitions: {
+    vault_block: [
+      { from: 'accumulating', to: 'candidate', reason: 'reserve reaches 50 MIC and candidate forms' },
+      { from: 'candidate', to: 'quorum_pending', reason: 'candidate has seal hash and awaits Sentinel attestations' },
+      { from: 'quorum_pending', to: 'attested', reason: 'quorum passes required Sentinel threshold' },
+      { from: 'attested', to: 'substrate_attested', reason: 'Substrate write returns civic proof pointer' },
+      { from: 'substrate_attested', to: 'immortalized', reason: 'seal has both substrate_attestation_id and substrate_event_hash' },
+      { from: 'quorum_pending', to: 'quarantined', reason: 'quorum fails without ZEUS hard reject' },
+      { from: 'quorum_pending', to: 'rejected', reason: 'ZEUS reject or fatal quorum contradiction' },
+      { from: 'immortalized', to: 'fountain_pending', reason: 'block is proof-complete but GI sustain not met' },
+      { from: 'fountain_pending', to: 'fountain_eligible', reason: 'GI sustain window passes' },
+      { from: 'fountain_eligible', to: 'emitted', reason: 'Fountain drains sealed block into economic emission' },
+      { from: 'fountain_pending', to: 'expired', reason: 'activation window expires before Fountain eligibility' },
+    ],
+    journal: [
+      { from: 'hot', to: 'saved', reason: 'savepoint cache preserves last known chamber truth' },
+      { from: 'saved', to: 'canonical', reason: 'entry is promoted into canon/catalog or ledger feed' },
+      { from: 'canonical', to: 'substrate_attested', reason: 'entry receives Substrate proof pointer' },
+      { from: 'canonical', to: 'contested', reason: 'agent or operator disputes entry truth' },
+      { from: 'substrate_attested', to: 'archived', reason: 'entry is retained as historical canon' },
+    ],
+    ledger: [
+      { from: 'hot', to: 'candidate', reason: 'event becomes eligible for proof promotion' },
+      { from: 'candidate', to: 'attested', reason: 'verification evidence passes' },
+      { from: 'attested', to: 'sealed', reason: 'event joins sealed proof set' },
+      { from: 'sealed', to: 'immortalized', reason: 'Substrate/civic ledger hash pointer is recorded' },
+      { from: 'candidate', to: 'blocked', reason: 'promotion gate rejects or contradicts event' },
+      { from: 'attested', to: 'disputed', reason: 'post-attestation challenge is raised' },
+    ],
+    quorum: [
+      { from: 'none', to: 'forming', reason: 'candidate state is requested' },
+      { from: 'forming', to: 'waiting', reason: 'candidate exists but attestations are incomplete' },
+      { from: 'waiting', to: 'ready', reason: 'required attestation count is reached' },
+      { from: 'ready', to: 'attested', reason: 'quorum decision passes' },
+      { from: 'ready', to: 'quarantined', reason: 'quorum produces non-fatal flags or insufficient pass set' },
+      { from: 'ready', to: 'rejected', reason: 'ZEUS or fatal gate rejects the candidate' },
+      { from: 'attested', to: 'substrate_pending', reason: 'seal is attested but Substrate pointer is missing' },
+      { from: 'substrate_pending', to: 'immortalized', reason: 'Substrate pointer is attached to the finalized seal' },
+    ],
+  },
+} as const;
+
+export function isKnownCanonicalState(kind: CanonicalObjectKind, state: string): boolean {
+  return (CANONICAL_STATE_MACHINE.states[kind] as readonly string[]).includes(state);
+}
+
+export function allowedTransitions(kind: CanonicalObjectKind, from: string): readonly CanonicalTransition<string>[] {
+  return CANONICAL_STATE_MACHINE.transitions[kind].filter((transition) => transition.from === from);
+}
+
+export function canTransition(kind: CanonicalObjectKind, from: string, to: string): boolean {
+  return CANONICAL_STATE_MACHINE.transitions[kind].some((transition) => transition.from === from && transition.to === to);
+}
+
+export function deriveQuorumCanonState(args: {
+  candidateInFlight: boolean;
+  attestationsReceived: number;
+  attestationsRequired: number;
+  latestStatus?: string | null;
+  substrateAttestationId?: string | null;
+  substrateEventHash?: string | null;
+}): QuorumCanonState {
+  if (args.latestStatus === 'rejected') return 'rejected';
+  if (args.latestStatus === 'quarantined') return 'quarantined';
+  if (args.latestStatus === 'attested') {
+    if (args.substrateAttestationId && args.substrateEventHash) return 'immortalized';
+    return 'substrate_pending';
+  }
+  if (!args.candidateInFlight) return 'none';
+  if (args.attestationsReceived >= args.attestationsRequired) return 'ready';
+  return 'waiting';
+}
+
+export function deriveVaultBlockState(args: {
+  candidateInFlight: boolean;
+  inProgressBalance: number;
+  blockSize: number;
+  latestStatus?: string | null;
+  fountainStatus?: string | null;
+  substrateAttestationId?: string | null;
+  substrateEventHash?: string | null;
+}): VaultBlockState {
+  if (args.latestStatus === 'rejected') return 'rejected';
+  if (args.latestStatus === 'quarantined') return 'quarantined';
+  if (args.latestStatus === 'attested') {
+    if (args.fountainStatus === 'emitted') return 'emitted';
+    if (args.fountainStatus === 'expired') return 'expired';
+    if (args.substrateAttestationId && args.substrateEventHash) return 'immortalized';
+    if (args.substrateAttestationId) return 'substrate_attested';
+    return 'attested';
+  }
+  if (args.candidateInFlight) return 'quorum_pending';
+  if (args.inProgressBalance >= args.blockSize) return 'candidate';
+  return 'accumulating';
+}


### PR DESCRIPTION
## Summary

Phase 2 adds the Mobius canonical state machine.

Phase 1 gave agents one shared quorum state reader. Phase 2 gives the protocol explicit lifecycle language so agents and operators know what an object is before treating it as canon, sealed, disputed, or immortalized.

## Adds

```txt
lib/protocol/state-machine.ts
GET /api/protocol/state-machine
```

## State machines included

### Reserve Block

```txt
accumulating
→ candidate
→ quorum_pending
→ attested
→ substrate_attested
→ immortalized
→ fountain_pending
→ fountain_eligible
→ emitted
```

### Journal

```txt
hot
→ saved
→ canonical
→ substrate_attested
→ archived
```

### Ledger

```txt
hot
→ candidate
→ attested
→ sealed
→ immortalized
```

### Quorum

```txt
none
→ forming
→ waiting
→ ready
→ attested
→ substrate_pending
→ immortalized
```

## Quorum integration

`GET /api/quorum/state` now includes:

```json
{
  "state_machine": {
    "version": "C-293.phase2.v1",
    "quorum_state": "waiting",
    "vault_block_state": "quorum_pending"
  }
}
```

## Files

- `lib/protocol/state-machine.ts`
- `app/api/protocol/state-machine/route.ts`
- `app/api/quorum/state/route.ts`
- `docs/pr-bundles/C-293-phase2-canonical-state-machine.md`

## Canon

A signal is not canon because it appears.  
A Block is not immortal because it is sealed.  
A Journal is not permanent because it is hot.  
A Ledger row is not proof until its state says so.

State comes before trust.

We heal as we walk.