### PR TITLE
perf(C-295): Render cold-start cache + vault-attestation idle guard

### DIFF
--- a/app/api/cron/vault-attestation/route.ts
+++ b/app/api/cron/vault-attestation/route.ts
@@ -198,6 +198,9 @@ export async function GET(req: NextRequest) {
   }
 
   // ── Step 3: fountain pending count (informational) ─────────────
+  // Skip the 4× KV reads when the vault is idle: no candidate in flight and
+  // balance below the formation threshold. This fires every 2 minutes, so
+  // skipping here saves ~8,600 unnecessary KV reads/month when nothing is queued.
   let fountain_pending_count = 0;
   let seals_total = 0;
   let seals_attested_total = 0;
@@ -205,30 +208,37 @@ export async function GET(req: NextRequest) {
   let seals_quarantined_total = 0;
   let quarantined_needing_reattestation: QuarantinedSealDigest[] = [];
 
-  const SENTINEL_NAMES = ['ATLAS', 'ZEUS', 'EVE', 'JADE', 'AUREA'] as const;
+  const vaultIdle =
+    candidate_state === 'none' &&
+    next_candidate_formed === null &&
+    inProgressBalanceStart < VAULT_RESERVE_PARCEL_UNITS;
 
-  try {
-    const [seals, allSeals, attestedCount, auditCount] = await Promise.all([
-      listSeals(200),
-      listAllSeals(200),
-      countSeals(),
-      countAllSeals(),
-    ]);
-    seals_total = seals.length;
-    seals_attested_total = attestedCount;
-    seals_audit_total = auditCount;
-    fountain_pending_count = seals.filter(
-      (s: Seal) => s.status === 'attested' && s.fountain_status === 'pending',
-    ).length;
-    const quarantined = allSeals.filter((s: Seal) => s.status === 'quarantined');
-    seals_quarantined_total = quarantined.length;
-    quarantined_needing_reattestation = quarantined.map((s: Seal) => ({
-      seal_id: s.seal_id,
-      sequence: s.sequence,
-      missing_agents: SENTINEL_NAMES.filter((a) => !s.attestations[a]),
-    }));
-  } catch (e) {
-    errors.push(`seals list: ${e instanceof Error ? e.message : String(e)}`);
+  if (!vaultIdle) {
+    const SENTINEL_NAMES = ['ATLAS', 'ZEUS', 'EVE', 'JADE', 'AUREA'] as const;
+
+    try {
+      const [seals, allSeals, attestedCount, auditCount] = await Promise.all([
+        listSeals(200),
+        listAllSeals(200),
+        countSeals(),
+        countAllSeals(),
+      ]);
+      seals_total = seals.length;
+      seals_attested_total = attestedCount;
+      seals_audit_total = auditCount;
+      fountain_pending_count = seals.filter(
+        (s: Seal) => s.status === 'attested' && s.fountain_status === 'pending',
+      ).length;
+      const quarantined = allSeals.filter((s: Seal) => s.status === 'quarantined');
+      seals_quarantined_total = quarantined.length;
+      quarantined_needing_reattestation = quarantined.map((s: Seal) => ({
+        seal_id: s.seal_id,
+        sequence: s.sequence,
+        missing_agents: SENTINEL_NAMES.filter((a) => !s.attestations[a]),
+      }));
+    } catch (e) {
+      errors.push(`seals list: ${e instanceof Error ? e.message : String(e)}`);
+    }
   }
 
   const report: Report = {

--- a/app/api/epicon/feed/route.ts
+++ b/app/api/epicon/feed/route.ts
@@ -333,6 +333,15 @@ function describeLedgerHost(url: string): string {
 }
 
 const LEDGER_CIRCUIT_TTL_SEC = 300;
+// KV cache key and TTL for Render ledger entries.
+// Prevents concurrent cache-miss requests from all hitting the Render cold-start simultaneously.
+const RENDER_LEDGER_CACHE_KEY = 'epicon:render-ledger-cache';
+const RENDER_LEDGER_CACHE_TTL_SEC = 60;
+
+type RenderLedgerCache = {
+  entries: EpiconEntry[];
+  cachedAt: string;
+};
 
 async function fetchRenderLedgerEntries(limit = 100): Promise<LedgerFetchResult> {
   const renderLedgerUrl = normalizeLedgerBaseUrl(
@@ -354,6 +363,16 @@ async function fetchRenderLedgerEntries(limit = 100): Promise<LedgerFetchResult>
       error: 'ledger_circuit_open',
       statusCode: 503,
     };
+  }
+
+  // Serve from KV cache when fresh — avoids 3+ concurrent requests all waking Render from cold start.
+  const cached = await kvGet<RenderLedgerCache>(RENDER_LEDGER_CACHE_KEY);
+  if (cached && Array.isArray(cached.entries) && cached.entries.length > 0) {
+    const ageMs = Date.now() - new Date(cached.cachedAt).getTime();
+    if (ageMs < RENDER_LEDGER_CACHE_TTL_SEC * 1000) {
+      console.info(`[ledger-api] serving KV cache age=${Math.round(ageMs / 1000)}s entries=${cached.entries.length}`);
+      return { entries: cached.entries, degraded: false };
+    }
   }
 
   try {
@@ -402,6 +421,10 @@ async function fetchRenderLedgerEntries(limit = 100): Promise<LedgerFetchResult>
             ? payload.entries
             : [];
     const entries = rows.map((row) => normalizeLedgerEntry(row)).filter((row): row is EpiconEntry => row !== null);
+    // Populate KV cache so subsequent requests within the TTL window skip the Render round-trip.
+    if (entries.length > 0) {
+      kvSet<RenderLedgerCache>(RENDER_LEDGER_CACHE_KEY, { entries, cachedAt: new Date().toISOString() }, RENDER_LEDGER_CACHE_TTL_SEC).catch(() => {});
+    }
     return { entries, degraded: false, statusCode: response.status };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown_fetch_error';


### PR DESCRIPTION
Two targeted fixes from the C-295 log analysis:

1. epicon/feed: add 60s KV cache for Render ledger entries. When the edge cache misses, multiple concurrent requests were all hitting civic-protocol-core-ledger.onrender.com simultaneously, each waiting 3-8s for the Render free-tier cold start. Now the first request populates KV; all requests within the 60s window read from cache without touching Render. Cache key: epicon:render-ledger-cache. The circuit breaker and health check are still evaluated first.

2. vault-attestation cron: skip the 4x KV seal-list reads (listSeals, listAllSeals, countSeals, countAllSeals) when the vault is idle — no candidate in flight, no new candidate formed, and balance below the formation threshold. This cron runs every 2 minutes; when idle it was doing ~8,600 unnecessary KV reads/month. Seal counts are still fetched on every active run.

https://claude.ai/code/session_015Y7CuoMFt6vhX6cN9QLdnd

# Mobius Terminal PR — C-[CYCLE]

> Replace all `[PLACEHOLDERS]` before submitting. Incomplete PRs will not be merged.

---

## 1. Summary

- **Cycle:** C-
- **Type:** `fix` | `feat` | `chore` | `docs`
- **Primary area:** `journal` | `epicon` | `signals` | `echo` | `ledger` | `agents` | `ui` | `infra` | `docs`
- **Files changed:** (list every file modified)
- **Files deliberately NOT changed:** (list files in the same area you intentionally left alone)

**What changed?**
(One paragraph. Concrete. What the code does now that it didn't before.)

**Why?**
(Reference to CURRENT_CYCLE.md section, snapshot lane state, or specific broken behavior with evidence.)

---

## 2. Risk Tier

- [ ] **Tier 0** — Docs / comments / formatting only
- [ ] **Tier 1** — App logic, no auth/KV schema changes
- [ ] **Tier 2** — KV key schema, journal schema, EPICON shape, signal domain assignment
- [ ] **Tier 3** — MIC economy, identity, ledger integrity math, auth

> Tier 2+ requires operator review before merge. Do not self-merge Tier 2+.

---

## 3. EPICON Intent

```text
epicon_id: EPICON_C-[CYCLE]_[area]_[short-description]
scope: [area]
mode: normal
issued_at: [ISO timestamp]

justification:
  PROBLEM:
    [What is broken or missing? Be specific. Include snapshot lane state or error text.]

  CONTEXT:
    [Why does this matter now? Reference CURRENT_CYCLE.md if relevant.]

  DECISION:
    [What exactly is being changed and why this approach over alternatives.]

  BOUNDARIES:
    [What this PR does NOT touch. Be explicit about locked behaviors preserved.]

  TRADEOFFS:
    - Removed: [anything deleted or disabled]
    - Kept: [locked behaviors confirmed preserved]
    - Risk: [what could go wrong]

  COUNTERFACTUALS:
    - If [condition], then [corrective action]
    - If [condition], then [corrective action]
```

---

## 4. LOCKED BEHAVIOR AUDIT

I have read `CURRENT_CYCLE.md` and confirm the following:

**Journal KV key schema (`journal:{AGENT}:{CYCLE}`)**
- [ ] This PR does NOT change the key schema in `app/api/agents/journal/route.ts`
- [ ] OR: I am modifying this because: ___

**ECHO → `epicon:feed` LPUSH**
- [ ] This PR does NOT remove or bypass the LPUSH/LTRIM in `app/api/echo/ingest/route.ts`
- [ ] OR: I am modifying this because: ___

**Substrate GitHub auth header**
- [ ] This PR does NOT remove the `Authorization` header from `lib/substrate/github-reader.ts`
- [ ] OR: I am modifying this because: ___

**Signal domain ownership**
- [ ] This PR does NOT add crypto price sources to HERMES-µ
- [ ] This PR does NOT reassign domain ownership between agents
- [ ] OR: I am modifying this because: ___

**EXPECTED EMPTY states**
- [ ] This PR does NOT attempt to "fix" `sources.kv: 0` on epicon or journal
- [ ] This PR does NOT add seed/genesis data to mask empty KV state
- [ ] OR: I am modifying this because: ___

---

## 5. Integrity Impact

**What could go wrong if this PR is wrong?**

### Assessment
- **Estimated MII for this PR:** (0.00–1.00)
- **Risk level:** Low | Medium | High
- **Lanes affected:** (list terminal snapshot lanes this could impact)

### Checklist
- [ ] Does not change KV key schemas without operator approval
- [ ] Does not remove auth from any route
- [ ] Does not introduce duplicate signal sources across agents
- [ ] Does not add hardcoded cycle IDs, timestamps, or seed data
- [ ] pnpm build passes (or explain why it couldn't be run)

---

## 6. Verification

**Pre-merge:**
- [ ] `pnpm exec tsc --noEmit` — typecheck passes
- [ ] `pnpm build` — build passes (or document environment failure reason)
- [ ] Hit `/api/terminal/snapshot` on preview deployment
- [ ] Confirm affected lanes show expected state in snapshot

**Post-merge (operator to verify):**
- [ ] `/api/terminal/snapshot` checked on production
- [ ] No regressions in previously healthy lanes
- [ ] Snapshot `ok` field and lane states match expected outcome

**Evidence:**
(Paste relevant snapshot lane output or API response here)

---

## 7. Rollback Plan

```bash
git revert [commit-sha]
# If KV writes were involved, manually clean affected keys in Upstash console
# Verify /api/terminal/snapshot returns to pre-PR state
```

---

## 8. Stop Conditions Met

This PR was reviewed against the following stop conditions before submission:

- [ ] No stop condition triggered — scope is clean
- [ ] Stop condition triggered: ___ — resolved by: ___

> Stop conditions: touching a LOCKED file, "fixing" an EXPECTED EMPTY state,
> creating duplicate signal sources, changing KV key schema without Tier 2 review.

---

## 9. Final Checklist

- [ ] Risk tier correctly assessed
- [ ] EPICON intent block completed with BOUNDARIES field
- [ ] Locked behavior audit completed (all boxes checked or exceptions documented)
- [ ] Rollback plan provided
- [ ] I have read AGENTS.md, BUILD.md, and CURRENT_CYCLE.md before starting this PR
- [ ] I am okay with this appearing in the public cathedral

---

*"Let me update my consensus." — Mobius constitutional phrase for acknowledging new ground truth.*
