### PR TITLE
fix(epicon): restore promotion flow with cycle-scoped dedup TTL and add journal trim telemetry

### DIFF
--- a/app/api/admin/epicon-dedup-reset/route.ts
+++ b/app/api/admin/epicon-dedup-reset/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { kvDel } from '@/lib/kv/store';
+
+export const dynamic = 'force-dynamic';
+
+function getAuthToken(request: NextRequest): string {
+  const auth = request.headers.get('authorization') ?? '';
+  if (auth.startsWith('Bearer ')) return auth.slice('Bearer '.length).trim();
+  return '';
+}
+
+export async function POST(request: NextRequest) {
+  const serviceToken = process.env.AGENT_SERVICE_TOKEN?.trim() ?? '';
+  const token = getAuthToken(request);
+
+  if (!serviceToken || token !== serviceToken) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = (await request.json().catch(() => ({}))) as { cycleId?: string };
+  const cycleId = typeof body.cycleId === 'string' && body.cycleId.trim() ? body.cycleId.trim() : null;
+
+  const keys = [
+    cycleId ? `epicon:promotion:dedup:${cycleId}` : null,
+    cycleId ? `epicon:promotion:stall:${cycleId}` : null,
+  ].filter((key): key is string => Boolean(key));
+
+  const results: Record<string, 'deleted' | 'error'> = {};
+  for (const key of keys) {
+    try {
+      await kvDel(key);
+      results[key] = 'deleted';
+    } catch {
+      results[key] = 'error';
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    cycleId,
+    results,
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -458,6 +458,14 @@ export async function GET(request: NextRequest) {
   const subMax = maxTs(substrateEntries);
   const archiveStale =
     substrateEntries.length > 0 && kvMax > 0 && subMax > 0 && kvMax - subMax > 60 * 60 * 1000;
+  const journalListCapRaw = Number(process.env.JOURNAL_LIVE_LIST_MAX ?? 1200);
+  const journalListCap = Number.isFinite(journalListCapRaw) ? Math.max(200, Math.min(Math.floor(journalListCapRaw), 10_000)) : 1200;
+  const [trimCount, trimLastAt] = redis
+    ? await Promise.all([
+        redis.get<number>('journal:all:trim_count').catch(() => 0),
+        redis.get<string>('journal:all:trim_last_at').catch(() => null),
+      ])
+    : [0, null];
 
   return NextResponse.json(
     {
@@ -478,6 +486,11 @@ export async function GET(request: NextRequest) {
       archive_stale: archiveStale,
       hot_authoritative: mode === 'hot' || mode === 'merged',
       archive_enriching: mode === 'merged' && (substrateEntries.length > 0 || Boolean(substrateError)),
+      journal_window: {
+        list_cap: journalListCap,
+        trim_count: typeof trimCount === 'number' ? trimCount : 0,
+        trim_last_at: typeof trimLastAt === 'string' ? trimLastAt : null,
+      },
     },
     {
       headers: {

--- a/app/api/epicon/promote/route.ts
+++ b/app/api/epicon/promote/route.ts
@@ -11,6 +11,7 @@ import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { defaultPromotionState, getPromotionState, savePromotionState } from '@/lib/epicon/promotion';
 import { appendJournalLaneEntry, getJournalRedisClient } from '@/lib/agents/journalLane';
 import { getAgentBearerToken, writeToSubstrate } from '@/lib/substrate/client';
+import { kvDel, kvGet, kvSet } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
 
@@ -29,7 +30,20 @@ type PromotionTrace = {
   promoter_eligible_count: number;
   promoter_excluded_reasons: Record<ExclusionReason, number>;
   promoted_ids_this_cycle: string[];
+  rechecked_ids_this_cycle?: string[];
 };
+
+type PromotionDedupEntry = {
+  promotedAt: string;
+  cycle: string;
+  confidenceTier: number;
+};
+
+type PromotionDedupMap = Record<string, PromotionDedupEntry>;
+
+const CYCLE_DEDUP_TTL_SECONDS = 60 * 60 * 72;
+const RECHECK_WINDOW_HOURS = 6;
+const PROMOTION_STALL_THRESHOLD = 3;
 
 const AGENT_ROUTING: Record<EpiconItem['category'], Agent[]> = {
   market: ['HERMES', 'ZEUS', 'AUREA'],
@@ -260,9 +274,10 @@ async function ensureEchoIngested(): Promise<void> {
 }
 
 async function getPromotablePending(
-  state: PromotionState,
   nowIso: string,
+  dedupMap: PromotionDedupMap,
   promotedIdsThisCycle: string[] = [],
+  recheckedIdsThisCycle: string[] = [],
 ): Promise<{ pending: EpiconItem[]; trace: PromotionTrace }> {
   await ensureEchoIngested();
   const fromLedger = await getLedgerPendingEpicon();
@@ -313,6 +328,7 @@ async function getPromotablePending(
     });
   }
   const allCandidates = [...mergedById.values()];
+  const nowMs = new Date(nowIso).getTime();
 
   console.info('[epicon/promote] promoter_input_candidates', {
     count: allCandidates.length,
@@ -332,9 +348,13 @@ async function getPromotablePending(
       excluded.category_not_promotable += 1;
       continue;
     }
-    if (state[item.id]?.promotion_state === 'promoted') {
-      excluded.already_promoted += 1;
-      continue;
+    const dedup = dedupMap[item.id];
+    if (dedup) {
+      const ageHours = (nowMs - new Date(dedup.promotedAt).getTime()) / 3_600_000;
+      if (Number.isFinite(ageHours) && ageHours < RECHECK_WINDOW_HOURS) {
+        excluded.already_promoted += 1;
+        continue;
+      }
     }
     pendingById.set(item.id, item);
   }
@@ -355,19 +375,25 @@ async function getPromotablePending(
       promoter_eligible_count: pending.length,
       promoter_excluded_reasons: excluded,
       promoted_ids_this_cycle: promotedIdsThisCycle,
+      rechecked_ids_this_cycle: recheckedIdsThisCycle,
     },
   };
 }
 
 async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: string, state: PromotionState) {
-  const promotable = await getPromotablePending(state, nowIso);
+  const dedupKey = `epicon:promotion:dedup:${cycleId}`;
+  const stallKey = `epicon:promotion:stall:${cycleId}`;
+  const dedupMap = (await kvGet<PromotionDedupMap>(dedupKey)) ?? {};
+  const promotable = await getPromotablePending(nowIso, dedupMap);
   const pending = promotable.pending.slice(0, maxItems);
   let promoted = 0;
+  let rechecked = 0;
   let committed = 0;
   let failed = 0;
   let failedCommits = 0;
   let seq = 1;
   const promotedIdsThisCycle: string[] = [];
+  const recheckedIdsThisCycle: string[] = [];
 
   const agentToken = getAgentBearerToken();
   const ledgerReady = agentToken.length > 0;
@@ -380,6 +406,11 @@ async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: stri
   for (const epicon of pending) {
     const existing = state[epicon.id] ?? defaultPromotionState(nowIso);
     const assignedAgents = AGENT_ROUTING[epicon.category] ?? ['ZEUS'];
+    const existingDedup = dedupMap[epicon.id];
+    const dedupAgeHours = existingDedup
+      ? (new Date(nowIso).getTime() - new Date(existingDedup.promotedAt).getTime()) / 3_600_000
+      : Number.POSITIVE_INFINITY;
+    const isRecheck = Boolean(existingDedup) && Number.isFinite(dedupAgeHours) && dedupAgeHours >= RECHECK_WINDOW_HOURS;
 
     if (existing.promotion_state === 'promoted' && existing.assigned_agents.length > 0) {
       continue;
@@ -478,8 +509,18 @@ async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: stri
 
       if (anyCommitSucceeded || allAgentsSatisfied) {
         existing.promotion_state = 'promoted';
-        promoted += 1;
-        promotedIdsThisCycle.push(epicon.id);
+        dedupMap[epicon.id] = {
+          promotedAt: nowIso,
+          cycle: cycleId,
+          confidenceTier: epicon.confidenceTier,
+        };
+        if (isRecheck) {
+          rechecked += 1;
+          recheckedIdsThisCycle.push(epicon.id);
+        } else {
+          promoted += 1;
+          promotedIdsThisCycle.push(epicon.id);
+        }
       } else {
         existing.promotion_state = ledgerReady ? 'failed' : 'pending';
         existing.failed_attempts += 1;
@@ -494,16 +535,33 @@ async function runPromotionCycle(maxItems: number, nowIso: string, cycleId: stri
     state[epicon.id] = existing;
   }
 
+  await kvSet(dedupKey, dedupMap, CYCLE_DEDUP_TTL_SECONDS);
+  if (promoted === 0 && rechecked === 0 && pending.length > 0) {
+    const stallCount = ((await kvGet<number>(stallKey)) ?? 0) + 1;
+    await kvSet(stallKey, stallCount, CYCLE_DEDUP_TTL_SECONDS);
+    if (stallCount >= PROMOTION_STALL_THRESHOLD) {
+      console.error('[epicon/promote] PROMOTION_LANE_STALL', {
+        cycleId,
+        stallCount,
+        pending: pending.length,
+        excluded: promotable.trace.promoter_excluded_reasons,
+      });
+    }
+  } else {
+    await kvDel(stallKey);
+  }
+
   await savePromotionState(state);
-  const postRun = await getPromotablePending(state, nowIso, promotedIdsThisCycle);
-  return { pending, promoted, committed, failed, failedCommits, trace: postRun.trace };
+  const postRun = await getPromotablePending(nowIso, dedupMap, promotedIdsThisCycle, recheckedIdsThisCycle);
+  return { pending, promoted, rechecked, committed, failed, failedCommits, trace: postRun.trace };
 }
 
 export async function GET() {
   const nowIso = new Date().toISOString();
   const cycleId = currentCycleId();
   const state = await getPromotionState();
-  const promotable = await getPromotablePending(state, nowIso);
+  const dedupMap = (await kvGet<PromotionDedupMap>(`epicon:promotion:dedup:${cycleId}`)) ?? {};
+  const promotable = await getPromotablePending(nowIso, dedupMap);
   const pending = promotable.pending;
 
   let promotedThisCycle = 0;
@@ -574,6 +632,7 @@ export async function POST(request: NextRequest) {
     cycleId,
     processed: run.pending.length,
     promoted: run.promoted,
+    rechecked: run.rechecked,
     committed: run.committed,
     failed: run.failed,
     failedCommits: run.failedCommits,

--- a/lib/agents/journalLane.ts
+++ b/lib/agents/journalLane.ts
@@ -4,8 +4,9 @@ import { bumpTerminalWatermark } from '@/lib/terminal/watermark';
 import type { SubstrateJournalWriteInput } from '@/lib/substrate/github-journal';
 
 const KEY_ALL = 'journal:all';
-const MAX_LIST_ENTRIES = 200;
+const MAX_LIST_ENTRIES_DEFAULT = 1200;
 const IDEMPOTENCY_TTL_SECONDS = 60 * 60 * 24 * 14;
+const TRIM_EVENT_TTL_SECONDS = 60 * 60 * 24 * 7;
 
 export type AgentJournalLaneEntry = {
   id: string;
@@ -44,6 +45,12 @@ export function getJournalRedisClient(): Redis | null {
   const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
   if (!url || !token) return null;
   return new Redis({ url, token });
+}
+
+function journalListCap(): number {
+  const raw = Number(process.env.JOURNAL_LIVE_LIST_MAX ?? MAX_LIST_ENTRIES_DEFAULT);
+  if (!Number.isFinite(raw)) return MAX_LIST_ENTRIES_DEFAULT;
+  return Math.max(200, Math.min(Math.floor(raw), 10_000));
 }
 
 function normalizeDerivedFrom(derivedFrom: string[]): string[] {
@@ -128,11 +135,35 @@ export async function appendJournalLaneEntry(
 
   const packed = JSON.stringify(entry);
   const agentKey = `journal:${agent.toLowerCase()}`;
+  const maxListEntries = journalListCap();
+
+  const [allLen, agentLen] = await Promise.all([
+    redis.llen(KEY_ALL).catch(() => 0),
+    redis.llen(agentKey).catch(() => 0),
+  ]);
 
   await redis.lpush(KEY_ALL, packed);
-  await redis.ltrim(KEY_ALL, 0, MAX_LIST_ENTRIES - 1);
+  await redis.ltrim(KEY_ALL, 0, maxListEntries - 1);
   await redis.lpush(agentKey, packed);
-  await redis.ltrim(agentKey, 0, MAX_LIST_ENTRIES - 1);
+  await redis.ltrim(agentKey, 0, maxListEntries - 1);
+
+  if (allLen >= maxListEntries) {
+    const trimCountKey = 'journal:all:trim_count';
+    const trimLastAtKey = 'journal:all:trim_last_at';
+    await Promise.all([
+      redis.incr(trimCountKey),
+      redis.set(trimLastAtKey, new Date().toISOString(), { ex: TRIM_EVENT_TTL_SECONDS }),
+    ]);
+  }
+
+  if (agentLen >= maxListEntries) {
+    const trimCountKey = `${agentKey}:trim_count`;
+    const trimLastAtKey = `${agentKey}:trim_last_at`;
+    await Promise.all([
+      redis.incr(trimCountKey),
+      redis.set(trimLastAtKey, new Date().toISOString(), { ex: TRIM_EVENT_TTL_SECONDS }),
+    ]);
+  }
   await bumpTerminalWatermark(redis, 'journal', {
     cycle,
     status: canonEnabled ? 'pending' : 'hot',


### PR DESCRIPTION
### Motivation
- The EPICON promotion lane was completely blocked by an unbounded, global dedup key that never expired, causing live items to be pre-blocked and the feed to freeze.  
- Journal live-list trimming was silent and could drop entries invisibly; operators need explicit telemetry and a configurable cap to avoid hidden data loss.  

### Description
- Introduce cycle-scoped promotion dedup state stored in KV with a 72-hour TTL and structured dedup entries (`promotedAt`, `cycle`, `confidenceTier`) to prevent unbounded monotonic growth.  
- Add a 6-hour recheck window so items promoted >6h ago can re-enter as `rechecked` (confirmation) instead of being permanently hard-blocked.  
- Add stall detection: a per-cycle stall counter increments on consecutive zero-promotion runs and surfaces an error log when threshold exceeded.  
- Persist dedup map on each run and expose `rechecked` counts and `rechecked_ids_this_cycle` in promotion diagnostics and POST responses.  
- Add a secured one-time admin endpoint `POST /api/admin/epicon-dedup-reset` (Authorization: `Bearer $AGENT_SERVICE_TOKEN`) to clear cycle-specific dedup/stall keys after deploy.  
- Harden journal lane writes by making the live-list cap configurable via `JOURNAL_LIVE_LIST_MAX` (default 1200), trimming to that cap on push, and recording trim telemetry (`journal:all:trim_count`, `journal:all:trim_last_at`) and per-agent trim keys.  
- Surface journal window telemetry on the journal read endpoint (`/api/agents/journal`) under `journal_window` so operators can see list cap, trim count, and last trim timestamp.  
- Files changed: `app/api/epicon/promote/route.ts`, `app/api/admin/epicon-dedup-reset/route.ts` (new), `lib/agents/journalLane.ts`, `app/api/agents/journal/route.ts`.

### Testing
- Commands run: `pnpm exec tsc --noEmit` (typecheck), `pnpm build` (Next build), `pnpm lint` (lint).  
- Results: `pnpm exec tsc --noEmit` — pass.  
- Results: `pnpm build` — pass (production build and route generation succeeded).  
- Results: `pnpm lint` — not fully runnable here because `next lint` prompts interactively to configure ESLint in this environment (reported as interactive prompt); treat as not run/non-blocking for CI where ESLint is preconfigured.  
- Commit: changes committed and PR draft created; follow-up operational step: deploy and call `POST /api/admin/epicon-dedup-reset` with `Authorization: Bearer $AGENT_SERVICE_TOKEN` and `{ "cycleId": "<active-cycle>" }` once to flush the old dedup state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eff50e564c832d98763016466c1c42)