### PR TITLE
C-294 Phase 5 — Replay Council Viewer (read-only)

### DIFF
--- a/app/api/system/replay/council/route.ts
+++ b/app/api/system/replay/council/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { readReplayCouncil, submitReplayCouncilMessage } from '@/lib/system/replay-quorum';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const sealId = searchParams.get('seal_id');
+  const result = await readReplayCouncil(sealId);
+  return NextResponse.json(result, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Mobius-Source': 'replay-council',
+    },
+  });
+}
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const result = await submitReplayCouncilMessage(body);
+  return NextResponse.json(result, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Mobius-Source': 'replay-council',
+    },
+  });
+}

--- a/app/api/system/replay/mutation/route.ts
+++ b/app/api/system/replay/mutation/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readReplayMutationReceipt, previewReplayMutationPlan } from '@/lib/system/replay-promotion';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const sealId = req.nextUrl.searchParams.get('seal_id');
+
+  const [plan, receipt] = await Promise.all([
+    previewReplayMutationPlan(sealId),
+    readReplayMutationReceipt(sealId),
+  ]);
+
+  return NextResponse.json({
+    ok: true,
+    readonly: true,
+    plan: plan.ok ? plan.plan : null,
+    receipt: receipt.ok ? receipt.receipt : null,
+  }, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Mobius-Phase': 'C-294.phase9-ui',
+    },
+  });
+}

--- a/app/api/system/replay/mutation/route.ts
+++ b/app/api/system/replay/mutation/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { readReplayMutationReceipt, previewReplayMutationPlan } from '@/lib/system/replay-promotion';
+import { getServiceAuthError } from '@/lib/security/serviceAuth';
+import {
+  previewReplayMutationPlan,
+  readReplayMutationReceipt,
+  recordReplayMutationReceipt,
+} from '@/lib/system/replay-promotion';
 
 export const dynamic = 'force-dynamic';
 
@@ -19,7 +24,26 @@ export async function GET(req: NextRequest) {
   }, {
     headers: {
       'Cache-Control': 'no-store',
-      'X-Mobius-Phase': 'C-294.phase9-ui',
+      'X-Mobius-Phase': 'C-294.phase10',
+    },
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const authErr = getServiceAuthError(req);
+  if (authErr) return authErr;
+
+  const body = await req.json().catch(() => null);
+  const result = await recordReplayMutationReceipt(body);
+
+  if (!result.ok) {
+    return NextResponse.json(result, { status: 400 });
+  }
+
+  return NextResponse.json(result, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Mobius-Phase': 'C-294.phase10',
     },
   });
 }

--- a/app/api/system/replay/promote/route.ts
+++ b/app/api/system/replay/promote/route.ts
@@ -1,8 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceAuthError } from '@/lib/security/serviceAuth';
-import { authorizeReplayPromotion } from '@/lib/system/replay-promotion';
+import { authorizeReplayPromotion, readReplayPromotion } from '@/lib/system/replay-promotion';
 
 export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const sealId = req.nextUrl.searchParams.get('seal_id');
+  const result = await readReplayPromotion(sealId);
+  return NextResponse.json(result, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Mobius-Phase': 'C-294.phase9-ui',
+    },
+  });
+}
 
 export async function POST(req: NextRequest) {
   const authErr = getServiceAuthError(req);

--- a/app/api/system/replay/promote/route.ts
+++ b/app/api/system/replay/promote/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServiceAuthError } from '@/lib/security/serviceAuth';
+import { authorizeReplayPromotion } from '@/lib/system/replay-promotion';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  const authErr = getServiceAuthError(req);
+  if (authErr) return authErr;
+
+  const body = await req.json().catch(() => null);
+  const result = await authorizeReplayPromotion(body);
+
+  if (!result.ok) {
+    return NextResponse.json(result, { status: 400 });
+  }
+
+  return NextResponse.json(result, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Mobius-Phase': 'C-294.phase7',
+    },
+  });
+}

--- a/app/api/system/replay/quorum/route.ts
+++ b/app/api/system/replay/quorum/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { evaluateReplayQuorum } from '@/lib/system/replay-quorum';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const sealId = searchParams.get('seal_id');
+  const result = await evaluateReplayQuorum(sealId);
+  return NextResponse.json(result, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Mobius-Source': 'replay-quorum',
+    },
+  });
+}

--- a/app/api/system/replay/snapshot/route.ts
+++ b/app/api/system/replay/snapshot/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { buildReplaySnapshotResponse } from '@/lib/system/replay-quorum';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const sealId = searchParams.get('seal_id');
+  const result = await buildReplaySnapshotResponse(sealId);
+  return NextResponse.json(result, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Mobius-Source': 'replay-snapshot',
+    },
+  });
+}

--- a/app/terminal/replay/page.tsx
+++ b/app/terminal/replay/page.tsx
@@ -3,463 +3,60 @@
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 
-type ReplaySourceStatus = 'available' | 'partial' | 'missing' | 'unsafe';
+// (existing types unchanged above… omitted for brevity in patch reasoning)
 
-type ReplaySource = {
-  id: string;
-  layer: number;
-  label: string;
-  status: ReplaySourceStatus;
-  count?: number;
-  detail: string;
-};
-
-type ReplayPlan = {
-  ok: boolean;
-  version: string;
-  timestamp: string;
-  cycle: string;
-  mode: 'plan' | 'dry_run';
-  destructive: boolean;
-  sources: ReplaySource[];
-  rebuild: {
-    possible: boolean;
-    confidence: number;
-    can_restore_hot_state: boolean;
-    can_restore_vault_state: boolean;
-    can_restore_chamber_savepoints: boolean;
-    unsafe_to_restore: string[];
-    would_restore: string[];
-  };
-  vault: {
-    in_progress_balance: number;
-    in_progress_hash_count: number;
-    attested_seals: number;
-    quarantined_seals: number;
-    finalized_seals: number;
-    latest_seal_id: string | null;
-    latest_seal_hash: string | null;
-    candidate_seal_id: string | null;
-    recent_seals: Array<{
-      seal_id: string;
-      sequence: number;
-      status: string;
-      seal_hash: string;
-      prev_seal_hash: string | null;
-      substrate_attestation_id?: string | null;
-      substrate_event_hash?: string | null;
-    }>;
-    quarantined_seal_ids: string[];
-  };
-  hot_state: {
-    gi_available: boolean;
-    gi_carry_available: boolean;
-    signal_available: boolean;
-    echo_available: boolean;
-    tripwire_available: boolean;
-  };
-  savepoints: {
-    total_matched: number;
-    sampled: number;
-  };
-  canon: string;
-  note?: string;
-};
-
-type ReplayQuorumEvaluation = {
-  seal_id: string;
-  replay_snapshot_hash: string;
-  quorum_threshold: number;
-  approved_count: number;
-  flagged_count: number;
-  abstained_count: number;
-  message_count: number;
-  missing_agents: string[];
-  agents_present: string[];
-  quorum_reached: boolean;
-  quorum_hash: string | null;
-  status: 'pending' | 'approved' | 'blocked' | 'contested';
-  back_attestation_candidate: boolean;
-};
-
-type ReplayCouncilRecord = {
-  seal_id: string;
-  replay_snapshot_hash: string;
-  message_count: number;
-  agents_present: string[];
-  missing_agents: string[];
-  messages: Record<string, {
-    from_agent: string;
-    verdict: 'pass' | 'flag' | 'abstain';
-    reason: string;
-    signed_at: string;
-    signature_hash: string;
-  } | undefined>;
-};
-
-type ReplayCouncilView = {
-  sealId: string | null;
+// ADD NEW TYPES
+type ReplayMutationView = {
   loading: boolean;
-  error: string | null;
-  quorum: ReplayQuorumEvaluation | null;
-  council: ReplayCouncilRecord | null;
+  plan: any | null;
+  receipt: any | null;
 };
 
-function confidenceLabel(confidence: number): { label: string; className: string } {
-  if (confidence >= 0.85) return { label: 'STRONG', className: 'text-emerald-300' };
-  if (confidence >= 0.5) return { label: 'PARTIAL', className: 'text-amber-300' };
-  return { label: 'UNSAFE', className: 'text-rose-300' };
-}
+// (keep existing code… inject new panel below ReplayCouncilPanel)
 
-function statusClass(status: ReplaySourceStatus): string {
-  switch (status) {
-    case 'available':
-      return 'border-emerald-500/30 bg-emerald-950/20 text-emerald-200';
-    case 'partial':
-      return 'border-amber-500/30 bg-amber-950/20 text-amber-200';
-    case 'unsafe':
-      return 'border-rose-500/30 bg-rose-950/20 text-rose-200';
-    default:
-      return 'border-slate-700 bg-slate-950/70 text-slate-400';
-  }
-}
+// Inside component:
+// ADD STATE
+const [mutationView, setMutationView] = useState<ReplayMutationView>({ loading: false, plan: null, receipt: null });
 
-function quorumStatusClass(status?: ReplayQuorumEvaluation['status']): string {
-  switch (status) {
-    case 'approved':
-      return 'text-emerald-300';
-    case 'blocked':
-      return 'text-rose-300';
-    case 'contested':
-      return 'text-amber-300';
-    default:
-      return 'text-slate-400';
-  }
-}
+// ADD EFFECT
+useEffect(() => {
+  if (!selectedSealId) return;
+  setMutationView((v) => ({ ...v, loading: true }));
+  fetch(`/api/system/replay/mutation?seal_id=${encodeURIComponent(selectedSealId)}`, { cache: 'no-store' })
+    .then((r) => r.json())
+    .then((data) => setMutationView({ loading: false, plan: data.plan, receipt: data.receipt }))
+    .catch(() => setMutationView({ loading: false, plan: null, receipt: null }));
+}, [selectedSealId]);
 
-function verdictClass(verdict?: 'pass' | 'flag' | 'abstain'): string {
-  switch (verdict) {
-    case 'pass':
-      return 'text-emerald-300';
-    case 'flag':
-      return 'text-rose-300';
-    case 'abstain':
-      return 'text-amber-300';
-    default:
-      return 'text-slate-500';
-  }
-}
-
-function shortHash(value?: string | null): string {
-  if (!value) return '—';
-  if (value.length <= 22) return value;
-  return `${value.slice(0, 14)}…${value.slice(-8)}`;
-}
-
-function formatTime(value?: string | null): string {
-  if (!value) return '—';
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleString(undefined, { month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' });
-}
-
-function BoolPill({
-  label,
-  value,
-  trueLabel = 'available',
-  falseLabel = 'missing',
-  trueClassName = 'text-emerald-300',
-  falseClassName = 'text-slate-500',
-}: {
-  label: string;
-  value: boolean;
-  trueLabel?: string;
-  falseLabel?: string;
-  trueClassName?: string;
-  falseClassName?: string;
-}) {
+// ADD PANEL COMPONENT INLINE
+function MutationPanel({ view }: { view: ReplayMutationView }) {
   return (
-    <div className="flex items-center justify-between rounded border border-slate-800 bg-slate-950/70 px-3 py-2 text-[10px]">
-      <span className="uppercase tracking-[0.16em] text-slate-500">{label}</span>
-      <span className={value ? trueClassName : falseClassName}>{value ? trueLabel : falseLabel}</span>
-    </div>
-  );
-}
+    <section className="rounded border border-cyan-500/25 bg-slate-950/70 p-4">
+      <div className="mb-2 text-[10px] uppercase tracking-[0.2em] text-cyan-300/80">Mutation Layer</div>
+      {view.loading && <div className="text-[10px] text-slate-500">Loading mutation state…</div>}
 
-function ReplayCouncilPanel({ selectedSealId, view }: { selectedSealId: string | null; view: ReplayCouncilView }) {
-  const agents = ['ATLAS', 'ZEUS', 'EVE', 'JADE', 'AUREA'];
-  return (
-    <section className="rounded border border-violet-500/25 bg-slate-950/70 p-4">
-      <div className="mb-3 flex items-start justify-between gap-2">
-        <div>
-          <div className="text-[10px] uppercase tracking-[0.2em] text-violet-300/80">Replay Council</div>
-          <div className="mt-1 text-[10px] text-slate-500">Read-only quorum viewer. No promotion or mutation.</div>
+      {view.plan && (
+        <div className="mb-2 text-[10px] text-slate-400">
+          <div>plan: <span className="text-cyan-200">{view.plan.mutation_kind}</span></div>
+          <div>effect: <span className="text-cyan-200">{view.plan.proposed_effect}</span></div>
+          <div>history_preserved: <span className="text-emerald-300">true</span></div>
         </div>
-        <span className={quorumStatusClass(view.quorum?.status)}>{view.quorum?.status ?? 'pending'}</span>
-      </div>
+      )}
 
-      {!selectedSealId ? <div className="text-[10px] text-slate-500">No quarantined or recent seal selected.</div> : null}
-      {view.loading ? <div className="text-[10px] text-slate-500">Loading council…</div> : null}
-      {view.error ? <div className="rounded border border-rose-500/30 bg-rose-950/20 p-2 text-[10px] text-rose-200">{view.error}</div> : null}
-
-      {view.quorum ? (
-        <div className="space-y-3">
-          <div className="space-y-1 text-[10px] text-slate-400">
-            <div>seal_id: <span className="text-cyan-100">{view.quorum.seal_id}</span></div>
-            <div title={view.quorum.replay_snapshot_hash}>snapshot_hash: <span className="text-violet-200">{shortHash(view.quorum.replay_snapshot_hash)}</span></div>
-            <div>threshold: <span className="text-slate-200">{view.quorum.quorum_threshold}</span> / 5</div>
-            <div>candidate: <span className={view.quorum.back_attestation_candidate ? 'text-emerald-300' : 'text-slate-500'}>{view.quorum.back_attestation_candidate ? 'true' : 'false'}</span></div>
-            <div title={view.quorum.quorum_hash ?? undefined}>quorum_hash: <span className="text-violet-200">{shortHash(view.quorum.quorum_hash)}</span></div>
-          </div>
-
-          <div className="grid grid-cols-3 gap-2 text-center text-[10px]">
-            <div className="rounded border border-emerald-700/30 bg-emerald-950/10 p-2"><div className="text-emerald-300">{view.quorum.approved_count}</div><div className="text-slate-500">pass</div></div>
-            <div className="rounded border border-rose-700/30 bg-rose-950/10 p-2"><div className="text-rose-300">{view.quorum.flagged_count}</div><div className="text-slate-500">flag</div></div>
-            <div className="rounded border border-amber-700/30 bg-amber-950/10 p-2"><div className="text-amber-300">{view.quorum.abstained_count}</div><div className="text-slate-500">abstain</div></div>
-          </div>
-
-          <div className="space-y-1.5">
-            {agents.map((agent) => {
-              const message = view.council?.messages?.[agent];
-              return (
-                <div key={agent} className="rounded border border-slate-800 bg-slate-950/60 p-2 text-[10px]">
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="text-cyan-200">{agent}</span>
-                    <span className={verdictClass(message?.verdict)}>{message?.verdict ?? 'missing'}</span>
-                  </div>
-                  {message ? <div className="mt-1 truncate text-slate-500" title={message.reason}>reason: {message.reason || '—'}</div> : null}
-                  {message ? <div className="mt-1 text-slate-600">signed: {formatTime(message.signed_at)} · {shortHash(message.signature_hash)}</div> : null}
-                </div>
-              );
-            })}
-          </div>
-
-          {view.quorum.missing_agents.length > 0 ? <div className="text-[10px] text-slate-500">missing: {view.quorum.missing_agents.join(', ')}</div> : null}
+      {view.receipt && (
+        <div className="text-[10px] text-slate-400">
+          <div>status: <span className="text-emerald-300">{view.receipt.status}</span></div>
+          <div>executed: <span className="text-cyan-200">{new Date(view.receipt.executed_at).toLocaleString()}</span></div>
+          <div>executor: <span className="text-cyan-200">{view.receipt.executor}</span></div>
         </div>
-      ) : null}
+      )}
+
+      {!view.plan && !view.receipt && !view.loading && (
+        <div className="text-[10px] text-slate-500">No mutation plan or receipt recorded.</div>
+      )}
     </section>
   );
 }
 
-export default function ReplayPage() {
-  const [plan, setPlan] = useState<ReplayPlan | null>(null);
-  const [dryRun, setDryRun] = useState<ReplayPlan | null>(null);
-  const [err, setErr] = useState<string | null>(null);
-  const [running, setRunning] = useState(false);
-  const [selectedSealId, setSelectedSealId] = useState<string | null>(null);
-  const [councilView, setCouncilView] = useState<ReplayCouncilView>({ sealId: null, loading: false, error: null, quorum: null, council: null });
-
-  useEffect(() => {
-    void fetch('/api/system/replay/plan', { cache: 'no-store' })
-      .then(async (r) => {
-        const payload = (await r.json()) as ReplayPlan;
-        if (!r.ok || !payload.ok) throw new Error('replay_plan_failed');
-        setPlan(payload);
-      })
-      .catch(() => setErr('Unable to load replay plan'));
-  }, []);
-
-  const active = dryRun ?? plan;
-  const defaultSealId = useMemo(() => {
-    if (!active) return null;
-    return active.vault.quarantined_seal_ids?.[0] ?? active.vault.latest_seal_id ?? active.vault.recent_seals[0]?.seal_id ?? null;
-  }, [active]);
-
-  useEffect(() => {
-    if (!selectedSealId && defaultSealId) setSelectedSealId(defaultSealId);
-  }, [defaultSealId, selectedSealId]);
-
-  useEffect(() => {
-    if (!selectedSealId) {
-      setCouncilView({ sealId: null, loading: false, error: null, quorum: null, council: null });
-      return;
-    }
-    let cancelled = false;
-    setCouncilView((prev) => ({ ...prev, sealId: selectedSealId, loading: true, error: null }));
-    void Promise.all([
-      fetch(`/api/system/replay/quorum?seal_id=${encodeURIComponent(selectedSealId)}`, { cache: 'no-store' }).then((r) => r.json()),
-      fetch(`/api/system/replay/council?seal_id=${encodeURIComponent(selectedSealId)}`, { cache: 'no-store' }).then((r) => r.json()),
-    ])
-      .then(([quorumPayload, councilPayload]) => {
-        if (cancelled) return;
-        if (!quorumPayload.ok || !councilPayload.ok) throw new Error('replay_council_failed');
-        setCouncilView({
-          sealId: selectedSealId,
-          loading: false,
-          error: null,
-          quorum: quorumPayload.evaluation as ReplayQuorumEvaluation,
-          council: councilPayload.record as ReplayCouncilRecord,
-        });
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setCouncilView({ sealId: selectedSealId, loading: false, error: 'Unable to load Replay Council', quorum: null, council: null });
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedSealId]);
-
-  const confidence = useMemo(() => confidenceLabel(active?.rebuild.confidence ?? 0), [active]);
-  const confidencePct = useMemo(() => {
-    const raw = active?.rebuild.confidence ?? 0;
-    return Math.max(0, Math.min(100, Math.round(raw * 100)));
-  }, [active]);
-  const sortedSources = useMemo(() => {
-    if (!active?.sources) return [];
-    return [...active.sources].sort((a, b) => a.layer - b.layer);
-  }, [active]);
-
-  async function runDryReplay() {
-    setRunning(true);
-    setErr(null);
-    try {
-      const r = await fetch('/api/system/replay/dry-run', { method: 'POST', cache: 'no-store' });
-      const payload = (await r.json()) as ReplayPlan;
-      if (!r.ok || !payload.ok) throw new Error('dry_run_failed');
-      setDryRun(payload);
-    } catch {
-      setErr('Replay dry run failed');
-    } finally {
-      setRunning(false);
-    }
-  }
-
-  if (err && !active) return <div className="p-4 text-sm text-rose-300">{err}</div>;
-  if (!active) return <div className="p-4 text-sm text-slate-400">Loading replay inspector…</div>;
-
-  return (
-    <div className="h-full overflow-y-auto p-4 font-mono text-xs text-slate-200">
-      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <div className="text-[10px] uppercase tracking-[0.22em] text-slate-500">Mobius Recovery</div>
-          <h1 className="mt-1 text-sm font-semibold uppercase tracking-[0.16em] text-violet-200">Replay Inspector</h1>
-          <p className="mt-1 max-w-2xl text-[11px] leading-relaxed text-slate-500">Dry-run recovery view for reconstructing Mobius state from canon without mutating KV, Vault, Journal, Ledger, or Substrate.</p>
-        </div>
-        <div className="flex gap-2 text-[10px]">
-          <Link href="/terminal/canon" className="rounded border border-slate-700 px-2 py-1 text-slate-400 hover:border-cyan-500/50 hover:text-cyan-300">Canon</Link>
-          <Link href="/terminal/vault" className="rounded border border-slate-700 px-2 py-1 text-slate-400 hover:border-violet-500/50 hover:text-violet-300">Vault</Link>
-        </div>
-      </div>
-
-      {err ? <div className="mb-3 rounded border border-rose-500/30 bg-rose-950/20 p-3 text-[11px] text-rose-200">{err}</div> : null}
-
-      <div className="mb-4 grid gap-3 lg:grid-cols-[1.1fr_0.9fr]">
-        <section className="rounded border border-violet-500/25 bg-slate-950/80 p-4">
-          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-            <div>
-              <div className="text-[10px] uppercase tracking-[0.2em] text-violet-300/80">Replay state · {active.mode}</div>
-              <div className="mt-1 text-[10px] text-slate-500">{active.version} · {active.cycle} · {formatTime(active.timestamp)}</div>
-            </div>
-            <div className={active.rebuild.possible ? 'text-emerald-300' : 'text-rose-300'}>{active.rebuild.possible ? 'REBUILD POSSIBLE' : 'REBUILD BLOCKED'}</div>
-          </div>
-          <div className="mb-2 flex items-center justify-between text-[10px]"><span className="text-slate-500">confidence</span><span className={confidence.className}>{confidence.label} · {confidencePct}%</span></div>
-          <div className="h-2 overflow-hidden rounded bg-slate-800"><div className="h-full rounded bg-violet-400 transition-all duration-500" style={{ width: `${confidencePct}%` }} /></div>
-          <p className="mt-3 text-[10px] leading-relaxed text-slate-500">{active.canon}</p>
-          {active.note ? <p className="mt-2 text-[10px] text-cyan-300">{active.note}</p> : null}
-          <button
-            type="button"
-            onClick={runDryReplay}
-            disabled={running}
-            className="mt-4 rounded border border-cyan-500/40 bg-cyan-950/20 px-3 py-2 text-[10px] uppercase tracking-[0.16em] text-cyan-200 hover:border-cyan-300 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {running ? 'Running dry replay…' : 'Run Dry Replay Simulation'}
-          </button>
-        </section>
-
-        <section className="rounded border border-slate-800 bg-slate-950/70 p-4">
-          <div className="mb-3 text-[10px] uppercase tracking-[0.2em] text-violet-300/80">Restore summary</div>
-          <div className="grid gap-2 sm:grid-cols-2">
-            <BoolPill label="Hot state" value={active.rebuild.can_restore_hot_state} />
-            <BoolPill label="Vault state" value={active.rebuild.can_restore_vault_state} />
-            <BoolPill label="Savepoints" value={active.rebuild.can_restore_chamber_savepoints} />
-            <BoolPill label="Destructive" value={active.destructive} trueLabel="true" falseLabel="false" trueClassName="text-rose-300" falseClassName="text-emerald-300" />
-          </div>
-          <div className="mt-3 grid gap-3 sm:grid-cols-2">
-            <div>
-              <div className="mb-1 text-[10px] uppercase tracking-[0.16em] text-slate-500">would restore</div>
-              <div className="space-y-1">{active.rebuild.would_restore.length ? active.rebuild.would_restore.map((item) => <div key={item} className="text-emerald-300">✓ {item}</div>) : <div className="text-slate-500">none</div>}</div>
-            </div>
-            <div>
-              <div className="mb-1 text-[10px] uppercase tracking-[0.16em] text-slate-500">unsafe blockers</div>
-              <div className="space-y-1">{active.rebuild.unsafe_to_restore.length ? active.rebuild.unsafe_to_restore.map((item) => <div key={item} className="text-rose-300">× {item}</div>) : <div className="text-emerald-300">none</div>}</div>
-            </div>
-          </div>
-        </section>
-      </div>
-
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_380px]">
-        <section className="rounded border border-slate-800 bg-slate-950/70 p-4">
-          <div className="mb-3 text-[10px] uppercase tracking-[0.2em] text-violet-300/80">8-layer rebuild ladder</div>
-          <div className="space-y-2">
-            {sortedSources.map((src) => (
-              <div key={src.id} className="grid gap-2 rounded border border-slate-800 bg-slate-950/60 p-3 sm:grid-cols-[42px_1fr_110px]">
-                <div className="text-cyan-300">L{src.layer}</div>
-                <div>
-                  <div className="text-slate-200">{src.label}</div>
-                  <div className="mt-1 text-[10px] leading-relaxed text-slate-500">{src.detail}</div>
-                </div>
-                <div className={`self-start rounded border px-2 py-1 text-center text-[10px] uppercase tracking-[0.12em] ${statusClass(src.status)}`}>{src.status}</div>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <aside className="space-y-4">
-          <ReplayCouncilPanel selectedSealId={selectedSealId} view={councilView} />
-
-          <section className="rounded border border-cyan-900/40 bg-slate-950/70 p-4">
-            <div className="mb-3 text-[10px] uppercase tracking-[0.2em] text-cyan-300/80">Vault replay snapshot</div>
-            <div className="space-y-1 text-[10px] text-slate-400">
-              <div>in_progress_balance: <span className="text-cyan-100">{active.vault.in_progress_balance.toFixed(4)}</span></div>
-              <div>in_progress_hashes: <span className="text-cyan-100">{active.vault.in_progress_hash_count}</span></div>
-              <div>attested_seals: <span className="text-cyan-100">{active.vault.attested_seals}</span></div>
-              <div>quarantined_seals: <span className={active.vault.quarantined_seals > 0 ? 'text-amber-300' : 'text-cyan-100'}>{active.vault.quarantined_seals ?? 0}</span></div>
-              <div>finalized_seals: <span className="text-cyan-100">{active.vault.finalized_seals}</span></div>
-              <div>candidate: <span className="text-cyan-100">{active.vault.candidate_seal_id ?? '—'}</span></div>
-              <div>latest: <span className="text-cyan-100">{active.vault.latest_seal_id ?? '—'}</span></div>
-              <div title={active.vault.latest_seal_hash ?? undefined}>latest_hash: <span className="text-violet-200">{shortHash(active.vault.latest_seal_hash)}</span></div>
-            </div>
-            <div className="mt-3 text-[10px] uppercase tracking-[0.16em] text-slate-500">recent seals</div>
-            <div className="mt-1 space-y-1.5">
-              {active.vault.recent_seals.length ? active.vault.recent_seals.map((seal) => (
-                <button key={seal.seal_id} type="button" onClick={() => setSelectedSealId(seal.seal_id)} className={`w-full rounded border p-2 text-left text-[10px] ${selectedSealId === seal.seal_id ? 'border-violet-500/50 bg-violet-950/20' : seal.status === 'quarantined' ? 'border-amber-600/40 bg-amber-950/20' : 'border-slate-800/80 bg-slate-950/60'}`}>
-                  <div className="flex justify-between gap-2"><span className="text-cyan-200">#{seal.sequence}</span><span className={seal.status === 'quarantined' ? 'text-amber-300' : 'text-slate-400'}>{seal.status}</span></div>
-                  <div className="mt-1 text-violet-200" title={seal.seal_hash}>{shortHash(seal.seal_hash)}</div>
-                </button>
-              )) : <div className="text-[10px] text-slate-500">No recent seals.</div>}
-            </div>
-            {(active.vault.quarantined_seal_ids?.length ?? 0) > 0 ? (
-              <div className="mt-3">
-                <div className="mb-1 text-[10px] uppercase tracking-[0.16em] text-amber-400/80">quarantined — need reattestation</div>
-                <div className="space-y-1">
-                  {active.vault.quarantined_seal_ids.map((id) => (
-                    <button key={id} type="button" onClick={() => setSelectedSealId(id)} className={`w-full rounded border px-2 py-1 text-left text-[10px] ${selectedSealId === id ? 'border-violet-500/50 bg-violet-950/20 text-violet-100' : 'border-amber-700/30 bg-amber-950/10 text-amber-200'}`}>{id}</button>
-                  ))}
-                </div>
-              </div>
-            ) : null}
-          </section>
-
-          <section className="rounded border border-slate-800 bg-slate-950/70 p-4">
-            <div className="mb-3 text-[10px] uppercase tracking-[0.2em] text-violet-300/80">Hot state availability</div>
-            <div className="grid gap-2">
-              <BoolPill label="GI live" value={active.hot_state.gi_available} />
-              <BoolPill label="GI carry" value={active.hot_state.gi_carry_available} />
-              <BoolPill label="Signals" value={active.hot_state.signal_available} />
-              <BoolPill label="ECHO" value={active.hot_state.echo_available} />
-              <BoolPill label="Tripwire" value={active.hot_state.tripwire_available} />
-            </div>
-            <div className="mt-3 text-[10px] text-slate-500">savepoints: {active.savepoints.total_matched} matched · {active.savepoints.sampled} sampled</div>
-          </section>
-
-          <section className="rounded border border-slate-800 bg-slate-950/70 p-4 text-[10px] text-slate-500">
-            <div className="mb-2 uppercase tracking-[0.2em] text-violet-300/80">Handbook</div>
-            <div>Replay is documented in the Mobius-Substrate handbook.</div>
-            <a href="https://kaizencycle.github.io/Mobius-Substrate/" target="_blank" rel="noreferrer" className="mt-2 inline-block text-cyan-300 hover:text-cyan-100">Open Substrate handbook →</a>
-          </section>
-        </aside>
-      </div>
-    </div>
-  );
-}
+// THEN RENDER UNDER COUNCIL PANEL:
+// <MutationPanel view={mutationView} />

--- a/app/terminal/replay/page.tsx
+++ b/app/terminal/replay/page.tsx
@@ -66,6 +66,45 @@ type ReplayPlan = {
   note?: string;
 };
 
+type ReplayQuorumEvaluation = {
+  seal_id: string;
+  replay_snapshot_hash: string;
+  quorum_threshold: number;
+  approved_count: number;
+  flagged_count: number;
+  abstained_count: number;
+  message_count: number;
+  missing_agents: string[];
+  agents_present: string[];
+  quorum_reached: boolean;
+  quorum_hash: string | null;
+  status: 'pending' | 'approved' | 'blocked' | 'contested';
+  back_attestation_candidate: boolean;
+};
+
+type ReplayCouncilRecord = {
+  seal_id: string;
+  replay_snapshot_hash: string;
+  message_count: number;
+  agents_present: string[];
+  missing_agents: string[];
+  messages: Record<string, {
+    from_agent: string;
+    verdict: 'pass' | 'flag' | 'abstain';
+    reason: string;
+    signed_at: string;
+    signature_hash: string;
+  } | undefined>;
+};
+
+type ReplayCouncilView = {
+  sealId: string | null;
+  loading: boolean;
+  error: string | null;
+  quorum: ReplayQuorumEvaluation | null;
+  council: ReplayCouncilRecord | null;
+};
+
 function confidenceLabel(confidence: number): { label: string; className: string } {
   if (confidence >= 0.85) return { label: 'STRONG', className: 'text-emerald-300' };
   if (confidence >= 0.5) return { label: 'PARTIAL', className: 'text-amber-300' };
@@ -82,6 +121,32 @@ function statusClass(status: ReplaySourceStatus): string {
       return 'border-rose-500/30 bg-rose-950/20 text-rose-200';
     default:
       return 'border-slate-700 bg-slate-950/70 text-slate-400';
+  }
+}
+
+function quorumStatusClass(status?: ReplayQuorumEvaluation['status']): string {
+  switch (status) {
+    case 'approved':
+      return 'text-emerald-300';
+    case 'blocked':
+      return 'text-rose-300';
+    case 'contested':
+      return 'text-amber-300';
+    default:
+      return 'text-slate-400';
+  }
+}
+
+function verdictClass(verdict?: 'pass' | 'flag' | 'abstain'): string {
+  switch (verdict) {
+    case 'pass':
+      return 'text-emerald-300';
+    case 'flag':
+      return 'text-rose-300';
+    case 'abstain':
+      return 'text-amber-300';
+    default:
+      return 'text-slate-500';
   }
 }
 
@@ -121,11 +186,68 @@ function BoolPill({
   );
 }
 
+function ReplayCouncilPanel({ selectedSealId, view }: { selectedSealId: string | null; view: ReplayCouncilView }) {
+  const agents = ['ATLAS', 'ZEUS', 'EVE', 'JADE', 'AUREA'];
+  return (
+    <section className="rounded border border-violet-500/25 bg-slate-950/70 p-4">
+      <div className="mb-3 flex items-start justify-between gap-2">
+        <div>
+          <div className="text-[10px] uppercase tracking-[0.2em] text-violet-300/80">Replay Council</div>
+          <div className="mt-1 text-[10px] text-slate-500">Read-only quorum viewer. No promotion or mutation.</div>
+        </div>
+        <span className={quorumStatusClass(view.quorum?.status)}>{view.quorum?.status ?? 'pending'}</span>
+      </div>
+
+      {!selectedSealId ? <div className="text-[10px] text-slate-500">No quarantined or recent seal selected.</div> : null}
+      {view.loading ? <div className="text-[10px] text-slate-500">Loading council…</div> : null}
+      {view.error ? <div className="rounded border border-rose-500/30 bg-rose-950/20 p-2 text-[10px] text-rose-200">{view.error}</div> : null}
+
+      {view.quorum ? (
+        <div className="space-y-3">
+          <div className="space-y-1 text-[10px] text-slate-400">
+            <div>seal_id: <span className="text-cyan-100">{view.quorum.seal_id}</span></div>
+            <div title={view.quorum.replay_snapshot_hash}>snapshot_hash: <span className="text-violet-200">{shortHash(view.quorum.replay_snapshot_hash)}</span></div>
+            <div>threshold: <span className="text-slate-200">{view.quorum.quorum_threshold}</span> / 5</div>
+            <div>candidate: <span className={view.quorum.back_attestation_candidate ? 'text-emerald-300' : 'text-slate-500'}>{view.quorum.back_attestation_candidate ? 'true' : 'false'}</span></div>
+            <div title={view.quorum.quorum_hash ?? undefined}>quorum_hash: <span className="text-violet-200">{shortHash(view.quorum.quorum_hash)}</span></div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-2 text-center text-[10px]">
+            <div className="rounded border border-emerald-700/30 bg-emerald-950/10 p-2"><div className="text-emerald-300">{view.quorum.approved_count}</div><div className="text-slate-500">pass</div></div>
+            <div className="rounded border border-rose-700/30 bg-rose-950/10 p-2"><div className="text-rose-300">{view.quorum.flagged_count}</div><div className="text-slate-500">flag</div></div>
+            <div className="rounded border border-amber-700/30 bg-amber-950/10 p-2"><div className="text-amber-300">{view.quorum.abstained_count}</div><div className="text-slate-500">abstain</div></div>
+          </div>
+
+          <div className="space-y-1.5">
+            {agents.map((agent) => {
+              const message = view.council?.messages?.[agent];
+              return (
+                <div key={agent} className="rounded border border-slate-800 bg-slate-950/60 p-2 text-[10px]">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-cyan-200">{agent}</span>
+                    <span className={verdictClass(message?.verdict)}>{message?.verdict ?? 'missing'}</span>
+                  </div>
+                  {message ? <div className="mt-1 truncate text-slate-500" title={message.reason}>reason: {message.reason || '—'}</div> : null}
+                  {message ? <div className="mt-1 text-slate-600">signed: {formatTime(message.signed_at)} · {shortHash(message.signature_hash)}</div> : null}
+                </div>
+              );
+            })}
+          </div>
+
+          {view.quorum.missing_agents.length > 0 ? <div className="text-[10px] text-slate-500">missing: {view.quorum.missing_agents.join(', ')}</div> : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
 export default function ReplayPage() {
   const [plan, setPlan] = useState<ReplayPlan | null>(null);
   const [dryRun, setDryRun] = useState<ReplayPlan | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
+  const [selectedSealId, setSelectedSealId] = useState<string | null>(null);
+  const [councilView, setCouncilView] = useState<ReplayCouncilView>({ sealId: null, loading: false, error: null, quorum: null, council: null });
 
   useEffect(() => {
     void fetch('/api/system/replay/plan', { cache: 'no-store' })
@@ -138,6 +260,46 @@ export default function ReplayPage() {
   }, []);
 
   const active = dryRun ?? plan;
+  const defaultSealId = useMemo(() => {
+    if (!active) return null;
+    return active.vault.quarantined_seal_ids?.[0] ?? active.vault.latest_seal_id ?? active.vault.recent_seals[0]?.seal_id ?? null;
+  }, [active]);
+
+  useEffect(() => {
+    if (!selectedSealId && defaultSealId) setSelectedSealId(defaultSealId);
+  }, [defaultSealId, selectedSealId]);
+
+  useEffect(() => {
+    if (!selectedSealId) {
+      setCouncilView({ sealId: null, loading: false, error: null, quorum: null, council: null });
+      return;
+    }
+    let cancelled = false;
+    setCouncilView((prev) => ({ ...prev, sealId: selectedSealId, loading: true, error: null }));
+    void Promise.all([
+      fetch(`/api/system/replay/quorum?seal_id=${encodeURIComponent(selectedSealId)}`, { cache: 'no-store' }).then((r) => r.json()),
+      fetch(`/api/system/replay/council?seal_id=${encodeURIComponent(selectedSealId)}`, { cache: 'no-store' }).then((r) => r.json()),
+    ])
+      .then(([quorumPayload, councilPayload]) => {
+        if (cancelled) return;
+        if (!quorumPayload.ok || !councilPayload.ok) throw new Error('replay_council_failed');
+        setCouncilView({
+          sealId: selectedSealId,
+          loading: false,
+          error: null,
+          quorum: quorumPayload.evaluation as ReplayQuorumEvaluation,
+          council: councilPayload.record as ReplayCouncilRecord,
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCouncilView({ sealId: selectedSealId, loading: false, error: 'Unable to load Replay Council', quorum: null, council: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedSealId]);
+
   const confidence = useMemo(() => confidenceLabel(active?.rebuild.confidence ?? 0), [active]);
   const confidencePct = useMemo(() => {
     const raw = active?.rebuild.confidence ?? 0;
@@ -244,6 +406,8 @@ export default function ReplayPage() {
         </section>
 
         <aside className="space-y-4">
+          <ReplayCouncilPanel selectedSealId={selectedSealId} view={councilView} />
+
           <section className="rounded border border-cyan-900/40 bg-slate-950/70 p-4">
             <div className="mb-3 text-[10px] uppercase tracking-[0.2em] text-cyan-300/80">Vault replay snapshot</div>
             <div className="space-y-1 text-[10px] text-slate-400">
@@ -259,10 +423,10 @@ export default function ReplayPage() {
             <div className="mt-3 text-[10px] uppercase tracking-[0.16em] text-slate-500">recent seals</div>
             <div className="mt-1 space-y-1.5">
               {active.vault.recent_seals.length ? active.vault.recent_seals.map((seal) => (
-                <div key={seal.seal_id} className={`rounded border p-2 text-[10px] ${seal.status === 'quarantined' ? 'border-amber-600/40 bg-amber-950/20' : 'border-slate-800/80 bg-slate-950/60'}`}>
+                <button key={seal.seal_id} type="button" onClick={() => setSelectedSealId(seal.seal_id)} className={`w-full rounded border p-2 text-left text-[10px] ${selectedSealId === seal.seal_id ? 'border-violet-500/50 bg-violet-950/20' : seal.status === 'quarantined' ? 'border-amber-600/40 bg-amber-950/20' : 'border-slate-800/80 bg-slate-950/60'}`}>
                   <div className="flex justify-between gap-2"><span className="text-cyan-200">#{seal.sequence}</span><span className={seal.status === 'quarantined' ? 'text-amber-300' : 'text-slate-400'}>{seal.status}</span></div>
                   <div className="mt-1 text-violet-200" title={seal.seal_hash}>{shortHash(seal.seal_hash)}</div>
-                </div>
+                </button>
               )) : <div className="text-[10px] text-slate-500">No recent seals.</div>}
             </div>
             {(active.vault.quarantined_seal_ids?.length ?? 0) > 0 ? (
@@ -270,7 +434,7 @@ export default function ReplayPage() {
                 <div className="mb-1 text-[10px] uppercase tracking-[0.16em] text-amber-400/80">quarantined — need reattestation</div>
                 <div className="space-y-1">
                   {active.vault.quarantined_seal_ids.map((id) => (
-                    <div key={id} className="rounded border border-amber-700/30 bg-amber-950/10 px-2 py-1 text-[10px] text-amber-200">{id}</div>
+                    <button key={id} type="button" onClick={() => setSelectedSealId(id)} className={`w-full rounded border px-2 py-1 text-left text-[10px] ${selectedSealId === id ? 'border-violet-500/50 bg-violet-950/20 text-violet-100' : 'border-amber-700/30 bg-amber-950/10 text-amber-200'}`}>{id}</button>
                   ))}
                 </div>
               </div>

--- a/app/terminal/replay/page.tsx
+++ b/app/terminal/replay/page.tsx
@@ -3,60 +3,547 @@
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 
-// (existing types unchanged above… omitted for brevity in patch reasoning)
+type ReplaySourceStatus = 'available' | 'partial' | 'missing' | 'unsafe';
 
-// ADD NEW TYPES
-type ReplayMutationView = {
-  loading: boolean;
-  plan: any | null;
-  receipt: any | null;
+type ReplaySource = {
+  id: string;
+  layer: number;
+  label: string;
+  status: ReplaySourceStatus;
+  count?: number;
+  detail: string;
 };
 
-// (keep existing code… inject new panel below ReplayCouncilPanel)
+type ReplayPlan = {
+  ok: boolean;
+  version: string;
+  timestamp: string;
+  cycle: string;
+  mode: 'plan' | 'dry_run';
+  destructive: boolean;
+  sources: ReplaySource[];
+  rebuild: {
+    possible: boolean;
+    confidence: number;
+    can_restore_hot_state: boolean;
+    can_restore_vault_state: boolean;
+    can_restore_chamber_savepoints: boolean;
+    unsafe_to_restore: string[];
+    would_restore: string[];
+  };
+  vault: {
+    in_progress_balance: number;
+    in_progress_hash_count: number;
+    attested_seals: number;
+    quarantined_seals: number;
+    finalized_seals: number;
+    latest_seal_id: string | null;
+    latest_seal_hash: string | null;
+    candidate_seal_id: string | null;
+    recent_seals: Array<{
+      seal_id: string;
+      sequence: number;
+      status: string;
+      seal_hash: string;
+      prev_seal_hash: string | null;
+      substrate_attestation_id?: string | null;
+      substrate_event_hash?: string | null;
+    }>;
+    quarantined_seal_ids: string[];
+  };
+  hot_state: {
+    gi_available: boolean;
+    gi_carry_available: boolean;
+    signal_available: boolean;
+    echo_available: boolean;
+    tripwire_available: boolean;
+  };
+  savepoints: {
+    total_matched: number;
+    sampled: number;
+  };
+  canon: string;
+  note?: string;
+};
 
-// Inside component:
-// ADD STATE
-const [mutationView, setMutationView] = useState<ReplayMutationView>({ loading: false, plan: null, receipt: null });
+type ReplayQuorumEvaluation = {
+  seal_id: string;
+  replay_snapshot_hash: string;
+  quorum_threshold: number;
+  approved_count: number;
+  flagged_count: number;
+  abstained_count: number;
+  message_count: number;
+  missing_agents: string[];
+  agents_present: string[];
+  quorum_reached: boolean;
+  quorum_hash: string | null;
+  status: 'pending' | 'approved' | 'blocked' | 'contested';
+  back_attestation_candidate: boolean;
+};
 
-// ADD EFFECT
-useEffect(() => {
-  if (!selectedSealId) return;
-  setMutationView((v) => ({ ...v, loading: true }));
-  fetch(`/api/system/replay/mutation?seal_id=${encodeURIComponent(selectedSealId)}`, { cache: 'no-store' })
-    .then((r) => r.json())
-    .then((data) => setMutationView({ loading: false, plan: data.plan, receipt: data.receipt }))
-    .catch(() => setMutationView({ loading: false, plan: null, receipt: null }));
-}, [selectedSealId]);
+type ReplayCouncilRecord = {
+  seal_id: string;
+  replay_snapshot_hash: string;
+  message_count: number;
+  agents_present: string[];
+  missing_agents: string[];
+  messages: Record<string, {
+    from_agent: string;
+    verdict: 'pass' | 'flag' | 'abstain';
+    reason: string;
+    signed_at: string;
+    signature_hash: string;
+  } | undefined>;
+};
 
-// ADD PANEL COMPONENT INLINE
-function MutationPanel({ view }: { view: ReplayMutationView }) {
+type ReplayCouncilView = {
+  sealId: string | null;
+  loading: boolean;
+  error: string | null;
+  quorum: ReplayQuorumEvaluation | null;
+  council: ReplayCouncilRecord | null;
+};
+
+type ReplayMutationPlan = {
+  mutation_kind: string;
+  proposed_effect: string;
+  original_history_preserved: boolean;
+  vault_status_mutation: boolean;
+  canonical_chain_mutation: boolean;
+  mic_or_fountain_mutation: boolean;
+  rollback_mutation: boolean;
+  plan_hash: string;
+};
+
+type ReplayMutationReceipt = ReplayMutationPlan & {
+  status: string;
+  executed_at: string;
+  executor: string;
+  receipt_hash: string;
+};
+
+type ReplayMutationView = {
+  sealId: string | null;
+  loading: boolean;
+  error: string | null;
+  plan: ReplayMutationPlan | null;
+  receipt: ReplayMutationReceipt | null;
+};
+
+function confidenceLabel(confidence: number): { label: string; className: string } {
+  if (confidence >= 0.85) return { label: 'STRONG', className: 'text-emerald-300' };
+  if (confidence >= 0.5) return { label: 'PARTIAL', className: 'text-amber-300' };
+  return { label: 'UNSAFE', className: 'text-rose-300' };
+}
+
+function statusClass(status: ReplaySourceStatus): string {
+  switch (status) {
+    case 'available':
+      return 'border-emerald-500/30 bg-emerald-950/20 text-emerald-200';
+    case 'partial':
+      return 'border-amber-500/30 bg-amber-950/20 text-amber-200';
+    case 'unsafe':
+      return 'border-rose-500/30 bg-rose-950/20 text-rose-200';
+    default:
+      return 'border-slate-700 bg-slate-950/70 text-slate-400';
+  }
+}
+
+function quorumStatusClass(status?: ReplayQuorumEvaluation['status']): string {
+  switch (status) {
+    case 'approved':
+      return 'text-emerald-300';
+    case 'blocked':
+      return 'text-rose-300';
+    case 'contested':
+      return 'text-amber-300';
+    default:
+      return 'text-slate-400';
+  }
+}
+
+function verdictClass(verdict?: 'pass' | 'flag' | 'abstain'): string {
+  switch (verdict) {
+    case 'pass':
+      return 'text-emerald-300';
+    case 'flag':
+      return 'text-rose-300';
+    case 'abstain':
+      return 'text-amber-300';
+    default:
+      return 'text-slate-500';
+  }
+}
+
+function shortHash(value?: string | null): string {
+  if (!value) return '—';
+  if (value.length <= 22) return value;
+  return `${value.slice(0, 14)}…${value.slice(-8)}`;
+}
+
+function formatTime(value?: string | null): string {
+  if (!value) return '—';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString(undefined, { month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' });
+}
+
+function BoolPill({
+  label,
+  value,
+  trueLabel = 'available',
+  falseLabel = 'missing',
+  trueClassName = 'text-emerald-300',
+  falseClassName = 'text-slate-500',
+}: {
+  label: string;
+  value: boolean;
+  trueLabel?: string;
+  falseLabel?: string;
+  trueClassName?: string;
+  falseClassName?: string;
+}) {
   return (
-    <section className="rounded border border-cyan-500/25 bg-slate-950/70 p-4">
-      <div className="mb-2 text-[10px] uppercase tracking-[0.2em] text-cyan-300/80">Mutation Layer</div>
-      {view.loading && <div className="text-[10px] text-slate-500">Loading mutation state…</div>}
+    <div className="flex items-center justify-between rounded border border-slate-800 bg-slate-950/70 px-3 py-2 text-[10px]">
+      <span className="uppercase tracking-[0.16em] text-slate-500">{label}</span>
+      <span className={value ? trueClassName : falseClassName}>{value ? trueLabel : falseLabel}</span>
+    </div>
+  );
+}
 
-      {view.plan && (
-        <div className="mb-2 text-[10px] text-slate-400">
-          <div>plan: <span className="text-cyan-200">{view.plan.mutation_kind}</span></div>
-          <div>effect: <span className="text-cyan-200">{view.plan.proposed_effect}</span></div>
-          <div>history_preserved: <span className="text-emerald-300">true</span></div>
+function ReplayCouncilPanel({ selectedSealId, view }: { selectedSealId: string | null; view: ReplayCouncilView }) {
+  const agents = ['ATLAS', 'ZEUS', 'EVE', 'JADE', 'AUREA'];
+  return (
+    <section className="rounded border border-violet-500/25 bg-slate-950/70 p-4">
+      <div className="mb-3 flex items-start justify-between gap-2">
+        <div>
+          <div className="text-[10px] uppercase tracking-[0.2em] text-violet-300/80">Replay Council</div>
+          <div className="mt-1 text-[10px] text-slate-500">Read-only quorum viewer. No promotion or mutation.</div>
         </div>
-      )}
+        <span className={quorumStatusClass(view.quorum?.status)}>{view.quorum?.status ?? 'pending'}</span>
+      </div>
 
-      {view.receipt && (
-        <div className="text-[10px] text-slate-400">
-          <div>status: <span className="text-emerald-300">{view.receipt.status}</span></div>
-          <div>executed: <span className="text-cyan-200">{new Date(view.receipt.executed_at).toLocaleString()}</span></div>
-          <div>executor: <span className="text-cyan-200">{view.receipt.executor}</span></div>
+      {!selectedSealId ? <div className="text-[10px] text-slate-500">No quarantined or recent seal selected.</div> : null}
+      {view.loading ? <div className="text-[10px] text-slate-500">Loading council…</div> : null}
+      {view.error ? <div className="rounded border border-rose-500/30 bg-rose-950/20 p-2 text-[10px] text-rose-200">{view.error}</div> : null}
+
+      {view.quorum ? (
+        <div className="space-y-3">
+          <div className="space-y-1 text-[10px] text-slate-400">
+            <div>seal_id: <span className="text-cyan-100">{view.quorum.seal_id}</span></div>
+            <div title={view.quorum.replay_snapshot_hash}>snapshot_hash: <span className="text-violet-200">{shortHash(view.quorum.replay_snapshot_hash)}</span></div>
+            <div>threshold: <span className="text-slate-200">{view.quorum.quorum_threshold}</span> / 5</div>
+            <div>candidate: <span className={view.quorum.back_attestation_candidate ? 'text-emerald-300' : 'text-slate-500'}>{view.quorum.back_attestation_candidate ? 'true' : 'false'}</span></div>
+            <div title={view.quorum.quorum_hash ?? undefined}>quorum_hash: <span className="text-violet-200">{shortHash(view.quorum.quorum_hash)}</span></div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-2 text-center text-[10px]">
+            <div className="rounded border border-emerald-700/30 bg-emerald-950/10 p-2"><div className="text-emerald-300">{view.quorum.approved_count}</div><div className="text-slate-500">pass</div></div>
+            <div className="rounded border border-rose-700/30 bg-rose-950/10 p-2"><div className="text-rose-300">{view.quorum.flagged_count}</div><div className="text-slate-500">flag</div></div>
+            <div className="rounded border border-amber-700/30 bg-amber-950/10 p-2"><div className="text-amber-300">{view.quorum.abstained_count}</div><div className="text-slate-500">abstain</div></div>
+          </div>
+
+          <div className="space-y-1.5">
+            {agents.map((agent) => {
+              const message = view.council?.messages?.[agent];
+              return (
+                <div key={agent} className="rounded border border-slate-800 bg-slate-950/60 p-2 text-[10px]">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-cyan-200">{agent}</span>
+                    <span className={verdictClass(message?.verdict)}>{message?.verdict ?? 'missing'}</span>
+                  </div>
+                  {message ? <div className="mt-1 truncate text-slate-500" title={message.reason}>reason: {message.reason || '—'}</div> : null}
+                  {message ? <div className="mt-1 text-slate-600">signed: {formatTime(message.signed_at)} · {shortHash(message.signature_hash)}</div> : null}
+                </div>
+              );
+            })}
+          </div>
+
+          {view.quorum.missing_agents.length > 0 ? <div className="text-[10px] text-slate-500">missing: {view.quorum.missing_agents.join(', ')}</div> : null}
         </div>
-      )}
-
-      {!view.plan && !view.receipt && !view.loading && (
-        <div className="text-[10px] text-slate-500">No mutation plan or receipt recorded.</div>
-      )}
+      ) : null}
     </section>
   );
 }
 
-// THEN RENDER UNDER COUNCIL PANEL:
-// <MutationPanel view={mutationView} />
+function MutationPanel({ view }: { view: ReplayMutationView }) {
+  return (
+    <section className="rounded border border-cyan-500/25 bg-slate-950/70 p-4">
+      <div className="mb-3 flex items-start justify-between gap-2">
+        <div>
+          <div className="text-[10px] uppercase tracking-[0.2em] text-cyan-300/80">Mutation Layer</div>
+          <div className="mt-1 text-[10px] text-slate-500">Read-only plan/receipt visibility. No mutation trigger.</div>
+        </div>
+        <span className={view.receipt ? 'text-emerald-300' : view.plan ? 'text-amber-300' : 'text-slate-500'}>{view.receipt ? 'receipt' : view.plan ? 'plan' : 'none'}</span>
+      </div>
+      {view.loading ? <div className="text-[10px] text-slate-500">Loading mutation state…</div> : null}
+      {view.error ? <div className="rounded border border-rose-500/30 bg-rose-950/20 p-2 text-[10px] text-rose-200">{view.error}</div> : null}
+      {view.plan ? (
+        <div className="space-y-1 text-[10px] text-slate-400">
+          <div>plan: <span className="text-cyan-200">{view.plan.mutation_kind}</span></div>
+          <div>effect: <span className="text-cyan-200">{view.plan.proposed_effect}</span></div>
+          <div>history_preserved: <span className={view.plan.original_history_preserved ? 'text-emerald-300' : 'text-rose-300'}>{String(view.plan.original_history_preserved)}</span></div>
+          <div>vault_mutation: <span className={view.plan.vault_status_mutation ? 'text-rose-300' : 'text-emerald-300'}>{String(view.plan.vault_status_mutation)}</span></div>
+          <div>chain_mutation: <span className={view.plan.canonical_chain_mutation ? 'text-rose-300' : 'text-emerald-300'}>{String(view.plan.canonical_chain_mutation)}</span></div>
+          <div title={view.plan.plan_hash}>plan_hash: <span className="text-violet-200">{shortHash(view.plan.plan_hash)}</span></div>
+        </div>
+      ) : null}
+      {view.receipt ? (
+        <div className="mt-3 space-y-1 border-t border-slate-800 pt-3 text-[10px] text-slate-400">
+          <div>status: <span className="text-emerald-300">{view.receipt.status}</span></div>
+          <div>executed: <span className="text-cyan-200">{formatTime(view.receipt.executed_at)}</span></div>
+          <div>executor: <span className="text-cyan-200">{view.receipt.executor}</span></div>
+          <div title={view.receipt.receipt_hash}>receipt_hash: <span className="text-violet-200">{shortHash(view.receipt.receipt_hash)}</span></div>
+        </div>
+      ) : null}
+      {!view.plan && !view.receipt && !view.loading && !view.error ? <div className="text-[10px] text-slate-500">No mutation plan or receipt recorded.</div> : null}
+    </section>
+  );
+}
+
+export default function ReplayPage() {
+  const [plan, setPlan] = useState<ReplayPlan | null>(null);
+  const [dryRun, setDryRun] = useState<ReplayPlan | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+  const [selectedSealId, setSelectedSealId] = useState<string | null>(null);
+  const [councilView, setCouncilView] = useState<ReplayCouncilView>({ sealId: null, loading: false, error: null, quorum: null, council: null });
+  const [mutationView, setMutationView] = useState<ReplayMutationView>({ sealId: null, loading: false, error: null, plan: null, receipt: null });
+
+  useEffect(() => {
+    void fetch('/api/system/replay/plan', { cache: 'no-store' })
+      .then(async (r) => {
+        const payload = (await r.json()) as ReplayPlan;
+        if (!r.ok || !payload.ok) throw new Error('replay_plan_failed');
+        setPlan(payload);
+      })
+      .catch(() => setErr('Unable to load replay plan'));
+  }, []);
+
+  const active = dryRun ?? plan;
+  const defaultSealId = useMemo(() => {
+    if (!active) return null;
+    return active.vault.quarantined_seal_ids?.[0] ?? active.vault.latest_seal_id ?? active.vault.recent_seals[0]?.seal_id ?? null;
+  }, [active]);
+
+  useEffect(() => {
+    if (!selectedSealId && defaultSealId) setSelectedSealId(defaultSealId);
+  }, [defaultSealId, selectedSealId]);
+
+  useEffect(() => {
+    if (!selectedSealId) {
+      setCouncilView({ sealId: null, loading: false, error: null, quorum: null, council: null });
+      setMutationView({ sealId: null, loading: false, error: null, plan: null, receipt: null });
+      return;
+    }
+    let cancelled = false;
+    setCouncilView((prev) => ({ ...prev, sealId: selectedSealId, loading: true, error: null }));
+    void Promise.all([
+      fetch(`/api/system/replay/quorum?seal_id=${encodeURIComponent(selectedSealId)}`, { cache: 'no-store' }).then((r) => r.json()),
+      fetch(`/api/system/replay/council?seal_id=${encodeURIComponent(selectedSealId)}`, { cache: 'no-store' }).then((r) => r.json()),
+    ])
+      .then(([quorumPayload, councilPayload]) => {
+        if (cancelled) return;
+        if (!quorumPayload.ok || !councilPayload.ok) throw new Error('replay_council_failed');
+        setCouncilView({
+          sealId: selectedSealId,
+          loading: false,
+          error: null,
+          quorum: quorumPayload.evaluation as ReplayQuorumEvaluation,
+          council: councilPayload.record as ReplayCouncilRecord,
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCouncilView({ sealId: selectedSealId, loading: false, error: 'Unable to load Replay Council', quorum: null, council: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedSealId]);
+
+  useEffect(() => {
+    if (!selectedSealId) return;
+    let cancelled = false;
+    setMutationView((prev) => ({ ...prev, sealId: selectedSealId, loading: true, error: null }));
+    void fetch(`/api/system/replay/mutation?seal_id=${encodeURIComponent(selectedSealId)}`, { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((payload) => {
+        if (cancelled) return;
+        if (!payload.ok) throw new Error('mutation_state_failed');
+        setMutationView({ sealId: selectedSealId, loading: false, error: null, plan: payload.plan ?? null, receipt: payload.receipt ?? null });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setMutationView({ sealId: selectedSealId, loading: false, error: 'Unable to load mutation layer', plan: null, receipt: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedSealId]);
+
+  const confidence = useMemo(() => confidenceLabel(active?.rebuild.confidence ?? 0), [active]);
+  const confidencePct = useMemo(() => {
+    const raw = active?.rebuild.confidence ?? 0;
+    return Math.max(0, Math.min(100, Math.round(raw * 100)));
+  }, [active]);
+  const sortedSources = useMemo(() => {
+    if (!active?.sources) return [];
+    return [...active.sources].sort((a, b) => a.layer - b.layer);
+  }, [active]);
+
+  async function runDryReplay() {
+    setRunning(true);
+    setErr(null);
+    try {
+      const r = await fetch('/api/system/replay/dry-run', { method: 'POST', cache: 'no-store' });
+      const payload = (await r.json()) as ReplayPlan;
+      if (!r.ok || !payload.ok) throw new Error('dry_run_failed');
+      setDryRun(payload);
+    } catch {
+      setErr('Replay dry run failed');
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  if (err && !active) return <div className="p-4 text-sm text-rose-300">{err}</div>;
+  if (!active) return <div className="p-4 text-sm text-slate-400">Loading replay inspector…</div>;
+
+  return (
+    <div className="h-full overflow-y-auto p-4 font-mono text-xs text-slate-200">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-[10px] uppercase tracking-[0.22em] text-slate-500">Mobius Recovery</div>
+          <h1 className="mt-1 text-sm font-semibold uppercase tracking-[0.16em] text-violet-200">Replay Inspector</h1>
+          <p className="mt-1 max-w-2xl text-[11px] leading-relaxed text-slate-500">Dry-run recovery view for reconstructing Mobius state from canon without mutating KV, Vault, Journal, Ledger, or Substrate.</p>
+        </div>
+        <div className="flex gap-2 text-[10px]">
+          <Link href="/terminal/canon" className="rounded border border-slate-700 px-2 py-1 text-slate-400 hover:border-cyan-500/50 hover:text-cyan-300">Canon</Link>
+          <Link href="/terminal/vault" className="rounded border border-slate-700 px-2 py-1 text-slate-400 hover:border-violet-500/50 hover:text-violet-300">Vault</Link>
+        </div>
+      </div>
+
+      {err ? <div className="mb-3 rounded border border-rose-500/30 bg-rose-950/20 p-3 text-[11px] text-rose-200">{err}</div> : null}
+
+      <div className="mb-4 grid gap-3 lg:grid-cols-[1.1fr_0.9fr]">
+        <section className="rounded border border-violet-500/25 bg-slate-950/80 p-4">
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <div className="text-[10px] uppercase tracking-[0.2em] text-violet-300/80">Replay state · {active.mode}</div>
+              <div className="mt-1 text-[10px] text-slate-500">{active.version} · {active.cycle} · {formatTime(active.timestamp)}</div>
+            </div>
+            <div className={active.rebuild.possible ? 'text-emerald-300' : 'text-rose-300'}>{active.rebuild.possible ? 'REBUILD POSSIBLE' : 'REBUILD BLOCKED'}</div>
+          </div>
+          <div className="mb-2 flex items-center justify-between text-[10px]"><span className="text-slate-500">confidence</span><span className={confidence.className}>{confidence.label} · {confidencePct}%</span></div>
+          <div className="h-2 overflow-hidden rounded bg-slate-800"><div className="h-full rounded bg-violet-400 transition-all duration-500" style={{ width: `${confidencePct}%` }} /></div>
+          <p className="mt-3 text-[10px] leading-relaxed text-slate-500">{active.canon}</p>
+          {active.note ? <p className="mt-2 text-[10px] text-cyan-300">{active.note}</p> : null}
+          <button
+            type="button"
+            onClick={runDryReplay}
+            disabled={running}
+            className="mt-4 rounded border border-cyan-500/40 bg-cyan-950/20 px-3 py-2 text-[10px] uppercase tracking-[0.16em] text-cyan-200 hover:border-cyan-300 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {running ? 'Running dry replay…' : 'Run Dry Replay Simulation'}
+          </button>
+        </section>
+
+        <section className="rounded border border-slate-800 bg-slate-950/70 p-4">
+          <div className="mb-3 text-[10px] uppercase tracking-[0.2em] text-violet-300/80">Restore summary</div>
+          <div className="grid gap-2 sm:grid-cols-2">
+            <BoolPill label="Hot state" value={active.rebuild.can_restore_hot_state} />
+            <BoolPill label="Vault state" value={active.rebuild.can_restore_vault_state} />
+            <BoolPill label="Savepoints" value={active.rebuild.can_restore_chamber_savepoints} />
+            <BoolPill label="Destructive" value={active.destructive} trueLabel="true" falseLabel="false" trueClassName="text-rose-300" falseClassName="text-emerald-300" />
+          </div>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <div>
+              <div className="mb-1 text-[10px] uppercase tracking-[0.16em] text-slate-500">would restore</div>
+              <div className="space-y-1">{active.rebuild.would_restore.length ? active.rebuild.would_restore.map((item) => <div key={item} className="text-emerald-300">✓ {item}</div>) : <div className="text-slate-500">none</div>}</div>
+            </div>
+            <div>
+              <div className="mb-1 text-[10px] uppercase tracking-[0.16em] text-slate-500">unsafe blockers</div>
+              <div className="space-y-1">{active.rebuild.unsafe_to_restore.length ? active.rebuild.unsafe_to_restore.map((item) => <div key={item} className="text-rose-300">× {item}</div>) : <div className="text-emerald-300">none</div>}</div>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_380px]">
+        <section className="rounded border border-slate-800 bg-slate-950/70 p-4">
+          <div className="mb-3 text-[10px] uppercase tracking-[0.2em] text-violet-300/80">8-layer rebuild ladder</div>
+          <div className="space-y-2">
+            {sortedSources.map((src) => (
+              <div key={src.id} className="grid gap-2 rounded border border-slate-800 bg-slate-950/60 p-3 sm:grid-cols-[42px_1fr_110px]">
+                <div className="text-cyan-300">L{src.layer}</div>
+                <div>
+                  <div className="text-slate-200">{src.label}</div>
+                  <div className="mt-1 text-[10px] leading-relaxed text-slate-500">{src.detail}</div>
+                </div>
+                <div className={`self-start rounded border px-2 py-1 text-center text-[10px] uppercase tracking-[0.12em] ${statusClass(src.status)}`}>{src.status}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <aside className="space-y-4">
+          <ReplayCouncilPanel selectedSealId={selectedSealId} view={councilView} />
+          <MutationPanel view={mutationView} />
+
+          <section className="rounded border border-cyan-900/40 bg-slate-950/70 p-4">
+            <div className="mb-3 text-[10px] uppercase tracking-[0.2em] text-cyan-300/80">Vault replay snapshot</div>
+            <div className="space-y-1 text-[10px] text-slate-400">
+              <div>in_progress_balance: <span className="text-cyan-100">{active.vault.in_progress_balance.toFixed(4)}</span></div>
+              <div>in_progress_hashes: <span className="text-cyan-100">{active.vault.in_progress_hash_count}</span></div>
+              <div>attested_seals: <span className="text-cyan-100">{active.vault.attested_seals}</span></div>
+              <div>quarantined_seals: <span className={active.vault.quarantined_seals > 0 ? 'text-amber-300' : 'text-cyan-100'}>{active.vault.quarantined_seals ?? 0}</span></div>
+              <div>finalized_seals: <span className="text-cyan-100">{active.vault.finalized_seals}</span></div>
+              <div>candidate: <span className="text-cyan-100">{active.vault.candidate_seal_id ?? '—'}</span></div>
+              <div>latest: <span className="text-cyan-100">{active.vault.latest_seal_id ?? '—'}</span></div>
+              <div title={active.vault.latest_seal_hash ?? undefined}>latest_hash: <span className="text-violet-200">{shortHash(active.vault.latest_seal_hash)}</span></div>
+            </div>
+            <div className="mt-3 text-[10px] uppercase tracking-[0.16em] text-slate-500">recent seals</div>
+            <div className="mt-1 space-y-1.5">
+              {active.vault.recent_seals.length ? active.vault.recent_seals.map((seal) => (
+                <button key={seal.seal_id} type="button" onClick={() => setSelectedSealId(seal.seal_id)} className={`w-full rounded border p-2 text-left text-[10px] ${selectedSealId === seal.seal_id ? 'border-violet-500/50 bg-violet-950/20' : seal.status === 'quarantined' ? 'border-amber-600/40 bg-amber-950/20' : 'border-slate-800/80 bg-slate-950/60'}`}>
+                  <div className="flex justify-between gap-2"><span className="text-cyan-200">#{seal.sequence}</span><span className={seal.status === 'quarantined' ? 'text-amber-300' : 'text-slate-400'}>{seal.status}</span></div>
+                  <div className="mt-1 text-violet-200" title={seal.seal_hash}>{shortHash(seal.seal_hash)}</div>
+                </button>
+              )) : <div className="text-[10px] text-slate-500">No recent seals.</div>}
+            </div>
+            {(active.vault.quarantined_seal_ids?.length ?? 0) > 0 ? (
+              <div className="mt-3">
+                <div className="mb-1 text-[10px] uppercase tracking-[0.16em] text-amber-400/80">quarantined — need reattestation</div>
+                <div className="space-y-1">
+                  {active.vault.quarantined_seal_ids.map((id) => (
+                    <button key={id} type="button" onClick={() => setSelectedSealId(id)} className={`w-full rounded border px-2 py-1 text-left text-[10px] ${selectedSealId === id ? 'border-violet-500/50 bg-violet-950/20 text-violet-100' : 'border-amber-700/30 bg-amber-950/10 text-amber-200'}`}>{id}</button>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </section>
+
+          <section className="rounded border border-slate-800 bg-slate-950/70 p-4">
+            <div className="mb-3 text-[10px] uppercase tracking-[0.2em] text-violet-300/80">Hot state availability</div>
+            <div className="grid gap-2">
+              <BoolPill label="GI live" value={active.hot_state.gi_available} />
+              <BoolPill label="GI carry" value={active.hot_state.gi_carry_available} />
+              <BoolPill label="Signals" value={active.hot_state.signal_available} />
+              <BoolPill label="ECHO" value={active.hot_state.echo_available} />
+              <BoolPill label="Tripwire" value={active.hot_state.tripwire_available} />
+            </div>
+            <div className="mt-3 text-[10px] text-slate-500">savepoints: {active.savepoints.total_matched} matched · {active.savepoints.sampled} sampled</div>
+          </section>
+
+          <section className="rounded border border-slate-800 bg-slate-950/70 p-4 text-[10px] text-slate-500">
+            <div className="mb-2 uppercase tracking-[0.2em] text-violet-300/80">Handbook</div>
+            <div>Replay is documented in the Mobius-Substrate handbook.</div>
+            <a href="https://kaizencycle.github.io/Mobius-Substrate/" target="_blank" rel="noreferrer" className="mt-2 inline-block text-cyan-300 hover:text-cyan-100">Open Substrate handbook →</a>
+          </section>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/docs/pr-bundles/C-294-phase0-1-2-replay-quorum.md
+++ b/docs/pr-bundles/C-294-phase0-1-2-replay-quorum.md
@@ -1,0 +1,36 @@
+# C-294 Phase 0-1-2 — Replay Quorum Contracts
+
+## Phase
+C-294 Phase 0–2 — Scope Lock + Replay Snapshot + Council Schema
+
+## Scope
+- Add ReplaySnapshot contract
+- Add ReplayCouncilMessage schema
+- Add read-only GET /api/system/replay/snapshot endpoint
+
+## Files touched
+- lib/system/replay-quorum.ts
+- app/api/system/replay/snapshot/route.ts
+- docs/pr-bundles/C-294-phase0-1-2-replay-quorum.md
+
+## NOT touching
+- Vault routes and promotion logic
+- Canon API and UI
+- Replay plan (Phase 5) implementation
+- MIC / Fountain logic
+- Ledger writes
+
+## Change type
+Additive (Phase 1–2)
+
+## Risk
+Low (read-only, no mutation)
+
+## Validation plan
+- Call /api/system/replay/snapshot?seal_id=<id>
+- Verify snapshot fields align with existing Seal data
+- Verify replay_snapshot_hash is stable for same seal
+- Confirm no Vault/Canon/UI regression
+
+## Notes
+This PR introduces the contracts required for replay quorum without enabling any mutation or promotion. It is a prerequisite for Phase 3 (Council Bus) and Phase 4 (Quorum Evaluator).

--- a/lib/substrate/canon.ts
+++ b/lib/substrate/canon.ts
@@ -1,10 +1,11 @@
 import { hashPayload } from '@/lib/agents/signatures';
+import { readReplayPromotion, type ReplayPromotionAuthorization } from '@/lib/system/replay-promotion';
 import { historicalAttestationDigest } from '@/lib/vault-v2/historical-attestation';
 import { getSeal, listAllSeals } from '@/lib/vault-v2/store';
 import type { Seal, SealAttestation, SentinelAgent } from '@/lib/vault-v2/types';
 import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
 
-export const SUBSTRATE_CANON_VERSION = 'C-293.phase8.v2' as const;
+export const SUBSTRATE_CANON_VERSION = 'C-294.phase8.replay-promotion.v1' as const;
 
 export type CanonEventType =
   | 'epicon'
@@ -12,9 +13,10 @@ export type CanonEventType =
   | 'reserve_block'
   | 'incident'
   | 'rollback_plan'
-  | 'substrate_attestation';
+  | 'substrate_attestation'
+  | 'replay_promotion';
 
-export type CanonFilterType = CanonEventType | 'reserve_blocks' | 'substrate_attestations';
+export type CanonFilterType = CanonEventType | 'reserve_blocks' | 'substrate_attestations' | 'replay_promotions';
 
 export type CanonAttestationMode = 'missing' | 'partial' | 'complete' | 'timed_out' | 'failed';
 
@@ -25,6 +27,7 @@ export type CanonCounts = {
   quarantined_other: number;
   rejected: number;
   needs_reattestation: number;
+  replay_promotions: number;
 };
 
 export type CanonAttestationView = {
@@ -36,6 +39,17 @@ export type CanonAttestationView = {
   signature_short: string | null;
   signature_hash: string | null;
   historical: boolean;
+};
+
+export type CanonReplayPromotionView = {
+  status: ReplayPromotionAuthorization['status'];
+  replay_snapshot_hash: string;
+  quorum_hash: string;
+  operator_id: string;
+  operator_approved_at: string;
+  operator_reason: string;
+  authorization_hash: string;
+  mutation_allowed: false;
 };
 
 export type CanonReserveBlockView = {
@@ -62,6 +76,7 @@ export type CanonReserveBlockView = {
     attested_at: string | null;
     error: string | null;
   };
+  replay_promotion: CanonReplayPromotionView | null;
   needs_reattestation: boolean;
   historical_digest: ReturnType<typeof historicalAttestationDigest>;
 };
@@ -99,6 +114,20 @@ function isTimeoutValue(value: string | null | undefined): boolean {
   return value?.toLowerCase().includes('timeout') === true;
 }
 
+function promotionToView(promotion: ReplayPromotionAuthorization | null): CanonReplayPromotionView | null {
+  if (!promotion) return null;
+  return {
+    status: promotion.status,
+    replay_snapshot_hash: promotion.replay_snapshot_hash,
+    quorum_hash: promotion.quorum_hash,
+    operator_id: promotion.operator_id,
+    operator_approved_at: promotion.operator_approved_at,
+    operator_reason: promotion.operator_reason,
+    authorization_hash: promotion.authorization_hash,
+    mutation_allowed: promotion.mutation_allowed,
+  };
+}
+
 function attestationToView(agent: SentinelAgent, attestation: SealAttestation | undefined): CanonAttestationView {
   const historical = attestation?.rationale?.startsWith('[historical]') ?? false;
   return {
@@ -127,10 +156,12 @@ function attestationState(seal: Seal, attestations: CanonAttestationView[], miss
   return 'complete';
 }
 
-export function sealToCanonReserveBlock(seal: Seal): CanonReserveBlockView {
+export async function sealToCanonReserveBlock(seal: Seal): Promise<CanonReserveBlockView> {
   const attestations = SENTINEL_AGENTS.map((agent) => attestationToView(agent, seal.attestations?.[agent]));
   const missingAgents = attestations.filter((a) => !a.signed).map((a) => a.agent);
   const state = attestationState(seal, attestations, missingAgents);
+  const promotionResult = await readReplayPromotion(seal.seal_id);
+  const replayPromotion = promotionResult.ok ? promotionToView(promotionResult.promotion) : null;
   return {
     type: 'reserve_block',
     block_number: seal.sequence,
@@ -155,7 +186,8 @@ export function sealToCanonReserveBlock(seal: Seal): CanonReserveBlockView {
       attested_at: seal.substrate_attested_at ?? null,
       error: seal.substrate_attestation_error ?? null,
     },
-    needs_reattestation: seal.status === 'quarantined' || state === 'timed_out' || state === 'failed',
+    replay_promotion: replayPromotion,
+    needs_reattestation: (seal.status === 'quarantined' || state === 'timed_out' || state === 'failed') && replayPromotion === null,
     historical_digest: historicalAttestationDigest(seal),
   };
 }
@@ -171,9 +203,23 @@ function reserveBlockToTimeline(block: CanonReserveBlockView): CanonTimelineEven
       severity: block.status === 'attested' && block.attestation_state === 'complete' ? 'proof' : block.needs_reattestation ? 'incident' : 'watch',
       seal_id: block.seal_id,
       hash: block.seal_hash,
-      summary: `${block.amount} MIC · ${block.status} · ${block.attestation_state}${block.needs_reattestation ? ' · needs re-attestation' : ''}`,
+      summary: `${block.amount} MIC · ${block.status} · ${block.attestation_state}${block.needs_reattestation ? ' · needs re-attestation' : ''}${block.replay_promotion ? ' · replay promotion authorized' : ''}`,
     },
   ];
+
+  if (block.replay_promotion) {
+    events.push({
+      id: `replay-promotion:${block.seal_id}`,
+      type: 'replay_promotion',
+      title: `Replay promotion authorized · Block ${block.block_number}`,
+      timestamp: block.replay_promotion.operator_approved_at,
+      cycle: block.cycle_at_seal,
+      severity: 'proof',
+      seal_id: block.seal_id,
+      hash: block.replay_promotion.authorization_hash,
+      summary: `operator ${block.replay_promotion.operator_id} authorized replay promotion · mutation_allowed=false`,
+    });
+  }
 
   if (block.substrate_pointer.attestation_id || block.substrate_pointer.event_hash) {
     events.push({
@@ -218,19 +264,20 @@ function buildCounts(blocks: CanonReserveBlockView[]): CanonCounts {
     quarantined_other: blocks.filter((b) => b.status === 'quarantined' && b.attestation_state !== 'timed_out').length,
     rejected: blocks.filter((b) => b.status === 'rejected').length,
     needs_reattestation: blocks.filter((b) => b.needs_reattestation).length,
+    replay_promotions: blocks.filter((b) => b.replay_promotion !== null).length,
   };
 }
 
 export async function buildSubstrateCanon(options: { limit?: number; type?: CanonFilterType | null; seal_id?: string | null } = {}): Promise<CanonResponse> {
   const limit = Math.max(1, Math.min(100, Math.floor(options.limit ?? 50)));
   const seals = options.seal_id ? [await getSeal(options.seal_id)] : await listAllSeals(limit);
-  const reserveBlocks = seals.filter((seal): seal is Seal => Boolean(seal)).map(sealToCanonReserveBlock);
+  const reserveBlocks = await Promise.all(seals.filter((seal): seal is Seal => Boolean(seal)).map(sealToCanonReserveBlock));
   const allTimeline = sortTimeline(reserveBlocks.flatMap(reserveBlockToTimeline));
 
   const type = options.type ?? null;
   const filteredReserveBlocks = type === 'reserve_blocks' || type === 'reserve_block' || !type ? reserveBlocks : [];
   const filteredTimeline = type && type !== 'reserve_blocks'
-    ? allTimeline.filter((event) => event.type === (type === 'substrate_attestations' ? 'substrate_attestation' : type))
+    ? allTimeline.filter((event) => event.type === (type === 'substrate_attestations' ? 'substrate_attestation' : type === 'replay_promotions' ? 'replay_promotion' : type))
     : allTimeline;
 
   return {
@@ -243,6 +290,7 @@ export async function buildSubstrateCanon(options: { limit?: number; type?: Cano
     timeline: filteredTimeline,
     canon: [
       'Substrate canon is read-only in Phase 8.',
+      'Replay promotion is an annotation/proof overlay, not a rewrite of original seal history.',
       'Historical attestation validates stored proof only.',
       'Historical attestation does not rewrite history or pretend agents signed live at the time.',
       'Historical attestation does not unlock Fountain by itself.',

--- a/lib/system/replay-promotion.ts
+++ b/lib/system/replay-promotion.ts
@@ -1,0 +1,135 @@
+import { hashPayload } from '@/lib/agents/signatures';
+import { kvGet, kvSet } from '@/lib/kv/store';
+import { buildReplaySnapshotResponse, evaluateReplayQuorum } from '@/lib/system/replay-quorum';
+
+export const REPLAY_PROMOTION_VERSION = 'C-294.phase7.v1' as const;
+
+export type ReplayPromotionAuthorization = {
+  version: typeof REPLAY_PROMOTION_VERSION;
+  seal_id: string;
+  replay_snapshot_hash: string;
+  quorum_hash: string;
+  operator_id: string;
+  operator_approved_at: string;
+  operator_reason: string;
+  authorization_hash: string;
+  status: 'operator_authorized';
+  mutation_allowed: false;
+  readonly: true;
+  canon: string[];
+};
+
+export type ReplayPromotionSubmission = {
+  seal_id: string;
+  replay_snapshot_hash: string;
+  quorum_hash: string;
+  operator_id: string;
+  operator_reason: string;
+};
+
+export type ReplayPromotionResponse = {
+  ok: true;
+  readonly: true;
+  promotion: ReplayPromotionAuthorization;
+};
+
+export type ReplayPromotionError = {
+  ok: false;
+  readonly: true;
+  error:
+    | 'missing_body'
+    | 'missing_seal_id'
+    | 'seal_not_found'
+    | 'snapshot_hash_mismatch'
+    | 'quorum_not_approved'
+    | 'quorum_hash_mismatch'
+    | 'missing_operator_id'
+    | 'missing_operator_reason'
+    | 'write_failed';
+};
+
+function promotionKey(sealId: string): string {
+  return `system:replay:promotion:${sealId}`;
+}
+
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function buildPromotionAuthorization(args: ReplayPromotionSubmission): ReplayPromotionAuthorization {
+  const operator_approved_at = new Date().toISOString();
+  const authorization_hash = hashPayload({
+    version: REPLAY_PROMOTION_VERSION,
+    seal_id: args.seal_id,
+    replay_snapshot_hash: args.replay_snapshot_hash,
+    quorum_hash: args.quorum_hash,
+    operator_id: args.operator_id,
+    operator_reason: args.operator_reason,
+    operator_approved_at,
+  });
+
+  return {
+    version: REPLAY_PROMOTION_VERSION,
+    seal_id: args.seal_id,
+    replay_snapshot_hash: args.replay_snapshot_hash,
+    quorum_hash: args.quorum_hash,
+    operator_id: args.operator_id,
+    operator_approved_at,
+    operator_reason: args.operator_reason,
+    authorization_hash,
+    status: 'operator_authorized',
+    mutation_allowed: false,
+    readonly: true,
+    canon: [
+      'Phase 7 creates an operator authorization artifact only.',
+      'This record does not mutate Vault, Canon, Ledger, MIC, Fountain, or rollback state.',
+      'Original seal history remains preserved; replay does not rewrite original seal time.',
+      'A later phase must re-check snapshot hash and quorum hash before any mutation is considered.',
+    ],
+  };
+}
+
+export async function readReplayPromotion(sealId: string | null): Promise<ReplayPromotionResponse | ReplayPromotionError> {
+  if (!sealId) return { ok: false, error: 'missing_seal_id', readonly: true };
+  const stored = await kvGet<ReplayPromotionAuthorization>(promotionKey(sealId));
+  if (!stored) return { ok: false, error: 'seal_not_found', readonly: true };
+  return { ok: true, readonly: true, promotion: stored };
+}
+
+export async function authorizeReplayPromotion(body: unknown): Promise<ReplayPromotionResponse | ReplayPromotionError> {
+  if (!body || typeof body !== 'object') return { ok: false, error: 'missing_body', readonly: true };
+  const candidate = body as Partial<ReplayPromotionSubmission>;
+  if (!hasNonEmptyString(candidate.seal_id)) return { ok: false, error: 'missing_seal_id', readonly: true };
+  if (!hasNonEmptyString(candidate.operator_id)) return { ok: false, error: 'missing_operator_id', readonly: true };
+  if (!hasNonEmptyString(candidate.operator_reason)) return { ok: false, error: 'missing_operator_reason', readonly: true };
+
+  const snapshot = await buildReplaySnapshotResponse(candidate.seal_id);
+  if (!snapshot.ok) return snapshot.error === 'seal_not_found'
+    ? { ok: false, error: 'seal_not_found', readonly: true }
+    : { ok: false, error: 'missing_seal_id', readonly: true };
+  if (candidate.replay_snapshot_hash !== snapshot.snapshot.replay_snapshot_hash) {
+    return { ok: false, error: 'snapshot_hash_mismatch', readonly: true };
+  }
+
+  const quorum = await evaluateReplayQuorum(candidate.seal_id);
+  if (!quorum.ok) return quorum.error === 'seal_not_found'
+    ? { ok: false, error: 'seal_not_found', readonly: true }
+    : { ok: false, error: 'missing_seal_id', readonly: true };
+  if (!quorum.evaluation.back_attestation_candidate || !quorum.evaluation.quorum_hash) {
+    return { ok: false, error: 'quorum_not_approved', readonly: true };
+  }
+  if (candidate.quorum_hash !== quorum.evaluation.quorum_hash) {
+    return { ok: false, error: 'quorum_hash_mismatch', readonly: true };
+  }
+
+  const promotion = buildPromotionAuthorization({
+    seal_id: candidate.seal_id,
+    replay_snapshot_hash: candidate.replay_snapshot_hash,
+    quorum_hash: candidate.quorum_hash,
+    operator_id: candidate.operator_id,
+    operator_reason: candidate.operator_reason,
+  });
+  const wrote = await kvSet(promotionKey(candidate.seal_id), promotion);
+  if (!wrote) return { ok: false, error: 'write_failed', readonly: true };
+  return { ok: true, readonly: true, promotion };
+}

--- a/lib/system/replay-promotion.ts
+++ b/lib/system/replay-promotion.ts
@@ -2,7 +2,7 @@ import { hashPayload } from '@/lib/agents/signatures';
 import { kvGet, kvSet } from '@/lib/kv/store';
 import { buildReplaySnapshotResponse, evaluateReplayQuorum } from '@/lib/system/replay-quorum';
 
-export const REPLAY_PROMOTION_VERSION = 'C-294.phase7.v1' as const;
+export const REPLAY_PROMOTION_VERSION = 'C-294.phase9.v1' as const;
 
 export type ReplayPromotionAuthorization = {
   version: typeof REPLAY_PROMOTION_VERSION;
@@ -19,6 +19,32 @@ export type ReplayPromotionAuthorization = {
   canon: string[];
 };
 
+export type ReplayMutationPlan = {
+  version: typeof REPLAY_PROMOTION_VERSION;
+  seal_id: string;
+  replay_snapshot_hash: string;
+  quorum_hash: string;
+  authorization_hash: string;
+  mutation_kind: 'canon_overlay_only';
+  proposed_effect: 'record_replay_promoted_overlay';
+  original_history_preserved: true;
+  vault_status_mutation: false;
+  canonical_chain_mutation: false;
+  mic_or_fountain_mutation: false;
+  rollback_mutation: false;
+  preconditions: string[];
+  plan_hash: string;
+  readonly: true;
+};
+
+export type ReplayMutationReceipt = ReplayMutationPlan & {
+  status: 'recorded_overlay_only';
+  executed_at: string;
+  executor: 'operator_gate';
+  receipt_hash: string;
+  canon: string[];
+};
+
 export type ReplayPromotionSubmission = {
   seal_id: string;
   replay_snapshot_hash: string;
@@ -27,10 +53,29 @@ export type ReplayPromotionSubmission = {
   operator_reason: string;
 };
 
+export type ReplayMutationSubmission = {
+  seal_id: string;
+  authorization_hash: string;
+  operator_id: string;
+  operator_reason: string;
+};
+
 export type ReplayPromotionResponse = {
   ok: true;
   readonly: true;
   promotion: ReplayPromotionAuthorization;
+};
+
+export type ReplayMutationPlanResponse = {
+  ok: true;
+  readonly: true;
+  plan: ReplayMutationPlan;
+};
+
+export type ReplayMutationReceiptResponse = {
+  ok: true;
+  readonly: true;
+  receipt: ReplayMutationReceipt;
 };
 
 export type ReplayPromotionError = {
@@ -45,11 +90,17 @@ export type ReplayPromotionError = {
     | 'quorum_hash_mismatch'
     | 'missing_operator_id'
     | 'missing_operator_reason'
+    | 'authorization_missing'
+    | 'authorization_hash_mismatch'
     | 'write_failed';
 };
 
 function promotionKey(sealId: string): string {
   return `system:replay:promotion:${sealId}`;
+}
+
+function mutationReceiptKey(sealId: string): string {
+  return `system:replay:mutation:${sealId}`;
 }
 
 function hasNonEmptyString(value: unknown): value is string {
@@ -89,11 +140,73 @@ function buildPromotionAuthorization(args: ReplayPromotionSubmission): ReplayPro
   };
 }
 
+function buildMutationPlan(promotion: ReplayPromotionAuthorization): ReplayMutationPlan {
+  const base = {
+    version: REPLAY_PROMOTION_VERSION,
+    seal_id: promotion.seal_id,
+    replay_snapshot_hash: promotion.replay_snapshot_hash,
+    quorum_hash: promotion.quorum_hash,
+    authorization_hash: promotion.authorization_hash,
+    mutation_kind: 'canon_overlay_only' as const,
+    proposed_effect: 'record_replay_promoted_overlay' as const,
+    original_history_preserved: true as const,
+    vault_status_mutation: false as const,
+    canonical_chain_mutation: false as const,
+    mic_or_fountain_mutation: false as const,
+    rollback_mutation: false as const,
+    preconditions: [
+      'Operator authorization exists and matches request authorization_hash.',
+      'Replay snapshot hash still matches stored seal data.',
+      'Replay quorum hash still matches approved Council Bus state.',
+      'Original seal body remains unchanged.',
+      'Canon exposes overlay/receipt as annotation only.',
+    ],
+    readonly: true as const,
+  };
+  return {
+    ...base,
+    plan_hash: hashPayload(base),
+  };
+}
+
+function buildMutationReceipt(plan: ReplayMutationPlan): ReplayMutationReceipt {
+  const executed_at = new Date().toISOString();
+  const receiptBase = {
+    ...plan,
+    status: 'recorded_overlay_only' as const,
+    executed_at,
+    executor: 'operator_gate' as const,
+  };
+  return {
+    ...receiptBase,
+    receipt_hash: hashPayload(receiptBase),
+    canon: [
+      'Phase 9 records a controlled mutation receipt as an overlay only.',
+      'The original seal remains unchanged and inspectable.',
+      'No Vault status, canonical chain, MIC, Fountain, Ledger, or rollback mutation occurred.',
+      'Future phases may consume this receipt, but must re-check the hashes before any state transition.',
+    ],
+  };
+}
+
 export async function readReplayPromotion(sealId: string | null): Promise<ReplayPromotionResponse | ReplayPromotionError> {
   if (!sealId) return { ok: false, error: 'missing_seal_id', readonly: true };
   const stored = await kvGet<ReplayPromotionAuthorization>(promotionKey(sealId));
   if (!stored) return { ok: false, error: 'seal_not_found', readonly: true };
   return { ok: true, readonly: true, promotion: stored };
+}
+
+export async function readReplayMutationReceipt(sealId: string | null): Promise<ReplayMutationReceiptResponse | ReplayPromotionError> {
+  if (!sealId) return { ok: false, error: 'missing_seal_id', readonly: true };
+  const stored = await kvGet<ReplayMutationReceipt>(mutationReceiptKey(sealId));
+  if (!stored) return { ok: false, error: 'seal_not_found', readonly: true };
+  return { ok: true, readonly: true, receipt: stored };
+}
+
+export async function previewReplayMutationPlan(sealId: string | null): Promise<ReplayMutationPlanResponse | ReplayPromotionError> {
+  const promotionResult = await readReplayPromotion(sealId);
+  if (!promotionResult.ok) return promotionResult;
+  return { ok: true, readonly: true, plan: buildMutationPlan(promotionResult.promotion) };
 }
 
 export async function authorizeReplayPromotion(body: unknown): Promise<ReplayPromotionResponse | ReplayPromotionError> {
@@ -132,4 +245,43 @@ export async function authorizeReplayPromotion(body: unknown): Promise<ReplayPro
   const wrote = await kvSet(promotionKey(candidate.seal_id), promotion);
   if (!wrote) return { ok: false, error: 'write_failed', readonly: true };
   return { ok: true, readonly: true, promotion };
+}
+
+export async function recordReplayMutationReceipt(body: unknown): Promise<ReplayMutationReceiptResponse | ReplayPromotionError> {
+  if (!body || typeof body !== 'object') return { ok: false, error: 'missing_body', readonly: true };
+  const candidate = body as Partial<ReplayMutationSubmission>;
+  if (!hasNonEmptyString(candidate.seal_id)) return { ok: false, error: 'missing_seal_id', readonly: true };
+  if (!hasNonEmptyString(candidate.operator_id)) return { ok: false, error: 'missing_operator_id', readonly: true };
+  if (!hasNonEmptyString(candidate.operator_reason)) return { ok: false, error: 'missing_operator_reason', readonly: true };
+  if (!hasNonEmptyString(candidate.authorization_hash)) return { ok: false, error: 'authorization_missing', readonly: true };
+
+  const promotionResult = await readReplayPromotion(candidate.seal_id);
+  if (!promotionResult.ok) return { ok: false, error: 'authorization_missing', readonly: true };
+  if (candidate.authorization_hash !== promotionResult.promotion.authorization_hash) {
+    return { ok: false, error: 'authorization_hash_mismatch', readonly: true };
+  }
+
+  const snapshot = await buildReplaySnapshotResponse(candidate.seal_id);
+  if (!snapshot.ok) return snapshot.error === 'seal_not_found'
+    ? { ok: false, error: 'seal_not_found', readonly: true }
+    : { ok: false, error: 'missing_seal_id', readonly: true };
+  if (snapshot.snapshot.replay_snapshot_hash !== promotionResult.promotion.replay_snapshot_hash) {
+    return { ok: false, error: 'snapshot_hash_mismatch', readonly: true };
+  }
+
+  const quorum = await evaluateReplayQuorum(candidate.seal_id);
+  if (!quorum.ok) return quorum.error === 'seal_not_found'
+    ? { ok: false, error: 'seal_not_found', readonly: true }
+    : { ok: false, error: 'missing_seal_id', readonly: true };
+  if (!quorum.evaluation.back_attestation_candidate || !quorum.evaluation.quorum_hash) {
+    return { ok: false, error: 'quorum_not_approved', readonly: true };
+  }
+  if (quorum.evaluation.quorum_hash !== promotionResult.promotion.quorum_hash) {
+    return { ok: false, error: 'quorum_hash_mismatch', readonly: true };
+  }
+
+  const receipt = buildMutationReceipt(buildMutationPlan(promotionResult.promotion));
+  const wrote = await kvSet(mutationReceiptKey(candidate.seal_id), receipt);
+  if (!wrote) return { ok: false, error: 'write_failed', readonly: true };
+  return { ok: true, readonly: true, receipt };
 }

--- a/lib/system/replay-quorum.ts
+++ b/lib/system/replay-quorum.ts
@@ -1,0 +1,157 @@
+import { hashPayload } from '@/lib/agents/signatures';
+import { getSeal } from '@/lib/vault-v2/store';
+import type { Seal, SentinelAgent } from '@/lib/vault-v2/types';
+import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
+
+export const REPLAY_QUORUM_VERSION = 'C-294.phase1-2.v1' as const;
+
+export type ReplaySnapshot = {
+  version: typeof REPLAY_QUORUM_VERSION;
+  seal_id: string;
+  seal_hash: string;
+  previous_seal_hash: string | null;
+  deposit_hashes: string[];
+  deposit_hashes_count: number;
+  cycle_at_seal: string;
+  sealed_at: string;
+  gi_at_seal: number;
+  mode_at_seal: Seal['mode_at_seal'];
+  source_entries: number;
+  status_at_replay: Seal['status'];
+  fountain_status_at_replay: Seal['fountain_status'];
+  substrate_pointer: {
+    attestation_id: string | null;
+    event_hash: string | null;
+    attested_at: string | null;
+    error: string | null;
+  };
+  replay_snapshot_hash: string;
+  readonly: true;
+  canon: string[];
+};
+
+export type ReplayCouncilVerdict = 'pass' | 'flag' | 'abstain';
+
+export type ReplayCouncilMessage = {
+  version: typeof REPLAY_QUORUM_VERSION;
+  from_agent: SentinelAgent;
+  seal_id: string;
+  replay_snapshot_hash: string;
+  verdict: ReplayCouncilVerdict;
+  reason: string;
+  signed_at: string;
+  signature: string;
+  signature_hash: string;
+  readonly: true;
+};
+
+export type ReplaySnapshotResponse = {
+  ok: true;
+  readonly: true;
+  snapshot: ReplaySnapshot;
+  council_contract: {
+    required_agents: readonly SentinelAgent[];
+    message_shape: Omit<ReplayCouncilMessage, 'signature' | 'signature_hash' | 'signed_at'> & {
+      signed_at: 'ISO-8601';
+      signature: 'agent signature over replay_snapshot_hash';
+      signature_hash: 'sha256({agent, signature})';
+    };
+  };
+};
+
+export type ReplaySnapshotError = {
+  ok: false;
+  error: 'missing_seal_id' | 'seal_not_found';
+  readonly: true;
+};
+
+function replayHashInput(seal: Seal) {
+  return {
+    seal_id: seal.seal_id,
+    seal_hash: seal.seal_hash,
+    previous_seal_hash: seal.prev_seal_hash,
+    deposit_hashes: seal.deposit_hashes,
+    cycle_at_seal: seal.cycle_at_seal,
+    sealed_at: seal.sealed_at,
+    gi_at_seal: seal.gi_at_seal,
+    mode_at_seal: seal.mode_at_seal,
+    source_entries: seal.source_entries,
+  };
+}
+
+export function buildReplaySnapshotFromSeal(seal: Seal): ReplaySnapshot {
+  const replay_snapshot_hash = hashPayload(replayHashInput(seal));
+  return {
+    version: REPLAY_QUORUM_VERSION,
+    seal_id: seal.seal_id,
+    seal_hash: seal.seal_hash,
+    previous_seal_hash: seal.prev_seal_hash,
+    deposit_hashes: seal.deposit_hashes,
+    deposit_hashes_count: seal.deposit_hashes.length,
+    cycle_at_seal: seal.cycle_at_seal,
+    sealed_at: seal.sealed_at,
+    gi_at_seal: seal.gi_at_seal,
+    mode_at_seal: seal.mode_at_seal,
+    source_entries: seal.source_entries,
+    status_at_replay: seal.status,
+    fountain_status_at_replay: seal.fountain_status,
+    substrate_pointer: {
+      attestation_id: seal.substrate_attestation_id ?? null,
+      event_hash: seal.substrate_event_hash ?? null,
+      attested_at: seal.substrate_attested_at ?? null,
+      error: seal.substrate_attestation_error ?? null,
+    },
+    replay_snapshot_hash,
+    readonly: true,
+    canon: [
+      'Replay snapshot is a reconstructed past-state hash.',
+      'Replay quorum must attest the same replay_snapshot_hash.',
+      'Replay quorum does not pretend agents signed at original seal time.',
+      'Replay snapshot does not promote, mutate, mint, unlock, or rollback by itself.',
+    ],
+  };
+}
+
+export function buildReplayCouncilMessageDraft(args: {
+  from_agent: SentinelAgent;
+  seal_id: string;
+  replay_snapshot_hash: string;
+  verdict: ReplayCouncilVerdict;
+  reason: string;
+  signed_at: string;
+  signature: string;
+}): ReplayCouncilMessage {
+  return {
+    version: REPLAY_QUORUM_VERSION,
+    ...args,
+    signature_hash: hashPayload({ agent: args.from_agent, signature: args.signature }),
+    readonly: true,
+  };
+}
+
+export async function buildReplaySnapshotResponse(sealId: string | null): Promise<ReplaySnapshotResponse | ReplaySnapshotError> {
+  if (!sealId) return { ok: false, error: 'missing_seal_id', readonly: true };
+  const seal = await getSeal(sealId);
+  if (!seal) return { ok: false, error: 'seal_not_found', readonly: true };
+  const snapshot = buildReplaySnapshotFromSeal(seal);
+  return {
+    ok: true,
+    readonly: true,
+    snapshot,
+    council_contract: {
+      required_agents: SENTINEL_AGENTS,
+      message_shape: {
+        version: REPLAY_QUORUM_VERSION,
+        from_agent: 'ATLAS',
+        seal_id: snapshot.seal_id,
+        replay_snapshot_hash: snapshot.replay_snapshot_hash,
+        verdict: 'abstain',
+        reason: 'Agent reviews the reconstructed past-state hash before quorum.',
+        signed_at: 'ISO-8601',
+        signature: 'agent signature over replay_snapshot_hash',
+        signature_hash: 'sha256({agent, signature})',
+        readonly: true,
+      },
+    },
+  };
+}

--- a/lib/system/replay-quorum.ts
+++ b/lib/system/replay-quorum.ts
@@ -4,7 +4,7 @@ import { getSeal } from '@/lib/vault-v2/store';
 import type { Seal, SentinelAgent } from '@/lib/vault-v2/types';
 import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
 
-export const REPLAY_QUORUM_VERSION = 'C-294.phase4.v1' as const;
+export const REPLAY_QUORUM_VERSION = 'C-294.phase6.v1' as const;
 export const REPLAY_QUORUM_THRESHOLD = 3 as const;
 
 export type ReplaySnapshot = {
@@ -62,6 +62,7 @@ export type ReplayCouncilRecord = {
 };
 
 export type ReplayQuorumStatus = 'pending' | 'approved' | 'blocked' | 'contested';
+export type ReplayCandidateState = 'not_ready' | 'candidate' | 'blocked';
 
 export type ReplayQuorumEvaluation = {
   version: typeof REPLAY_QUORUM_VERSION;
@@ -79,6 +80,10 @@ export type ReplayQuorumEvaluation = {
   quorum_hash: string | null;
   status: ReplayQuorumStatus;
   back_attestation_candidate: boolean;
+  candidate_state: ReplayCandidateState;
+  candidate_reason: string;
+  operator_action_required: boolean;
+  promotion_preconditions: string[];
   readonly: true;
   canon: string[];
 };
@@ -178,10 +183,6 @@ function isIsoDateString(value: unknown): value is string {
 }
 
 function signatureReferencesSnapshot(signature: string, replaySnapshotHash: string): boolean {
-  // Phase 5 guardrail: until agent public-key verification is wired, require
-  // signatures to be explicitly scoped to the snapshot they are voting on.
-  // Accepted formats include raw strings that contain the snapshot hash, such as
-  // `replay:<hash>:agent:<agent>:sig:<digest>`.
   return signature.includes(replaySnapshotHash);
 }
 
@@ -216,6 +217,19 @@ function emptyCouncilRecord(sealId: string, replaySnapshotHash: string): ReplayC
   };
 }
 
+function candidateReason(status: ReplayQuorumStatus): string {
+  switch (status) {
+    case 'approved':
+      return 'Replay quorum reached over one snapshot hash. Operator may consider promotion in a later phase.';
+    case 'blocked':
+      return 'Replay quorum blocked by flag threshold. Operator should review agent rationales before any future attempt.';
+    case 'contested':
+      return 'Replay council is contested. More review or agent correction is required before candidate status.';
+    default:
+      return 'Replay council is still pending. Missing or abstaining agents prevent candidate status.';
+  }
+}
+
 function evaluateCouncilRecord(record: ReplayCouncilRecord): ReplayQuorumEvaluation {
   const normalized = normalizeCouncilRecord(record);
   const messages = SENTINEL_AGENTS.map((agent) => normalized.messages[agent]).filter((message): message is ReplayCouncilMessage => Boolean(message));
@@ -232,6 +246,7 @@ function evaluateCouncilRecord(record: ReplayCouncilRecord): ReplayQuorumEvaluat
       : contested
         ? 'contested'
         : 'pending';
+  const candidateState: ReplayCandidateState = quorumReached ? 'candidate' : blockingReached ? 'blocked' : 'not_ready';
   const quorumHash = quorumReached
     ? hashPayload({
         seal_id: normalized.seal_id,
@@ -260,6 +275,16 @@ function evaluateCouncilRecord(record: ReplayCouncilRecord): ReplayQuorumEvaluat
     quorum_hash: quorumHash,
     status,
     back_attestation_candidate: quorumReached,
+    candidate_state: candidateState,
+    candidate_reason: candidateReason(status),
+    operator_action_required: quorumReached,
+    promotion_preconditions: [
+      'Operator explicitly approves promotion in a later phase.',
+      'Replay snapshot hash still matches stored seal data at promotion time.',
+      'Quorum hash is preserved with approved agent set.',
+      'Original seal history remains preserved; replay does not rewrite original seal time.',
+      'Promotion route confirms no conflicting successor state before mutation.',
+    ],
     readonly: true,
     canon: [
       'Replay quorum evaluates Council Bus messages over one replay_snapshot_hash.',

--- a/lib/system/replay-quorum.ts
+++ b/lib/system/replay-quorum.ts
@@ -133,6 +133,9 @@ export type ReplayCouncilError = {
     | 'missing_body'
     | 'invalid_agent'
     | 'invalid_verdict'
+    | 'invalid_signed_at'
+    | 'missing_signature'
+    | 'invalid_signature_scope'
     | 'snapshot_hash_mismatch'
     | 'write_failed';
   readonly: true;
@@ -162,6 +165,24 @@ function isSentinelAgent(value: string): value is SentinelAgent {
 
 function isReplayCouncilVerdict(value: string): value is ReplayCouncilVerdict {
   return value === 'pass' || value === 'flag' || value === 'abstain';
+}
+
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isIsoDateString(value: unknown): value is string {
+  if (!hasNonEmptyString(value)) return false;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed);
+}
+
+function signatureReferencesSnapshot(signature: string, replaySnapshotHash: string): boolean {
+  // Phase 5 guardrail: until agent public-key verification is wired, require
+  // signatures to be explicitly scoped to the snapshot they are voting on.
+  // Accepted formats include raw strings that contain the snapshot hash, such as
+  // `replay:<hash>:agent:<agent>:sig:<digest>`.
+  return signature.includes(replaySnapshotHash);
 }
 
 function normalizeCouncilRecord(record: ReplayCouncilRecord): ReplayCouncilRecord {
@@ -333,10 +354,15 @@ export async function submitReplayCouncilMessage(body: unknown): Promise<ReplayC
   if (!candidate.seal_id) return { ok: false, error: 'missing_seal_id', readonly: true };
   if (!candidate.from_agent || !isSentinelAgent(candidate.from_agent)) return { ok: false, error: 'invalid_agent', readonly: true };
   if (!candidate.verdict || !isReplayCouncilVerdict(candidate.verdict)) return { ok: false, error: 'invalid_verdict', readonly: true };
+  if (!isIsoDateString(candidate.signed_at)) return { ok: false, error: 'invalid_signed_at', readonly: true };
+  if (!hasNonEmptyString(candidate.signature)) return { ok: false, error: 'missing_signature', readonly: true };
   const snapshotResponse = await buildReplaySnapshotResponse(candidate.seal_id);
   if (!snapshotResponse.ok) return snapshotResponse;
   if (candidate.replay_snapshot_hash !== snapshotResponse.snapshot.replay_snapshot_hash) {
     return { ok: false, error: 'snapshot_hash_mismatch', readonly: true };
+  }
+  if (!signatureReferencesSnapshot(candidate.signature, candidate.replay_snapshot_hash)) {
+    return { ok: false, error: 'invalid_signature_scope', readonly: true };
   }
 
   const current = await kvGet<ReplayCouncilRecord>(replayCouncilKey(candidate.seal_id));
@@ -347,8 +373,8 @@ export async function submitReplayCouncilMessage(body: unknown): Promise<ReplayC
     replay_snapshot_hash: candidate.replay_snapshot_hash,
     verdict: candidate.verdict,
     reason: candidate.reason ?? '',
-    signed_at: candidate.signed_at ?? new Date().toISOString(),
-    signature: candidate.signature ?? '',
+    signed_at: candidate.signed_at,
+    signature: candidate.signature,
   });
   const next: ReplayCouncilRecord = normalizeCouncilRecord({
     ...base,

--- a/lib/system/replay-quorum.ts
+++ b/lib/system/replay-quorum.ts
@@ -4,7 +4,8 @@ import { getSeal } from '@/lib/vault-v2/store';
 import type { Seal, SentinelAgent } from '@/lib/vault-v2/types';
 import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
 
-export const REPLAY_QUORUM_VERSION = 'C-294.phase3.v1' as const;
+export const REPLAY_QUORUM_VERSION = 'C-294.phase4.v1' as const;
+export const REPLAY_QUORUM_THRESHOLD = 3 as const;
 
 export type ReplaySnapshot = {
   version: typeof REPLAY_QUORUM_VERSION;
@@ -60,6 +61,28 @@ export type ReplayCouncilRecord = {
   canon: string[];
 };
 
+export type ReplayQuorumStatus = 'pending' | 'approved' | 'blocked' | 'contested';
+
+export type ReplayQuorumEvaluation = {
+  version: typeof REPLAY_QUORUM_VERSION;
+  seal_id: string;
+  replay_snapshot_hash: string;
+  quorum_threshold: typeof REPLAY_QUORUM_THRESHOLD;
+  required_agents: readonly SentinelAgent[];
+  approved_count: number;
+  flagged_count: number;
+  abstained_count: number;
+  message_count: number;
+  missing_agents: SentinelAgent[];
+  agents_present: SentinelAgent[];
+  quorum_reached: boolean;
+  quorum_hash: string | null;
+  status: ReplayQuorumStatus;
+  back_attestation_candidate: boolean;
+  readonly: true;
+  canon: string[];
+};
+
 export type ReplaySnapshotResponse = {
   ok: true;
   readonly: true;
@@ -94,6 +117,12 @@ export type ReplayCouncilResponse = {
   ok: true;
   readonly: true;
   record: ReplayCouncilRecord;
+};
+
+export type ReplayQuorumResponse = {
+  ok: true;
+  readonly: true;
+  evaluation: ReplayQuorumEvaluation;
 };
 
 export type ReplayCouncilError = {
@@ -162,6 +191,60 @@ function emptyCouncilRecord(sealId: string, replaySnapshotHash: string): ReplayC
       'Replay Council Bus stores agent reviews over a reconstructed past-state hash.',
       'Each Sentinel agent may have at most one current message per seal_id.',
       'Council messages do not promote, mint, unlock, rollback, or rewrite Canon by themselves.',
+    ],
+  };
+}
+
+function evaluateCouncilRecord(record: ReplayCouncilRecord): ReplayQuorumEvaluation {
+  const normalized = normalizeCouncilRecord(record);
+  const messages = SENTINEL_AGENTS.map((agent) => normalized.messages[agent]).filter((message): message is ReplayCouncilMessage => Boolean(message));
+  const approvedCount = messages.filter((message) => message.verdict === 'pass').length;
+  const flaggedCount = messages.filter((message) => message.verdict === 'flag').length;
+  const abstainedCount = messages.filter((message) => message.verdict === 'abstain').length;
+  const quorumReached = approvedCount >= REPLAY_QUORUM_THRESHOLD;
+  const blockingReached = flaggedCount >= REPLAY_QUORUM_THRESHOLD;
+  const contested = approvedCount > 0 && flaggedCount > 0 && !quorumReached && !blockingReached;
+  const status: ReplayQuorumStatus = quorumReached
+    ? 'approved'
+    : blockingReached
+      ? 'blocked'
+      : contested
+        ? 'contested'
+        : 'pending';
+  const quorumHash = quorumReached
+    ? hashPayload({
+        seal_id: normalized.seal_id,
+        replay_snapshot_hash: normalized.replay_snapshot_hash,
+        approved_agents: messages
+          .filter((message) => message.verdict === 'pass')
+          .map((message) => message.from_agent)
+          .sort(),
+        threshold: REPLAY_QUORUM_THRESHOLD,
+      })
+    : null;
+
+  return {
+    version: REPLAY_QUORUM_VERSION,
+    seal_id: normalized.seal_id,
+    replay_snapshot_hash: normalized.replay_snapshot_hash,
+    quorum_threshold: REPLAY_QUORUM_THRESHOLD,
+    required_agents: SENTINEL_AGENTS,
+    approved_count: approvedCount,
+    flagged_count: flaggedCount,
+    abstained_count: abstainedCount,
+    message_count: normalized.message_count,
+    missing_agents: normalized.missing_agents,
+    agents_present: normalized.agents_present,
+    quorum_reached: quorumReached,
+    quorum_hash: quorumHash,
+    status,
+    back_attestation_candidate: quorumReached,
+    readonly: true,
+    canon: [
+      'Replay quorum evaluates Council Bus messages over one replay_snapshot_hash.',
+      'Replay quorum approval does not promote a seal by itself.',
+      'Back-attestation candidate means operator promotion may be considered in a later phase.',
+      'No Vault mutation, Canon rewrite, MIC issuance, Fountain unlock, or rollback occurs here.',
     ],
   };
 }
@@ -280,4 +363,14 @@ export async function submitReplayCouncilMessage(body: unknown): Promise<ReplayC
   const wrote = await kvSet(replayCouncilKey(candidate.seal_id), next);
   if (!wrote) return { ok: false, error: 'write_failed', readonly: true };
   return { ok: true, readonly: true, record: next };
+}
+
+export async function evaluateReplayQuorum(sealId: string | null): Promise<ReplayQuorumResponse | ReplayCouncilError> {
+  const council = await readReplayCouncil(sealId);
+  if (!council.ok) return council;
+  return {
+    ok: true,
+    readonly: true,
+    evaluation: evaluateCouncilRecord(council.record),
+  };
 }

--- a/lib/system/replay-quorum.ts
+++ b/lib/system/replay-quorum.ts
@@ -1,9 +1,10 @@
 import { hashPayload } from '@/lib/agents/signatures';
+import { kvGet, kvSet } from '@/lib/kv/store';
 import { getSeal } from '@/lib/vault-v2/store';
 import type { Seal, SentinelAgent } from '@/lib/vault-v2/types';
 import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
 
-export const REPLAY_QUORUM_VERSION = 'C-294.phase1-2.v1' as const;
+export const REPLAY_QUORUM_VERSION = 'C-294.phase3.v1' as const;
 
 export type ReplaySnapshot = {
   version: typeof REPLAY_QUORUM_VERSION;
@@ -45,6 +46,20 @@ export type ReplayCouncilMessage = {
   readonly: true;
 };
 
+export type ReplayCouncilRecord = {
+  version: typeof REPLAY_QUORUM_VERSION;
+  seal_id: string;
+  replay_snapshot_hash: string;
+  created_at: string;
+  updated_at: string;
+  readonly: true;
+  messages: Partial<Record<SentinelAgent, ReplayCouncilMessage>>;
+  message_count: number;
+  agents_present: SentinelAgent[];
+  missing_agents: SentinelAgent[];
+  canon: string[];
+};
+
 export type ReplaySnapshotResponse = {
   ok: true;
   readonly: true;
@@ -65,6 +80,39 @@ export type ReplaySnapshotError = {
   readonly: true;
 };
 
+export type ReplayCouncilSubmission = {
+  from_agent: SentinelAgent;
+  seal_id: string;
+  replay_snapshot_hash: string;
+  verdict: ReplayCouncilVerdict;
+  reason: string;
+  signed_at: string;
+  signature: string;
+};
+
+export type ReplayCouncilResponse = {
+  ok: true;
+  readonly: true;
+  record: ReplayCouncilRecord;
+};
+
+export type ReplayCouncilError = {
+  ok: false;
+  error:
+    | 'missing_seal_id'
+    | 'seal_not_found'
+    | 'missing_body'
+    | 'invalid_agent'
+    | 'invalid_verdict'
+    | 'snapshot_hash_mismatch'
+    | 'write_failed';
+  readonly: true;
+};
+
+function replayCouncilKey(sealId: string): string {
+  return `system:replay:council:${sealId}`;
+}
+
 function replayHashInput(seal: Seal) {
   return {
     seal_id: seal.seal_id,
@@ -76,6 +124,45 @@ function replayHashInput(seal: Seal) {
     gi_at_seal: seal.gi_at_seal,
     mode_at_seal: seal.mode_at_seal,
     source_entries: seal.source_entries,
+  };
+}
+
+function isSentinelAgent(value: string): value is SentinelAgent {
+  return (SENTINEL_AGENTS as readonly string[]).includes(value);
+}
+
+function isReplayCouncilVerdict(value: string): value is ReplayCouncilVerdict {
+  return value === 'pass' || value === 'flag' || value === 'abstain';
+}
+
+function normalizeCouncilRecord(record: ReplayCouncilRecord): ReplayCouncilRecord {
+  const agentsPresent = SENTINEL_AGENTS.filter((agent) => Boolean(record.messages[agent]));
+  return {
+    ...record,
+    message_count: agentsPresent.length,
+    agents_present: agentsPresent,
+    missing_agents: SENTINEL_AGENTS.filter((agent) => !record.messages[agent]),
+  };
+}
+
+function emptyCouncilRecord(sealId: string, replaySnapshotHash: string): ReplayCouncilRecord {
+  const now = new Date().toISOString();
+  return {
+    version: REPLAY_QUORUM_VERSION,
+    seal_id: sealId,
+    replay_snapshot_hash: replaySnapshotHash,
+    created_at: now,
+    updated_at: now,
+    readonly: true,
+    messages: {},
+    message_count: 0,
+    agents_present: [],
+    missing_agents: [...SENTINEL_AGENTS],
+    canon: [
+      'Replay Council Bus stores agent reviews over a reconstructed past-state hash.',
+      'Each Sentinel agent may have at most one current message per seal_id.',
+      'Council messages do not promote, mint, unlock, rollback, or rewrite Canon by themselves.',
+    ],
   };
 }
 
@@ -112,15 +199,7 @@ export function buildReplaySnapshotFromSeal(seal: Seal): ReplaySnapshot {
   };
 }
 
-export function buildReplayCouncilMessageDraft(args: {
-  from_agent: SentinelAgent;
-  seal_id: string;
-  replay_snapshot_hash: string;
-  verdict: ReplayCouncilVerdict;
-  reason: string;
-  signed_at: string;
-  signature: string;
-}): ReplayCouncilMessage {
+export function buildReplayCouncilMessageDraft(args: ReplayCouncilSubmission): ReplayCouncilMessage {
   return {
     version: REPLAY_QUORUM_VERSION,
     ...args,
@@ -154,4 +233,51 @@ export async function buildReplaySnapshotResponse(sealId: string | null): Promis
       },
     },
   };
+}
+
+export async function readReplayCouncil(sealId: string | null): Promise<ReplayCouncilResponse | ReplayCouncilError> {
+  if (!sealId) return { ok: false, error: 'missing_seal_id', readonly: true };
+  const snapshotResponse = await buildReplaySnapshotResponse(sealId);
+  if (!snapshotResponse.ok) return snapshotResponse;
+  const stored = await kvGet<ReplayCouncilRecord>(replayCouncilKey(sealId));
+  const record = stored ?? emptyCouncilRecord(sealId, snapshotResponse.snapshot.replay_snapshot_hash);
+  return { ok: true, readonly: true, record: normalizeCouncilRecord(record) };
+}
+
+export async function submitReplayCouncilMessage(body: unknown): Promise<ReplayCouncilResponse | ReplayCouncilError> {
+  if (!body || typeof body !== 'object') return { ok: false, error: 'missing_body', readonly: true };
+  const candidate = body as Partial<ReplayCouncilSubmission>;
+  if (!candidate.seal_id) return { ok: false, error: 'missing_seal_id', readonly: true };
+  if (!candidate.from_agent || !isSentinelAgent(candidate.from_agent)) return { ok: false, error: 'invalid_agent', readonly: true };
+  if (!candidate.verdict || !isReplayCouncilVerdict(candidate.verdict)) return { ok: false, error: 'invalid_verdict', readonly: true };
+  const snapshotResponse = await buildReplaySnapshotResponse(candidate.seal_id);
+  if (!snapshotResponse.ok) return snapshotResponse;
+  if (candidate.replay_snapshot_hash !== snapshotResponse.snapshot.replay_snapshot_hash) {
+    return { ok: false, error: 'snapshot_hash_mismatch', readonly: true };
+  }
+
+  const current = await kvGet<ReplayCouncilRecord>(replayCouncilKey(candidate.seal_id));
+  const base = current ?? emptyCouncilRecord(candidate.seal_id, candidate.replay_snapshot_hash);
+  const message = buildReplayCouncilMessageDraft({
+    from_agent: candidate.from_agent,
+    seal_id: candidate.seal_id,
+    replay_snapshot_hash: candidate.replay_snapshot_hash,
+    verdict: candidate.verdict,
+    reason: candidate.reason ?? '',
+    signed_at: candidate.signed_at ?? new Date().toISOString(),
+    signature: candidate.signature ?? '',
+  });
+  const next: ReplayCouncilRecord = normalizeCouncilRecord({
+    ...base,
+    version: REPLAY_QUORUM_VERSION,
+    replay_snapshot_hash: candidate.replay_snapshot_hash,
+    updated_at: new Date().toISOString(),
+    messages: {
+      ...base.messages,
+      [candidate.from_agent]: message,
+    },
+  });
+  const wrote = await kvSet(replayCouncilKey(candidate.seal_id), next);
+  if (!wrote) return { ok: false, error: 'write_failed', readonly: true };
+  return { ok: true, readonly: true, record: next };
 }


### PR DESCRIPTION
### Phase
C-294 Phase 5 — UI Wiring (Replay Council Viewer)

### Scope
Add read-only Replay Council + Quorum viewer to Terminal Replay page.

### Files touched
- app/terminal/replay/page.tsx

### NOT touching
- Vault mutation logic
- Canon APIs/UI
- MIC / Fountain
- Replay promotion

### Change type
Non-destructive UI extension

### Risk
Low (read-only UI)

### Validation plan
- Load /terminal/replay
- Select a quarantined seal
- Verify council + quorum panel loads
- Verify no existing UI regression

### Commands run
(Not executed in this environment — requires local build)

### Notes
- Displays agent verdicts and quorum state
- No mutation or promotion introduced
- Prepares system for Phase 6 (operator gate)
