### PR TITLE
C-300 Fix — Journal Canon Index Drain + Sorting Integrity

### DIFF
--- a/app/api/cron/journal-canonize/route.ts
+++ b/app/api/cron/journal-canonize/route.ts
@@ -1,0 +1,44 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getJournalRedisClient } from '@/lib/agents/journalLane';
+import { processJournalCanonOutbox } from '@/lib/agents/journalCanonOutbox';
+import { bearerMatchesToken } from '@/lib/vault-v2/auth';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+function clampLimit(input: string | null): number {
+  const parsed = Number(input ?? '10');
+  if (!Number.isFinite(parsed) || parsed <= 0) return 10;
+  return Math.min(50, Math.max(1, Math.floor(parsed)));
+}
+
+export async function GET(request: NextRequest) {
+  const cronHeader = request.headers.get('x-vercel-cron');
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET || '';
+  const manuallyAuthed = bearerMatchesToken(authHeader, cronSecret);
+
+  if (!cronHeader && !manuallyAuthed) {
+    return NextResponse.json({ ok: false, error: 'Cron-only endpoint' }, { status: 403 });
+  }
+
+  const redis = getJournalRedisClient();
+  const limit = clampLimit(request.nextUrl.searchParams.get('limit'));
+  const result = await processJournalCanonOutbox(redis, limit);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      source: 'cron-journal-canonize',
+      limit,
+      ...result,
+      timestamp: new Date().toISOString(),
+    },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}
+
+export async function POST(request: NextRequest) {
+  return GET(request);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -35,6 +35,10 @@
       "schedule": "*/10 * * * *"
     },
     {
+      "path": "/api/cron/journal-canonize",
+      "schedule": "*/10 * * * *"
+    },
+    {
       "path": "/api/cron/publish-oaa-snapshots",
       "schedule": "*/15 * * * *"
     },


### PR DESCRIPTION
## Problem
- journal:canon:item:* accumulating
- NOT draining to substrate
- UI confusion / perceived indexing bug

## Root Cause
1. Canon outbox is ENQUEUED but NEVER PROCESSED
2. No cron calls processJournalCanonOutbox
3. Keys appear in KV but never leave

## Fix
### 1. Add cron endpoint
- /api/cron/journal-canonize
- processes outbox every 10 min

### 2. Add Vercel cron
- drains canon queue continuously

## Result
- journal:canon:item:* → processed → removed
- entries written to Substrate (GitHub)
- journal lane reflects true HOT vs CANON separation

## Expected Behavior
HOT lane:
- fast KV writes

CANON:
- async drain → substrate

## After Deploy
You should see:
- canon_pending → canon_written
- KV keys disappearing over time
- Substrate repo filling with journal entries

## Next Phase
- Phase: Canon visibility UI (show canon status per row)
- Phase: Seal-ready journal blocks
