### PR TITLE
C-298 Phase 1-2 — Mobius Router Read-Only + Metrics

### DIFF
--- a/app/api/agents/reasoning/route.ts
+++ b/app/api/agents/reasoning/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { routeTask, type RouterRoute } from '@/lib/router/decision';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -20,6 +21,15 @@ type AgentDecision = {
   confidence: number;
   reasoning: string;
   inputs: string[];
+};
+
+type RoutedAgentDecision = AgentDecision & {
+  router: {
+    route: RouterRoute;
+    reason: string;
+    verified_required: boolean;
+    enforced: false;
+  };
 };
 
 async function getJson<T extends JsonObject>(request: NextRequest, path: string): Promise<FetchResult<T>> {
@@ -50,6 +60,36 @@ function stringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
 }
 
+function routerTaskForDecision(decision: AgentDecision) {
+  const affectsLedger = decision.action === 'verify' || decision.action === 'attest' || decision.action === 'replay_check';
+  const highImpact = decision.priority === 'critical' || decision.priority === 'high' || decision.action === 'stabilize' || decision.action === 'escalate';
+  const repetitive = decision.action === 'observe';
+  const privateTask = decision.inputs.some((input) => input.includes('vault') || input.includes('canon') || input.includes('replay'));
+  return {
+    type: `agent:${decision.agent}:${decision.action}`,
+    agent: decision.agent,
+    affectsLedger,
+    highImpact,
+    repetitive,
+    private: privateTask,
+  };
+}
+
+function annotateWithRouter(decisions: AgentDecision[]): RoutedAgentDecision[] {
+  return decisions.map((decision) => {
+    const routed = routeTask(routerTaskForDecision(decision));
+    return {
+      ...decision,
+      router: {
+        route: routed.route,
+        reason: routed.reason,
+        verified_required: routed.verified_required,
+        enforced: false,
+      },
+    };
+  });
+}
+
 function decideAgents(signalExplain: JsonObject | null, vaultContext: JsonObject | null): AgentDecision[] {
   const signalSnapshot = signalExplain?.signal_snapshot as JsonObject | null | undefined;
   const giState = signalExplain?.gi_state as JsonObject | null | undefined;
@@ -70,7 +110,7 @@ function decideAgents(signalExplain: JsonObject | null, vaultContext: JsonObject
   const signalRisk = criticalCount > 0 ? 'critical' : anomalyCount > 5 ? 'high' : anomalyCount > 0 ? 'medium' : 'low';
   const baseConfidence = Math.max(0.35, Math.min(0.95, gi || 0.5));
 
-  const decisions: AgentDecision[] = [
+  return [
     {
       agent: 'ATLAS',
       role: 'anomaly sentinel',
@@ -119,10 +159,10 @@ function decideAgents(signalExplain: JsonObject | null, vaultContext: JsonObject
     {
       agent: 'ECHO',
       role: 'event pulse recorder',
-      action: agentTasks.length > 0 ? 'observe' : 'observe',
+      action: 'observe',
       priority: agentTasks.some((task) => task.includes('MISSING')) ? 'high' : 'medium',
       confidence: baseConfidence,
-      reasoning: `ECHO should pulse agent tasks into operator awareness without writing new truth automatically.`,
+      reasoning: 'ECHO should pulse agent tasks into operator awareness without writing new truth automatically.',
       inputs: ['agents.vault-context.agent_tasks', 'signals.gi-explain.alignment'],
     },
     {
@@ -144,8 +184,6 @@ function decideAgents(signalExplain: JsonObject | null, vaultContext: JsonObject
       inputs: ['terminal.snapshot-health', 'vercel.build'],
     },
   ];
-
-  return decisions;
 }
 
 export async function GET(request: NextRequest) {
@@ -154,17 +192,21 @@ export async function GET(request: NextRequest) {
     getJson<JsonObject>(request, '/api/agents/vault-context'),
   ]);
 
-  const decisions = decideAgents(signalExplain.data, vaultContext.data);
+  const decisions = annotateWithRouter(decideAgents(signalExplain.data, vaultContext.data));
 
   return NextResponse.json(
     {
       ok: signalExplain.ok || vaultContext.ok,
       readonly: true,
-      version: 'C-297.phase5.agent-reasoning.v1',
-      source: 'signals-plus-vault-canon-replay',
+      version: 'C-298.phase3.agent-reasoning-router-annotated.v1',
+      source: 'signals-plus-vault-canon-replay-router-annotated',
       endpoints: {
         signal_gi_explain: { ok: signalExplain.ok, status: signalExplain.status, error: signalExplain.error },
         vault_context: { ok: vaultContext.ok, status: vaultContext.status, error: vaultContext.error },
+      },
+      router: {
+        enforced: false,
+        note: 'Router recommendations are metadata only in C-298 Phase 3.',
       },
       decisions,
       summary: {
@@ -172,18 +214,25 @@ export async function GET(request: NextRequest) {
         critical: decisions.filter((d) => d.priority === 'critical').length,
         high: decisions.filter((d) => d.priority === 'high').length,
         active_actions: decisions.filter((d) => d.action !== 'observe').length,
+        routes: decisions.reduce<Record<RouterRoute, number>>(
+          (acc, d) => {
+            acc[d.router.route] += 1;
+            return acc;
+          },
+          { local: 0, cloud: 0, 'cloud+zeus': 0, hybrid: 0 },
+        ),
       },
       canon_law: [
         'Agent reasoning must be grounded in canonical signals and Vault/Canon/Replay context.',
-        'This endpoint recommends agent actions but does not mutate Ledger, Vault, Canon, Replay, MIC, or Fountain.',
-        'Future write phases must require receipts, quorum, and preserved history.',
+        'Router annotations recommend compute route only; they do not execute models or enforce routes yet.',
+        'Future write phases must require receipts, quorum, preserved history, and verified cloud/ZEUS path when truth layers are affected.',
       ],
       timestamp: new Date().toISOString(),
     },
     {
       headers: {
         'Cache-Control': 'private, no-store, max-age=0, must-revalidate',
-        'X-Mobius-Source': 'agent-reasoning',
+        'X-Mobius-Source': 'agent-reasoning-router-annotated',
       },
     },
   );

--- a/app/api/router/decide/route.ts
+++ b/app/api/router/decide/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type Task = {
+  type?: string;
+  affectsLedger?: boolean;
+  highImpact?: boolean;
+  repetitive?: boolean;
+  private?: boolean;
+};
+
+function routeTask(task: Task) {
+  if (task.affectsLedger) return 'cloud+zeus';
+  if (task.highImpact) return 'cloud';
+  if (task.repetitive) return 'local';
+  if (task.private) return 'local';
+  return 'hybrid';
+}
+
+export async function POST(req: NextRequest) {
+  let task: Task = {};
+  try {
+    task = await req.json();
+  } catch {
+    task = {};
+  }
+
+  const route = routeTask(task);
+
+  return NextResponse.json({
+    ok: true,
+    route,
+    task,
+    phase: 'C-298.phase1.readonly',
+    notes: [
+      'No model execution performed',
+      'No ledger/canon/replay mutation',
+      'Routing decision only'
+    ],
+    timestamp: new Date().toISOString()
+  }, {
+    headers: {
+      'Cache-Control': 'private, no-store, max-age=0, must-revalidate',
+      'X-Mobius-Source': 'router-decide'
+    }
+  });
+}
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    version: 'C-298.phase1.router.v1',
+    usage: {
+      method: 'POST',
+      example: {
+        affectsLedger: true,
+        highImpact: true
+      }
+    }
+  });
+}

--- a/app/api/router/decide/route.ts
+++ b/app/api/router/decide/route.ts
@@ -1,63 +1,59 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { kvGet, kvSet } from '@/lib/kv/store';
+import { createRouterDecisionRecord, type RouterDecisionRecord, type RouterTask } from '@/lib/router/decision';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-type Task = {
-  type?: string;
-  affectsLedger?: boolean;
-  highImpact?: boolean;
-  repetitive?: boolean;
-  private?: boolean;
-};
+const ROUTER_LOG_KEY = 'router:decisions';
+const MAX_LOG = 100;
 
-function routeTask(task: Task) {
-  if (task.affectsLedger) return 'cloud+zeus';
-  if (task.highImpact) return 'cloud';
-  if (task.repetitive) return 'local';
-  if (task.private) return 'local';
-  return 'hybrid';
+async function appendDecision(record: RouterDecisionRecord) {
+  const existing = (await kvGet<RouterDecisionRecord[]>(ROUTER_LOG_KEY)) ?? [];
+  const next = [record, ...existing].slice(0, MAX_LOG);
+  await kvSet(ROUTER_LOG_KEY, next, 60 * 60 * 24);
 }
 
 export async function POST(req: NextRequest) {
-  let task: Task = {};
+  let task: RouterTask = {};
   try {
     task = await req.json();
   } catch {
     task = {};
   }
 
-  const route = routeTask(task);
+  const record = createRouterDecisionRecord(task);
+  await appendDecision(record);
 
-  return NextResponse.json({
-    ok: true,
-    route,
-    task,
-    phase: 'C-298.phase1.readonly',
-    notes: [
-      'No model execution performed',
-      'No ledger/canon/replay mutation',
-      'Routing decision only'
-    ],
-    timestamp: new Date().toISOString()
-  }, {
-    headers: {
-      'Cache-Control': 'private, no-store, max-age=0, must-revalidate',
-      'X-Mobius-Source': 'router-decide'
-    }
-  });
+  return NextResponse.json(
+    {
+      ok: true,
+      route: record.route,
+      record,
+      phase: 'C-298.phase2.instrumentation',
+      notes: [
+        'Decision recorded to KV (capped log)',
+        'No model execution performed',
+        'No ledger/canon/replay mutation',
+      ],
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'private, no-store, max-age=0, must-revalidate',
+        'X-Mobius-Source': 'router-decide',
+      },
+    },
+  );
 }
 
 export async function GET() {
+  const records = (await kvGet<RouterDecisionRecord[]>(ROUTER_LOG_KEY)) ?? [];
+
   return NextResponse.json({
     ok: true,
-    version: 'C-298.phase1.router.v1',
-    usage: {
-      method: 'POST',
-      example: {
-        affectsLedger: true,
-        highImpact: true
-      }
-    }
+    version: 'C-298.phase2.router.v2',
+    stored_decisions: records.length,
+    sample: records.slice(0, 5),
   });
 }

--- a/app/api/router/feedback/route.ts
+++ b/app/api/router/feedback/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { kvGet, kvSet } from '@/lib/kv/store';
+import { createRouterFeedbackRecord, type RouterFeedbackRecord } from '@/lib/router/decision';
+
+export const dynamic = 'force-dynamic';
+
+const KEY = 'router:feedback';
+const MAX = 100;
+
+async function append(record: RouterFeedbackRecord) {
+  const existing = (await kvGet<RouterFeedbackRecord[]>(KEY)) ?? [];
+  const next = [record, ...existing].slice(0, MAX);
+  await kvSet(KEY, next, 60 * 60 * 24);
+}
+
+export async function POST(req: NextRequest) {
+  let body: any = {};
+  try { body = await req.json(); } catch {}
+
+  const record = createRouterFeedbackRecord(body);
+  await append(record);
+
+  return NextResponse.json({ ok: true, record });
+}
+
+export async function GET() {
+  const records = (await kvGet<RouterFeedbackRecord[]>(KEY)) ?? [];
+  return NextResponse.json({ ok: true, records });
+}

--- a/app/api/router/metrics/route.ts
+++ b/app/api/router/metrics/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { kvGet } from '@/lib/kv/store';
+import { summarizeRouterDecisions, type RouterDecisionRecord } from '@/lib/router/decision';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const ROUTER_LOG_KEY = 'router:decisions';
+
+export async function GET() {
+  const records = (await kvGet<RouterDecisionRecord[]>(ROUTER_LOG_KEY)) ?? [];
+  const summary = summarizeRouterDecisions(records);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      phase: 'C-298.phase2.instrumentation',
+      summary,
+      recent: records.slice(0, 20),
+      canon_law: [
+        'Router metrics are observational only in Phase 2.',
+        'No execution, no model calls, no ledger mutation.',
+        'CIS is placeholder until verification layer is wired.',
+      ],
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'private, no-store, max-age=0, must-revalidate',
+        'X-Mobius-Source': 'router-metrics',
+      },
+    },
+  );
+}

--- a/app/api/router/recommendations/route.ts
+++ b/app/api/router/recommendations/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server';
+import { kvGet } from '@/lib/kv/store';
+import type { RouterDecisionRecord, RouterFeedbackRecord, RouterRoute } from '@/lib/router/decision';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const DECISIONS_KEY = 'router:decisions';
+const FEEDBACK_KEY = 'router:feedback';
+
+type RouteRecommendation = {
+  route: RouterRoute;
+  recommendation: 'hold' | 'use_more' | 'use_less' | 'review';
+  reason: string;
+  confidence: number;
+};
+
+function feedbackForRoute(route: RouterRoute, decisions: RouterDecisionRecord[], feedback: RouterFeedbackRecord[]) {
+  const decisionIds = new Set(decisions.filter((d) => d.route === route).map((d) => d.id));
+  return feedback.filter((f) => decisionIds.has(f.decision_id));
+}
+
+function recommendForRoute(route: RouterRoute, decisions: RouterDecisionRecord[], feedback: RouterFeedbackRecord[]): RouteRecommendation {
+  const routeDecisions = decisions.filter((d) => d.route === route);
+  const routeFeedback = feedbackForRoute(route, decisions, feedback);
+  const correctionCount = routeFeedback.filter((f) => f.outcome === 'corrected' || f.outcome === 'rejected').length;
+  const confirmationCount = routeFeedback.filter((f) => f.outcome === 'confirmed').length;
+  const correctionRate = routeFeedback.length > 0 ? correctionCount / routeFeedback.length : 0;
+  const confirmationRate = routeFeedback.length > 0 ? confirmationCount / routeFeedback.length : 0;
+  const usageShare = decisions.length > 0 ? routeDecisions.length / decisions.length : 0;
+
+  if (routeFeedback.length < 3) {
+    return { route, recommendation: 'hold', reason: 'insufficient_feedback_for_adaptation', confidence: 0.35 };
+  }
+  if (correctionRate >= 0.35) {
+    return { route, recommendation: 'use_less', reason: 'feedback_correction_rate_high', confidence: Number(Math.min(0.9, correctionRate).toFixed(2)) };
+  }
+  if (confirmationRate >= 0.8 && usageShare < 0.4) {
+    return { route, recommendation: 'use_more', reason: 'high_confirmation_low_usage', confidence: Number(confirmationRate.toFixed(2)) };
+  }
+  if (usageShare > 0.65 && route !== 'local') {
+    return { route, recommendation: 'review', reason: 'cloud_or_hybrid_overuse_possible', confidence: Number(usageShare.toFixed(2)) };
+  }
+  return { route, recommendation: 'hold', reason: 'route_performance_within_expected_bounds', confidence: Number(Math.max(0.5, confirmationRate).toFixed(2)) };
+}
+
+export async function GET() {
+  const [decisions, feedback] = await Promise.all([
+    kvGet<RouterDecisionRecord[]>(DECISIONS_KEY),
+    kvGet<RouterFeedbackRecord[]>(FEEDBACK_KEY),
+  ]);
+
+  const decisionRows = decisions ?? [];
+  const feedbackRows = feedback ?? [];
+  const routes: RouterRoute[] = ['local', 'cloud', 'cloud+zeus', 'hybrid'];
+  const recommendations = routes.map((route) => recommendForRoute(route, decisionRows, feedbackRows));
+
+  return NextResponse.json(
+    {
+      ok: true,
+      phase: 'C-298.phase7.adaptive-routing-recommendations',
+      enforced: false,
+      decisions: decisionRows.length,
+      feedback: feedbackRows.length,
+      recommendations,
+      next_best_action:
+        feedbackRows.length < 3
+          ? 'collect_more_feedback_before_route_adjustment'
+          : 'review_recommendations_before_any_enforcement_phase',
+      canon_law: [
+        'Recommendations are advisory only.',
+        'No route is enforced by this endpoint.',
+        'No model execution, Ledger, Canon, Replay, Vault, MIC, or GI mutation occurs here.',
+      ],
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'private, no-store, max-age=0, must-revalidate',
+        'X-Mobius-Source': 'router-recommendations',
+      },
+    },
+  );
+}

--- a/app/api/router/recommendations/summary/route.ts
+++ b/app/api/router/recommendations/summary/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      ok: true,
+      phase: 'C-298.phase8.router-ui-signals',
+      advisory: true,
+      signals: [
+        {
+          type: 'warning',
+          message: 'Routing recommendations available (Phase 7).',
+        },
+        {
+          type: 'info',
+          message: 'Automation Index advisory loaded (no execution).',
+        },
+      ],
+      canon_law: [
+        'Signals are advisory only.',
+        'No routing decisions are enforced.',
+        'No mutation of Canon, Ledger, Vault, or Replay occurs.',
+      ],
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'private, no-store, max-age=0',
+      },
+    },
+  );
+}

--- a/app/api/system/automation-readiness/route.ts
+++ b/app/api/system/automation-readiness/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type FetchResult<T> = {
+  ok: boolean;
+  status: number;
+  data: T | null;
+  error: string | null;
+};
+
+type RouterMetrics = {
+  ok?: boolean;
+  summary?: {
+    total?: number;
+    estimatedCis?: number | null;
+    feedback?: {
+      total?: number;
+      confirmationRate?: number | null;
+      correctionRate?: number | null;
+    };
+  };
+};
+
+type RouterRecommendations = {
+  ok?: boolean;
+  recommendations?: Array<{
+    route: string;
+    recommendation: string;
+    confidence: number;
+  }>;
+};
+
+type AgentReasoning = {
+  ok?: boolean;
+  decisions?: unknown[];
+  summary?: {
+    active_actions?: number;
+  };
+};
+
+type VaultContext = {
+  ok?: boolean;
+  endpoints?: Record<string, { ok?: boolean }>;
+  agent_tasks?: string[];
+};
+
+async function getJson<T>(request: NextRequest, path: string): Promise<FetchResult<T>> {
+  try {
+    const response = await fetch(new URL(path, request.nextUrl.origin), { cache: 'no-store' });
+    const data = (await response.json()) as T;
+    return {
+      ok: response.ok && (data as { ok?: boolean })?.ok !== false,
+      status: response.status,
+      data: response.ok ? data : null,
+      error: response.ok ? null : `http_${response.status}`,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      data: null,
+      error: error instanceof Error ? error.message : 'fetch_failed',
+    };
+  }
+}
+
+function readinessLine(name: string, passed: boolean, detail: string, severity: 'p0' | 'p1' | 'p2' = 'p1') {
+  return { name, passed, severity, detail };
+}
+
+export async function GET(request: NextRequest) {
+  const [routerMetrics, routerRecommendations, agentReasoning, vaultContext] = await Promise.all([
+    getJson<RouterMetrics>(request, '/api/router/metrics'),
+    getJson<RouterRecommendations>(request, '/api/router/recommendations'),
+    getJson<AgentReasoning>(request, '/api/agents/reasoning'),
+    getJson<VaultContext>(request, '/api/agents/vault-context'),
+  ]);
+
+  const metrics = routerMetrics.data?.summary;
+  const decisions = metrics?.total ?? 0;
+  const feedback = metrics?.feedback?.total ?? 0;
+  const estimatedCis = metrics?.estimatedCis ?? null;
+  const correctionRate = metrics?.feedback?.correctionRate ?? null;
+  const recommendations = routerRecommendations.data?.recommendations ?? [];
+  const reviewCount = recommendations.filter((item) => item.recommendation === 'review' || item.recommendation === 'use_less').length;
+  const agentDecisionCount = agentReasoning.data?.decisions?.length ?? 0;
+  const activeActions = agentReasoning.data?.summary?.active_actions ?? 0;
+  const vaultEndpoints = vaultContext.data?.endpoints ?? {};
+  const vaultReadable = Object.values(vaultEndpoints).filter((endpoint) => endpoint?.ok).length;
+
+  const checks = [
+    readinessLine('router_metrics_available', routerMetrics.ok, `router metrics endpoint status=${routerMetrics.status}`, 'p0'),
+    readinessLine('router_decision_density', decisions >= 5, `${decisions} router decisions recorded; target >=5 before automation`, 'p1'),
+    readinessLine('router_feedback_density', feedback >= 3, `${feedback} feedback records recorded; target >=3 before adaptation`, 'p1'),
+    readinessLine('compute_integrity_floor', estimatedCis != null && estimatedCis >= 0.75, `estimated CIS=${estimatedCis ?? 'unknown'}; target >=0.75`, 'p0'),
+    readinessLine('correction_rate_safe', correctionRate == null || correctionRate <= 0.35, `correction rate=${correctionRate ?? 'unknown'}; target <=0.35`, 'p1'),
+    readinessLine('recommendations_not_overheated', reviewCount <= 1, `${reviewCount} routes need review/use_less; target <=1`, 'p1'),
+    readinessLine('agent_reasoning_available', agentReasoning.ok && agentDecisionCount > 0, `${agentDecisionCount} agent decisions visible`, 'p0'),
+    readinessLine('active_actions_visible', activeActions >= 0, `${activeActions} active agent actions visible`, 'p2'),
+    readinessLine('vault_canon_replay_context_available', vaultContext.ok && vaultReadable >= 2, `${vaultReadable} vault/canon/replay endpoints readable`, 'p0'),
+  ];
+
+  const p0Failed = checks.filter((check) => check.severity === 'p0' && !check.passed);
+  const failed = checks.filter((check) => !check.passed);
+  const score = Number((checks.filter((check) => check.passed).length / checks.length).toFixed(3));
+  const status = p0Failed.length > 0 ? 'blocked' : failed.length > 0 ? 'not_ready' : 'ready_for_dry_run';
+
+  return NextResponse.json(
+    {
+      ok: true,
+      readonly: true,
+      phase: 'C-298.phase9.automation-readiness',
+      status,
+      readiness_score: score,
+      checks,
+      endpoints: {
+        router_metrics: { ok: routerMetrics.ok, status: routerMetrics.status, error: routerMetrics.error },
+        router_recommendations: { ok: routerRecommendations.ok, status: routerRecommendations.status, error: routerRecommendations.error },
+        agent_reasoning: { ok: agentReasoning.ok, status: agentReasoning.status, error: agentReasoning.error },
+        vault_context: { ok: vaultContext.ok, status: vaultContext.status, error: vaultContext.error },
+      },
+      next_action:
+        status === 'ready_for_dry_run'
+          ? 'allow_phase10_dry_run_orchestration_plan_only'
+          : p0Failed.length > 0
+            ? 'fix_p0_readiness_failures_before_any_orchestration'
+            : 'collect_more_router_decisions_and_feedback_before_dry_run',
+      canon_law: [
+        'Automation readiness is a gate, not execution.',
+        'This endpoint does not run cron jobs, agents, model calls, ledger writes, seals, replay, Canon, Vault, MIC, Fountain, or GI mutation.',
+        'No automation should move past dry-run until p0 checks pass and operator review confirms readiness.',
+      ],
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'private, no-store, max-age=0, must-revalidate',
+        'X-Mobius-Source': 'automation-readiness',
+      },
+    },
+  );
+}

--- a/app/api/system/class2-execution-gate/route.ts
+++ b/app/api/system/class2-execution-gate/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type QuorumIntegrityPayload = {
+  ok?: boolean;
+  quorum_integrity?: {
+    missing_agents?: string[];
+    passed_agents?: number;
+    average_integrity?: number;
+    partial_consensus_score?: number;
+    degraded?: boolean;
+    state?: string;
+    rows?: Array<{
+      agent: string;
+      present: boolean;
+      confidence: number;
+      passed: boolean;
+      route: string;
+      integrity_score: number;
+    }>;
+  };
+};
+
+type GateBody = {
+  operator_ack?: boolean;
+  operator_override?: boolean;
+  reason?: string;
+};
+
+async function getQuorumIntegrity(request: NextRequest): Promise<QuorumIntegrityPayload | null> {
+  try {
+    const response = await fetch(new URL('/api/system/quorum-integrity', request.nextUrl.origin), { cache: 'no-store' });
+    if (!response.ok) return null;
+    return (await response.json()) as QuorumIntegrityPayload;
+  } catch {
+    return null;
+  }
+}
+
+function evaluateGate(quorum: QuorumIntegrityPayload | null, body: GateBody) {
+  const integrity = quorum?.quorum_integrity;
+  const mii = integrity?.partial_consensus_score ?? 0;
+  const missingAgents = integrity?.missing_agents ?? [];
+  const degraded = integrity?.degraded ?? true;
+  const passedAgents = integrity?.passed_agents ?? 0;
+  const blockedBy: string[] = [];
+
+  if (!integrity) blockedBy.push('quorum_integrity_unavailable');
+  if (mii < 0.85) blockedBy.push('mii_below_class2_threshold');
+  if (missingAgents.length > 0) blockedBy.push(`missing_agents:${missingAgents.join(',')}`);
+  if (degraded) blockedBy.push('quorum_integrity_degraded');
+  if (passedAgents < 5) blockedBy.push('required_agents_not_all_passed');
+  if (body.operator_ack !== true) blockedBy.push('operator_ack_required');
+
+  const overrideEligible = body.operator_override === true && body.operator_ack === true && Boolean(body.reason);
+  const wouldAllow = blockedBy.length === 0;
+
+  return {
+    mii,
+    passedAgents,
+    missingAgents,
+    degraded,
+    overrideEligible,
+    wouldAllow,
+    blockedBy,
+  };
+}
+
+async function handle(request: NextRequest, body: GateBody = {}) {
+  const quorum = await getQuorumIntegrity(request);
+  const gate = evaluateGate(quorum, body);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      readonly: true,
+      phase: 'C-298.phase17.class2-execution-gate',
+      class: 'Class 2 — Quorum Attestation',
+      authority: false,
+      execution_enabled: false,
+      would_execute: false,
+      gate,
+      override: {
+        requested: body.operator_override === true,
+        eligible: gate.overrideEligible,
+        note: gate.overrideEligible
+          ? 'Override is recorded as eligible for review only; it still does not execute in Phase 17.'
+          : 'Override requires operator_ack=true and a non-empty reason.',
+      },
+      quorum_integrity: quorum?.quorum_integrity ?? null,
+      next_action: gate.wouldAllow
+        ? 'operator_may_review_phase18_class2_dry_run_receipt_write_contract'
+        : 'resolve_blockers_before_any_class2_execution_design',
+      canon_law: [
+        'Class 2 gate evaluates whether quorum attestation execution would be allowed.',
+        'Phase 17 never executes quorum, writes attestations, seals Vault, promotes Canon, mutates Replay, changes GI, MIC, or Fountain.',
+        'Operator override is advisory review metadata only in this phase.',
+        'MII below threshold must block execution design until corrected or explicitly reviewed by operator policy.',
+      ],
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'private, no-store, max-age=0, must-revalidate',
+        'X-Mobius-Source': 'class2-execution-gate',
+      },
+    },
+  );
+}
+
+export async function GET(request: NextRequest) {
+  return handle(request, {});
+}
+
+export async function POST(request: NextRequest) {
+  let body: GateBody = {};
+  try {
+    body = (await request.json()) as GateBody;
+  } catch {
+    body = {};
+  }
+  return handle(request, body);
+}

--- a/app/api/system/execution-receipt-preview/route.ts
+++ b/app/api/system/execution-receipt-preview/route.ts
@@ -1,0 +1,102 @@
+import { createHash } from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type ExecutionDryRunPayload = {
+  ok?: boolean;
+  phase?: string;
+  execution_dryrun?: {
+    allowed?: boolean;
+    confidence?: number;
+    steps?: Array<{
+      step: number;
+      action: string;
+      allowed: boolean;
+      reason: string;
+    }>;
+    simulated_effects?: Record<string, string>;
+  };
+};
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+    .join(',')}}`;
+}
+
+function sha256(value: unknown): string {
+  return createHash('sha256').update(stableStringify(value)).digest('hex');
+}
+
+async function getDryRun(request: NextRequest): Promise<ExecutionDryRunPayload | null> {
+  try {
+    const response = await fetch(new URL('/api/system/execution-dryrun', request.nextUrl.origin), { cache: 'no-store' });
+    if (!response.ok) return null;
+    return (await response.json()) as ExecutionDryRunPayload;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const dryRun = await getDryRun(request);
+  const execution = dryRun?.execution_dryrun ?? null;
+  const createdAt = new Date().toISOString();
+
+  const receiptPayload = {
+    phase: 'C-298.phase19.execution-receipt-preview',
+    source_phase: dryRun?.phase ?? 'unknown',
+    dry_run_allowed: execution?.allowed ?? false,
+    confidence: execution?.confidence ?? 0,
+    steps: execution?.steps ?? [],
+    simulated_effects: execution?.simulated_effects ?? {},
+    created_at: createdAt,
+  };
+
+  const payloadHash = sha256(receiptPayload);
+  const stepsHash = sha256(receiptPayload.steps);
+  const effectsHash = sha256(receiptPayload.simulated_effects);
+  const receiptHash = sha256({ payloadHash, stepsHash, effectsHash, createdAt });
+
+  return NextResponse.json(
+    {
+      ok: true,
+      readonly: true,
+      phase: 'C-298.phase19.execution-receipt-preview',
+      authoritative: false,
+      receipt_preview: {
+        id: `execution-dryrun-${receiptHash}`,
+        type: 'execution_dryrun_receipt_preview',
+        payload_hash: payloadHash,
+        steps_hash: stepsHash,
+        effects_hash: effectsHash,
+        receipt_hash: receiptHash,
+        allowed: receiptPayload.dry_run_allowed,
+        confidence: receiptPayload.confidence,
+        created_at: createdAt,
+      },
+      payload: receiptPayload,
+      next_action: execution?.allowed
+        ? 'operator_may_review_phase20_receipt_persistence_contract'
+        : 'resolve_execution_dryrun_blockers_before_receipt_persistence',
+      canon_law: [
+        'Execution receipt preview is not a ledger receipt.',
+        'This endpoint produces deterministic hashes only and writes nothing.',
+        'No Ledger, Vault, Canon, Replay, MIC, Fountain, GI, or seal mutation occurs.',
+        'Future receipt persistence must require operator acknowledgement and dedupe protection.',
+      ],
+      timestamp: createdAt,
+    },
+    {
+      headers: {
+        'Cache-Control': 'private, no-store, max-age=0, must-revalidate',
+        'X-Mobius-Source': 'execution-receipt-preview',
+      },
+    },
+  );
+}

--- a/app/api/system/orchestration-dry-run/route.ts
+++ b/app/api/system/orchestration-dry-run/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type ReadinessPayload = {
+  ok?: boolean;
+  status?: 'blocked' | 'not_ready' | 'ready_for_dry_run';
+  readiness_score?: number;
+  checks?: Array<{ name: string; passed: boolean; severity: string; detail: string }>;
+};
+
+type Stage = {
+  offset: string;
+  label: string;
+  agents: string[];
+  simulated_status: 'planned' | 'blocked' | 'degraded';
+  would_write: false;
+  expected_receipts: string[];
+  notes: string[];
+};
+
+async function fetchReadiness(request: NextRequest): Promise<ReadinessPayload> {
+  const res = await fetch(new URL('/api/system/automation-readiness', request.nextUrl.origin), { cache: 'no-store' });
+  return (await res.json()) as ReadinessPayload;
+}
+
+function buildStages(readiness: ReadinessPayload): Stage[] {
+  const p0Failed = (readiness.checks ?? []).filter((check) => check.severity === 'p0' && !check.passed);
+  const blocked = p0Failed.length > 0;
+
+  return [
+    {
+      offset: 't+0:00',
+      label: 'Bootstrap agents',
+      agents: ['ATLAS', 'DAEDALUS', 'ECHO'],
+      simulated_status: blocked ? 'blocked' : 'planned',
+      would_write: false,
+      expected_receipts: ['agent_journal_preview', 'heartbeat_preview', 'signal_ingest_preview'],
+      notes: ['No agent code is executed in dry-run mode.', 'Would validate bootstrap health and source freshness.'],
+    },
+    {
+      offset: 't+1:00',
+      label: 'Vault attestation collection',
+      agents: ['VAULT-ATTESTATION'],
+      simulated_status: blocked ? 'blocked' : 'planned',
+      would_write: false,
+      expected_receipts: ['attestation_collection_preview', 'missing_agent_list'],
+      notes: ['Would collect attestations without writing Vault state.', 'Partial attestations remain preview-only.'],
+    },
+    {
+      offset: 't+3:00',
+      label: 'Signal routing',
+      agents: ['HERMES'],
+      simulated_status: blocked ? 'blocked' : 'planned',
+      would_write: false,
+      expected_receipts: ['route_decision_preview', 'signal_source_health_preview'],
+      notes: ['Would route signals through Mobius Router advisory mode.', 'No model execution or external fetch is performed.'],
+    },
+    {
+      offset: 't+5:00',
+      label: 'Quorum agents',
+      agents: ['ZEUS', 'EVE', 'JADE', 'AUREA'],
+      simulated_status: blocked ? 'blocked' : readiness.status === 'not_ready' ? 'degraded' : 'planned',
+      would_write: false,
+      expected_receipts: ['quorum_preview', 'ethics_review_preview', 'proof_lane_preview'],
+      notes: ['Would simulate 5-agent quorum.', 'No ledger or seal writes are allowed.'],
+    },
+    {
+      offset: 't+6:00',
+      label: 'Seal eligibility check',
+      agents: ['VAULT-ATTESTATION', 'ZEUS'],
+      simulated_status: blocked ? 'blocked' : readiness.status === 'ready_for_dry_run' ? 'planned' : 'degraded',
+      would_write: false,
+      expected_receipts: ['seal_eligibility_preview', 'gi_gate_preview', 'sustain_gate_preview'],
+      notes: ['Would evaluate GI, quorum, sustain, and degraded-agent count.', 'Even if eligible, dry-run cannot execute a seal.'],
+    },
+  ];
+}
+
+export async function GET(request: NextRequest) {
+  const readiness = await fetchReadiness(request);
+  const stages = buildStages(readiness);
+  const blockedStages = stages.filter((stage) => stage.simulated_status === 'blocked').length;
+  const degradedStages = stages.filter((stage) => stage.simulated_status === 'degraded').length;
+
+  return NextResponse.json(
+    {
+      ok: true,
+      readonly: true,
+      dry_run: true,
+      phase: 'C-298.phase10.orchestration-dry-run',
+      readiness: {
+        status: readiness.status ?? 'unknown',
+        score: readiness.readiness_score ?? null,
+        p0_failures: (readiness.checks ?? []).filter((check) => check.severity === 'p0' && !check.passed).map((check) => check.name),
+      },
+      orchestration_window: {
+        cycle: 'C-298',
+        duration: '10m',
+        stages,
+      },
+      simulation_result: {
+        executable: false,
+        would_mutate: false,
+        blocked_stages: blockedStages,
+        degraded_stages: degradedStages,
+        dry_run_status: blockedStages > 0 ? 'blocked_preview' : degradedStages > 0 ? 'degraded_preview' : 'clean_preview',
+      },
+      next_action:
+        blockedStages > 0
+          ? 'fix_p0_readiness_failures_before_orchestration_testing'
+          : degradedStages > 0
+            ? 'collect_more_feedback_and_resolve_not_ready_checks_before_execution_design'
+            : 'operator_may_review_phase11_execution_contract_docs_only',
+      canon_law: [
+        'This endpoint simulates orchestration only.',
+        'No cron jobs are run and no agents execute.',
+        'No KV, Ledger, Vault, Canon, Replay, MIC, Fountain, GI, or seal mutation occurs.',
+        'Dry-run output may inform a future execution contract but cannot itself become execution authority.',
+      ],
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'private, no-store, max-age=0, must-revalidate',
+        'X-Mobius-Source': 'orchestration-dry-run',
+      },
+    },
+  );
+}

--- a/app/api/system/quorum-integrity/route.ts
+++ b/app/api/system/quorum-integrity/route.ts
@@ -3,6 +3,15 @@ import { NextRequest, NextResponse } from 'next/server';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
+type ShadowQuorumRow = {
+  agent: string;
+  present: boolean;
+  confidence: number;
+  passed: boolean;
+  action: string;
+  route: string;
+};
+
 type ShadowQuorumPayload = {
   ok?: boolean;
   shadow_mode?: boolean;
@@ -12,14 +21,7 @@ type ShadowQuorumPayload = {
     present?: number;
     passed?: number;
     quorum_met_shadow?: boolean;
-    rows?: Array<{
-      agent: string;
-      present: boolean;
-      confidence: number;
-      passed: boolean;
-      action: string;
-      route: string;
-    }>;
+    rows?: ShadowQuorumRow[];
   };
   readiness?: {
     status?: string;
@@ -38,7 +40,7 @@ async function getShadow(request: NextRequest): Promise<ShadowQuorumPayload | nu
   }
 }
 
-function scoreRow(row: NonNullable<ShadowQuorumPayload['quorum']>['rows'][number]) {
+function scoreRow(row: ShadowQuorumRow) {
   const missingPenalty = row.present ? 0 : 0.25;
   const confidencePenalty = Math.max(0, 0.85 - row.confidence);
   const routePenalty = row.route === 'cloud+zeus' || row.route === 'cloud' ? 0 : 0.08;
@@ -48,7 +50,7 @@ function scoreRow(row: NonNullable<ShadowQuorumPayload['quorum']>['rows'][number
 
 export async function GET(request: NextRequest) {
   const shadow = await getShadow(request);
-  const rows = shadow?.quorum?.rows ?? [];
+  const rows: ShadowQuorumRow[] = shadow?.quorum?.rows ?? [];
   const required = shadow?.quorum?.required_agents ?? ['ATLAS', 'ZEUS', 'EVE', 'JADE', 'AUREA'];
   const timeoutWindowSeconds = 45;
 

--- a/app/api/system/quorum-integrity/route.ts
+++ b/app/api/system/quorum-integrity/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type ShadowQuorumPayload = {
+  ok?: boolean;
+  shadow_mode?: boolean;
+  quorum?: {
+    required_agents?: string[];
+    threshold?: number;
+    present?: number;
+    passed?: number;
+    quorum_met_shadow?: boolean;
+    rows?: Array<{
+      agent: string;
+      present: boolean;
+      confidence: number;
+      passed: boolean;
+      action: string;
+      route: string;
+    }>;
+  };
+  readiness?: {
+    status?: string;
+    score?: number | null;
+    p0_failures?: string[];
+  };
+};
+
+async function getShadow(request: NextRequest): Promise<ShadowQuorumPayload | null> {
+  try {
+    const response = await fetch(new URL('/api/system/quorum-shadow', request.nextUrl.origin), { cache: 'no-store' });
+    if (!response.ok) return null;
+    return (await response.json()) as ShadowQuorumPayload;
+  } catch {
+    return null;
+  }
+}
+
+function scoreRow(row: NonNullable<ShadowQuorumPayload['quorum']>['rows'][number]) {
+  const missingPenalty = row.present ? 0 : 0.25;
+  const confidencePenalty = Math.max(0, 0.85 - row.confidence);
+  const routePenalty = row.route === 'cloud+zeus' || row.route === 'cloud' ? 0 : 0.08;
+  const score = Math.max(0, Math.min(1, row.confidence - missingPenalty - confidencePenalty - routePenalty));
+  return Number(score.toFixed(3));
+}
+
+export async function GET(request: NextRequest) {
+  const shadow = await getShadow(request);
+  const rows = shadow?.quorum?.rows ?? [];
+  const required = shadow?.quorum?.required_agents ?? ['ATLAS', 'ZEUS', 'EVE', 'JADE', 'AUREA'];
+  const timeoutWindowSeconds = 45;
+
+  const scoredRows = rows.map((row) => ({
+    ...row,
+    integrity_score: scoreRow(row),
+    penalties: {
+      missing: row.present ? 0 : 0.25,
+      low_confidence: Number(Math.max(0, 0.85 - row.confidence).toFixed(3)),
+      route_not_verified: row.route === 'cloud+zeus' || row.route === 'cloud' ? 0 : 0.08,
+    },
+  }));
+
+  const missingAgents = required.filter((agent) => !rows.some((row) => row.agent === agent && row.present));
+  const passed = scoredRows.filter((row) => row.integrity_score >= 0.85).length;
+  const averageIntegrity = scoredRows.length > 0
+    ? Number((scoredRows.reduce((sum, row) => sum + row.integrity_score, 0) / scoredRows.length).toFixed(3))
+    : 0;
+  const partialConsensusScore = Number(((passed / Math.max(1, required.length)) * averageIntegrity).toFixed(3));
+  const degraded = missingAgents.length > 0 || partialConsensusScore < 0.75;
+
+  return NextResponse.json(
+    {
+      ok: true,
+      readonly: true,
+      phase: 'C-298.phase15.quorum-integrity-rules',
+      authoritative: false,
+      timeout: {
+        window_seconds: timeoutWindowSeconds,
+        behavior: 'missing agents are penalized, not silently ignored',
+      },
+      quorum_integrity: {
+        required_agents: required,
+        missing_agents: missingAgents,
+        passed_agents: passed,
+        average_integrity: averageIntegrity,
+        partial_consensus_score: partialConsensusScore,
+        degraded,
+        state: degraded ? 'degraded_shadow_consensus' : shadow?.quorum?.quorum_met_shadow ? 'clean_shadow_consensus' : 'partial_shadow_consensus',
+        rows: scoredRows,
+      },
+      next_action: degraded
+        ? 'collect_missing_agent_receipts_or_raise_confidence_before_any_class2_execution_design'
+        : 'operator_may_review_phase16_quorum_receipt_contract',
+      canon_law: [
+        'Quorum integrity rules are scoring rules only in Phase 15.',
+        'Missing agents create penalties and explicit degraded state; they are not hidden.',
+        'Partial consensus is observable but not authoritative.',
+        'No real quorum enforcement, seal execution, Canon promotion, Replay mutation, Vault mutation, Ledger write, MIC, Fountain, or GI mutation occurs here.',
+      ],
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'private, no-store, max-age=0, must-revalidate',
+        'X-Mobius-Source': 'quorum-integrity',
+      },
+    },
+  );
+}

--- a/app/api/system/quorum-shadow/route.ts
+++ b/app/api/system/quorum-shadow/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type OrchestrationDryRun = {
+  ok?: boolean;
+  readiness?: {
+    status?: string;
+    score?: number | null;
+    p0_failures?: string[];
+  };
+  orchestration_window?: {
+    stages?: Array<{
+      offset: string;
+      label: string;
+      agents: string[];
+      simulated_status: 'planned' | 'blocked' | 'degraded';
+      expected_receipts: string[];
+    }>;
+  };
+  simulation_result?: {
+    dry_run_status?: string;
+    blocked_stages?: number;
+    degraded_stages?: number;
+  };
+};
+
+type AgentReasoning = {
+  ok?: boolean;
+  decisions?: Array<{
+    agent: string;
+    action: string;
+    priority: string;
+    confidence: number;
+    router?: {
+      route: string;
+      verified_required: boolean;
+    };
+  }>;
+};
+
+async function getJson<T>(request: NextRequest, path: string): Promise<T | null> {
+  try {
+    const response = await fetch(new URL(path, request.nextUrl.origin), { cache: 'no-store' });
+    if (!response.ok) return null;
+    return (await response.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+function evaluateShadowQuorum(decisions: AgentReasoning['decisions'] = []) {
+  const requiredAgents = ['ATLAS', 'ZEUS', 'EVE', 'JADE', 'AUREA'];
+  const rows = requiredAgents.map((agent) => {
+    const decision = decisions.find((item) => item.agent === agent);
+    const confidence = decision?.confidence ?? 0;
+    const passed = confidence >= 0.85 && decision?.router?.verified_required === true;
+    return {
+      agent,
+      present: Boolean(decision),
+      confidence,
+      passed,
+      action: decision?.action ?? 'missing',
+      route: decision?.router?.route ?? 'unknown',
+    };
+  });
+  const passed = rows.filter((row) => row.passed).length;
+  const present = rows.filter((row) => row.present).length;
+  return {
+    required_agents: requiredAgents,
+    threshold: 5,
+    present,
+    passed,
+    quorum_met_shadow: passed >= 5,
+    rows,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const [dryRun, reasoning] = await Promise.all([
+    getJson<OrchestrationDryRun>(request, '/api/system/orchestration-dry-run'),
+    getJson<AgentReasoning>(request, '/api/agents/reasoning'),
+  ]);
+
+  const quorum = evaluateShadowQuorum(reasoning?.decisions ?? []);
+  const dryRunStatus = dryRun?.simulation_result?.dry_run_status ?? 'unknown';
+  const p0Failures = dryRun?.readiness?.p0_failures ?? [];
+  const blocked = p0Failures.length > 0 || dryRunStatus === 'blocked_preview';
+
+  return NextResponse.json(
+    {
+      ok: true,
+      readonly: true,
+      shadow_mode: true,
+      phase: 'C-298.phase13.quorum-shadow-mode',
+      dry_run_status: dryRunStatus,
+      readiness: dryRun?.readiness ?? null,
+      quorum,
+      shadow_result: {
+        consensus_state: blocked ? 'blocked' : quorum.quorum_met_shadow ? 'shadow_pass' : 'shadow_fail',
+        authoritative: false,
+        can_seal: false,
+        can_promote_canon: false,
+        would_mutate: false,
+      },
+      next_action: blocked
+        ? 'fix_readiness_failures_before_shadow_quorum_can_be_trusted'
+        : quorum.quorum_met_shadow
+          ? 'operator_may_review_phase14_receipt_to_quorum_mapping_docs'
+          : 'collect_stronger_agent_reasoning_or_receipts_before_any_quorum_execution_design',
+      canon_law: [
+        'Shadow quorum is not authoritative quorum.',
+        'This endpoint does not write attestations, execute seals, promote Canon, mutate Replay, or change GI.',
+        'A future Class 2 phase must use real receipts, timeout behavior, missing-agent reports, and operator review before any enforcement.',
+      ],
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'private, no-store, max-age=0, must-revalidate',
+        'X-Mobius-Source': 'quorum-shadow-mode',
+      },
+    },
+  );
+}

--- a/app/terminal/router/RouterPageClient.tsx
+++ b/app/terminal/router/RouterPageClient.tsx
@@ -1,14 +1,65 @@
 'use client';
 
-import useSWR from 'swr';
+import { useEffect, useState } from 'react';
 
-const fetcher = (url: string) => fetch(url).then((r) => r.json());
+type RouterMetrics = {
+  summary?: {
+    byRoute?: Record<string, number>;
+  };
+  recent?: Array<{
+    id: string;
+    route: string;
+    reason: string;
+  }>;
+};
+
+type AgentReasoning = {
+  decisions?: Array<{
+    agent: string;
+    router?: {
+      route: string;
+      reason: string;
+    };
+  }>;
+};
+
+async function getJson<T>(url: string): Promise<T | null> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
 
 export default function RouterPageClient() {
-  const { data: metrics } = useSWR('/api/router/metrics', fetcher, { refreshInterval: 5000 });
-  const { data: reasoning } = useSWR('/api/agents/reasoning', fetcher, { refreshInterval: 5000 });
+  const [metrics, setMetrics] = useState<RouterMetrics | null>(null);
+  const [reasoning, setReasoning] = useState<AgentReasoning | null>(null);
 
-  const summary = metrics?.summary;
+  useEffect(() => {
+    let mounted = true;
+
+    async function load() {
+      const [nextMetrics, nextReasoning] = await Promise.all([
+        getJson<RouterMetrics>('/api/router/metrics'),
+        getJson<AgentReasoning>('/api/agents/reasoning'),
+      ]);
+      if (!mounted) return;
+      setMetrics(nextMetrics);
+      setReasoning(nextReasoning);
+    }
+
+    void load();
+    const timer = window.setInterval(() => void load(), 5000);
+
+    return () => {
+      mounted = false;
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  const byRoute = metrics?.summary?.byRoute ?? { local: 0, cloud: 0, 'cloud+zeus': 0, hybrid: 0 };
 
   return (
     <div className="h-full overflow-y-auto p-4 space-y-4">
@@ -20,10 +71,10 @@ export default function RouterPageClient() {
       <section className="rounded border border-slate-800 bg-slate-900/60 p-3">
         <div className="text-xs text-slate-400 mb-2">Route Distribution</div>
         <div className="grid grid-cols-4 gap-2 text-xs">
-          {summary && Object.entries(summary.byRoute).map(([k, v]) => (
+          {Object.entries(byRoute).map(([k, v]) => (
             <div key={k} className="rounded border border-slate-700 p-2 text-center">
               <div className="font-mono text-slate-200">{k}</div>
-              <div className="text-slate-400">{v as number}</div>
+              <div className="text-slate-400">{v}</div>
             </div>
           ))}
         </div>
@@ -32,27 +83,29 @@ export default function RouterPageClient() {
       <section className="rounded border border-slate-800 bg-slate-900/60 p-3">
         <div className="text-xs text-slate-400 mb-2">Recent Decisions</div>
         <div className="space-y-2 text-xs">
-          {metrics?.recent?.map((r: any) => (
-            <div key={r.id} className="rounded border border-slate-800 p-2">
-              <div className="text-slate-200 font-mono">{r.route}</div>
-              <div className="text-slate-400">{r.reason}</div>
+          {(metrics?.recent ?? []).map((record) => (
+            <div key={record.id} className="rounded border border-slate-800 p-2">
+              <div className="text-slate-200 font-mono">{record.route}</div>
+              <div className="text-slate-400">{record.reason}</div>
             </div>
           ))}
+          {(metrics?.recent ?? []).length === 0 ? <div className="text-slate-500">No router decisions recorded yet.</div> : null}
         </div>
       </section>
 
       <section className="rounded border border-slate-800 bg-slate-900/60 p-3">
         <div className="text-xs text-slate-400 mb-2">Agent Routing</div>
         <div className="space-y-2 text-xs">
-          {reasoning?.decisions?.map((d: any) => (
-            <div key={d.agent} className="rounded border border-slate-800 p-2">
+          {(reasoning?.decisions ?? []).map((decision) => (
+            <div key={decision.agent} className="rounded border border-slate-800 p-2">
               <div className="flex justify-between">
-                <span className="text-slate-200">{d.agent}</span>
-                <span className="font-mono text-cyan-300">{d.router.route}</span>
+                <span className="text-slate-200">{decision.agent}</span>
+                <span className="font-mono text-cyan-300">{decision.router?.route ?? 'unknown'}</span>
               </div>
-              <div className="text-slate-400">{d.router.reason}</div>
+              <div className="text-slate-400">{decision.router?.reason ?? 'router metadata unavailable'}</div>
             </div>
           ))}
+          {(reasoning?.decisions ?? []).length === 0 ? <div className="text-slate-500">Agent reasoning unavailable.</div> : null}
         </div>
       </section>
     </div>

--- a/app/terminal/router/RouterPageClient.tsx
+++ b/app/terminal/router/RouterPageClient.tsx
@@ -5,11 +5,15 @@ import { useEffect, useState } from 'react';
 type RouterMetrics = {
   summary?: {
     byRoute?: Record<string, number>;
+    estimatedCis?: number | null;
+    estimatedCost?: number | null;
+    cis_mode?: string;
   };
   recent?: Array<{
     id: string;
     route: string;
     reason: string;
+    cis_estimate?: number;
   }>;
 };
 
@@ -65,7 +69,20 @@ export default function RouterPageClient() {
     <div className="h-full overflow-y-auto p-4 space-y-4">
       <section className="rounded border border-slate-700 bg-slate-950/70 p-3">
         <h1 className="text-lg font-semibold">Mobius Router</h1>
-        <p className="text-xs text-slate-400 mt-1">Read-only compute routing intelligence (Phase 4)</p>
+        <p className="text-xs text-slate-400 mt-1">Compute integrity layer (Phase 5)</p>
+      </section>
+
+      <section className="rounded border border-slate-800 bg-slate-900/60 p-3">
+        <div className="text-xs text-slate-400 mb-2">Compute Integrity Score (CIS)</div>
+        <div className="flex justify-between text-sm">
+          <span className="text-slate-200">Estimated CIS</span>
+          <span className="font-mono text-emerald-400">{metrics?.summary?.estimatedCis ?? '—'}</span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-slate-200">Estimated Cost</span>
+          <span className="font-mono text-amber-400">{metrics?.summary?.estimatedCost ?? '—'}</span>
+        </div>
+        <div className="text-xs text-slate-500 mt-1">Mode: {metrics?.summary?.cis_mode ?? '—'}</div>
       </section>
 
       <section className="rounded border border-slate-800 bg-slate-900/60 p-3">
@@ -85,11 +102,13 @@ export default function RouterPageClient() {
         <div className="space-y-2 text-xs">
           {(metrics?.recent ?? []).map((record) => (
             <div key={record.id} className="rounded border border-slate-800 p-2">
-              <div className="text-slate-200 font-mono">{record.route}</div>
+              <div className="flex justify-between">
+                <span className="text-slate-200 font-mono">{record.route}</span>
+                <span className="text-emerald-400">{record.cis_estimate?.toFixed?.(2) ?? '—'}</span>
+              </div>
               <div className="text-slate-400">{record.reason}</div>
             </div>
           ))}
-          {(metrics?.recent ?? []).length === 0 ? <div className="text-slate-500">No router decisions recorded yet.</div> : null}
         </div>
       </section>
 
@@ -105,7 +124,6 @@ export default function RouterPageClient() {
               <div className="text-slate-400">{decision.router?.reason ?? 'router metadata unavailable'}</div>
             </div>
           ))}
-          {(reasoning?.decisions ?? []).length === 0 ? <div className="text-slate-500">Agent reasoning unavailable.</div> : null}
         </div>
       </section>
     </div>

--- a/app/terminal/router/RouterPageClient.tsx
+++ b/app/terminal/router/RouterPageClient.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export default function RouterPageClient() {
+  const { data: metrics } = useSWR('/api/router/metrics', fetcher, { refreshInterval: 5000 });
+  const { data: reasoning } = useSWR('/api/agents/reasoning', fetcher, { refreshInterval: 5000 });
+
+  const summary = metrics?.summary;
+
+  return (
+    <div className="h-full overflow-y-auto p-4 space-y-4">
+      <section className="rounded border border-slate-700 bg-slate-950/70 p-3">
+        <h1 className="text-lg font-semibold">Mobius Router</h1>
+        <p className="text-xs text-slate-400 mt-1">Read-only compute routing intelligence (Phase 4)</p>
+      </section>
+
+      <section className="rounded border border-slate-800 bg-slate-900/60 p-3">
+        <div className="text-xs text-slate-400 mb-2">Route Distribution</div>
+        <div className="grid grid-cols-4 gap-2 text-xs">
+          {summary && Object.entries(summary.byRoute).map(([k, v]) => (
+            <div key={k} className="rounded border border-slate-700 p-2 text-center">
+              <div className="font-mono text-slate-200">{k}</div>
+              <div className="text-slate-400">{v as number}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded border border-slate-800 bg-slate-900/60 p-3">
+        <div className="text-xs text-slate-400 mb-2">Recent Decisions</div>
+        <div className="space-y-2 text-xs">
+          {metrics?.recent?.map((r: any) => (
+            <div key={r.id} className="rounded border border-slate-800 p-2">
+              <div className="text-slate-200 font-mono">{r.route}</div>
+              <div className="text-slate-400">{r.reason}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded border border-slate-800 bg-slate-900/60 p-3">
+        <div className="text-xs text-slate-400 mb-2">Agent Routing</div>
+        <div className="space-y-2 text-xs">
+          {reasoning?.decisions?.map((d: any) => (
+            <div key={d.agent} className="rounded border border-slate-800 p-2">
+              <div className="flex justify-between">
+                <span className="text-slate-200">{d.agent}</span>
+                <span className="font-mono text-cyan-300">{d.router.route}</span>
+              </div>
+              <div className="text-slate-400">{d.router.reason}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/terminal/router/page.tsx
+++ b/app/terminal/router/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import RouterPageClient from './RouterPageClient';
+
+export const metadata: Metadata = {
+  title: 'Router · Mobius Terminal',
+};
+
+export default function RouterPage() {
+  return <RouterPageClient />;
+}

--- a/docs/compute-integrity.md
+++ b/docs/compute-integrity.md
@@ -1,0 +1,27 @@
+# Compute Integrity — C-298
+
+## InferenceRecord
+
+```ts
+export type InferenceRecord = {
+  model: string;
+  location: 'local' | 'cloud';
+  latency_ms: number;
+  cost: number;
+  confidence: number;
+  verified: boolean;
+};
+```
+
+## Compute Integrity Score (CIS)
+
+CIS = verified_outputs / total_outputs
+
+## Rules
+
+Unverified inference is not truth.
+Only verified outputs may enter the Ledger or influence Global Integrity.
+
+## Phase 1 Boundary
+
+C-298 Phase 1 does not persist InferenceRecords yet. It only prepares the schema and routing contract.

--- a/docs/execution-contract-c298.md
+++ b/docs/execution-contract-c298.md
@@ -1,0 +1,135 @@
+# C-298 Execution Contract Layer
+
+## Purpose
+
+Define the minimum requirements for any future transition from orchestration dry-run to controlled execution.
+
+This contract is not executable code. It is a policy gate for future implementation.
+
+## Core Law
+
+Simulation is not execution.
+Readiness is not authorization.
+Recommendation is not enforcement.
+Local inference is not truth.
+
+## Execution Preconditions
+
+Before any orchestration endpoint may mutate state, all conditions below must be true:
+
+1. Automation readiness status is `ready_for_dry_run` for at least one full cycle.
+2. Router correction rate is within accepted bounds.
+3. Compute Integrity Score is above the configured threshold.
+4. Agent reasoning is available and route annotated.
+5. Vault, Canon, and Replay context are readable.
+6. Operator acknowledgement is present for the execution class.
+7. Quorum rules are satisfied for the target action.
+8. Receipt bundle exists before execution.
+9. Execution result is written as a receipt before any downstream promotion.
+10. Rollback or quarantine path exists for degraded or failed execution.
+
+## Authority Boundaries
+
+| Layer | May Execute | May Mutate Truth | Notes |
+| --- | --- | --- | --- |
+| Router | No | No | Advisory only until enforcement phase |
+| Local agents | Limited | No | May produce previews, summaries, and receipts |
+| Cloud agents | Limited | No | May verify or reason, but cannot alone define truth |
+| ZEUS | Verify | No direct mutation | Verification authority, not sole writer |
+| Ledger adapter | Write receipts | Yes, receipt layer only | Requires receipt bundle + operator ack |
+| Vault | Seal only after gates | Yes | Requires quorum, GI, sustain, degraded-count gates |
+| Canon | Promote only by policy | Yes | No direct agent promotion without policy approval |
+| Replay | Inspect/rebuild plan | No rewrite | Replay can annotate, not rewrite history |
+
+## Execution Classes
+
+### Class 0 — Observation
+
+Examples: health checks, metrics, router decisions.
+
+Requirements:
+- no operator ack required
+- no mutation allowed
+
+### Class 1 — Receipt Write
+
+Examples: agent action receipt written to Ledger.
+
+Requirements:
+- receipt bundle
+- operator ack
+- dedupe key
+- dry-run preview available
+
+### Class 2 — Quorum Attestation
+
+Examples: agent attestation set for seal consideration.
+
+Requirements:
+- required agent list
+- threshold rule
+- timeout behavior
+- missing-agent report
+- no partial promotion
+
+### Class 3 — Vault Seal
+
+Examples: reserve block or tranche seal.
+
+Requirements:
+- GI threshold met
+- sustain streak met
+- quorum met
+- degraded agent count acceptable
+- idempotency guard
+- ledger receipt
+- quarantine fallback
+
+### Class 4 — Canon Promotion
+
+Examples: promoting a sealed receipt/tranche into canonical timeline.
+
+Requirements:
+- explicit policy approval
+- replay comparison
+- immutable historical preservation
+- operator-visible diff
+
+## Rollback and Quarantine Rules
+
+Rollback must never erase history.
+
+Allowed:
+- mark receipt as superseded
+- quarantine candidate execution
+- append corrective receipt
+- annotate Canon timeline as disputed
+
+Forbidden:
+- deleting historical receipts
+- rewriting sealed blocks
+- hiding failed attempts
+- treating fallback output as verified truth
+
+## Required Endpoint Behavior
+
+Future execution endpoints must return:
+
+```json
+{
+  "ok": true,
+  "executed": false,
+  "dry_run": true,
+  "class": "Class 1",
+  "preconditions": [],
+  "receipts": [],
+  "blocked_by": [],
+  "would_mutate": false
+}
+```
+
+If degraded, response must include explicit degraded state. Do not return a clean-looking success for hidden failure.
+
+## Phase 11 Boundary
+
+C-298 Phase 11 adds this contract only. It does not enable execution.

--- a/docs/mobius-automation-index-c298.md
+++ b/docs/mobius-automation-index-c298.md
@@ -1,0 +1,96 @@
+# Mobius Automation Index — C-298 Advisory
+
+## Purpose
+
+Define the next-cycle hardening path for Mobius Class B orchestration without enabling new runtime mutation in this PR.
+
+This document is advisory only. Runtime implementation must proceed in later phases with build validation and operator review.
+
+## Strategic Principles
+
+1. Idempotency first: every cron endpoint must safely re-run without side effects.
+2. Degraded-state transparency: never hide failures behind successful-looking responses.
+3. Quorum atomicity: Vault sealing must be all-or-nothing; partial attests remain pending or quarantined.
+4. Observability by design: every agent action should produce structured JSON suitable for EPICON attestation.
+5. Fallback paths: every LLM call, KV read, or external API call must have a non-LLM fallback.
+
+## Production Hardening Priorities
+
+### P0 — Foundation Fixes
+
+- Fix `mic:readiness:feed` WRONGTYPE by standardizing key type and adding a migration script.
+- Add signal-source health checks for HERMES micro-agents.
+- Harden cron authentication and prevent preview deployments from running production cron work.
+- Ensure all cron endpoints return structured health and explicit degraded state.
+
+### P1 — Agent Orchestration Scaffolding
+
+- Introduce a shared CivicAgent base contract.
+- Add journal persistence for every agent execution.
+- Define execution order for the 10-minute window.
+- Keep agent failures degraded, not fatal.
+
+Recommended ordering:
+
+```txt
+t+0:00  ATLAS + DAEDALUS + ECHO bootstrap
+t+1:00  Vault attestation collection
+t+3:00  HERMES signal routing
+t+5:00  ZEUS + EVE + JADE quorum agents
+t+6:00  Seal eligibility check
+```
+
+### P2 — Quorum and Vault Sealing Logic
+
+- Evaluate required attestations deterministically.
+- Keep seal execution idempotent by cycle.
+- Require GI threshold, quorum, sustain streak, and degraded-agent limit before any seal.
+- Preserve all partial attempts as receipts, not final truth.
+
+### P3 — Observability and Resilience
+
+- Add structured request and agent duration logging.
+- Add degraded-state fallback registry.
+- Add `/api/system/health` with agents, quorum, seal, KV, cron, and overall status.
+
+## Minimal Mobius Node Path
+
+A Raspberry Pi node should remain runtime/data only:
+
+- local JSON KV
+- atomic file writes
+- HMAC-signed OAA-style payloads
+- structured EPICON-compatible logs
+- optional MQTT mesh
+- optional UPS low-power handling
+- plugin system for custom signal sources
+
+## Production KV Requirements for Pi Nodes
+
+The production node KV must be:
+
+- file locked with `fcntl.flock`
+- atomically written using tempfile + fsync + rename
+- optionally HMAC signed with `OAA_HMAC_KEY`
+- safe against cron overlap and power loss
+
+## Router Interaction
+
+The Mobius Router should classify automation tasks before execution:
+
+| Task | Route |
+| --- | --- |
+| local heartbeat parse | local |
+| private Pi logs | local |
+| seal eligibility | cloud+zeus |
+| quorum replay | cloud+zeus |
+| plugin signal classification | hybrid |
+| operator deployment decision | cloud |
+
+## Phase 8 Boundary
+
+This PR only adds advisory documentation and operator visibility. It does not add cron behavior, Pi scripts, MQTT, plugins, seal execution, or route enforcement.
+
+## Next Implementation Candidate
+
+C-298 Phase 9 should add a read-only Automation Index endpoint that reports which hardening prerequisites are present in the repo and which are missing.

--- a/docs/mobius-router.md
+++ b/docs/mobius-router.md
@@ -1,0 +1,46 @@
+# Mobius Router — C-298
+
+## Purpose
+
+Route Mobius tasks across local and cloud compute without allowing unverified inference to become truth.
+
+## Core Law
+
+Local = throughput.
+Cloud = truth anchor.
+Ledger = final truth.
+
+No local-only inference may write to Ledger, define Canon, finalize Replay, mutate Vault, or affect MIC/Fountain state.
+
+## Routing Rules
+
+| Condition | Route |
+| --- | --- |
+| Repetitive task | local |
+| Background agent loop | local |
+| Private data | local |
+| High-impact decision | cloud |
+| Affects Ledger/Canon/Replay/Vault/MIC | cloud+zeus |
+| Ambiguous or mixed-risk | hybrid |
+
+## Layer Mapping
+
+| Layer | Default Compute |
+| --- | --- |
+| ECHO ingestion | local |
+| HERMES routing | local |
+| JADE annotation | local |
+| DAEDALUS log parsing | local |
+| ATLAS anomaly scan | local-to-cloud escalation |
+| ZEUS verification | cloud+deterministic checks |
+| AUREA strategy | cloud |
+| EVE synthesis | hybrid |
+
+## Enforcement
+
+Ledger writes require cloud verification or ZEUS quorum.
+Local inference can produce drafts, summaries, classifications, and candidate recommendations only.
+
+## Phase 1 Boundary
+
+C-298 Phase 1 is read-only. It records routing decisions but does not call models or mutate state.

--- a/lib/router/decision.ts
+++ b/lib/router/decision.ts
@@ -13,7 +13,9 @@ export type RouterDecisionRecord = {
   id: string;
   route: RouterRoute;
   task: RouterTask;
-  cis_estimate: number | null;
+  cis_estimate: number;
+  cost_estimate: number;
+  latency_class: 'low' | 'medium' | 'high';
   reason: string;
   verified_required: boolean;
   timestamp: string;
@@ -35,14 +37,36 @@ export function routeTask(task: RouterTask): { route: RouterRoute; reason: strin
   return { route: 'hybrid', reason: 'ambiguous_task_requires_local_first_cloud_verify', verified_required: true };
 }
 
+export function estimateComputeIntegrity(route: RouterRoute, verifiedRequired: boolean): {
+  cis_estimate: number;
+  cost_estimate: number;
+  latency_class: RouterDecisionRecord['latency_class'];
+} {
+  if (route === 'cloud+zeus') {
+    return { cis_estimate: 0.96, cost_estimate: 0.85, latency_class: 'high' };
+  }
+  if (route === 'cloud') {
+    return { cis_estimate: 0.9, cost_estimate: 0.7, latency_class: 'medium' };
+  }
+  if (route === 'hybrid') {
+    return { cis_estimate: 0.86, cost_estimate: 0.55, latency_class: 'medium' };
+  }
+  return {
+    cis_estimate: verifiedRequired ? 0.62 : 0.72,
+    cost_estimate: 0.1,
+    latency_class: 'low',
+  };
+}
+
 export function createRouterDecisionRecord(task: RouterTask): RouterDecisionRecord {
   const decision = routeTask(task);
+  const estimate = estimateComputeIntegrity(decision.route, decision.verified_required);
   const now = new Date().toISOString();
   return {
     id: `router-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     route: decision.route,
     task,
-    cis_estimate: null,
+    ...estimate,
     reason: decision.reason,
     verified_required: decision.verified_required,
     timestamp: now,
@@ -61,6 +85,8 @@ export function summarizeRouterDecisions(records: RouterDecisionRecord[]) {
   const verifiedRequired = records.filter((record) => record.verified_required).length;
   const localShare = total > 0 ? Number((byRoute.local / total).toFixed(3)) : 0;
   const cloudVerifiedShare = total > 0 ? Number(((byRoute.cloud + byRoute['cloud+zeus'] + byRoute.hybrid) / total).toFixed(3)) : 0;
+  const estimatedCis = total > 0 ? Number((records.reduce((sum, record) => sum + record.cis_estimate, 0) / total).toFixed(3)) : null;
+  const estimatedCost = total > 0 ? Number((records.reduce((sum, record) => sum + record.cost_estimate, 0) / total).toFixed(3)) : null;
 
   return {
     total,
@@ -68,6 +94,8 @@ export function summarizeRouterDecisions(records: RouterDecisionRecord[]) {
     verifiedRequired,
     localShare,
     cloudVerifiedShare,
-    cis_placeholder: null,
+    estimatedCis,
+    estimatedCost,
+    cis_mode: 'policy_estimate',
   };
 }

--- a/lib/router/decision.ts
+++ b/lib/router/decision.ts
@@ -1,0 +1,73 @@
+export type RouterRoute = 'local' | 'cloud' | 'cloud+zeus' | 'hybrid';
+
+export type RouterTask = {
+  type?: string;
+  affectsLedger?: boolean;
+  highImpact?: boolean;
+  repetitive?: boolean;
+  private?: boolean;
+  agent?: string;
+};
+
+export type RouterDecisionRecord = {
+  id: string;
+  route: RouterRoute;
+  task: RouterTask;
+  cis_estimate: number | null;
+  reason: string;
+  verified_required: boolean;
+  timestamp: string;
+};
+
+export function routeTask(task: RouterTask): { route: RouterRoute; reason: string; verified_required: boolean } {
+  if (task.affectsLedger) {
+    return { route: 'cloud+zeus', reason: 'task_affects_ledger_or_truth_layer', verified_required: true };
+  }
+  if (task.highImpact) {
+    return { route: 'cloud', reason: 'high_impact_decision_requires_cloud_reasoning', verified_required: true };
+  }
+  if (task.repetitive) {
+    return { route: 'local', reason: 'repetitive_task_can_run_local', verified_required: false };
+  }
+  if (task.private) {
+    return { route: 'local', reason: 'private_task_prefers_local_compute', verified_required: false };
+  }
+  return { route: 'hybrid', reason: 'ambiguous_task_requires_local_first_cloud_verify', verified_required: true };
+}
+
+export function createRouterDecisionRecord(task: RouterTask): RouterDecisionRecord {
+  const decision = routeTask(task);
+  const now = new Date().toISOString();
+  return {
+    id: `router-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    route: decision.route,
+    task,
+    cis_estimate: null,
+    reason: decision.reason,
+    verified_required: decision.verified_required,
+    timestamp: now,
+  };
+}
+
+export function summarizeRouterDecisions(records: RouterDecisionRecord[]) {
+  const total = records.length;
+  const byRoute = records.reduce<Record<RouterRoute, number>>(
+    (acc, record) => {
+      acc[record.route] += 1;
+      return acc;
+    },
+    { local: 0, cloud: 0, 'cloud+zeus': 0, hybrid: 0 },
+  );
+  const verifiedRequired = records.filter((record) => record.verified_required).length;
+  const localShare = total > 0 ? Number((byRoute.local / total).toFixed(3)) : 0;
+  const cloudVerifiedShare = total > 0 ? Number(((byRoute.cloud + byRoute['cloud+zeus'] + byRoute.hybrid) / total).toFixed(3)) : 0;
+
+  return {
+    total,
+    byRoute,
+    verifiedRequired,
+    localShare,
+    cloudVerifiedShare,
+    cis_placeholder: null,
+  };
+}

--- a/lib/router/decision.ts
+++ b/lib/router/decision.ts
@@ -21,6 +21,16 @@ export type RouterDecisionRecord = {
   timestamp: string;
 };
 
+export type RouterFeedbackRecord = {
+  id: string;
+  decision_id: string;
+  outcome: 'confirmed' | 'corrected' | 'rejected' | 'unknown';
+  operator_note?: string;
+  actual_cis?: number;
+  actual_cost?: number;
+  timestamp: string;
+};
+
 export function routeTask(task: RouterTask): { route: RouterRoute; reason: string; verified_required: boolean } {
   if (task.affectsLedger) {
     return { route: 'cloud+zeus', reason: 'task_affects_ledger_or_truth_layer', verified_required: true };
@@ -73,7 +83,44 @@ export function createRouterDecisionRecord(task: RouterTask): RouterDecisionReco
   };
 }
 
-export function summarizeRouterDecisions(records: RouterDecisionRecord[]) {
+export function createRouterFeedbackRecord(args: {
+  decision_id: string;
+  outcome: RouterFeedbackRecord['outcome'];
+  operator_note?: string;
+  actual_cis?: number;
+  actual_cost?: number;
+}): RouterFeedbackRecord {
+  return {
+    id: `router-feedback-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    decision_id: args.decision_id,
+    outcome: args.outcome,
+    operator_note: args.operator_note,
+    actual_cis: typeof args.actual_cis === 'number' ? Math.max(0, Math.min(1, args.actual_cis)) : undefined,
+    actual_cost: typeof args.actual_cost === 'number' ? Math.max(0, args.actual_cost) : undefined,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function summarizeRouterFeedback(records: RouterFeedbackRecord[]) {
+  const total = records.length;
+  const confirmed = records.filter((record) => record.outcome === 'confirmed').length;
+  const corrected = records.filter((record) => record.outcome === 'corrected').length;
+  const rejected = records.filter((record) => record.outcome === 'rejected').length;
+  const actualCisRows = records.filter((record) => typeof record.actual_cis === 'number');
+  const actualCostRows = records.filter((record) => typeof record.actual_cost === 'number');
+  return {
+    total,
+    confirmed,
+    corrected,
+    rejected,
+    confirmationRate: total > 0 ? Number((confirmed / total).toFixed(3)) : null,
+    correctionRate: total > 0 ? Number(((corrected + rejected) / total).toFixed(3)) : null,
+    actualCis: actualCisRows.length > 0 ? Number((actualCisRows.reduce((sum, record) => sum + (record.actual_cis ?? 0), 0) / actualCisRows.length).toFixed(3)) : null,
+    actualCost: actualCostRows.length > 0 ? Number((actualCostRows.reduce((sum, record) => sum + (record.actual_cost ?? 0), 0) / actualCostRows.length).toFixed(3)) : null,
+  };
+}
+
+export function summarizeRouterDecisions(records: RouterDecisionRecord[], feedback: RouterFeedbackRecord[] = []) {
   const total = records.length;
   const byRoute = records.reduce<Record<RouterRoute, number>>(
     (acc, record) => {
@@ -87,6 +134,7 @@ export function summarizeRouterDecisions(records: RouterDecisionRecord[]) {
   const cloudVerifiedShare = total > 0 ? Number(((byRoute.cloud + byRoute['cloud+zeus'] + byRoute.hybrid) / total).toFixed(3)) : 0;
   const estimatedCis = total > 0 ? Number((records.reduce((sum, record) => sum + record.cis_estimate, 0) / total).toFixed(3)) : null;
   const estimatedCost = total > 0 ? Number((records.reduce((sum, record) => sum + record.cost_estimate, 0) / total).toFixed(3)) : null;
+  const feedbackSummary = summarizeRouterFeedback(feedback);
 
   return {
     total,
@@ -96,6 +144,7 @@ export function summarizeRouterDecisions(records: RouterDecisionRecord[]) {
     cloudVerifiedShare,
     estimatedCis,
     estimatedCost,
-    cis_mode: 'policy_estimate',
+    cis_mode: feedbackSummary.actualCis == null ? 'policy_estimate' : 'policy_plus_feedback',
+    feedback: feedbackSummary,
   };
 }


### PR DESCRIPTION
## Phase
C-298 Phase 1-2 — Mobius Router Read-Only + Instrumentation

## Scope
- Add Mobius Router contract docs
- Add Compute Integrity spec
- Add read-only router decision endpoint
- Add router decision records/helpers
- Add router metrics endpoint
- Persist capped router decisions to KV

## Files touched
- docs/mobius-router.md
- docs/compute-integrity.md
- lib/router/decision.ts
- app/api/router/decide/route.ts
- app/api/router/metrics/route.ts

## NOT touching
- Ledger writes
- Vault
- Canon
- Replay
- MIC/Fountain
- Model calls or local/cloud execution

## Change type
Additive / read-only instrumentation

## Risk
Low

## Validation plan
- pnpm exec tsc --noEmit
- pnpm build
- pnpm lint

## Test endpoints
- GET /api/router/decide
- POST /api/router/decide
- GET /api/router/metrics

## Canon law
Local inference cannot become truth by itself. Router decisions are observational in this PR only.