### PR TITLE
C-300 EPICON Runtime Foundation — Packets, Consensus, Endpoint

### DIFF
--- a/docs/epicon/EPICON_RUNTIME_FOUNDATION.md
+++ b/docs/epicon/EPICON_RUNTIME_FOUNDATION.md
@@ -1,0 +1,29 @@
+# EPICON Runtime Foundation (C-300)
+
+## Purpose
+
+Introduce EPICON as a runtime-usable structure without enforcing hard mutation blocking yet.
+
+## What is added
+
+- EpiconPacket types
+- Consensus scoring engine (ECS)
+- API endpoint for validation (/api/epicon/check)
+
+## What is NOT enforced yet
+
+- No mutation blocking
+- No merge gating
+- No ledger enforcement
+
+## Next Phase (C-301)
+
+- Gate cron endpoints behind EPICON-03 PASS
+- Attach epicon_hash to ledger writes
+- Surface consensus in UI
+
+## Operator Note
+
+This phase establishes structure, not authority.
+
+Authority begins when EPICON blocks reality changes.

--- a/lib/epicon/consensus.ts
+++ b/lib/epicon/consensus.ts
@@ -1,0 +1,31 @@
+import { EpiconAgentReport, EpiconConsensus } from './types';
+
+export function computeConsensus(reports: EpiconAgentReport[]): EpiconConsensus {
+  const total = reports.length;
+  const support = reports.filter(r => r.stance === 'support').length;
+  const conditional = reports.filter(r => r.stance === 'conditional').length;
+  const oppose = reports.filter(r => r.stance === 'oppose').length;
+
+  const ecs = total === 0 ? 0 : (support + 0.5 * conditional) / total;
+
+  let status: EpiconConsensus['status'] = 'fail';
+  if (ecs >= 0.8 && oppose === 0) status = 'pass';
+  else if (ecs >= 0.6) status = 'needs_clarification';
+
+  return {
+    status,
+    ecs,
+    vote: { support, conditional, oppose },
+    quorum: {
+      agents: total,
+      min_required: 5,
+      independent_ok: total >= 5,
+    },
+    dissent_set: reports
+      .filter(r => r.stance !== 'support')
+      .map(r => ({ agent: r.agent, stance: r.stance, reason: r.ej.reasoning })),
+    required_questions: status === 'needs_clarification'
+      ? ['Clarify EJ anchors', 'Resolve dissent']
+      : [],
+  };
+}

--- a/lib/epicon/types.ts
+++ b/lib/epicon/types.ts
@@ -1,0 +1,74 @@
+export type EpiconAgentId = 'ATLAS' | 'ZEUS' | 'EVE' | 'AUREA' | 'JADE';
+
+export type EpiconScope =
+  | 'journal'
+  | 'canon'
+  | 'vault'
+  | 'ledger'
+  | 'merge'
+  | 'governance'
+  | 'runtime';
+
+export type EpiconRiskLevel = 'low' | 'medium' | 'high';
+export type EpiconStance = 'support' | 'oppose' | 'conditional';
+export type EpiconStatus = 'pass' | 'needs_clarification' | 'fail';
+
+export type EpiconIntent = {
+  action: string;
+  scope: EpiconScope[];
+  risk_level: EpiconRiskLevel;
+  intent_hash: string;
+  summary: string;
+  changed_files?: string[];
+};
+
+export type EpiconEJ = {
+  reasoning: string;
+  anchors: string[];
+  counterfactuals: string[];
+  ccr_score: number;
+  css_pass: boolean;
+};
+
+export type EpiconAgentReport = {
+  agent: EpiconAgentId;
+  stance: EpiconStance;
+  confidence: number;
+  ej: EpiconEJ;
+  ej_hash: string;
+  generated_at: string;
+};
+
+export type EpiconConsensus = {
+  status: EpiconStatus;
+  ecs: number;
+  vote: {
+    support: number;
+    conditional: number;
+    oppose: number;
+  };
+  quorum: {
+    agents: number;
+    min_required: number;
+    independent_ok: boolean;
+  };
+  dissent_set: Array<{
+    agent: EpiconAgentId;
+    stance: EpiconStance;
+    reason: string;
+  }>;
+  required_questions: string[];
+};
+
+export type EpiconPacket = {
+  version: 'EPICON-03';
+  request_id: string;
+  generated_at: string;
+  intent: EpiconIntent;
+  agent_reports: EpiconAgentReport[];
+  consensus: EpiconConsensus;
+  attestation: {
+    packet_hash: string;
+    sealed: boolean;
+  };
+};

--- a/pages/api/epicon/check.ts
+++ b/pages/api/epicon/check.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { computeConsensus } from '@/lib/epicon/consensus';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const { reports } = req.body || {};
+
+    if (!reports || !Array.isArray(reports)) {
+      return res.status(400).json({ error: 'invalid_reports' });
+    }
+
+    const consensus = computeConsensus(reports);
+
+    return res.status(200).json({
+      status: consensus.status,
+      ecs: consensus.ecs,
+      vote: consensus.vote,
+      quorum: consensus.quorum,
+      dissent: consensus.dissent_set,
+    });
+  } catch (err) {
+    return res.status(500).json({ error: 'epicon_check_failed' });
+  }
+}


### PR DESCRIPTION
# 🧠 C-300 — EPICON Runtime Foundation

## Phase
Phase 1 — Additive Only

## Scope
Introduce EPICON runtime primitives without enforcing mutation blocking yet.

## Files Added
- lib/epicon/types.ts
- lib/epicon/consensus.ts
- pages/api/epicon/check.ts
- docs/epicon/EPICON_RUNTIME_FOUNDATION.md

## NOT touching
- existing cron endpoints
- ledger writes
- UI rendering

## Change Type
Additive (non-breaking)

## Risk
Low

## Validation Plan
- POST /api/epicon/check with agent reports
- Verify ECS scoring
- Verify PASS / NEEDS_CLARIFICATION / FAIL

## Outcome
Mobius now has a formal EPICON packet + consensus system available at runtime.

## Next Phase (C-301)
- Gate mutations behind EPICON-03
- Attach epicon_hash to ledger
- Surface consensus in UI

---

## Operator Note

This is the moment EPICON becomes real.

Not enforced yet — but now it exists in runtime.
