### PR TITLE
Optimize journal pruning & add window_hours filtering

### DIFF
--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -416,8 +416,9 @@ export async function GET(request: NextRequest) {
   const limitRaw = Number(searchParams.get('limit') ?? '20');
   const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(Math.floor(limitRaw), MAX_READ) : 20;
   const windowHoursRaw = Number(searchParams.get('window_hours') ?? String(WINDOW_HOURS_DEFAULT));
-  const windowHours = Number.isFinite(windowHoursRaw) && windowHoursRaw > 0
-    ? Math.min(Math.floor(windowHoursRaw), WINDOW_HOURS_MAX)
+  const windowHoursFloored = Math.floor(windowHoursRaw);
+  const windowHours = Number.isFinite(windowHoursRaw) && windowHoursFloored >= 1
+    ? Math.min(windowHoursFloored, WINDOW_HOURS_MAX)
     : WINDOW_HOURS_DEFAULT;
   const windowCutoff = Date.now() - windowHours * 60 * 60 * 1000;
 

--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -52,7 +52,9 @@ type AgentJournalCreateInput = Omit<AgentJournalEntry, 'id' | 'timestamp' | 'sta
   summary?: string;
 };
 
-const MAX_READ = 100;
+const MAX_READ = 250;
+const WINDOW_HOURS_DEFAULT = 48;
+const WINDOW_HOURS_MAX = 72; // aligned with the hot-store rolling window
 const KV_JOURNAL_PER_AGENT_CAP = 50;
 const KV_JOURNAL_FAIR_MERGE_MAX = 600;
 const KV_JOURNAL_LIST_READ_MAX = 200;
@@ -413,6 +415,11 @@ export async function GET(request: NextRequest) {
   const cycleFilter = asString(searchParams.get('cycle'));
   const limitRaw = Number(searchParams.get('limit') ?? '20');
   const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(Math.floor(limitRaw), MAX_READ) : 20;
+  const windowHoursRaw = Number(searchParams.get('window_hours') ?? String(WINDOW_HOURS_DEFAULT));
+  const windowHours = Number.isFinite(windowHoursRaw) && windowHoursRaw > 0
+    ? Math.min(Math.floor(windowHoursRaw), WINDOW_HOURS_MAX)
+    : WINDOW_HOURS_DEFAULT;
+  const windowCutoff = Date.now() - windowHours * 60 * 60 * 1000;
 
   const shouldReadKv = mode === 'hot' || mode === 'merged';
   const shouldReadSubstrate = mode === 'canon' || mode === 'merged';
@@ -448,6 +455,7 @@ export async function GET(request: NextRequest) {
   const filtered = merged
     .filter((entry) => (agentFilters.length > 0 ? agentFilterSet.has(entry.agentOrigin.toUpperCase()) : true))
     .filter((entry) => (cycleFilter ? entry.cycle === cycleFilter : true))
+    .filter((entry) => new Date(entry.timestamp).getTime() >= windowCutoff)
     .slice(0, limit);
 
   const agents = Array.from(new Set(filtered.map((entry) => entry.agent)));
@@ -467,6 +475,7 @@ export async function GET(request: NextRequest) {
       entries: filtered,
       agents,
       timestamp: new Date().toISOString(),
+      window_hours: windowHours,
       sources: {
         kv: kvForSources.length,
         substrate: substrateEntries.length,

--- a/app/api/chambers/journal/route.ts
+++ b/app/api/chambers/journal/route.ts
@@ -30,7 +30,9 @@ type JournalChamberPayload = {
   [key: string]: unknown;
 };
 
-const MAX_READ = 100;
+const MAX_READ = 250;
+const WINDOW_HOURS_DEFAULT = 48;
+const WINDOW_HOURS_MAX = 72;
 
 const DVA_TIER_AGENTS: Record<Exclude<DvaTier, 'ALL'>, string[]> = {
   t1: ['ECHO'],
@@ -112,6 +114,12 @@ async function respondWithSavepoint(payload: JournalChamberPayload, scope: Recor
   });
 }
 
+function clampWindowHours(input: string | null): number {
+  const parsed = Number(input ?? String(WINDOW_HOURS_DEFAULT));
+  if (!Number.isFinite(parsed) || parsed <= 0) return WINDOW_HOURS_DEFAULT;
+  return Math.min(WINDOW_HOURS_MAX, Math.max(1, Math.floor(parsed)));
+}
+
 export async function GET(request: NextRequest) {
   const mode = request.nextUrl.searchParams.get('mode') ?? 'merged';
   const limit = clampLimit(request.nextUrl.searchParams.get('limit'));
@@ -119,7 +127,8 @@ export async function GET(request: NextRequest) {
   const requestedScope = resolveRequestedAgents(request, tier);
   const requestedAgents = requestedScope.agents;
   const cycle = request.nextUrl.searchParams.get('cycle');
-  const savepointScope = { mode, limit, tier, agents: requestedAgents.join(','), cycle: cycle ?? '' };
+  const windowHours = clampWindowHours(request.nextUrl.searchParams.get('window_hours'));
+  const savepointScope = { mode, limit, tier, agents: requestedAgents.join(','), cycle: cycle ?? '', windowHours };
 
   if (requestedScope.conflictingExplicitScope) {
     return respondWithSavepoint(
@@ -129,7 +138,7 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const q = new URLSearchParams({ mode, limit: String(limit) });
+  const q = new URLSearchParams({ mode, limit: String(limit), window_hours: String(windowHours) });
   for (const agent of requestedAgents) q.append('agent', agent);
   if (cycle) q.set('cycle', cycle);
 

--- a/app/api/epicon/feed/route.ts
+++ b/app/api/epicon/feed/route.ts
@@ -336,7 +336,8 @@ const LEDGER_CIRCUIT_TTL_SEC = 300;
 // KV cache key and TTL for Render ledger entries.
 // Prevents concurrent cache-miss requests from all hitting the Render cold-start simultaneously.
 const RENDER_LEDGER_CACHE_KEY = 'epicon:render-ledger-cache';
-const RENDER_LEDGER_CACHE_TTL_SEC = 60;
+// 90s > 60s polling interval so the cache is always warm on arrival
+const RENDER_LEDGER_CACHE_TTL_SEC = 90;
 
 type RenderLedgerCache = {
   entries: EpiconEntry[];

--- a/app/api/terminal/shell/route.ts
+++ b/app/api/terminal/shell/route.ts
@@ -41,6 +41,12 @@ export async function GET() {
       },
       source: micRaw.source === 'none' ? 'fallback' : 'live',
       timestamp,
+    }, {
+      headers: {
+        // Allow Vercel edge to serve a single computed response to concurrent tab polls.
+        // GI/tripwire state changes on cron cadence (~60s), so 20s is safely fresh.
+        'Cache-Control': 'public, s-maxage=20, stale-while-revalidate=40',
+      },
     });
   } catch {
     return NextResponse.json({

--- a/hooks/useJournalChamber.ts
+++ b/hooks/useJournalChamber.ts
@@ -126,19 +126,20 @@ function entryBelongsToTier(entry: unknown, tierAgents: Set<string>): boolean {
   return agent.length > 0 && tierAgents.has(agent);
 }
 
-export function useJournalChamber(enabled: boolean, mode: 'hot' | 'canon' | 'merged', limit = 100, tier: DvaTier = 'ALL') {
+export function useJournalChamber(enabled: boolean, mode: 'hot' | 'canon' | 'merged', limit = 250, tier: DvaTier = 'ALL', windowHours = 48) {
   const { snapshot } = useTerminalSnapshot();
   const { digest } = useEchoDigest(enabled);
   const stabilizationActive = digest?.predictive.risk_level === 'elevated' || digest?.predictive.risk_level === 'critical';
-  const safeLimit = Math.max(1, Math.min(100, Math.floor(limit)));
+  const safeLimit = Math.max(1, Math.min(250, Math.floor(limit)));
+  const safeWindowHours = Math.max(1, Math.min(72, Math.floor(windowHours)));
   const tierAgentsList = useMemo(() => resolveTierAgents(tier), [tier]);
   const getSavepointCount = useCallback((payload: JournalChamberPayload) => Array.isArray(payload.entries) ? payload.entries.length : 0, []);
   const url = useMemo(() => {
-    const params = new URLSearchParams({ mode, limit: String(safeLimit) });
+    const params = new URLSearchParams({ mode, limit: String(safeLimit), window_hours: String(safeWindowHours) });
     params.set('tier', tier);
     for (const agent of tierAgentsList) params.append('agent', agent);
     return `/api/chambers/journal?${params.toString()}`;
-  }, [mode, safeLimit, tier, tierAgentsList]);
+  }, [mode, safeLimit, safeWindowHours, tier, tierAgentsList]);
 
   const preview = useMemo(() => {
     const summary = snapshot?.journal_summary;
@@ -181,7 +182,7 @@ export function useJournalChamber(enabled: boolean, mode: 'hot' | 'canon' | 'mer
     previewData: preview,
     lockToPreview: stabilizationActive,
     pollMs: 90_000,
-    savepointKey: `journal:${mode}:${tier}:${safeLimit}:${tierAgentsList.join(',')}`,
+    savepointKey: `journal:${mode}:${tier}:${safeLimit}:${safeWindowHours}h:${tierAgentsList.join(',')}`,
     getSavepointCount,
   });
 }

--- a/lib/agents/journalLane.ts
+++ b/lib/agents/journalLane.ts
@@ -75,40 +75,35 @@ async function pruneStaleEntries(redis: Redis, key: string): Promise<number> {
   const len = await redis.llen(key);
   if (len < SOFT_CAP) return 0;
 
-  console.warn(`[journalLane] soft-cap reached on ${key}: ${len}/${MAX_LIST_ENTRIES} entries. Running time-based prune.`);
+  const label = len >= MAX_LIST_ENTRIES ? 'hard-cap' : 'soft-cap';
+  console.warn(`[journalLane] ${label} reached on ${key}: ${len}/${MAX_LIST_ENTRIES} entries. Running time-based prune.`);
+
+  // Fetch all entries in one round-trip, scan from the tail to count stale ones,
+  // then trim with a single LTRIM — O(2) Redis ops instead of O(3n).
+  const all = await redis.lrange(key, 0, -1);
+  if (all.length === 0) return 0;
 
   const cutoff = Date.now() - ROLLING_WINDOW_MS;
-  let pruned = 0;
-
-  // Atomically pop stale entries from the tail (oldest end) one at a time.
-  // RPOP is a single Redis command and therefore atomic — concurrent LPUSH writes
-  // at the head are never affected. We stop as soon as the tail is within the
-  // rolling window or the list drops below SOFT_CAP.
-  while (true) {
-    const currentLen = await redis.llen(key);
-    if (currentLen < SOFT_CAP) break;
-
-    const tail = await redis.lindex(key, -1);
-    if (tail === null || tail === undefined) break;
-
+  let staleCount = 0;
+  for (let i = all.length - 1; i >= 0; i--) {
     try {
-      const parsed = typeof tail === 'string'
-        ? (JSON.parse(tail) as { timestamp?: string })
-        : (tail as { timestamp?: string });
+      const parsed = typeof all[i] === 'string'
+        ? (JSON.parse(all[i] as string) as { timestamp?: string })
+        : (all[i] as { timestamp?: string });
       const ts = parsed?.timestamp ? new Date(parsed.timestamp).getTime() : 0;
-      if (ts > cutoff) break; // Oldest entry is within the window — stop pruning
-      await redis.rpop(key);
-      pruned += 1;
+      if (ts > cutoff) break; // reached a fresh entry — everything newer is clean
+      staleCount += 1;
     } catch {
-      break; // Unparseable tail — leave it, let the hard ltrim decide its fate
+      break; // unparseable tail — leave it for hard ltrim
     }
   }
 
-  if (pruned > 0) {
-    console.warn(`[journalLane] pruned ${pruned} stale entries from ${key}`);
-  }
+  if (staleCount === 0) return 0;
 
-  return pruned;
+  // Keep head .. (len - staleCount - 1), drop stale tail entries atomically.
+  await redis.ltrim(key, 0, all.length - staleCount - 1);
+  console.warn(`[journalLane] pruned ${staleCount} stale entries from ${key}`);
+  return staleCount;
 }
 
 function toSubstrateJournalInput(entry: AgentJournalLaneEntry, giAtTime?: number): SubstrateJournalWriteInput {
@@ -177,8 +172,7 @@ export async function appendJournalLaneEntry(
   const agentKey = `journal:${agent.toLowerCase()}`;
 
   // Time-based rolling prune before hard count trim — prevents silent data loss
-  await pruneStaleEntries(redis, KEY_ALL);
-  await pruneStaleEntries(redis, agentKey);
+  await Promise.all([pruneStaleEntries(redis, KEY_ALL), pruneStaleEntries(redis, agentKey)]);
 
   await redis.lpush(KEY_ALL, packed);
   await redis.ltrim(KEY_ALL, 0, MAX_LIST_ENTRIES - 1);

--- a/lib/agents/journalLane.ts
+++ b/lib/agents/journalLane.ts
@@ -100,8 +100,13 @@ async function pruneStaleEntries(redis: Redis, key: string): Promise<number> {
 
   if (staleCount === 0) return 0;
 
-  // Keep head .. (len - staleCount - 1), drop stale tail entries atomically.
-  await redis.ltrim(key, 0, all.length - staleCount - 1);
+  if (staleCount === all.length) {
+    // Every entry is stale — DEL is required because ltrim(key, 0, -1) is a no-op.
+    await redis.del(key);
+  } else {
+    // Keep head .. (all.length - staleCount - 1), drop stale tail entries atomically.
+    await redis.ltrim(key, 0, all.length - staleCount - 1);
+  }
   console.warn(`[journalLane] pruned ${staleCount} stale entries from ${key}`);
   return staleCount;
 }


### PR DESCRIPTION
# Mobius Terminal PR — C-[CYCLE]

## 1. Summary

- **Cycle:** C-[CYCLE]
- **Type:** `feat`
- **Primary area:** `journal`
- **Files changed:** 
  - `lib/agents/journalLane.ts`
  - `app/api/chambers/journal/route.ts`
  - `app/api/agents/journal/route.ts`
  - `hooks/useJournalChamber.ts`
  - `app/api/terminal/shell/route.ts`
  - `app/api/epicon/feed/route.ts`
- **Files deliberately NOT changed:** 
  - `app/api/echo/ingest/route.ts` (LPUSH/LTRIM preserved)
  - `lib/substrate/github-reader.ts` (auth header preserved)

**What changed?**

Journal pruning now uses a single `LRANGE` + `LTRIM` instead of looping `RPOP` calls, reducing Redis round-trips from O(3n) to O(2). Added optional `window_hours` query parameter (default 48h, max 72h) to both `/api/agents/journal` and `/api/chambers/journal` endpoints, allowing clients to filter entries by recency. Increased `MAX_READ` from 100 to 250 entries. Updated `useJournalChamber` hook to accept and propagate `windowHours` parameter. Added cache headers to `/api/terminal/shell` (20s max-age) and increased RENDER_LEDGER_CACHE_TTL from 60s to 90s to align with polling intervals.

**Why?**

Pruning optimization reduces latency and Redis load during high-volume journal writes. Window-based filtering enables clients to request time-scoped journal views without fetching entire history, improving API responsiveness and reducing payload size. Cache headers prevent thundering herd on edge during concurrent tab polls. Higher read limits accommodate larger journal queries without additional round-trips.

---

## 2. Risk Tier

- [ ] **Tier 0** — Docs / comments / formatting only
- [x] **Tier 1** — App logic, no auth/KV schema changes
- [ ] **Tier 2** — KV key schema, journal schema, EPICON shape, signal domain assignment
- [ ] **Tier 3** — MIC economy, identity, ledger integrity math, auth

---

## 3. EPICON Intent

```text
epicon_id: EPICON_C-[CYCLE]_journal_prune-optimize-window-filter
scope: journal
mode: normal
issued_at: [ISO timestamp]

justification:
  PROBLEM:
    Journal pruning uses a loop of RPOP calls (O(3n) Redis ops) when list exceeds 
    soft-cap. High-volume agents trigger this frequently, causing latency spikes.
    No time-window filtering on journal reads — clients must fetch full history.

  CONTEXT:
    Pruning runs before every LPUSH in appendJournalLaneEntry. With concurrent 
    writes, this becomes a bottleneck. Clients need ability to request recent 
    entries only (e.g., last 48h) without full scan.

  DECISION:
    - Fetch all entries once with LRANGE, scan tail to count stale entries, 
      trim atomically with LTRIM (2 ops vs 3n).
    - Add window_hours query param to journal endpoints, default 48h, max 72h.
    - Filter entries client-side after merge, respecting window cutoff.
    - Parallelize pruning calls with Promise.all.
    - Increase MAX_READ to 250 to match higher throughput.

  BOUNDARIES:
    - Does NOT change journal KV key schema (journal:{AGENT})
    - Does NOT remove LPUSH/LTRIM hard cap enforcement
    - Does NOT modify ECHO ingest or Substrate auth
    - Does NOT add seed data or mask empty KV states
    - window_hours is optional; defaults to 48h if omitted

  TRADEOFFS:
    - Removed: O

https://claude.ai/code/session_011enJHCThHzaAh7RXQp1uCu