### PR TITLE
C-293 Phase 7 — Historical Reserve Block Back-Attestation

### DIFF
--- a/app/api/vault/blocks/historical/attest/route.ts
+++ b/app/api/vault/blocks/historical/attest/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type { HistoricalAttestationSubmission } from '@/lib/vault-v2/historical-attestation';
+import { submitHistoricalBlockAttestation } from '@/lib/vault-v2/historical-attestation';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as HistoricalAttestationSubmission;
+    const result = await submitHistoricalBlockAttestation(body);
+    return NextResponse.json({
+      ...result,
+      canon: 'Historical attestation validates stored proof. It cannot rewrite history, invent missing hashes, or unlock the Fountain by itself.',
+    }, {
+      status: result.ok ? 200 : 400,
+      headers: {
+        'Cache-Control': 'no-store',
+        'X-Mobius-Source': 'historical-block-attest',
+      },
+    });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: error instanceof Error ? error.message : 'historical_attestation_failed',
+    }, { status: 500 });
+  }
+}

--- a/app/api/vault/blocks/historical/route.ts
+++ b/app/api/vault/blocks/historical/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSeal } from '@/lib/vault-v2/store';
+import { historicalAttestationDigest, listHistoricalBackfillCandidates } from '@/lib/vault-v2/historical-attestation';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+function clampLimit(value: string | null): number {
+  const parsed = Number(value ?? '25');
+  if (!Number.isFinite(parsed) || parsed <= 0) return 25;
+  return Math.max(1, Math.min(100, Math.floor(parsed)));
+}
+
+export async function GET(request: NextRequest) {
+  const sealId = request.nextUrl.searchParams.get('seal_id');
+  if (sealId) {
+    const seal = await getSeal(sealId);
+    if (!seal) return NextResponse.json({ ok: false, error: 'seal_not_found', seal_id: sealId }, { status: 404 });
+    return NextResponse.json({
+      ok: true,
+      seal_id: sealId,
+      digest: historicalAttestationDigest(seal),
+      canon: 'Historical attestation validates stored proof. It does not rewrite live history.',
+    }, { headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'historical-block-attestation' } });
+  }
+
+  const limit = clampLimit(request.nextUrl.searchParams.get('limit'));
+  const candidates = await listHistoricalBackfillCandidates(limit);
+  return NextResponse.json({
+    ok: true,
+    count: candidates.length,
+    candidates,
+    canon: 'Historical back-attestation lists completed Reserve Blocks that still need Sentinel signatures.',
+  }, { headers: { 'Cache-Control': 'no-store', 'X-Mobius-Source': 'historical-block-attestation' } });
+}

--- a/docs/pr-bundles/C-293-phase7-historical-block-attestation.md
+++ b/docs/pr-bundles/C-293-phase7-historical-block-attestation.md
@@ -1,0 +1,88 @@
+# C-293 Phase 7 — Historical Reserve Block Back-Attestation
+
+## Purpose
+
+Allow Sentinel agents to back-attest completed Reserve Blocks whose proof records already exist but were finalized before the current quorum/signature loop was fully active.
+
+This phase does **not** rewrite history. It lets agents review stored proof and sign a historical attestation over the exact stored Reserve Block payload.
+
+## New module
+
+```txt
+lib/vault-v2/historical-attestation.ts
+```
+
+## New endpoints
+
+```txt
+GET  /api/vault/blocks/historical
+GET  /api/vault/blocks/historical?seal_id=<seal_id>
+POST /api/vault/blocks/historical/attest
+```
+
+## What agents sign
+
+Historical agents sign this canonical payload:
+
+```json
+{
+  "version": "C-293.phase7.v1",
+  "action": "historical_quorum_attestation",
+  "seal_id": "...",
+  "seal_hash": "...",
+  "sequence": 1,
+  "cycle_at_seal": "C-293",
+  "reserve": 50,
+  "gi_at_seal": 0.67,
+  "mode_at_seal": "red",
+  "source_entries": 123,
+  "deposit_hashes": ["..."],
+  "prev_seal_hash": null,
+  "historical": true,
+  "review_basis": "stored_seal_record"
+}
+```
+
+## Back-attestation flow
+
+```txt
+completed Reserve Block
+→ GET /api/vault/blocks/historical?seal_id=...
+→ agent signs historical_quorum_attestation payload
+→ POST /api/vault/blocks/historical/attest
+→ signature verifies
+→ dedupe key is consumed
+→ attestation is attached to the existing Seal record
+```
+
+## Safety rules
+
+Historical attestation:
+
+- validates stored proof
+- cannot rewrite original seal_hash
+- cannot invent deposit_hashes
+- cannot pretend the attestation was live
+- cannot unlock Fountain by itself
+- must pass the Phase 4 signature + dedupe layer
+
+## Scope update
+
+Sentinel agents now include `historical_quorum_attestation` in their signature action list:
+
+```txt
+ATLAS
+ZEUS
+EVE
+JADE
+AUREA
+```
+
+## Canon
+
+Historical attestation validates stored proof.
+It does not rewrite history.
+It does not pretend agents signed live at the time.
+It does not unlock the Fountain by itself.
+
+We heal as we walk.

--- a/lib/agents/registry.ts
+++ b/lib/agents/registry.ts
@@ -51,6 +51,8 @@ export type AgentScopeCard = {
   canon: string;
 };
 
+const SENTINEL_SIGNATURE_ACTIONS = ['quorum_attestation', 'historical_quorum_attestation'];
+
 export const MOBIUS_AGENT_REGISTRY: Record<MobiusAgentId, AgentScopeCard> = {
   ECHO: {
     id: 'ECHO',
@@ -81,7 +83,7 @@ export const MOBIUS_AGENT_REGISTRY: Record<MobiusAgentId, AgentScopeCard> = {
     forbidden: ['rewrite_governance_meaning', 'mint_MIC', 'unlock_fountain', 'override_operator'],
     outputs: ['heartbeat report', 'integrity diagnostic', 'quorum attestation'],
     automation_hints: ['heartbeat', 'sentinel check', 'quorum structural pass'],
-    signature: { phase: 'planned', public_key_env: 'ATLAS_PUBLIC_KEY', signs: ['heartbeat', 'journal_entry', 'quorum_attestation'] },
+    signature: { phase: 'planned', public_key_env: 'ATLAS_PUBLIC_KEY', signs: ['heartbeat', 'journal_entry', ...SENTINEL_SIGNATURE_ACTIONS] },
     canon: 'ATLAS checks structure before memory becomes trust.',
   },
   ZEUS: {
@@ -97,7 +99,7 @@ export const MOBIUS_AGENT_REGISTRY: Record<MobiusAgentId, AgentScopeCard> = {
     forbidden: ['synthesize_final_strategy', 'rewrite_JADE_canon', 'mint_MIC', 'unlock_fountain_without_state_machine'],
     outputs: ['verification report', 'quorum attestation', 'reject rationale'],
     automation_hints: ['watchdog', 'vault quorum', 'verification pass'],
-    signature: { phase: 'planned', public_key_env: 'ZEUS_PUBLIC_KEY', signs: ['verification_report', 'journal_entry', 'quorum_attestation'] },
+    signature: { phase: 'planned', public_key_env: 'ZEUS_PUBLIC_KEY', signs: ['verification_report', 'journal_entry', ...SENTINEL_SIGNATURE_ACTIONS] },
     canon: 'ZEUS verifies and may veto. ZEUS does not narrate around failed proof.',
   },
   AUREA: {
@@ -113,7 +115,7 @@ export const MOBIUS_AGENT_REGISTRY: Record<MobiusAgentId, AgentScopeCard> = {
     forbidden: ['directly_mint_MIC', 'finalize_quorum', 'override_ZEUS_verification', 'modify_source_code_from_class_b_automation'],
     outputs: ['daily close', 'strategic synthesis', 'AUREA posture'],
     automation_hints: ['daily close at end of cycle', 'strategic synthesis read'],
-    signature: { phase: 'planned', public_key_env: 'AUREA_PUBLIC_KEY', signs: ['daily_close', 'journal_entry', 'quorum_attestation'] },
+    signature: { phase: 'planned', public_key_env: 'AUREA_PUBLIC_KEY', signs: ['daily_close', 'journal_entry', ...SENTINEL_SIGNATURE_ACTIONS] },
     canon: 'AUREA sees the arc. AUREA advises; proof decides.',
   },
   EVE: {
@@ -129,7 +131,7 @@ export const MOBIUS_AGENT_REGISTRY: Record<MobiusAgentId, AgentScopeCard> = {
     forbidden: ['silently_approve_high_risk_change', 'mint_MIC', 'override_ZEUS', 'erase_operator_review_need'],
     outputs: ['risk synthesis', 'escalation entry', 'quorum attestation'],
     automation_hints: ['cycle synthesis', 'critical GI escalation', 'ethics pass'],
-    signature: { phase: 'planned', public_key_env: 'EVE_PUBLIC_KEY', signs: ['risk_synthesis', 'journal_entry', 'quorum_attestation'] },
+    signature: { phase: 'planned', public_key_env: 'EVE_PUBLIC_KEY', signs: ['risk_synthesis', 'journal_entry', ...SENTINEL_SIGNATURE_ACTIONS] },
     canon: 'EVE protects the civic boundary where optimization could harm people.',
   },
   JADE: {
@@ -145,7 +147,7 @@ export const MOBIUS_AGENT_REGISTRY: Record<MobiusAgentId, AgentScopeCard> = {
     forbidden: ['alter_numeric_state', 'change_proof_math', 'mint_MIC', 'override_substrate_record'],
     outputs: ['canon annotation', 'memory frame', 'quorum attestation'],
     automation_hints: ['constitutional annotation pass', 'canon synthesis'],
-    signature: { phase: 'planned', public_key_env: 'JADE_PUBLIC_KEY', signs: ['canon_annotation', 'journal_entry', 'quorum_attestation'] },
+    signature: { phase: 'planned', public_key_env: 'JADE_PUBLIC_KEY', signs: ['canon_annotation', 'journal_entry', ...SENTINEL_SIGNATURE_ACTIONS] },
     canon: 'JADE frames memory. JADE does not change the math.',
   },
   HERMES: {

--- a/lib/vault-v2/historical-attestation.ts
+++ b/lib/vault-v2/historical-attestation.ts
@@ -1,0 +1,134 @@
+import type { Seal, SealAttestation, SentinelAgent } from '@/lib/vault-v2/types';
+import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
+import { getSeal, listAllSeals, writeSeal } from '@/lib/vault-v2/store';
+import type { AgentSignedAction } from '@/lib/agents/signatures';
+import { hashPayload, verifyAgentAction } from '@/lib/agents/signatures';
+import { consumeDedupeKey } from '@/lib/agents/dedupe';
+
+export const HISTORICAL_ATTESTATION_VERSION = 'C-293.phase7.v1' as const;
+
+export type HistoricalBlockAttestationPayload = {
+  version: typeof HISTORICAL_ATTESTATION_VERSION;
+  action: 'historical_quorum_attestation';
+  seal_id: string;
+  seal_hash: string;
+  sequence: number;
+  cycle_at_seal: string;
+  reserve: 50;
+  gi_at_seal: number;
+  mode_at_seal: Seal['mode_at_seal'];
+  source_entries: number;
+  deposit_hashes: string[];
+  prev_seal_hash: string | null;
+  historical: true;
+  review_basis: 'stored_seal_record';
+};
+
+export type HistoricalAttestationSubmission = {
+  agent: SentinelAgent;
+  seal_id: string;
+  verdict: SealAttestation['verdict'];
+  rationale: string;
+  mii_at_attestation?: number | null;
+  posture?: SealAttestation['posture'];
+  signed: AgentSignedAction;
+};
+
+export function buildHistoricalAttestationPayload(seal: Seal): HistoricalBlockAttestationPayload {
+  return {
+    version: HISTORICAL_ATTESTATION_VERSION,
+    action: 'historical_quorum_attestation',
+    seal_id: seal.seal_id,
+    seal_hash: seal.seal_hash,
+    sequence: seal.sequence,
+    cycle_at_seal: seal.cycle_at_seal,
+    reserve: seal.reserve,
+    gi_at_seal: seal.gi_at_seal,
+    mode_at_seal: seal.mode_at_seal,
+    source_entries: seal.source_entries,
+    deposit_hashes: [...seal.deposit_hashes],
+    prev_seal_hash: seal.prev_seal_hash,
+    historical: true,
+    review_basis: 'stored_seal_record',
+  };
+}
+
+export function missingSentinelAgents(seal: Seal): SentinelAgent[] {
+  return SENTINEL_AGENTS.filter((agent) => !seal.attestations?.[agent]);
+}
+
+export async function listHistoricalBackfillCandidates(limit = 25) {
+  const seals = await listAllSeals(limit);
+  return seals.map((seal) => {
+    const missing = missingSentinelAgents(seal);
+    return {
+      seal_id: seal.seal_id,
+      sequence: seal.sequence,
+      status: seal.status,
+      seal_hash: seal.seal_hash,
+      missing_agents: missing,
+      ready_for_back_attestation: seal.deposit_hashes.length > 0 && Boolean(seal.seal_hash) && missing.length > 0,
+    };
+  });
+}
+
+export async function submitHistoricalBlockAttestation(submission: HistoricalAttestationSubmission) {
+  const seal = await getSeal(submission.seal_id);
+  if (!seal) return { ok: false, reason: 'seal_not_found' as const };
+  if (submission.agent !== submission.signed.agent) return { ok: false, reason: 'agent_mismatch' as const };
+  if (!SENTINEL_AGENTS.includes(submission.agent)) return { ok: false, reason: 'agent_not_sentinel' as const };
+  if (seal.attestations?.[submission.agent]) return { ok: false, reason: 'historical_attestation_already_present' as const, seal };
+
+  const payload = buildHistoricalAttestationPayload(seal);
+  if (submission.signed.action !== 'historical_quorum_attestation') {
+    return { ok: false, reason: 'invalid_signed_action' as const, payload };
+  }
+
+  const verification = verifyAgentAction({ signed: submission.signed, payload });
+  if (!verification.ok) return { ok: false, reason: verification.reason, payload };
+
+  const consumed = await consumeDedupeKey({
+    dedupe_key: submission.signed.dedupe_key,
+    agent: submission.signed.agent,
+    action: submission.signed.action,
+    payload_hash: submission.signed.payload_hash,
+  });
+  if (!consumed.ok) return { ok: false, reason: 'error' in consumed ? consumed.error : 'dedupe_key_already_consumed', payload };
+
+  const attestation: SealAttestation = {
+    agent: submission.agent,
+    verdict: submission.verdict,
+    rationale: `[historical] ${submission.rationale}`,
+    mii_at_attestation: submission.mii_at_attestation ?? null,
+    gi_at_attestation: seal.gi_at_seal,
+    timestamp: submission.signed.signed_at,
+    signature: submission.signed.signature,
+    posture: submission.agent === 'AUREA' ? submission.posture ?? seal.posture ?? 'cautionary' : undefined,
+  };
+
+  const next: Seal = {
+    ...seal,
+    attestations: { ...seal.attestations, [submission.agent]: attestation },
+    posture: submission.agent === 'AUREA' ? attestation.posture ?? seal.posture : seal.posture,
+  };
+
+  await writeSeal(next);
+  const missing = missingSentinelAgents(next);
+  return {
+    ok: true,
+    reason: missing.length === 0 ? 'historical_quorum_complete' : 'historical_attestation_recorded',
+    seal: next,
+    payload,
+    missing_agents: missing,
+  };
+}
+
+export function historicalAttestationDigest(seal: Seal) {
+  const payload = buildHistoricalAttestationPayload(seal);
+  return {
+    payload,
+    payload_hash: hashPayload(payload),
+    missing_agents: missingSentinelAgents(seal),
+    canon: 'Historical attestation validates stored proof. It does not rewrite live history or unlock the Fountain by itself.',
+  };
+}

--- a/lib/vault-v2/historical-attestation.ts
+++ b/lib/vault-v2/historical-attestation.ts
@@ -4,8 +4,10 @@ import { getSeal, listAllSeals, writeSeal } from '@/lib/vault-v2/store';
 import type { AgentSignedAction } from '@/lib/agents/signatures';
 import { hashPayload, verifyAgentAction } from '@/lib/agents/signatures';
 import { consumeDedupeKey } from '@/lib/agents/dedupe';
+import { kvGet, kvSet } from '@/lib/kv/store';
 
 export const HISTORICAL_ATTESTATION_VERSION = 'C-293.phase7.v1' as const;
+const HISTORICAL_ATTESTATION_TTL_SECONDS = 60 * 60 * 24 * 365;
 
 export type HistoricalBlockAttestationPayload = {
   version: typeof HISTORICAL_ATTESTATION_VERSION;
@@ -34,6 +36,10 @@ export type HistoricalAttestationSubmission = {
   signed: AgentSignedAction;
 };
 
+function historicalAttestationKey(sealId: string, agent: SentinelAgent): string {
+  return `vault:historical_attestation:${sealId}:${agent}`;
+}
+
 export function buildHistoricalAttestationPayload(seal: Seal): HistoricalBlockAttestationPayload {
   return {
     version: HISTORICAL_ATTESTATION_VERSION,
@@ -55,6 +61,26 @@ export function buildHistoricalAttestationPayload(seal: Seal): HistoricalBlockAt
 
 export function missingSentinelAgents(seal: Seal): SentinelAgent[] {
   return SENTINEL_AGENTS.filter((agent) => !seal.attestations?.[agent]);
+}
+
+async function loadHistoricalAttestationSidecars(sealId: string): Promise<Partial<Record<SentinelAgent, SealAttestation>>> {
+  const rows = await Promise.all(
+    SENTINEL_AGENTS.map(async (agent) => [agent, await kvGet<SealAttestation>(historicalAttestationKey(sealId, agent))] as const),
+  );
+  return Object.fromEntries(rows.filter(([, attestation]) => Boolean(attestation))) as Partial<Record<SentinelAgent, SealAttestation>>;
+}
+
+async function mergeHistoricalAttestationIntoSeal(sealId: string): Promise<Seal | null> {
+  const latest = await getSeal(sealId);
+  if (!latest) return null;
+  const sidecars = await loadHistoricalAttestationSidecars(sealId);
+  const next: Seal = {
+    ...latest,
+    attestations: { ...latest.attestations, ...sidecars },
+    posture: sidecars.AUREA?.posture ?? latest.posture,
+  };
+  await writeSeal(next);
+  return next;
 }
 
 export async function listHistoricalBackfillCandidates(limit = 25) {
@@ -87,14 +113,6 @@ export async function submitHistoricalBlockAttestation(submission: HistoricalAtt
   const verification = verifyAgentAction({ signed: submission.signed, payload });
   if (!verification.ok) return { ok: false, reason: verification.reason, payload };
 
-  const consumed = await consumeDedupeKey({
-    dedupe_key: submission.signed.dedupe_key,
-    agent: submission.signed.agent,
-    action: submission.signed.action,
-    payload_hash: submission.signed.payload_hash,
-  });
-  if (!consumed.ok) return { ok: false, reason: 'error' in consumed ? consumed.error : 'dedupe_key_already_consumed', payload };
-
   const attestation: SealAttestation = {
     agent: submission.agent,
     verdict: submission.verdict,
@@ -106,18 +124,32 @@ export async function submitHistoricalBlockAttestation(submission: HistoricalAtt
     posture: submission.agent === 'AUREA' ? submission.posture ?? seal.posture ?? 'cautionary' : undefined,
   };
 
-  const next: Seal = {
-    ...seal,
-    attestations: { ...seal.attestations, [submission.agent]: attestation },
-    posture: submission.agent === 'AUREA' ? attestation.posture ?? seal.posture : seal.posture,
-  };
+  const sidecarWritten = await kvSet(
+    historicalAttestationKey(submission.seal_id, submission.agent),
+    attestation,
+    HISTORICAL_ATTESTATION_TTL_SECONDS,
+  );
+  if (!sidecarWritten) return { ok: false, reason: 'historical_attestation_persistence_failed' as const, payload };
 
-  await writeSeal(next);
-  const missing = missingSentinelAgents(next);
+  const merged = await mergeHistoricalAttestationIntoSeal(submission.seal_id);
+  if (!merged?.attestations?.[submission.agent]) {
+    return { ok: false, reason: 'historical_attestation_merge_failed' as const, payload };
+  }
+
+  const consumed = await consumeDedupeKey({
+    dedupe_key: submission.signed.dedupe_key,
+    agent: submission.signed.agent,
+    action: submission.signed.action,
+    payload_hash: submission.signed.payload_hash,
+  });
+  if (!consumed.ok) return { ok: false, reason: 'error' in consumed ? consumed.error : 'dedupe_key_already_consumed', payload };
+
+  const finalSeal = await mergeHistoricalAttestationIntoSeal(submission.seal_id) ?? merged;
+  const missing = missingSentinelAgents(finalSeal);
   return {
     ok: true,
     reason: missing.length === 0 ? 'historical_quorum_complete' : 'historical_attestation_recorded',
-    seal: next,
+    seal: finalSeal,
     payload,
     missing_agents: missing,
   };


### PR DESCRIPTION
## Summary

Phase 7 adds Historical Reserve Block Back-Attestation.

This lets Sentinel agents review completed Reserve Blocks whose proof records already exist, then sign historical attestations over the exact stored block payload.

This does **not** rewrite history, pretend live attestation happened, or unlock the Fountain.

## Adds

```txt
lib/vault-v2/historical-attestation.ts
GET  /api/vault/blocks/historical
GET  /api/vault/blocks/historical?seal_id=<seal_id>
POST /api/vault/blocks/historical/attest
```

## Scope update

Sentinel agents can now sign:

```txt
historical_quorum_attestation
```

Agents:

```txt
ATLAS
ZEUS
EVE
JADE
AUREA
```

## What agents sign

Historical agents sign this canonical stored-seal payload:

```json
{
  "version": "C-293.phase7.v1",
  "action": "historical_quorum_attestation",
  "seal_id": "...",
  "seal_hash": "...",
  "sequence": 1,
  "cycle_at_seal": "C-293",
  "reserve": 50,
  "gi_at_seal": 0.67,
  "mode_at_seal": "red",
  "source_entries": 123,
  "deposit_hashes": ["..."],
  "prev_seal_hash": null,
  "historical": true,
  "review_basis": "stored_seal_record"
}
```

## Flow

```txt
completed Reserve Block
→ GET /api/vault/blocks/historical?seal_id=...
→ agent signs historical_quorum_attestation payload
→ POST /api/vault/blocks/historical/attest
→ signature verifies
→ dedupe key is consumed
→ attestation is attached to the existing Seal record
```

## Safety rules

Historical attestation:

- validates stored proof
- cannot rewrite original seal_hash
- cannot invent deposit_hashes
- cannot pretend the attestation was live
- cannot unlock Fountain by itself
- must pass Phase 4 signature + dedupe

## Files

- `lib/vault-v2/historical-attestation.ts`
- `app/api/vault/blocks/historical/route.ts`
- `app/api/vault/blocks/historical/attest/route.ts`
- `lib/agents/registry.ts`
- `docs/pr-bundles/C-293-phase7-historical-block-attestation.md`

## Notes

Branch is currently behind main because main advanced during Phase 6 merges. This PR should sync against current main before merge.

## Canon

Historical attestation validates stored proof.  
It does not rewrite history.  
It does not pretend agents signed live at the time.  
It does not unlock the Fountain by itself.

We heal as we walk.