### PR TITLE
C-293 Phase 6 — Incident + Rollback Protocol

### DIFF
--- a/app/api/system/incidents/report/route.ts
+++ b/app/api/system/incidents/report/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { reportIncident } from '@/lib/system/incidents';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type ReportBody = {
+  severity?: 'low' | 'medium' | 'high' | 'critical';
+  affected?: string[];
+  trigger?: string;
+  evidence?: string[];
+  fallback?: string;
+  source?: string;
+  rollback_recommendation?: 'none' | 'fallback' | 'revert_pr' | 'redeploy_previous' | 'operator_review';
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as ReportBody;
+    const incident = await reportIncident(body ?? {});
+    return NextResponse.json({
+      ok: true,
+      incident,
+      canon: 'Incident recorded. Rollback planning may recommend action, but execution remains operator-controlled.',
+    }, {
+      status: 201,
+      headers: {
+        'Cache-Control': 'no-store',
+        'X-Mobius-Source': 'incident-report',
+      },
+    });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: error instanceof Error ? error.message : 'incident_report_failed',
+    }, { status: 500 });
+  }
+}

--- a/app/api/system/incidents/route.ts
+++ b/app/api/system/incidents/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { listIncidents } from '@/lib/system/incidents';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+function clampLimit(input: string | null): number {
+  const parsed = Number(input ?? '50');
+  if (!Number.isFinite(parsed) || parsed <= 0) return 50;
+  return Math.min(100, Math.max(1, Math.floor(parsed)));
+}
+
+export async function GET(request: NextRequest) {
+  const limit = clampLimit(request.nextUrl.searchParams.get('limit'));
+  const incidents = await listIncidents(limit);
+  return NextResponse.json({
+    ok: true,
+    count: incidents.length,
+    incidents,
+    canon: 'Incidents are preserved as the survival trail of the system.',
+  }, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Mobius-Source': 'incident-registry',
+    },
+  });
+}

--- a/app/api/system/rollback/plan/route.ts
+++ b/app/api/system/rollback/plan/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildRollbackPlan, getIncident } from '@/lib/system/incidents';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type RollbackPlanBody = {
+  incident_id?: string;
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as RollbackPlanBody;
+    const incident = body.incident_id ? await getIncident(body.incident_id) : null;
+    if (body.incident_id && !incident) {
+      return NextResponse.json({ ok: false, error: 'incident_not_found', incident_id: body.incident_id }, { status: 404 });
+    }
+    const plan = buildRollbackPlan(incident);
+    return NextResponse.json(plan, {
+      headers: {
+        'Cache-Control': 'no-store',
+        'X-Mobius-Source': 'rollback-plan',
+      },
+    });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: error instanceof Error ? error.message : 'rollback_plan_failed',
+    }, { status: 500 });
+  }
+}

--- a/docs/pr-bundles/C-293-phase6-incident-rollback.md
+++ b/docs/pr-bundles/C-293-phase6-incident-rollback.md
@@ -1,0 +1,12 @@
+# C-293 Phase 6 — Incident + Rollback Protocol
+
+## Purpose
+
+Give Mobius a safe incident trail and rollback planning layer.
+
+Phase 5 taught Mobius how to ask whether it can rebuild from canon.
+Phase 6 teaches Mobius how to record a failure and recommend a survival path without erasing evidence or auto-mutating deployments.
+
+## New module
+
+```txt

--- a/docs/pr-bundles/C-293-phase6-incident-rollback.md
+++ b/docs/pr-bundles/C-293-phase6-incident-rollback.md
@@ -10,3 +10,94 @@ Phase 6 teaches Mobius how to record a failure and recommend a survival path wit
 ## New module
 
 ```txt
+lib/system/incidents.ts
+```
+
+## New endpoints
+
+```txt
+GET  /api/system/incidents
+POST /api/system/incidents/report
+POST /api/system/rollback/plan
+```
+
+## Incident object
+
+```json
+{
+  "incident_id": "INC-C293-...",
+  "cycle": "C-293",
+  "severity": "high",
+  "state": "open",
+  "affected": ["vault", "ledger"],
+  "trigger": "endpoint_failure",
+  "evidence": ["/api/vault/status returned 500"],
+  "fallback": "use savepoint cache",
+  "rollback_recommended": true,
+  "rollback_recommendation": "fallback",
+  "operator_required": true
+}
+```
+
+## Rollback planning
+
+`POST /api/system/rollback/plan` returns a safe plan only.
+
+It does not:
+
+- redeploy
+- revert PRs
+- delete evidence
+- mutate ledger/Substrate
+- unlock Fountain
+- modify Vault
+
+## Safety rules
+
+Rollback is not execution in this phase. It is recommendation.
+
+Every plan includes:
+
+- replay dry-run check
+- affected chamber inspection
+- savepoint or previous deployment confirmation
+- operator approval requirement
+- evidence preservation rule
+- forward-fix requirement
+
+## Forbidden actions
+
+```txt
+auto_rollback_without_operator
+delete_incident_evidence
+erase_ledger_or_substrate_records
+unlock_fountain_as_rollback_side_effect
+```
+
+## Future phase
+
+A later guarded execution phase may add:
+
+```txt
+POST /api/system/rollback/execute
+```
+
+Only after:
+
+- signed operator auth
+- incident exists
+- replay dry-run passes
+- state-machine transition is allowed
+- rollback target is explicit
+- evidence is preserved
+
+## Canon
+
+Replay tells Mobius how to remember.
+Rollback tells Mobius how to survive a bad change.
+
+No rollback without proof.
+No rollback without operator consent.
+No rollback that erases the incident trail.
+
+We heal as we walk.

--- a/lib/system/incidents.ts
+++ b/lib/system/incidents.ts
@@ -1,0 +1,167 @@
+import { currentCycleId } from '@/lib/eve/cycle-engine';
+import { kvGet, kvSet } from '@/lib/kv/store';
+
+export const INCIDENT_PROTOCOL_VERSION = 'C-293.phase6.v1' as const;
+
+export type IncidentSeverity = 'low' | 'medium' | 'high' | 'critical';
+export type IncidentState = 'open' | 'monitoring' | 'resolved' | 'dismissed';
+export type RollbackRecommendation = 'none' | 'fallback' | 'revert_pr' | 'redeploy_previous' | 'operator_review';
+
+export type IncidentRecord = {
+  incident_id: string;
+  version: typeof INCIDENT_PROTOCOL_VERSION;
+  cycle: string;
+  severity: IncidentSeverity;
+  state: IncidentState;
+  affected: string[];
+  trigger: string;
+  evidence: string[];
+  fallback: string;
+  rollback_recommended: boolean;
+  rollback_recommendation: RollbackRecommendation;
+  operator_required: boolean;
+  created_at: string;
+  updated_at: string;
+  source: string;
+  canon: string;
+};
+
+export type RollbackPlan = {
+  ok: boolean;
+  version: typeof INCIDENT_PROTOCOL_VERSION;
+  timestamp: string;
+  incident_id: string | null;
+  rollback_allowed: false;
+  operator_required: true;
+  recommendation: RollbackRecommendation;
+  steps: string[];
+  checks_before_action: string[];
+  forbidden: string[];
+  canon: string;
+};
+
+type ReportIncidentInput = {
+  severity?: IncidentSeverity;
+  affected?: string[];
+  trigger?: string;
+  evidence?: string[];
+  fallback?: string;
+  source?: string;
+  rollback_recommendation?: RollbackRecommendation;
+};
+
+const INCIDENT_INDEX_KEY = 'system:incidents:index';
+const INCIDENT_TTL_SECONDS = 60 * 60 * 24 * 90;
+
+function incidentKey(id: string): string {
+  return `system:incident:${id}`;
+}
+
+function normalizeSeverity(value: unknown): IncidentSeverity {
+  return value === 'critical' || value === 'high' || value === 'medium' || value === 'low' ? value : 'medium';
+}
+
+function normalizeRecommendation(value: unknown, severity: IncidentSeverity): RollbackRecommendation {
+  if (value === 'fallback' || value === 'revert_pr' || value === 'redeploy_previous' || value === 'operator_review' || value === 'none') {
+    return value;
+  }
+  if (severity === 'critical') return 'redeploy_previous';
+  if (severity === 'high') return 'fallback';
+  return 'operator_review';
+}
+
+function nextIncidentId(cycle: string): string {
+  const suffix = Date.now().toString(36).toUpperCase();
+  return `INC-${cycle}-${suffix}`;
+}
+
+async function readIndex(): Promise<string[]> {
+  const ids = await kvGet<string[]>(INCIDENT_INDEX_KEY);
+  return Array.isArray(ids) ? ids : [];
+}
+
+async function writeIndex(ids: string[]): Promise<void> {
+  await kvSet(INCIDENT_INDEX_KEY, Array.from(new Set(ids)).slice(-200), INCIDENT_TTL_SECONDS);
+}
+
+export async function listIncidents(limit = 50): Promise<IncidentRecord[]> {
+  const ids = await readIndex();
+  const recent = ids.slice(-Math.max(1, Math.min(100, limit))).reverse();
+  const rows = await Promise.all(recent.map((id) => kvGet<IncidentRecord>(incidentKey(id))));
+  return rows.filter((row): row is IncidentRecord => Boolean(row));
+}
+
+export async function getIncident(id: string): Promise<IncidentRecord | null> {
+  return kvGet<IncidentRecord>(incidentKey(id));
+}
+
+export async function reportIncident(input: ReportIncidentInput): Promise<IncidentRecord> {
+  const cycle = currentCycleId();
+  const now = new Date().toISOString();
+  const severity = normalizeSeverity(input.severity);
+  const recommendation = normalizeRecommendation(input.rollback_recommendation, severity);
+  const id = nextIncidentId(cycle);
+  const record: IncidentRecord = {
+    incident_id: id,
+    version: INCIDENT_PROTOCOL_VERSION,
+    cycle,
+    severity,
+    state: 'open',
+    affected: Array.from(new Set((input.affected ?? ['unknown']).map((x) => String(x).trim()).filter(Boolean))),
+    trigger: String(input.trigger ?? 'manual_report'),
+    evidence: (input.evidence ?? []).map((x) => String(x)).filter(Boolean).slice(0, 25),
+    fallback: String(input.fallback ?? 'use savepoint cache and replay dry-run before mutation'),
+    rollback_recommended: recommendation !== 'none',
+    rollback_recommendation: recommendation,
+    operator_required: true,
+    created_at: now,
+    updated_at: now,
+    source: String(input.source ?? 'operator'),
+    canon: 'Incidents are never erased by rollback. Rollback must preserve the incident trail.',
+  };
+  await kvSet(incidentKey(id), record, INCIDENT_TTL_SECONDS);
+  const ids = await readIndex();
+  ids.push(id);
+  await writeIndex(ids);
+  return record;
+}
+
+export function buildRollbackPlan(incident: IncidentRecord | null): RollbackPlan {
+  const recommendation = incident?.rollback_recommendation ?? 'operator_review';
+  const steps = [
+    'Run /api/system/replay/plan and confirm rebuild confidence.',
+    'Inspect affected chamber endpoints and recent deployment/build logs.',
+    'Confirm savepoint cache or previous deployment is available.',
+    'Have operator choose fallback, revert PR, or redeploy previous deployment outside this endpoint.',
+    'Record follow-up journal/incident update after action.',
+  ];
+
+  if (recommendation === 'fallback') steps.splice(2, 0, 'Serve saved chamber state while hot lane recovers.');
+  if (recommendation === 'revert_pr') steps.splice(2, 0, 'Identify the PR/commit to revert and create a reviewable revert PR.');
+  if (recommendation === 'redeploy_previous') steps.splice(2, 0, 'Identify last known good deployment and redeploy through Vercel/operator controls.');
+
+  return {
+    ok: true,
+    version: INCIDENT_PROTOCOL_VERSION,
+    timestamp: new Date().toISOString(),
+    incident_id: incident?.incident_id ?? null,
+    rollback_allowed: false,
+    operator_required: true,
+    recommendation,
+    steps,
+    checks_before_action: [
+      'Replay dry-run reviewed',
+      'State machine transition impact understood',
+      'No evidence will be deleted',
+      'Operator approves action',
+      'Rollback path has a forward-fix plan',
+    ],
+    forbidden: [
+      'auto_rollback_without_operator',
+      'delete_incident_evidence',
+      'erase_ledger_or_substrate_records',
+      'unlock_fountain_as_rollback_side_effect',
+    ],
+    canon: 'Rollback is survival, not erasure. No rollback without proof, operator consent, and preserved incident history.',
+  };
+}

--- a/lib/system/incidents.ts
+++ b/lib/system/incidents.ts
@@ -1,5 +1,7 @@
+import { randomUUID } from 'node:crypto';
+import { Redis } from '@upstash/redis';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
-import { kvGet, kvSet } from '@/lib/kv/store';
+import { kvGet, kvLpushCapped, kvSet } from '@/lib/kv/store';
 
 export const INCIDENT_PROTOCOL_VERSION = 'C-293.phase6.v1' as const;
 
@@ -52,9 +54,34 @@ type ReportIncidentInput = {
 
 const INCIDENT_INDEX_KEY = 'system:incidents:index';
 const INCIDENT_TTL_SECONDS = 60 * 60 * 24 * 90;
+const INCIDENT_INDEX_MAX = 200;
+const PREFIX = 'mobius:';
+
+let redisClient: Redis | null | undefined;
 
 function incidentKey(id: string): string {
   return `system:incident:${id}`;
+}
+
+function prefixed(key: string): string {
+  return `${PREFIX}${key}`;
+}
+
+function getRedis(): Redis | null {
+  if (redisClient !== undefined) return redisClient;
+  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    redisClient = null;
+    return null;
+  }
+  try {
+    redisClient = new Redis({ url, token });
+    return redisClient;
+  } catch {
+    redisClient = null;
+    return null;
+  }
 }
 
 function normalizeSeverity(value: unknown): IncidentSeverity {
@@ -71,23 +98,31 @@ function normalizeRecommendation(value: unknown, severity: IncidentSeverity): Ro
 }
 
 function nextIncidentId(cycle: string): string {
-  const suffix = Date.now().toString(36).toUpperCase();
-  return `INC-${cycle}-${suffix}`;
+  return `INC-${cycle}-${randomUUID()}`;
 }
 
-async function readIndex(): Promise<string[]> {
-  const ids = await kvGet<string[]>(INCIDENT_INDEX_KEY);
-  return Array.isArray(ids) ? ids : [];
+async function readIndex(limit = INCIDENT_INDEX_MAX): Promise<string[]> {
+  const redis = getRedis();
+  if (redis) {
+    try {
+      const ids = await redis.lrange<string>(prefixed(INCIDENT_INDEX_KEY), 0, Math.max(0, limit - 1));
+      return Array.isArray(ids) ? ids : [];
+    } catch {
+      // Fall through to legacy array index read below.
+    }
+  }
+  const legacyIds = await kvGet<string[]>(INCIDENT_INDEX_KEY);
+  return Array.isArray(legacyIds) ? legacyIds.slice(-limit).reverse() : [];
 }
 
-async function writeIndex(ids: string[]): Promise<void> {
-  await kvSet(INCIDENT_INDEX_KEY, Array.from(new Set(ids)).slice(-200), INCIDENT_TTL_SECONDS);
+async function appendIndex(id: string): Promise<boolean> {
+  // LPUSH avoids the lost-update read/modify/write race from array index writes.
+  return kvLpushCapped(INCIDENT_INDEX_KEY, id, INCIDENT_INDEX_MAX);
 }
 
 export async function listIncidents(limit = 50): Promise<IncidentRecord[]> {
-  const ids = await readIndex();
-  const recent = ids.slice(-Math.max(1, Math.min(100, limit))).reverse();
-  const rows = await Promise.all(recent.map((id) => kvGet<IncidentRecord>(incidentKey(id))));
+  const ids = await readIndex(Math.max(1, Math.min(100, limit)));
+  const rows = await Promise.all(ids.map((id) => kvGet<IncidentRecord>(incidentKey(id))));
   return rows.filter((row): row is IncidentRecord => Boolean(row));
 }
 
@@ -119,10 +154,13 @@ export async function reportIncident(input: ReportIncidentInput): Promise<Incide
     source: String(input.source ?? 'operator'),
     canon: 'Incidents are never erased by rollback. Rollback must preserve the incident trail.',
   };
-  await kvSet(incidentKey(id), record, INCIDENT_TTL_SECONDS);
-  const ids = await readIndex();
-  ids.push(id);
-  await writeIndex(ids);
+
+  const recordWritten = await kvSet(incidentKey(id), record, INCIDENT_TTL_SECONDS);
+  if (!recordWritten) throw new Error('incident_record_persistence_failed');
+
+  const indexWritten = await appendIndex(id);
+  if (!indexWritten) throw new Error('incident_index_persistence_failed');
+
   return record;
 }
 


### PR DESCRIPTION
## Summary

Phase 6 adds the Incident + Rollback Protocol.

Phase 5 taught Mobius how to ask whether it can rebuild from canon. Phase 6 teaches Mobius how to record a failure and recommend a survival path without erasing evidence or auto-mutating deployments.

## Adds

```txt
lib/system/incidents.ts
GET  /api/system/incidents
POST /api/system/incidents/report
POST /api/system/rollback/plan
```

## Incident object

```json
{
  "incident_id": "INC-C293-...",
  "cycle": "C-293",
  "severity": "high",
  "state": "open",
  "affected": ["vault", "ledger"],
  "trigger": "endpoint_failure",
  "evidence": ["/api/vault/status returned 500"],
  "fallback": "use savepoint cache",
  "rollback_recommended": true,
  "rollback_recommendation": "fallback",
  "operator_required": true
}
```

## Rollback planning

`POST /api/system/rollback/plan` returns a safe plan only.

It does not:

- redeploy
- revert PRs
- delete evidence
- mutate ledger/Substrate
- unlock Fountain
- modify Vault

Every plan includes:

- replay dry-run check
- affected chamber inspection
- savepoint or previous deployment confirmation
- operator approval requirement
- evidence preservation rule
- forward-fix requirement

## Forbidden actions

```txt
auto_rollback_without_operator
delete_incident_evidence
erase_ledger_or_substrate_records
unlock_fountain_as_rollback_side_effect
```

## Files

- `lib/system/incidents.ts`
- `app/api/system/incidents/route.ts`
- `app/api/system/incidents/report/route.ts`
- `app/api/system/rollback/plan/route.ts`
- `docs/pr-bundles/C-293-phase6-incident-rollback.md`

## Canon

Replay tells Mobius how to remember.  
Rollback tells Mobius how to survive a bad change.

No rollback without proof.  
No rollback without operator consent.  
No rollback that erases the incident trail.

We heal as we walk.