### PR TITLE
C-293 Phase 3 — Agent Registry + Scope Cards

### DIFF
--- a/app/api/agents/registry/route.ts
+++ b/app/api/agents/registry/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { AGENT_REGISTRY_VERSION, getAgentScopeCard, listAgentScopeCards, scopeSummary } from '@/lib/agents/registry';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function GET(request: NextRequest) {
+  const agent = request.nextUrl.searchParams.get('agent');
+  const compact = request.nextUrl.searchParams.get('compact') === 'true';
+
+  if (agent) {
+    const card = getAgentScopeCard(agent);
+    if (!card) {
+      return NextResponse.json({ ok: false, error: 'agent_not_registered', agent }, { status: 404 });
+    }
+    return NextResponse.json({
+      ok: true,
+      version: AGENT_REGISTRY_VERSION,
+      agent: card,
+      canon: 'Registered agents have bounded scope. Scope precedes authority. Signatures are Phase 4.',
+    }, { headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'agent-registry' } });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    ...(compact ? scopeSummary() : { version: AGENT_REGISTRY_VERSION, agents: listAgentScopeCards() }),
+    canon: 'Every Mobius agent must know what it may read, write, decide, and never decide.',
+  }, { headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'agent-registry' } });
+}

--- a/app/api/automations/registry/route.ts
+++ b/app/api/automations/registry/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server';
+import { AGENT_REGISTRY_VERSION, MOBIUS_AGENT_REGISTRY } from '@/lib/agents/registry';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const automationRegistry = [
+  {
+    id: 'echo-sweep',
+    agent: 'ECHO',
+    status: 'declared',
+    schedule: 'cron/sweep',
+    reads: ['/api/epicon/feed', '/api/signals/micro', '/api/integrity-status'],
+    writes: ['/api/agents/journal', '/api/echo/ingest'],
+    scope_ref: MOBIUS_AGENT_REGISTRY.ECHO.registry_id,
+  },
+  {
+    id: 'atlas-heartbeat',
+    agent: 'ATLAS',
+    status: 'declared',
+    schedule: 'heartbeat / sentinel cron',
+    reads: ['/api/quorum/state', '/api/integrity-status', '/api/chambers/lane-diagnostics'],
+    writes: ['/api/agents/journal', 'docs/catalog/heartbeats'],
+    scope_ref: MOBIUS_AGENT_REGISTRY.ATLAS.registry_id,
+  },
+  {
+    id: 'zeus-watchdog',
+    agent: 'ZEUS',
+    status: 'declared',
+    schedule: 'cron/watchdog + quorum verification',
+    reads: ['/api/quorum/state', '/api/epicon/feed', '/api/chambers/ledger'],
+    writes: ['/api/agents/journal', 'docs/catalog/zeus'],
+    scope_ref: MOBIUS_AGENT_REGISTRY.ZEUS.registry_id,
+  },
+  {
+    id: 'aurea-daily-close',
+    agent: 'AUREA',
+    status: 'declared',
+    schedule: '23:00 UTC end-of-cycle',
+    reads: ['/api/epicon/feed', '/api/integrity-status', '/api/signals/micro', '/api/sentiment/composite'],
+    writes: ['/api/agents/journal', 'docs/catalog/aurea'],
+    scope_ref: MOBIUS_AGENT_REGISTRY.AUREA.registry_id,
+  },
+  {
+    id: 'eve-escalation',
+    agent: 'EVE',
+    status: 'declared',
+    schedule: 'GI critical / escalation trigger',
+    reads: ['/api/quorum/state', '/api/chambers/journal', '/api/integrity-status'],
+    writes: ['/api/agents/journal', 'docs/catalog/eve'],
+    scope_ref: MOBIUS_AGENT_REGISTRY.EVE.registry_id,
+  },
+  {
+    id: 'jade-canon-pass',
+    agent: 'JADE',
+    status: 'declared',
+    schedule: 'canon annotation pass',
+    reads: ['/api/quorum/state', '/api/chambers/journal', '/api/protocol/state-machine'],
+    writes: ['/api/agents/journal', 'docs/catalog/jade'],
+    scope_ref: MOBIUS_AGENT_REGISTRY.JADE.registry_id,
+  },
+  {
+    id: 'hermes-routing-sweep',
+    agent: 'HERMES',
+    status: 'declared',
+    schedule: 'routing / priority sweep',
+    reads: ['/api/terminal/snapshot', '/api/chambers/lane-diagnostics', '/api/echo/digest'],
+    writes: ['/api/agents/journal', 'KV routing hints'],
+    scope_ref: MOBIUS_AGENT_REGISTRY.HERMES.registry_id,
+  },
+  {
+    id: 'daedalus-infra-diagnostic',
+    agent: 'DAEDALUS',
+    status: 'declared',
+    schedule: 'infra diagnostic cron / build-failure review',
+    reads: ['/api/quorum/state', '/api/chambers/lane-diagnostics', '/api/terminal/shell'],
+    writes: ['/api/agents/journal', 'docs/catalog/daedalus'],
+    scope_ref: MOBIUS_AGENT_REGISTRY.DAEDALUS.registry_id,
+  },
+];
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    version: AGENT_REGISTRY_VERSION,
+    automations: automationRegistry,
+    note: 'This registry is declared from Mobius canonical agent scopes. It does not enumerate hidden Codex/Claude local automation IDs yet.',
+    canon: 'Mobius should know its own behaviors before it trusts its own automation loop.',
+  }, { headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'automation-registry' } });
+}

--- a/docs/pr-bundles/C-293-phase3-agent-registry-scope.md
+++ b/docs/pr-bundles/C-293-phase3-agent-registry-scope.md
@@ -1,0 +1,82 @@
+# C-293 Phase 3 — Agent Registry + Scope Cards
+
+## Purpose
+
+Give every Mobius agent a canonical identity and operating boundary.
+
+Phase 1 gave agents a shared quorum state reader.
+Phase 2 gave protocol objects explicit lifecycle states.
+Phase 3 gives agents explicit scope.
+
+## New module
+
+```txt
+lib/agents/registry.ts
+```
+
+Each agent now has a Scope Card defining:
+
+- registry ID
+- role
+- tier
+- authority
+- allowed reads
+- allowed writes
+- allowed decisions
+- forbidden actions
+- outputs
+- automation hints
+- planned public key env for Phase 4 signature work
+
+## New endpoints
+
+```txt
+GET /api/agents/registry
+GET /api/agents/registry?agent=ZEUS
+GET /api/agents/registry?compact=true
+GET /api/automations/registry
+```
+
+## Why this matters
+
+Without scopes, agents are just automations and prompts. They may overlap or drift into each other's authority.
+
+With scopes:
+
+- ECHO brings signal
+- ATLAS checks structure
+- ZEUS verifies and may veto
+- EVE escalates civic risk
+- JADE frames canon
+- AUREA synthesizes strategy
+- HERMES routes
+- DAEDALUS diagnoses infrastructure
+
+## Phase 4 handoff
+
+This PR does not enforce cryptographic signatures yet.
+
+It prepares the contract for Phase 4:
+
+```txt
+agent registry_id
++ public_key_env
++ signs[]
++ signed output
+```
+
+## Canon
+
+Agents without scope are workers.
+Agents with scope are institutions.
+
+Every Mobius agent must know:
+
+1. What it may read
+2. What it may write
+3. What it may decide
+4. What it must never decide
+5. What authority it holds
+6. What it will sign in Phase 4
+
+We heal as we walk.

--- a/lib/agents/registry.ts
+++ b/lib/agents/registry.ts
@@ -1,0 +1,219 @@
+/**
+ * Mobius Agent Registry + Scope Cards
+ *
+ * Phase 3 hardening layer. Registry describes who each agent is, what lanes it
+ * may read/write, what it may decide, and what it must never decide.
+ *
+ * This is not the signature layer yet. Phase 4 should bind these registry IDs
+ * to public keys and enforce signed outputs.
+ */
+
+export const AGENT_REGISTRY_VERSION = 'C-293.phase3.v1' as const;
+
+export type MobiusAgentId =
+  | 'ECHO'
+  | 'ATLAS'
+  | 'ZEUS'
+  | 'AUREA'
+  | 'EVE'
+  | 'JADE'
+  | 'HERMES'
+  | 'DAEDALUS';
+
+export type AgentAuthority =
+  | 'intake'
+  | 'sentinel'
+  | 'verification_veto'
+  | 'strategic_advisory'
+  | 'civic_risk_escalation'
+  | 'canon_framing'
+  | 'routing_orchestration'
+  | 'infrastructure_diagnostic';
+
+export type AgentScopeCard = {
+  id: MobiusAgentId;
+  registry_id: string;
+  display_name: string;
+  role: string;
+  tier: 'intake' | 'sentinel' | 'council' | 'strategic' | 'canon' | 'routing' | 'infrastructure';
+  authority: AgentAuthority;
+  reads: string[];
+  writes: string[];
+  decides: string[];
+  forbidden: string[];
+  outputs: string[];
+  automation_hints: string[];
+  signature: {
+    phase: 'planned';
+    public_key_env: string;
+    signs: string[];
+  };
+  canon: string;
+};
+
+export const MOBIUS_AGENT_REGISTRY: Record<MobiusAgentId, AgentScopeCard> = {
+  ECHO: {
+    id: 'ECHO',
+    registry_id: 'mobius.agent.echo',
+    display_name: 'ECHO',
+    role: 'Ingestion and hot-lane routing agent',
+    tier: 'intake',
+    authority: 'intake',
+    reads: ['/api/epicon/feed', '/api/signals/micro', '/api/integrity-status', '/api/quorum/state'],
+    writes: ['/api/agents/journal', '/api/echo/ingest', 'KV hot lanes'],
+    decides: ['classify_hot_signal', 'summarize_lane_digest', 'route_signal_priority'],
+    forbidden: ['decide_canon_alone', 'finalize_quorum', 'mint_MIC', 'unlock_fountain', 'override_ZEUS'],
+    outputs: ['hot journal entry', 'lane digest', 'intake summary'],
+    automation_hints: ['cron/sweep', 'echo ingest', 'KV sync'],
+    signature: { phase: 'planned', public_key_env: 'ECHO_PUBLIC_KEY', signs: ['journal_entry', 'lane_digest'] },
+    canon: 'ECHO brings signal. ECHO does not decide final truth.',
+  },
+  ATLAS: {
+    id: 'ATLAS',
+    registry_id: 'mobius.agent.atlas',
+    display_name: 'ATLAS',
+    role: 'System integrity sentinel',
+    tier: 'sentinel',
+    authority: 'sentinel',
+    reads: ['/api/quorum/state', '/api/integrity-status', '/api/chambers/lane-diagnostics', '/api/terminal/snapshot'],
+    writes: ['/api/agents/journal', 'docs/catalog/heartbeats'],
+    decides: ['flag_schema_drift', 'flag_state_inconsistency', 'attest_structural_integrity'],
+    forbidden: ['rewrite_governance_meaning', 'mint_MIC', 'unlock_fountain', 'override_operator'],
+    outputs: ['heartbeat report', 'integrity diagnostic', 'quorum attestation'],
+    automation_hints: ['heartbeat', 'sentinel check', 'quorum structural pass'],
+    signature: { phase: 'planned', public_key_env: 'ATLAS_PUBLIC_KEY', signs: ['heartbeat', 'journal_entry', 'quorum_attestation'] },
+    canon: 'ATLAS checks structure before memory becomes trust.',
+  },
+  ZEUS: {
+    id: 'ZEUS',
+    registry_id: 'mobius.agent.zeus',
+    display_name: 'ZEUS',
+    role: 'Verification authority and contradiction gate',
+    tier: 'council',
+    authority: 'verification_veto',
+    reads: ['/api/quorum/state', '/api/epicon/feed', '/api/integrity-status', '/api/chambers/ledger'],
+    writes: ['/api/agents/journal', 'docs/catalog/zeus'],
+    decides: ['verify', 'flag', 'reject', 'veto_quorum_candidate'],
+    forbidden: ['synthesize_final_strategy', 'rewrite_JADE_canon', 'mint_MIC', 'unlock_fountain_without_state_machine'],
+    outputs: ['verification report', 'quorum attestation', 'reject rationale'],
+    automation_hints: ['watchdog', 'vault quorum', 'verification pass'],
+    signature: { phase: 'planned', public_key_env: 'ZEUS_PUBLIC_KEY', signs: ['verification_report', 'journal_entry', 'quorum_attestation'] },
+    canon: 'ZEUS verifies and may veto. ZEUS does not narrate around failed proof.',
+  },
+  AUREA: {
+    id: 'AUREA',
+    registry_id: 'mobius.agent.aurea',
+    display_name: 'AUREA',
+    role: 'Strategic overseer and long-arc synthesis agent',
+    tier: 'strategic',
+    authority: 'strategic_advisory',
+    reads: ['/api/quorum/state', '/api/epicon/feed', '/api/integrity-status', '/api/signals/micro', '/api/sentiment/composite'],
+    writes: ['/api/agents/journal', 'docs/catalog/aurea'],
+    decides: ['strategic_posture', 'forward_signal', 'systemic_risk_pattern'],
+    forbidden: ['directly_mint_MIC', 'finalize_quorum', 'override_ZEUS_verification', 'modify_source_code_from_class_b_automation'],
+    outputs: ['daily close', 'strategic synthesis', 'AUREA posture'],
+    automation_hints: ['daily close at end of cycle', 'strategic synthesis read'],
+    signature: { phase: 'planned', public_key_env: 'AUREA_PUBLIC_KEY', signs: ['daily_close', 'journal_entry', 'quorum_attestation'] },
+    canon: 'AUREA sees the arc. AUREA advises; proof decides.',
+  },
+  EVE: {
+    id: 'EVE',
+    registry_id: 'mobius.agent.eve',
+    display_name: 'EVE',
+    role: 'Ethics, civic risk, and escalation agent',
+    tier: 'council',
+    authority: 'civic_risk_escalation',
+    reads: ['/api/quorum/state', '/api/epicon/feed', '/api/chambers/journal', '/api/integrity-status'],
+    writes: ['/api/agents/journal', 'docs/catalog/eve'],
+    decides: ['escalate_civic_risk', 'flag_human_impact', 'attest_ethics_risk'],
+    forbidden: ['silently_approve_high_risk_change', 'mint_MIC', 'override_ZEUS', 'erase_operator_review_need'],
+    outputs: ['risk synthesis', 'escalation entry', 'quorum attestation'],
+    automation_hints: ['cycle synthesis', 'critical GI escalation', 'ethics pass'],
+    signature: { phase: 'planned', public_key_env: 'EVE_PUBLIC_KEY', signs: ['risk_synthesis', 'journal_entry', 'quorum_attestation'] },
+    canon: 'EVE protects the civic boundary where optimization could harm people.',
+  },
+  JADE: {
+    id: 'JADE',
+    registry_id: 'mobius.agent.jade',
+    display_name: 'JADE',
+    role: 'Canon, memory, and constitutional framing agent',
+    tier: 'canon',
+    authority: 'canon_framing',
+    reads: ['/api/quorum/state', '/api/chambers/journal', '/api/chambers/ledger', '/api/protocol/state-machine'],
+    writes: ['/api/agents/journal', 'docs/catalog/jade'],
+    decides: ['canon_language', 'memory_framing', 'constitutional_annotation'],
+    forbidden: ['alter_numeric_state', 'change_proof_math', 'mint_MIC', 'override_substrate_record'],
+    outputs: ['canon annotation', 'memory frame', 'quorum attestation'],
+    automation_hints: ['constitutional annotation pass', 'canon synthesis'],
+    signature: { phase: 'planned', public_key_env: 'JADE_PUBLIC_KEY', signs: ['canon_annotation', 'journal_entry', 'quorum_attestation'] },
+    canon: 'JADE frames memory. JADE does not change the math.',
+  },
+  HERMES: {
+    id: 'HERMES',
+    registry_id: 'mobius.agent.hermes',
+    display_name: 'HERMES',
+    role: 'Routing, priority, and lane coordination agent',
+    tier: 'routing',
+    authority: 'routing_orchestration',
+    reads: ['/api/quorum/state', '/api/terminal/snapshot', '/api/chambers/lane-diagnostics', '/api/echo/digest'],
+    writes: ['/api/agents/journal', 'KV routing hints'],
+    decides: ['route_priority', 'lane_backpressure', 'packet_shape'],
+    forbidden: ['decide_final_truth', 'finalize_quorum', 'mint_MIC', 'override_ZEUS'],
+    outputs: ['routing sweep', 'lane priority note', 'packet shaping report'],
+    automation_hints: ['routing and priority sweep', 'lane coordination'],
+    signature: { phase: 'planned', public_key_env: 'HERMES_PUBLIC_KEY', signs: ['routing_report', 'journal_entry'] },
+    canon: 'HERMES moves the message. HERMES does not decide the verdict.',
+  },
+  DAEDALUS: {
+    id: 'DAEDALUS',
+    registry_id: 'mobius.agent.daedalus',
+    display_name: 'DAEDALUS',
+    role: 'Infrastructure diagnostic and build/deploy health agent',
+    tier: 'infrastructure',
+    authority: 'infrastructure_diagnostic',
+    reads: ['/api/quorum/state', '/api/chambers/lane-diagnostics', '/api/terminal/shell', 'deployment logs when provided'],
+    writes: ['/api/agents/journal', 'docs/catalog/daedalus'],
+    decides: ['flag_infra_failure', 'recommend_fallback', 'diagnose_build_deploy_health'],
+    forbidden: ['govern_civic_meaning', 'mint_MIC', 'override_quorum', 'unlock_fountain'],
+    outputs: ['infra diagnostic', 'fallback recommendation', 'deployment health note'],
+    automation_hints: ['infra diagnostic cron', 'build failure review'],
+    signature: { phase: 'planned', public_key_env: 'DAEDALUS_PUBLIC_KEY', signs: ['infra_diagnostic', 'journal_entry'] },
+    canon: 'DAEDALUS hardens the machine. DAEDALUS does not govern meaning.',
+  },
+};
+
+export function listAgentScopeCards(): AgentScopeCard[] {
+  return Object.values(MOBIUS_AGENT_REGISTRY);
+}
+
+export function getAgentScopeCard(agent: string): AgentScopeCard | null {
+  const key = agent.trim().toUpperCase() as MobiusAgentId;
+  return MOBIUS_AGENT_REGISTRY[key] ?? null;
+}
+
+export function isActionAllowed(agent: string, action: string): boolean {
+  const card = getAgentScopeCard(agent);
+  if (!card) return false;
+  const normalized = action.trim();
+  if (!normalized) return false;
+  if (card.forbidden.includes(normalized)) return false;
+  return card.decides.includes(normalized) || card.writes.includes(normalized) || card.reads.includes(normalized);
+}
+
+export function scopeSummary() {
+  return {
+    version: AGENT_REGISTRY_VERSION,
+    agents: listAgentScopeCards().map((card) => ({
+      id: card.id,
+      registry_id: card.registry_id,
+      role: card.role,
+      authority: card.authority,
+      tier: card.tier,
+      reads: card.reads.length,
+      writes: card.writes.length,
+      decides: card.decides,
+      forbidden: card.forbidden,
+      signature_phase: card.signature.phase,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary

Phase 3 gives every Mobius agent a canonical identity and operating boundary.

Phase 1 gave agents a shared quorum state reader.  
Phase 2 gave protocol objects explicit lifecycle states.  
Phase 3 gives agents explicit scope.

## Adds

```txt
lib/agents/registry.ts
GET /api/agents/registry
GET /api/agents/registry?agent=ZEUS
GET /api/agents/registry?compact=true
GET /api/automations/registry
```

## Scope cards include

- registry ID
- role
- tier
- authority
- allowed reads
- allowed writes
- allowed decisions
- forbidden actions
- outputs
- automation hints
- planned public key env for Phase 4 signatures

## Agents covered

```txt
ECHO
ATLAS
ZEUS
AUREA
EVE
JADE
HERMES
DAEDALUS
```

## Why

Without scopes, agents are just automations and prompts. They can overlap, drift, or act outside their intended authority.

With scopes:

- ECHO brings signal
- ATLAS checks structure
- ZEUS verifies and may veto
- EVE escalates civic risk
- JADE frames canon
- AUREA synthesizes strategy
- HERMES routes
- DAEDALUS diagnoses infrastructure

## Phase 4 handoff

This PR does not enforce cryptographic signatures yet.

It prepares the contract:

```txt
agent registry_id
+ public_key_env
+ signs[]
+ signed output
```

## Files

- `lib/agents/registry.ts`
- `app/api/agents/registry/route.ts`
- `app/api/automations/registry/route.ts`
- `docs/pr-bundles/C-293-phase3-agent-registry-scope.md`

## Canon

Agents without scope are workers.  
Agents with scope are institutions.

Every Mobius agent must know:

1. What it may read
2. What it may write
3. What it may decide
4. What it must never decide
5. What authority it holds
6. What it will sign in Phase 4

We heal as we walk.