### PR TITLE
fix(terminal): sustain floor → 0.75, add /api/vault/replay routes, and increase promote cron cadence

### DIFF
--- a/app/api/vault/replay/[sealId]/route.ts
+++ b/app/api/vault/replay/[sealId]/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSeal } from '@/lib/vault-v2/store';
+
+export const dynamic = 'force-dynamic';
+
+type ReplayRow = {
+  id: string;
+  title: string;
+  category: string;
+  original_verdict: string;
+  original_mii: number;
+  replay_verdict: 'verified' | 'flagged';
+  drift: number;
+};
+
+export async function GET(_req: NextRequest, context: { params: Promise<{ sealId: string }> }) {
+  const { sealId } = await context.params;
+  const seal = await getSeal(sealId);
+  if (!seal) return NextResponse.json({ ok: false, error: 'Seal not found' }, { status: 404 });
+
+  const events: ReplayRow[] = [];
+
+  return NextResponse.json({
+    ok: true,
+    seal_id: sealId,
+    seal: {
+      sealed_at: seal.sealed_at,
+      gi_at_seal: seal.gi_at_seal,
+      seal_hash: seal.seal_hash,
+      substrate_attested: Boolean(seal.substrate_attested_at),
+      quorum_agents: Object.keys(seal.attestations ?? {}),
+    },
+    replay: {
+      events,
+      total: events.length,
+      verified: events.filter((r) => r.replay_verdict === 'verified').length,
+      flagged: events.filter((r) => r.replay_verdict === 'flagged').length,
+      drifted: events.filter((r) => r.drift > 0.05).length,
+      max_drift: Math.max(...events.map((r) => r.drift), 0),
+      integrity_stable: events.every((r) => r.drift <= 0.05),
+    },
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/app/api/vault/replay/route.ts
+++ b/app/api/vault/replay/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { listAllSeals } from '@/lib/vault-v2/store';
+export const dynamic = 'force-dynamic';
+export async function GET() {
+  const seals = await listAllSeals(50);
+  return NextResponse.json({ ok: true, count: seals.length, seals: seals.sort((a, b) => new Date(b.sealed_at).getTime() - new Date(a.sealed_at).getTime()), timestamp: new Date().toISOString() });
+}

--- a/lib/mic/sustainTracker.ts
+++ b/lib/mic/sustainTracker.ts
@@ -5,7 +5,7 @@
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { kvGet, kvSet, KV_KEYS, KV_TTL_SECONDS } from '@/lib/kv/store';
 
-export const SUSTAIN_GI_THRESHOLD = 0.95;
+export const SUSTAIN_GI_THRESHOLD = 0.75;
 export const SUSTAIN_REQUIRED_CYCLES = 5;
 
 import type { MicSustainStatus } from '@/lib/mic/types';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.27(postcss@8.5.8)
+      dotenv:
+        specifier: ^16.6.1
+        version: 16.6.1
       postcss:
         specifier: ^8.4.47
         version: 8.5.8
@@ -163,105 +166,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -332,28 +319,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.14':
     resolution: {integrity: sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.14':
     resolution: {integrity: sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.14':
     resolution: {integrity: sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.14':
     resolution: {integrity: sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==}
@@ -693,6 +676,10 @@ packages:
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1951,6 +1938,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
+
+  dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/vercel.json
+++ b/vercel.json
@@ -16,11 +16,7 @@
     },
     {
       "path": "/api/cron/promote",
-      "schedule": "30 0 * * *"
-    },
-    {
-      "path": "/api/cron/promote",
-      "schedule": "30 12 * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/cron/gi-refresh",


### PR DESCRIPTION
### Motivation
- Address terminal health gaps surfaced by the C-299 scan: sustain eligibility was incorrectly gated by the fountain threshold, replay endpoints returned 404 preventing seal inspection, and the promoter cadence was too infrequent leading to stale promotion state.
- Provide a minimal, safe replay API envelope so the Terminal replay UI can list and inspect seals while a fuller replay/EPICON wire-up is completed.

### Description
- Lowered sustain eligibility floor from `0.95` to `0.75` in `lib/mic/sustainTracker.ts` so sustain counting proceeds correctly when GI ≥ 0.75.
- Added replay index and detail routes at `GET /api/vault/replay` (`app/api/vault/replay/route.ts`) and `GET /api/vault/replay/[sealId]` (`app/api/vault/replay/[sealId]/route.ts`) that return recent seals and a stable replay envelope respectively (detail route currently scaffolds an empty `events` array and returns seal metadata).
- Increased promotion cron cadence by updating `/api/cron/promote` schedule to run every 5 minutes in `vercel.json` and removed the duplicate once-daily entry.
- `pnpm-lock.yaml` was updated by dependency normalization in this environment; changes were committed alongside the above code edits.

### Testing
- Ran typecheck with `pnpm exec tsc --noEmit` and it passed successfully.
- Built the project with `pnpm build` and the Next.js production build completed successfully.
- Ran `pnpm lint` but it was blocked by an interactive Next.js ESLint setup prompt in this non-interactive environment, so lint was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f694cb9138832db668c578ea824651)