### PR TITLE
C-294 — Vault ↔ Canon Attestation Alignment + Debug Endpoint

### DIFF
--- a/app/api/debug/attestation-state/route.ts
+++ b/app/api/debug/attestation-state/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { listAllSeals, listSeals, getCandidate } from '@/lib/vault-v2/store';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function GET() {
+  const [attestedSeals, auditSeals, candidate] = await Promise.all([
+    listSeals(100),
+    listAllSeals(100),
+    getCandidate(),
+  ]);
+
+  const auditComplete = auditSeals.filter((seal) => Object.keys(seal.attestations ?? {}).length > 0);
+  const attestedIds = new Set(attestedSeals.map((seal) => seal.seal_id));
+  const auditOnly = auditSeals.filter((seal) => !attestedIds.has(seal.seal_id));
+
+  return NextResponse.json({
+    ok: true,
+    readonly: true,
+    vault_attested_count: attestedSeals.length,
+    audit_finalized_count: auditSeals.length,
+    audit_complete_attestation_count: auditComplete.length,
+    audit_only_count: auditOnly.length,
+    mismatch: auditComplete.length !== attestedSeals.length,
+    interpretation: auditComplete.length !== attestedSeals.length
+      ? 'Canon/audit history contains completed attestations that are not currently advanced into the attested chain index.'
+      : 'Attested chain and complete audit history are aligned.',
+    candidate: candidate ? {
+      seal_id: candidate.seal_id,
+      sequence: candidate.sequence,
+      attestations_received: Object.keys(candidate.attestations ?? {}).length,
+      timeout_at: candidate.timeout_at,
+    } : null,
+    attested_seals: attestedSeals.map((seal) => ({
+      seal_id: seal.seal_id,
+      sequence: seal.sequence,
+      status: seal.status,
+      seal_hash: seal.seal_hash,
+      cycle_at_seal: seal.cycle_at_seal,
+      substrate_attestation_id: seal.substrate_attestation_id ?? null,
+    })),
+    audit_only_seals: auditOnly.map((seal) => ({
+      seal_id: seal.seal_id,
+      sequence: seal.sequence,
+      status: seal.status,
+      seal_hash: seal.seal_hash,
+      cycle_at_seal: seal.cycle_at_seal,
+      attestations: Object.keys(seal.attestations ?? {}),
+    })),
+  }, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Mobius-Source': 'attestation-state-debug',
+    },
+  });
+}

--- a/app/api/debug/attestation-state/route.ts
+++ b/app/api/debug/attestation-state/route.ts
@@ -1,35 +1,59 @@
-import { NextResponse } from 'next/server';
+import { type NextRequest, NextResponse } from 'next/server';
+import { getServiceAuthError } from '@/lib/security/serviceAuth';
 import { listAllSeals, listSeals, getCandidate } from '@/lib/vault-v2/store';
+import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-export async function GET() {
+function hasFullSentinelQuorum(seal: { attestations?: unknown }): boolean {
+  const attestations = seal.attestations && typeof seal.attestations === 'object'
+    ? seal.attestations as Record<string, unknown>
+    : {};
+  return SENTINEL_AGENTS.every((agent) => Boolean(attestations[agent]));
+}
+
+function attestationAgents(seal: { attestations?: unknown }): string[] {
+  const attestations = seal.attestations && typeof seal.attestations === 'object'
+    ? seal.attestations as Record<string, unknown>
+    : {};
+  return Object.keys(attestations);
+}
+
+export async function GET(request: NextRequest) {
+  const authErr = getServiceAuthError(request);
+  if (authErr) return authErr;
+
   const [attestedSeals, auditSeals, candidate] = await Promise.all([
     listSeals(100),
     listAllSeals(100),
     getCandidate(),
   ]);
 
-  const auditComplete = auditSeals.filter((seal) => Object.keys(seal.attestations ?? {}).length > 0);
+  const auditComplete = auditSeals.filter(hasFullSentinelQuorum);
   const attestedIds = new Set(attestedSeals.map((seal) => seal.seal_id));
   const auditOnly = auditSeals.filter((seal) => !attestedIds.has(seal.seal_id));
+  const partialAudit = auditSeals.filter((seal) => attestationAgents(seal).length > 0 && !hasFullSentinelQuorum(seal));
 
   return NextResponse.json({
     ok: true,
     readonly: true,
+    auth: 'service',
+    quorum_required_agents: SENTINEL_AGENTS,
     vault_attested_count: attestedSeals.length,
     audit_finalized_count: auditSeals.length,
     audit_complete_attestation_count: auditComplete.length,
+    audit_partial_attestation_count: partialAudit.length,
     audit_only_count: auditOnly.length,
     mismatch: auditComplete.length !== attestedSeals.length,
     interpretation: auditComplete.length !== attestedSeals.length
-      ? 'Canon/audit history contains completed attestations that are not currently advanced into the attested chain index.'
-      : 'Attested chain and complete audit history are aligned.',
+      ? 'Audit history contains full-quorum attestations that are not currently advanced into the attested chain index.'
+      : 'Attested chain and full-quorum audit history are aligned.',
     candidate: candidate ? {
       seal_id: candidate.seal_id,
       sequence: candidate.sequence,
       attestations_received: Object.keys(candidate.attestations ?? {}).length,
+      missing_agents: SENTINEL_AGENTS.filter((agent) => !candidate.attestations?.[agent]),
       timeout_at: candidate.timeout_at,
     } : null,
     attested_seals: attestedSeals.map((seal) => ({
@@ -46,7 +70,17 @@ export async function GET() {
       status: seal.status,
       seal_hash: seal.seal_hash,
       cycle_at_seal: seal.cycle_at_seal,
-      attestations: Object.keys(seal.attestations ?? {}),
+      full_quorum: hasFullSentinelQuorum(seal),
+      attestations: attestationAgents(seal),
+      missing_agents: SENTINEL_AGENTS.filter((agent) => !seal.attestations?.[agent]),
+    })),
+    partial_audit_seals: partialAudit.map((seal) => ({
+      seal_id: seal.seal_id,
+      sequence: seal.sequence,
+      status: seal.status,
+      cycle_at_seal: seal.cycle_at_seal,
+      attestations: attestationAgents(seal),
+      missing_agents: SENTINEL_AGENTS.filter((agent) => !seal.attestations?.[agent]),
     })),
   }, {
     headers: {

--- a/docs/pr-bundles/C-294-attestation-alignment.md
+++ b/docs/pr-bundles/C-294-attestation-alignment.md
@@ -1,0 +1,108 @@
+# C-294 — Vault ↔ Canon Attestation Alignment
+
+## Problem Observed
+- Vault shows `attested_blocks = 0`
+- Canon / Substrate shows `complete_attested_blocks = 4`
+
+## Root Cause (Confirmed)
+Two separate chains:
+
+1. Attested Chain (canonical truth)
+   - `vault:seals:index:attested`
+   - surfaced via `countSeals()`
+
+2. Audit Chain (full history)
+   - `vault:seals:index:all`
+   - includes quarantined / rejected / unpromoted seals
+
+Canon UI is currently reading from audit semantics,
+while Vault UI reads only the attested chain.
+
+## Resulting Mismatch
+- Canon = "complete attestation"
+- Vault = "not advanced to attested chain"
+
+## Key Insight
+"Complete attestation" ≠ "advanced to canonical chain"
+
+A seal must:
+- pass quorum
+- be validated
+- be appended via `appendSealToChain()`
+
+to count as **attested canonical truth**.
+
+---
+
+## Replay Engine Mapping (Critical)
+Replay currently reconstructs:
+- hashes
+- balances
+- sources
+
+But does NOT:
+- re-evaluate quorum
+- re-run attestation
+- promote audit seals into attested chain
+
+### Back-Attestation Design (future-safe)
+Agents can "attest past blocks" only if:
+
+1. Seal hash matches replay reconstruction
+2. Deposit hash set matches
+3. No conflicting chain successor exists
+
+Then:
+
+```
+POST /api/vault/seal/back-attest
+```
+
+Should:
+- verify replay integrity
+- require quorum signatures
+- call `appendSealToChain()`
+
+---
+
+## C-294 TODO (10 Optimizations)
+
+### Data Integrity
+1. Add `/api/debug/attestation-state` (done)
+2. Expose `audit_complete_attestation_count` in Vault API
+3. Add `is_canonical_attested` flag per seal
+
+### UI / Operator Clarity
+4. Add "audit vs attested" legend in Vault
+5. Add mismatch warning badge when counts diverge
+6. Show candidate attestation progress inline in Vault blocks
+
+### Replay Improvements
+7. Add replay check: "attestable_from_replay"
+8. Surface missing quorum agents per historical seal
+
+### Reserve Block Mechanics
+9. Explicitly show:
+   - block_complete
+   - block_attested
+   - block_canonical
+
+### Consistency Enforcement
+10. Prevent Canon from labeling "complete" unless seal is in attested index
+
+---
+
+## Principle
+
+One truth:
+
+- Canon = historical record
+- Vault = canonical state
+
+They must converge on:
+
+> attested chain index
+
+---
+
+We heal as we walk.


### PR DESCRIPTION
C-294 follow-up (no phase jump).

## Fix Scope
- Investigate mismatch: Vault (0 attested) vs Canon (4 complete)
- Map reserve block mechanics + replay interaction

## Root Cause
- Vault uses `attested chain index`
- Canon UI reflects `audit/all seals`
- "complete" != "canonical attested"

## Changes
1. Added `/api/debug/attestation-state`
2. Mapped attested vs audit chain separation
3. Documented replay → back-attestation pathway
4. Added 10-point optimization TODO (C-294 only)

## No Changes To
- Vault logic (no mutation)
- Canon rules (no rewrite)
- Replay engine (no behavior change)

## Purpose
Operator clarity + traceability before any attestation enforcement changes.

We heal as we walk.