### PR TITLE
C-293 Phase 4 — Agent Signature Layer

### DIFF
--- a/app/api/agents/signature/consume/route.ts
+++ b/app/api/agents/signature/consume/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type { AgentSignedAction } from '@/lib/agents/signatures';
+import { verifyAgentAction } from '@/lib/agents/signatures';
+import { consumeDedupeKey } from '@/lib/agents/dedupe';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type ConsumeBody = {
+  signed?: AgentSignedAction;
+  payload?: unknown;
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as ConsumeBody;
+    if (!body.signed) return NextResponse.json({ ok: false, error: 'missing_signed_envelope' }, { status: 400 });
+
+    const verification = verifyAgentAction({ signed: body.signed, payload: body.payload ?? null });
+    if (!verification.ok) {
+      return NextResponse.json({ ok: false, reason: verification.reason }, { status: 400 });
+    }
+
+    const consumed = await consumeDedupeKey({
+      dedupe_key: body.signed.dedupe_key,
+      agent: body.signed.agent,
+      action: body.signed.action,
+      payload_hash: body.signed.payload_hash,
+    });
+
+    if (!consumed.ok) {
+      return NextResponse.json({
+        ok: false,
+        reason: 'dedupe_key_already_consumed',
+        existing: consumed.existing,
+      }, { status: 409 });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      reason: 'signature_verified_and_dedupe_consumed',
+      record: consumed.record,
+      envelope: verification.envelope ?? null,
+      canon: 'A signed action may execute once per dedupe key.',
+    }, { headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'agent-signature-consume' } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : 'signature_consume_failed' }, { status: 500 });
+  }
+}

--- a/app/api/agents/signature/consume/route.ts
+++ b/app/api/agents/signature/consume/route.ts
@@ -29,6 +29,13 @@ export async function POST(request: NextRequest) {
     });
 
     if (!consumed.ok) {
+      if ('error' in consumed) {
+        return NextResponse.json({
+          ok: false,
+          reason: consumed.error,
+          canon: 'Signed action rejected because dedupe persistence could not be proven.',
+        }, { status: 503 });
+      }
       return NextResponse.json({
         ok: false,
         reason: 'dedupe_key_already_consumed',

--- a/app/api/agents/signature/verify/route.ts
+++ b/app/api/agents/signature/verify/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type { AgentSignedAction } from '@/lib/agents/signatures';
+import { verifyAgentAction } from '@/lib/agents/signatures';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type VerifyBody = {
+  signed?: AgentSignedAction;
+  payload?: unknown;
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as VerifyBody;
+    if (!body.signed) {
+      return NextResponse.json({ ok: false, error: 'missing_signed_envelope' }, { status: 400 });
+    }
+    const result = verifyAgentAction({ signed: body.signed, payload: body.payload ?? null });
+    return NextResponse.json({
+      ok: result.ok,
+      reason: result.reason,
+      envelope: result.envelope ?? null,
+      canon: 'A signed agent action is valid only when registry, scope, payload hash, signature, and dedupe intent align.',
+    }, { status: result.ok ? 200 : 400, headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'agent-signature-verify' } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : 'signature_verify_failed' }, { status: 500 });
+  }
+}

--- a/docs/pr-bundles/C-293-phase4-agent-signature-layer.md
+++ b/docs/pr-bundles/C-293-phase4-agent-signature-layer.md
@@ -50,6 +50,21 @@ A signed action is valid only when:
 5. payload hash matches body
 6. signature verifies
 7. dedupe key has not already been consumed
+8. dedupe persistence succeeds
+
+## Atomic dedupe claim
+
+The dedupe layer now uses Redis `SET ... NX` semantics for one-time claims.
+
+That means two concurrent requests with the same `dedupe_key` cannot both pass as first use.
+
+If the dedupe store is unavailable, the consume endpoint fails closed with:
+
+```txt
+dedupe_store_unavailable
+```
+
+This prevents signed actions from executing when one-time persistence cannot be proven.
 
 ## Dedupe patterns
 
@@ -87,7 +102,7 @@ Quorum is not consensus by vibes.
 Quorum is signed agreement over one shared state.
 
 Signatures prevent impersonation.
-Dedupe prevents repeated action.
+Atomic dedupe prevents repeated action.
 Scope prevents authority drift.
 State machine prevents invalid transitions.
 

--- a/docs/pr-bundles/C-293-phase4-agent-signature-layer.md
+++ b/docs/pr-bundles/C-293-phase4-agent-signature-layer.md
@@ -1,0 +1,94 @@
+# C-293 Phase 4 — Agent Signature Layer
+
+## Purpose
+
+Bind registered Mobius agents to signed actions and dedupe keys.
+
+Phase 1: shared quorum state reader.  
+Phase 2: canonical state machine.  
+Phase 3: agent registry + scope cards.  
+Phase 4: signatures + dedupe.
+
+## New modules
+
+```txt
+lib/agents/signatures.ts
+lib/agents/dedupe.ts
+```
+
+## New endpoints
+
+```txt
+POST /api/agents/signature/verify
+POST /api/agents/signature/consume
+```
+
+## Signature envelope
+
+```json
+{
+  "version": "C-293.phase4.v1",
+  "agent": "ZEUS",
+  "registry_id": "mobius.agent.zeus",
+  "cycle": "C-293",
+  "action": "quorum_attestation",
+  "payload_hash": "sha256:...",
+  "dedupe_key": "ZEUS:C-293:quorum_attestation:seal-C-293-001",
+  "signed_at": "...",
+  "signature": "..."
+}
+```
+
+## What gets checked
+
+A signed action is valid only when:
+
+1. agent is registered
+2. registry ID matches
+3. action is within scope/signs list
+4. action is not forbidden
+5. payload hash matches body
+6. signature verifies
+7. dedupe key has not already been consumed
+
+## Dedupe patterns
+
+```txt
+AUREA:{cycle}:daily_close
+ZEUS:{cycle}:quorum_attestation:{seal_id}
+ATLAS:{cycle}:heartbeat:{hour_bucket}
+ECHO:{cycle}:ingest:{source_hash}
+JADE:{cycle}:canon:{target_hash}
+EVE:{cycle}:risk:{incident_or_signal_hash}
+HERMES:{cycle}:route:{lane}:{signal_hash}
+DAEDALUS:{cycle}:infra:{deployment_or_endpoint_hash}
+```
+
+## Current security posture
+
+This PR uses per-agent HMAC signing secrets:
+
+```txt
+ECHO_SIGNING_SECRET
+ATLAS_SIGNING_SECRET
+ZEUS_SIGNING_SECRET
+AUREA_SIGNING_SECRET
+EVE_SIGNING_SECRET
+JADE_SIGNING_SECRET
+HERMES_SIGNING_SECRET
+DAEDALUS_SIGNING_SECRET
+```
+
+This is Phase 4A. A later Phase 4B can move from shared server-side HMAC secrets to asymmetric public/private key verification.
+
+## Canon
+
+Quorum is not consensus by vibes.
+Quorum is signed agreement over one shared state.
+
+Signatures prevent impersonation.
+Dedupe prevents repeated action.
+Scope prevents authority drift.
+State machine prevents invalid transitions.
+
+We heal as we walk.

--- a/lib/agents/dedupe.ts
+++ b/lib/agents/dedupe.ts
@@ -1,6 +1,10 @@
-import { kvGet, kvSet } from '@/lib/kv/store';
+import { Redis } from '@upstash/redis';
+import { kvGet } from '@/lib/kv/store';
 
 const DEDUPE_TTL_SECONDS = 60 * 60 * 24 * 30;
+const PREFIX = 'mobius:';
+
+let _redis: Redis | null | undefined;
 
 export type DedupeRecord = {
   dedupe_key: string;
@@ -14,8 +18,40 @@ function keyFor(dedupeKey: string): string {
   return `agent:dedupe:${dedupeKey}`;
 }
 
+function prefixedKeyFor(dedupeKey: string): string {
+  return `${PREFIX}${keyFor(dedupeKey)}`;
+}
+
+function getRedis(): Redis | null {
+  if (_redis !== undefined) return _redis;
+  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const secret = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !secret) {
+    _redis = null;
+    return null;
+  }
+  try {
+    _redis = new Redis({ url, token: secret });
+    return _redis;
+  } catch {
+    _redis = null;
+    return null;
+  }
+}
+
 export async function readDedupeRecord(dedupeKey: string): Promise<DedupeRecord | null> {
   return kvGet<DedupeRecord>(keyFor(dedupeKey));
+}
+
+async function claimDedupeRecord(dedupeKey: string, record: DedupeRecord): Promise<'claimed' | 'exists' | 'unavailable'> {
+  const redis = getRedis();
+  if (!redis) return 'unavailable';
+  try {
+    const result = await redis.set(prefixedKeyFor(dedupeKey), record, { ex: DEDUPE_TTL_SECONDS, nx: true });
+    return result === 'OK' ? 'claimed' : 'exists';
+  } catch {
+    return 'unavailable';
+  }
 }
 
 export async function consumeDedupeKey(args: {
@@ -23,10 +59,11 @@ export async function consumeDedupeKey(args: {
   agent: string;
   action: string;
   payload_hash: string;
-}): Promise<{ ok: true; record: DedupeRecord } | { ok: false; existing: DedupeRecord }> {
-  const existing = await readDedupeRecord(args.dedupe_key);
-  if (existing) return { ok: false, existing };
-
+}): Promise<
+  | { ok: true; record: DedupeRecord }
+  | { ok: false; existing: DedupeRecord }
+  | { ok: false; error: 'dedupe_store_unavailable' }
+> {
   const record: DedupeRecord = {
     dedupe_key: args.dedupe_key,
     consumed_at: new Date().toISOString(),
@@ -34,6 +71,12 @@ export async function consumeDedupeKey(args: {
     action: args.action,
     payload_hash: args.payload_hash,
   };
-  await kvSet(keyFor(args.dedupe_key), record, DEDUPE_TTL_SECONDS);
-  return { ok: true, record };
+
+  const claim = await claimDedupeRecord(args.dedupe_key, record);
+  if (claim === 'claimed') return { ok: true, record };
+  if (claim === 'exists') {
+    const existing = await readDedupeRecord(args.dedupe_key);
+    return { ok: false, existing: existing ?? { ...record, consumed_at: 'existing_claim' } };
+  }
+  return { ok: false, error: 'dedupe_store_unavailable' };
 }

--- a/lib/agents/dedupe.ts
+++ b/lib/agents/dedupe.ts
@@ -1,0 +1,39 @@
+import { kvGet, kvSet } from '@/lib/kv/store';
+
+const DEDUPE_TTL_SECONDS = 60 * 60 * 24 * 30;
+
+export type DedupeRecord = {
+  dedupe_key: string;
+  consumed_at: string;
+  agent: string;
+  action: string;
+  payload_hash: string;
+};
+
+function keyFor(dedupeKey: string): string {
+  return `agent:dedupe:${dedupeKey}`;
+}
+
+export async function readDedupeRecord(dedupeKey: string): Promise<DedupeRecord | null> {
+  return kvGet<DedupeRecord>(keyFor(dedupeKey));
+}
+
+export async function consumeDedupeKey(args: {
+  dedupe_key: string;
+  agent: string;
+  action: string;
+  payload_hash: string;
+}): Promise<{ ok: true; record: DedupeRecord } | { ok: false; existing: DedupeRecord }> {
+  const existing = await readDedupeRecord(args.dedupe_key);
+  if (existing) return { ok: false, existing };
+
+  const record: DedupeRecord = {
+    dedupe_key: args.dedupe_key,
+    consumed_at: new Date().toISOString(),
+    agent: args.agent,
+    action: args.action,
+    payload_hash: args.payload_hash,
+  };
+  await kvSet(keyFor(args.dedupe_key), record, DEDUPE_TTL_SECONDS);
+  return { ok: true, record };
+}

--- a/lib/agents/signatures.ts
+++ b/lib/agents/signatures.ts
@@ -1,0 +1,116 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import { getAgentScopeCard } from '@/lib/agents/registry';
+
+export const AGENT_SIGNATURE_VERSION = 'C-293.phase4.v1' as const;
+
+export type AgentSignedAction = {
+  version: typeof AGENT_SIGNATURE_VERSION;
+  agent: string;
+  registry_id: string;
+  cycle: string;
+  action: string;
+  payload_hash: string;
+  dedupe_key: string;
+  signed_at: string;
+  signature: string;
+};
+
+export type SignatureVerification = {
+  ok: boolean;
+  reason: string;
+  envelope?: Omit<AgentSignedAction, 'signature'>;
+};
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`).join(',')}}`;
+}
+
+export function hashPayload(payload: unknown): string {
+  return `sha256:${createHash('sha256').update(stableJson(payload)).digest('hex')}`;
+}
+
+export function buildDedupeKey(args: { agent: string; cycle: string; action: string; target: string }): string {
+  return [args.agent.trim().toUpperCase(), args.cycle.trim(), args.action.trim(), args.target.trim()].join(':');
+}
+
+function signingBase(envelope: Omit<AgentSignedAction, 'signature'>): string {
+  return stableJson(envelope);
+}
+
+function agentSecret(agent: string): string | null {
+  const key = `${agent.trim().toUpperCase()}_SIGNING_SECRET`;
+  const value = process.env[key]?.trim();
+  return value || null;
+}
+
+function safeCompareHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+export function signAgentAction(args: {
+  agent: string;
+  cycle: string;
+  action: string;
+  target: string;
+  payload: unknown;
+  signedAt?: string;
+}): AgentSignedAction {
+  const agent = args.agent.trim().toUpperCase();
+  const card = getAgentScopeCard(agent);
+  if (!card) throw new Error(`agent_not_registered:${agent}`);
+  if (card.forbidden.includes(args.action)) throw new Error(`action_forbidden:${args.action}`);
+  if (!card.decides.includes(args.action) && !card.signature.signs.includes(args.action)) {
+    throw new Error(`action_out_of_scope:${args.action}`);
+  }
+
+  const secret = agentSecret(agent);
+  if (!secret) throw new Error(`missing_agent_signing_secret:${agent}`);
+
+  const envelope: Omit<AgentSignedAction, 'signature'> = {
+    version: AGENT_SIGNATURE_VERSION,
+    agent,
+    registry_id: card.registry_id,
+    cycle: args.cycle,
+    action: args.action,
+    payload_hash: hashPayload(args.payload),
+    dedupe_key: buildDedupeKey({ agent, cycle: args.cycle, action: args.action, target: args.target }),
+    signed_at: args.signedAt ?? new Date().toISOString(),
+  };
+
+  const signature = createHmac('sha256', secret).update(signingBase(envelope)).digest('hex');
+  return { ...envelope, signature };
+}
+
+export function verifyAgentAction(args: {
+  signed: AgentSignedAction;
+  payload: unknown;
+}): SignatureVerification {
+  const agent = args.signed.agent.trim().toUpperCase();
+  const card = getAgentScopeCard(agent);
+  if (!card) return { ok: false, reason: 'agent_not_registered' };
+  if (card.registry_id !== args.signed.registry_id) return { ok: false, reason: 'registry_id_mismatch' };
+  if (card.forbidden.includes(args.signed.action)) return { ok: false, reason: 'action_forbidden' };
+  if (!card.decides.includes(args.signed.action) && !card.signature.signs.includes(args.signed.action)) {
+    return { ok: false, reason: 'action_out_of_scope' };
+  }
+
+  const expectedHash = hashPayload(args.payload);
+  if (expectedHash !== args.signed.payload_hash) return { ok: false, reason: 'payload_hash_mismatch' };
+
+  const secret = agentSecret(agent);
+  if (!secret) return { ok: false, reason: 'missing_agent_signing_secret' };
+
+  const { signature, ...envelope } = args.signed;
+  const expected = createHmac('sha256', secret).update(signingBase(envelope)).digest('hex');
+  if (!safeCompareHex(expected, signature)) return { ok: false, reason: 'signature_mismatch' };
+
+  return { ok: true, reason: 'signature_verified', envelope };
+}


### PR DESCRIPTION
## Summary

Phase 4 adds the Agent Signature Layer.

Phase 1: shared quorum state reader.  
Phase 2: canonical state machine.  
Phase 3: agent registry + scope cards.  
Phase 4: signatures + dedupe.

## Adds

```txt
lib/agents/signatures.ts
lib/agents/dedupe.ts
POST /api/agents/signature/verify
POST /api/agents/signature/consume
```

## Signature envelope

```json
{
  "version": "C-293.phase4.v1",
  "agent": "ZEUS",
  "registry_id": "mobius.agent.zeus",
  "cycle": "C-293",
  "action": "quorum_attestation",
  "payload_hash": "sha256:...",
  "dedupe_key": "ZEUS:C-293:quorum_attestation:seal-C-293-001",
  "signed_at": "...",
  "signature": "..."
}
```

## What gets checked

A signed action is valid only when:

1. agent is registered
2. registry ID matches
3. action is within scope/signs list
4. action is not forbidden
5. payload hash matches body
6. signature verifies
7. dedupe key has not already been consumed

## Current security posture

This is Phase 4A. It uses per-agent HMAC signing secrets:

```txt
ECHO_SIGNING_SECRET
ATLAS_SIGNING_SECRET
ZEUS_SIGNING_SECRET
AUREA_SIGNING_SECRET
EVE_SIGNING_SECRET
JADE_SIGNING_SECRET
HERMES_SIGNING_SECRET
DAEDALUS_SIGNING_SECRET
```

A later Phase 4B can move from shared server-side HMAC secrets to asymmetric public/private key verification.

## Why

Signatures prevent impersonation.  
Dedupe prevents repeated action.  
Scope prevents authority drift.  
State machine prevents invalid transitions.

## Files

- `lib/agents/signatures.ts`
- `lib/agents/dedupe.ts`
- `app/api/agents/signature/verify/route.ts`
- `app/api/agents/signature/consume/route.ts`
- `docs/pr-bundles/C-293-phase4-agent-signature-layer.md`

## Canon

Quorum is not consensus by vibes.  
Quorum is signed agreement over one shared state.

The agents do not merely speak.  
They attest.  
And what they attest, the Ledger can prove.

We heal as we walk.