### PR TITLE
C-294 — Replay Quorum Contracts + EPICON Promotion Unblock

### DIFF
--- a/app/api/epicon/promote/route.ts
+++ b/app/api/epicon/promote/route.ts
@@ -494,7 +494,7 @@ async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: stri
     state[epicon.id] = existing;
   }
 
-  await savePromotionState(state);
+  await savePromotionState(state, cycleId);
   const postRun = await getPromotablePending(state, nowIso, promotedIdsThisCycle);
   return { pending, promoted, committed, failed, failedCommits, trace: postRun.trace };
 }
@@ -502,7 +502,7 @@ async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: stri
 export async function GET() {
   const nowIso = new Date().toISOString();
   const cycleId = currentCycleId();
-  const state = await getPromotionState();
+  const state = await getPromotionState(cycleId);
   const promotable = await getPromotablePending(state, nowIso);
   const pending = promotable.pending;
 
@@ -562,7 +562,7 @@ export async function POST(request: NextRequest) {
   const maxItems = typeof body.maxItems === 'number' ? Math.min(Math.max(body.maxItems, 1), 50) : 25;
   const nowIso = new Date().toISOString();
   const cycleId = currentCycleId();
-  const state = await getPromotionState();
+  const state = await getPromotionState(cycleId);
   const run = await runPromotionCycle(maxItems, nowIso, cycleId, state);
   const tokenPresent = Boolean(process.env.AGENT_SERVICE_TOKEN?.trim() || process.env.RENDER_API_KEY?.trim());
   if (!tokenPresent) {

--- a/lib/epicon/promotion.ts
+++ b/lib/epicon/promotion.ts
@@ -1,4 +1,5 @@
 import { kvGet, kvSet } from '@/lib/kv/store';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
 
 export type PromotionStateValue = {
   promotion_state: 'pending' | 'selected' | 'promoted' | 'failed';
@@ -18,26 +19,32 @@ const PROMOTION_STATE_TTL_SECONDS = 60 * 60 * 72;
 // Scoped by cycle so stale data from a prior cycle never bleeds into a new one.
 const memoryMirror = new Map<string, PromotionStateMap>();
 
+function activeCycleId(cycleId?: string): string {
+  return cycleId?.trim() || currentCycleId();
+}
+
 function cycleKey(cycleId: string): string {
   return `epicon:promotion:state:${cycleId}`;
 }
 
-export async function getPromotionState(cycleId: string): Promise<PromotionStateMap> {
-  const fromKv = await kvGet<PromotionStateMap>(cycleKey(cycleId));
+export async function getPromotionState(cycleId?: string): Promise<PromotionStateMap> {
+  const resolvedCycleId = activeCycleId(cycleId);
+  const fromKv = await kvGet<PromotionStateMap>(cycleKey(resolvedCycleId));
   if (fromKv && typeof fromKv === 'object') {
     // Keep mirror in sync whenever KV is healthy
-    memoryMirror.set(cycleId, fromKv);
+    memoryMirror.set(resolvedCycleId, fromKv);
     return fromKv;
   }
   // KV unavailable — return in-process mirror so promoted IDs are not forgotten
-  return memoryMirror.get(cycleId) ?? {};
+  return memoryMirror.get(resolvedCycleId) ?? {};
 }
 
-export async function savePromotionState(state: PromotionStateMap, cycleId: string): Promise<void> {
+export async function savePromotionState(state: PromotionStateMap, cycleId?: string): Promise<void> {
+  const resolvedCycleId = activeCycleId(cycleId);
   // Always update memory mirror first so the next getPromotionState within the same
   // process sees the latest state even if the KV write below is slow or fails.
-  memoryMirror.set(cycleId, state);
-  await kvSet(cycleKey(cycleId), state, PROMOTION_STATE_TTL_SECONDS);
+  memoryMirror.set(resolvedCycleId, state);
+  await kvSet(cycleKey(resolvedCycleId), state, PROMOTION_STATE_TTL_SECONDS);
 }
 
 export function defaultPromotionState(nowIso: string): PromotionStateValue {

--- a/lib/epicon/promotion.ts
+++ b/lib/epicon/promotion.ts
@@ -6,25 +6,38 @@ export type PromotionStateValue = {
   committed_entries: string[];
   failed_attempts: number;
   last_attempt_at: string;
+  promoted_at?: string;
 };
 
 export type PromotionStateMap = Record<string, PromotionStateValue>;
 
-const PROMOTION_STATE_KEY = 'epicon:promotion:state';
+// 72h TTL — covers any cycle overlap without leaking into the next cycle
+const PROMOTION_STATE_TTL_SECONDS = 60 * 60 * 72;
 
-const memoryState: PromotionStateMap = {};
+// In-memory mirror keyed by cycleId — survives KV outages within a single process.
+// Scoped by cycle so stale data from a prior cycle never bleeds into a new one.
+const memoryMirror = new Map<string, PromotionStateMap>();
 
-export async function getPromotionState(): Promise<PromotionStateMap> {
-  const fromKv = await kvGet<PromotionStateMap>(PROMOTION_STATE_KEY);
-  if (fromKv && typeof fromKv === 'object') {
-    return fromKv;
-  }
-  return { ...memoryState };
+function cycleKey(cycleId: string): string {
+  return `epicon:promotion:state:${cycleId}`;
 }
 
-export async function savePromotionState(state: PromotionStateMap): Promise<void> {
-  Object.assign(memoryState, state);
-  await kvSet(PROMOTION_STATE_KEY, state);
+export async function getPromotionState(cycleId: string): Promise<PromotionStateMap> {
+  const fromKv = await kvGet<PromotionStateMap>(cycleKey(cycleId));
+  if (fromKv && typeof fromKv === 'object') {
+    // Keep mirror in sync whenever KV is healthy
+    memoryMirror.set(cycleId, fromKv);
+    return fromKv;
+  }
+  // KV unavailable — return in-process mirror so promoted IDs are not forgotten
+  return memoryMirror.get(cycleId) ?? {};
+}
+
+export async function savePromotionState(state: PromotionStateMap, cycleId: string): Promise<void> {
+  // Always update memory mirror first so the next getPromotionState within the same
+  // process sees the latest state even if the KV write below is slow or fails.
+  memoryMirror.set(cycleId, state);
+  await kvSet(cycleKey(cycleId), state, PROMOTION_STATE_TTL_SECONDS);
 }
 
 export function defaultPromotionState(nowIso: string): PromotionStateValue {
@@ -35,4 +48,35 @@ export function defaultPromotionState(nowIso: string): PromotionStateValue {
     failed_attempts: 0,
     last_attempt_at: nowIso,
   };
+}
+
+// Stall counter — incremented each run where zero items are promoted.
+// Auto-expires after 72h so a dead cycle doesn't poison the next one.
+const STALL_TTL_SECONDS = 60 * 60 * 72;
+
+export async function incrementStallCounter(cycleId: string): Promise<number> {
+  const key = `epicon:promotion:stall:${cycleId}`;
+  const current = (await kvGet<number>(key)) ?? 0;
+  const next = current + 1;
+  await kvSet(key, next, STALL_TTL_SECONDS);
+  return next;
+}
+
+export async function resetStallCounter(cycleId: string): Promise<void> {
+  // Write 0 with TTL rather than delete so the key exists for diagnostics
+  await kvSet(`epicon:promotion:stall:${cycleId}`, 0, STALL_TTL_SECONDS);
+}
+
+export async function getStallCount(cycleId: string): Promise<number> {
+  return (await kvGet<number>(`epicon:promotion:stall:${cycleId}`)) ?? 0;
+}
+
+// Keys that the one-time admin flush endpoint should clear for a given cycle.
+export function promotionFlushKeys(cycleId: string): string[] {
+  return [
+    `epicon:promotion:state:${cycleId}`,
+    `epicon:promotion:stall:${cycleId}`,
+    // Legacy global key (no cycle scope) written before this fix shipped
+    'epicon:promotion:state',
+  ];
 }


### PR DESCRIPTION
### Phase
C-294 Replay Quorum Phases 0–10 + pre-Phase 11 EPICON unblock

### Scope
- Add Replay Snapshot contract and read-only snapshot endpoint
- Add Replay Council Bus and quorum evaluator
- Add operator authorization artifact for replay promotion
- Add Canon replay promotion annotation overlay
- Add overlay-only mutation plan/receipt layer and read-only UI visibility
- Add operator-gated mutation receipt POST endpoint
- Bring EPICON promotion state onto cycle-scoped state keys to prevent live promotion deadlock

### Files touched
- lib/system/replay-quorum.ts
- lib/system/replay-promotion.ts
- app/api/system/replay/snapshot/route.ts
- app/api/system/replay/council/route.ts
- app/api/system/replay/quorum/route.ts
- app/api/system/replay/promote/route.ts
- app/api/system/replay/mutation/route.ts
- app/terminal/replay/page.tsx
- lib/substrate/canon.ts
- lib/epicon/promotion.ts
- docs/pr-bundles/C-294-phase0-1-2-replay-quorum.md

### NOT touching
- No Vault seal status mutation
- No Canon base-history rewrite
- No MIC or Fountain unlock
- No rollback execution
- No true chain mutation

### Change type
Additive / overlay-only / operator-gated

### Risk
Medium. Replay system is additive, but `app/terminal/replay/page.tsx`, `lib/substrate/canon.ts`, and EPICON promotion state are sensitive operator surfaces.

### Validation plan
- Verify `/terminal/replay` loads
- Verify `GET /api/system/replay/snapshot?seal_id=...`
- Verify `GET /api/system/replay/council?seal_id=...`
- Verify `GET /api/system/replay/quorum?seal_id=...`
- Verify `GET /api/system/replay/promote?seal_id=...`
- Verify `GET /api/system/replay/mutation?seal_id=...`
- Verify `POST /api/system/replay/mutation` requires service auth and only records overlay receipt
- Verify `/api/substrate/canon` remains read-only and shows replay promotion overlays without rewriting original seal status
- Verify `/api/epicon/promote` uses cycle-scoped promotion state and no longer deadlocks on stale global promotion state

### Commands run
- Vercel build passed after Replay page module restoration, per operator report

### Result
- typecheck: passed in Vercel build per operator report
- build: passed in Vercel build per operator report
- lint: included in Vercel build/type validation path; local lint not run here

### Notes
- This PR deliberately stops before Phase 11 effective-state mutation.
- Phase 10 records accepted correction as an overlay receipt only.
- Original seal history remains preserved and inspectable.
