### PR TITLE
Improve chamber navigation feedback and vault degraded-state messaging

### DIFF
--- a/app/terminal/vault/page.tsx
+++ b/app/terminal/vault/page.tsx
@@ -157,13 +157,22 @@ export default function VaultPage() {
   const [contrib, setContrib] = useState<ContributionsPayload | null>(null);
   const [contribErr, setContribErr] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
   const focusCycle = currentCycleId();
 
   useEffect(() => {
     void fetch('/api/vault/status', { cache: 'no-store' })
-      .then((r) => r.json())
-      .then((j: VaultPayload) => setData(j))
-      .catch(() => setErr('Unable to load vault status'));
+      .then(async (r) => {
+        const j = (await r.json()) as VaultPayload & { error?: string };
+        if (!r.ok || !j.ok) {
+          setErr(j.error ?? `Vault status unavailable (HTTP ${r.status})`);
+          setData(j);
+          return;
+        }
+        setData(j);
+      })
+      .catch(() => setErr('Unable to load vault status'))
+      .finally(() => setLoading(false));
   }, []);
 
   useEffect(() => {
@@ -185,8 +194,9 @@ export default function VaultPage() {
       });
   }, [focusCycle]);
 
+  if (loading) return <div className="p-4 text-sm text-slate-400">Loading vault…</div>;
   if (err) return <div className="p-4 text-sm text-rose-300">{err}</div>;
-  if (!data?.ok) return <div className="p-4 text-sm text-slate-400">Loading vault…</div>;
+  if (!data?.ok) return <div className="p-4 text-sm text-amber-300">Vault status endpoint returned no usable payload. Check /api/vault/status and upstream vault lane health.</div>;
 
   const v1Bal = data.balance_reserve ?? 0;
   const block = data.reserve_block ?? fallbackReserveBlock(data);

--- a/components/terminal/ChamberSwitcher.tsx
+++ b/components/terminal/ChamberSwitcher.tsx
@@ -6,13 +6,13 @@ import { useEffect } from 'react';
 import { cn } from '@/lib/utils';
 
 const CHAMBERS = [
-  { label: 'Globe', mobileLabel: 'Glb', href: '/terminal/globe', icon: '◎', shortcut: 'Alt+1' },
-  { label: 'Pulse', mobileLabel: 'Pls', href: '/terminal/pulse', icon: '∿', shortcut: 'Alt+2' },
-  { label: 'Signals', mobileLabel: 'Sig', href: '/terminal/signals', icon: '⊕', shortcut: 'Alt+3' },
-  { label: 'Sentinel', mobileLabel: 'Snt', href: '/terminal/sentinel', icon: '◉', shortcut: 'Alt+4' },
-  { label: 'Ledger', mobileLabel: 'Ldg', href: '/terminal/ledger', icon: '⛓', shortcut: 'Alt+5' },
-  { label: 'Journal', mobileLabel: 'Jrl', href: '/terminal/journal', icon: '✦', shortcut: 'Alt+6' },
-  { label: 'Vault', mobileLabel: 'Vlt', href: '/terminal/vault', icon: '◇', shortcut: 'Alt+7' },
+  { label: 'Globe', mobileLabel: 'Glb', href: '/terminal/globe', icon: '◎', shortcut: 'Alt/Ctrl/Cmd+1' },
+  { label: 'Pulse', mobileLabel: 'Pls', href: '/terminal/pulse', icon: '∿', shortcut: 'Alt/Ctrl/Cmd+2' },
+  { label: 'Signals', mobileLabel: 'Sig', href: '/terminal/signals', icon: '⊕', shortcut: 'Alt/Ctrl/Cmd+3' },
+  { label: 'Sentinel', mobileLabel: 'Snt', href: '/terminal/sentinel', icon: '◉', shortcut: 'Alt/Ctrl/Cmd+4' },
+  { label: 'Ledger', mobileLabel: 'Ldg', href: '/terminal/ledger', icon: '⛓', shortcut: 'Alt/Ctrl/Cmd+5' },
+  { label: 'Journal', mobileLabel: 'Jrl', href: '/terminal/journal', icon: '✦', shortcut: 'Alt/Ctrl/Cmd+6' },
+  { label: 'Vault', mobileLabel: 'Vlt', href: '/terminal/vault', icon: '◇', shortcut: 'Alt/Ctrl/Cmd+7' },
 ] as const;
 
 const KEY_TO_ROUTE: Record<string, string> = {
@@ -31,7 +31,7 @@ export default function ChamberSwitcher() {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (!event.altKey) return;
+      if (!event.altKey && !event.ctrlKey && !event.metaKey) return;
       const target = event.target as HTMLElement | null;
       const tag = target?.tagName?.toLowerCase();
       if (tag === 'input' || tag === 'textarea' || target?.isContentEditable) return;
@@ -55,6 +55,7 @@ export default function ChamberSwitcher() {
             key={tab.href}
             href={tab.href}
             title={tab.shortcut}
+            aria-current={active ? 'page' : undefined}
             className={cn(
               'whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-mono uppercase tracking-[0.12em] transition-all duration-150 md:rounded md:px-2.5 md:py-1 md:text-[11px] md:tracking-wide',
               active

--- a/components/terminal/TerminalShell.tsx
+++ b/components/terminal/TerminalShell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Suspense, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
 import ChamberSwitcher from '@/components/terminal/ChamberSwitcher';
 import OnboardingOverlay from '@/components/terminal/OnboardingOverlay';
 import ShellBridgeBanner from '@/components/terminal/ShellBridgeBanner';
@@ -14,6 +15,19 @@ import type { SnapshotLaneState } from '@/lib/terminal/snapshotLanes';
 
 const SHELL_URL = 'https://mobius-browser-shell.vercel.app';
 
+function pathnameToLabel(pathname: string): string | null {
+  if (pathname.startsWith('/terminal/globe')) return 'Globe';
+  if (pathname.startsWith('/terminal/pulse')) return 'Pulse';
+  if (pathname.startsWith('/terminal/signals')) return 'Signals';
+  if (pathname.startsWith('/terminal/sentinel')) return 'Sentinel';
+  if (pathname.startsWith('/terminal/ledger')) return 'Ledger';
+  if (pathname.startsWith('/terminal/journal')) return 'Journal';
+  if (pathname.startsWith('/terminal/vault')) return 'Vault';
+  if (pathname.startsWith('/terminal/canon')) return 'Vault Canon';
+  if (pathname.startsWith('/terminal/replay')) return 'Vault Replay';
+  return null;
+}
+
 function runtimeBadgeClass(runtime: 'online' | 'degraded' | 'offline') {
   if (runtime === 'online') return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200';
   if (runtime === 'degraded') return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
@@ -21,6 +35,7 @@ function runtimeBadgeClass(runtime: 'online' | 'degraded' | 'offline') {
 }
 
 export default function TerminalShell({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
   const [clock, setClock] = useState('—');
   const [showLaneDiagnostics, setShowLaneDiagnostics] = useState(false);
   const [showDataflowCommand, setShowDataflowCommand] = useState(true);
@@ -76,6 +91,13 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
       } as unknown as SnapshotLaneState;
     });
   }, [laneDiagnostics.data]);
+
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const active = pathnameToLabel(pathname);
+    document.title = active ? `Mobius Terminal · ${active}` : 'Mobius Terminal';
+  }, [pathname]);
 
   useEffect(() => {
     const stored = localStorage.getItem('mobius_console_collapsed');


### PR DESCRIPTION
### Motivation
- Improve operator truth and ergonomics by making chamber switching keyboard-friendly and accessible, exposing the active chamber in the browser tab, and avoiding indefinite "Loading vault…" when the Vault API returns unusable payloads.
- Surface explicit degraded-state information for the Vault so operators can diagnose upstream lane problems without guessing.

### Description
- Expanded chamber keyboard navigation to accept Alt/Ctrl/Cmd + number and updated the visible shortcut hints, and added `aria-current="page"` to active chamber links in the ChamberSwitcher component (`components/terminal/ChamberSwitcher.tsx`).
- Added `pathnameToLabel` and `usePathname` usage in the TerminalShell to update `document.title` with the active chamber label so the browser tab reflects the operator context (`components/terminal/TerminalShell.tsx`).
- Hardened Vault loading logic by introducing a `loading` state, validating both `response.ok` and `payload.ok`, surfacing an explicit operator-facing error when the payload is unusable, and avoiding a permanent loading state (`app/terminal/vault/page.tsx`).
- Files changed: `components/terminal/ChamberSwitcher.tsx`, `components/terminal/TerminalShell.tsx`, `app/terminal/vault/page.tsx`.

### Testing
- Ran `pnpm exec tsc --noEmit` and the typecheck completed successfully.
- Ran `pnpm build` and the Next.js production build completed successfully and produced prerendered/dynamic routes.
- Ran `pnpm lint` which exited non-zero because the repo's `next lint` prompts for interactive ESLint configuration in this environment (interactive prompt), so lint did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f38fc826488325962ef917558d4374)