### PR TITLE
C-300 EPICON Visibility Panel — Runtime Consensus UI

### DIFF
--- a/app/terminal/epicon/page.tsx
+++ b/app/terminal/epicon/page.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+type EpiconStance = 'support' | 'oppose' | 'conditional';
+type EpiconStatus = 'pass' | 'needs_clarification' | 'fail';
+
+type EpiconCheckResponse = {
+  status: EpiconStatus;
+  ecs: number;
+  vote: {
+    support: number;
+    conditional: number;
+    oppose: number;
+  };
+  quorum: {
+    agents: number;
+    min_required: number;
+    independent_ok: boolean;
+  };
+  dissent: Array<{
+    agent: string;
+    stance: EpiconStance;
+    reason: string;
+  }>;
+};
+
+const SAMPLE_REPORTS = ['ATLAS', 'ZEUS', 'EVE', 'AUREA', 'JADE'].map((agent) => ({
+  agent,
+  stance: 'support' as const,
+  confidence: 0.9,
+  ej: {
+    reasoning: `${agent} supports the action for a low-risk EPICON runtime visibility check.`,
+    anchors: ['EPICON-01 EJ', 'EPICON-03 quorum'],
+    counterfactuals: ['If any agent opposed, action would not be considered pass.'],
+    ccr_score: 0.8,
+    css_pass: true,
+  },
+  ej_hash: `sha256:${agent.toLowerCase()}-sample`,
+  generated_at: new Date().toISOString(),
+}));
+
+const STATUS_CLASS: Record<EpiconStatus, string> = {
+  pass: 'text-emerald-300 border-emerald-500/30 bg-emerald-950/20',
+  needs_clarification: 'text-amber-300 border-amber-500/30 bg-amber-950/20',
+  fail: 'text-rose-300 border-rose-500/30 bg-rose-950/20',
+};
+
+export default function EpiconPage() {
+  const [result, setResult] = useState<EpiconCheckResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const consensusLabel = useMemo(() => {
+    if (!result) return 'not_checked';
+    return `${result.status.toUpperCase()} · ECS ${result.ecs.toFixed(2)}`;
+  }, [result]);
+
+  async function runSampleCheck() {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/epicon/check', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reports: SAMPLE_REPORTS }),
+      });
+      const payload = (await response.json()) as EpiconCheckResponse | { error?: string };
+      if (!response.ok || 'error' in payload) throw new Error('error' in payload ? payload.error ?? 'epicon_check_failed' : 'epicon_check_failed');
+      setResult(payload);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'epicon_check_failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="h-full overflow-y-auto p-4 font-mono text-xs text-slate-200">
+      <div className="mb-4">
+        <div className="text-[10px] uppercase tracking-[0.22em] text-slate-500">Mobius Governance</div>
+        <h1 className="mt-1 text-lg font-semibold uppercase tracking-[0.16em] text-violet-200">EPICON Runtime</h1>
+        <p className="mt-2 max-w-2xl text-[11px] leading-relaxed text-slate-500">
+          Runtime visibility for intent, epistemic justification, consensus scoring, and dissent preservation. This panel observes EPICON-03; it does not enforce mutation blocking yet.
+        </p>
+      </div>
+
+      <section className="mb-4 rounded border border-violet-500/25 bg-slate-950/80 p-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="text-[10px] uppercase tracking-[0.18em] text-violet-300/80">Consensus Check</div>
+            <div className="mt-1 text-slate-400">Sample Sentinel quorum: ATLAS · ZEUS · EVE · AUREA · JADE</div>
+          </div>
+          <button
+            type="button"
+            onClick={runSampleCheck}
+            disabled={loading}
+            className="rounded border border-cyan-500/40 px-3 py-1 text-cyan-200 hover:border-cyan-300 disabled:opacity-50"
+          >
+            {loading ? 'Checking…' : 'Run Sample EPICON Check'}
+          </button>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-4">
+          <div className="rounded border border-slate-800 bg-black/20 p-3">
+            <div className="text-slate-500">status</div>
+            <div className={result ? `mt-1 inline-block rounded border px-2 py-1 ${STATUS_CLASS[result.status]}` : 'mt-1 text-slate-400'}>{consensusLabel}</div>
+          </div>
+          <div className="rounded border border-slate-800 bg-black/20 p-3">
+            <div className="text-slate-500">quorum</div>
+            <div className="mt-1 text-slate-100">{result ? `${result.quorum.agents}/${result.quorum.min_required}` : '—'}</div>
+          </div>
+          <div className="rounded border border-slate-800 bg-black/20 p-3">
+            <div className="text-slate-500">support</div>
+            <div className="mt-1 text-emerald-300">{result?.vote.support ?? '—'}</div>
+          </div>
+          <div className="rounded border border-slate-800 bg-black/20 p-3">
+            <div className="text-slate-500">dissent</div>
+            <div className="mt-1 text-rose-300">{result?.dissent.length ?? '—'}</div>
+          </div>
+        </div>
+
+        {error ? <div className="mt-3 rounded border border-rose-500/30 bg-rose-950/20 p-2 text-rose-200">{error}</div> : null}
+      </section>
+
+      <section className="rounded border border-slate-800 bg-slate-950/70 p-4 text-[11px] text-slate-400">
+        <div className="mb-2 uppercase tracking-[0.18em] text-cyan-300/80">Runtime Law</div>
+        <div>EPICON-01 preserves meaning through EJ.</div>
+        <div>EPICON-02 preserves intent before action.</div>
+        <div>EPICON-03 preserves consensus and dissent before authority.</div>
+        <div className="mt-3 text-amber-300">Current mode: observe-only. Enforcement begins in the next phase.</div>
+      </section>
+    </div>
+  );
+}

--- a/app/terminal/epicon/page.tsx
+++ b/app/terminal/epicon/page.tsx
@@ -25,6 +25,18 @@ type EpiconCheckResponse = {
   }>;
 };
 
+type EpiconCheckError = { error?: string };
+
+function isEpiconCheckResponse(payload: EpiconCheckResponse | EpiconCheckError): payload is EpiconCheckResponse {
+  return (
+    typeof (payload as EpiconCheckResponse).status === 'string' &&
+    typeof (payload as EpiconCheckResponse).ecs === 'number' &&
+    Boolean((payload as EpiconCheckResponse).vote) &&
+    Boolean((payload as EpiconCheckResponse).quorum) &&
+    Array.isArray((payload as EpiconCheckResponse).dissent)
+  );
+}
+
 const SAMPLE_REPORTS = ['ATLAS', 'ZEUS', 'EVE', 'AUREA', 'JADE'].map((agent) => ({
   agent,
   stance: 'support' as const,
@@ -65,8 +77,10 @@ export default function EpiconPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ reports: SAMPLE_REPORTS }),
       });
-      const payload = (await response.json()) as EpiconCheckResponse | { error?: string };
-      if (!response.ok || 'error' in payload) throw new Error('error' in payload ? payload.error ?? 'epicon_check_failed' : 'epicon_check_failed');
+      const payload = (await response.json()) as EpiconCheckResponse | EpiconCheckError;
+      if (!response.ok || !isEpiconCheckResponse(payload)) {
+        throw new Error('error' in payload ? payload.error ?? 'epicon_check_failed' : 'epicon_check_failed');
+      }
       setResult(payload);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'epicon_check_failed');

--- a/app/terminal/journal/[agent]/page.tsx
+++ b/app/terminal/journal/[agent]/page.tsx
@@ -4,11 +4,18 @@ import { useParams } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 
 type Entry = { id: string; agent: string; category?: string; timestamp: string; observation?: string };
+type AgentRouteParams = { agent?: string | string[] };
+
+function firstParam(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) return value[0] ?? '';
+  return value ?? '';
+}
 
 export default function AgentJournalPage() {
-  const params = useParams<{ agent: string }>();
+  const params = useParams<AgentRouteParams>();
   const [entries, setEntries] = useState<Entry[]>([]);
-  const agent = useMemo(() => decodeURIComponent(params.agent ?? ''), [params.agent]);
+  const agentParam = firstParam(params?.agent);
+  const agent = useMemo(() => decodeURIComponent(agentParam), [agentParam]);
 
   useEffect(() => {
     if (!agent) return;

--- a/components/terminal/ChamberSwitcher.tsx
+++ b/components/terminal/ChamberSwitcher.tsx
@@ -27,6 +27,7 @@ const KEY_TO_ROUTE: Record<string, string> = {
 
 export default function ChamberSwitcher() {
   const pathname = usePathname();
+  const currentPath = pathname ?? '';
   const router = useRouter();
 
   useEffect(() => {
@@ -49,7 +50,7 @@ export default function ChamberSwitcher() {
   return (
     <nav className="-mx-1 flex gap-1 overflow-x-auto px-1 pb-0.5 md:mx-0 md:gap-2 md:px-0 md:pb-1" aria-label="Terminal chambers">
       {CHAMBERS.map((tab) => {
-        const active = pathname === tab.href || pathname.startsWith(`${tab.href}/`);
+        const active = currentPath === tab.href || currentPath.startsWith(`${tab.href}/`);
         return (
           <Link
             key={tab.href}

--- a/components/terminal/ShellBridgeBanner.tsx
+++ b/components/terminal/ShellBridgeBanner.tsx
@@ -19,11 +19,11 @@ export default function ShellBridgeBanner() {
   const [fromLab, setFromLab] = useState<string | null>(null);
 
   useEffect(() => {
-    const from = searchParams.get('from');
+    const from = searchParams?.get('from') ?? null;
     if (from !== 'shell') return;
 
     setVisible(true);
-    setFromLab(searchParams.get('lab'));
+    setFromLab(searchParams?.get('lab') ?? null);
 
     const url = new URL(window.location.href);
     url.searchParams.delete('from');

--- a/components/terminal/TerminalShell.tsx
+++ b/components/terminal/TerminalShell.tsx
@@ -25,6 +25,7 @@ function pathnameToLabel(pathname: string): string | null {
   if (pathname.startsWith('/terminal/vault')) return 'Vault';
   if (pathname.startsWith('/terminal/canon')) return 'Vault Canon';
   if (pathname.startsWith('/terminal/replay')) return 'Vault Replay';
+  if (pathname.startsWith('/terminal/epicon')) return 'EPICON';
   return null;
 }
 
@@ -36,6 +37,7 @@ function runtimeBadgeClass(runtime: 'online' | 'degraded' | 'offline') {
 
 export default function TerminalShell({ children }: { children: ReactNode }) {
   const pathname = usePathname();
+  const currentPath = pathname ?? '';
   const [clock, setClock] = useState('—');
   const [showLaneDiagnostics, setShowLaneDiagnostics] = useState(false);
   const [showDataflowCommand, setShowDataflowCommand] = useState(true);
@@ -95,9 +97,9 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
-    const active = pathnameToLabel(pathname);
+    const active = pathnameToLabel(currentPath);
     document.title = active ? `Mobius Terminal · ${active}` : 'Mobius Terminal';
-  }, [pathname]);
+  }, [currentPath]);
 
   useEffect(() => {
     const stored = localStorage.getItem('mobius_console_collapsed');


### PR DESCRIPTION
# 🧠 C-300 — EPICON Visibility Panel

## Phase
Phase 2 — UI Wiring (non-blocking)

## Scope
Surface EPICON runtime consensus in the Terminal UI using the newly introduced runtime endpoint.

## Files Added
- app/terminal/epicon/page.tsx

## NOT touching
- mutation flows
- ledger writes
- enforcement logic

## Change Type
Additive (non-breaking)

## What This Adds
- Live EPICON consensus panel
- ECS + quorum visibility
- Dissent surfacing
- Operator-triggered sample check

## Why This Matters
Before enforcement, operators must *see* consensus.

Mobius principle:
> Truth must be observable before it is enforced.

## Next Phase
- Gate mutations behind EPICON-03
- Attach epicon_hash to ledger
- Block unsafe writes

---

## Operator Note

EPICON is no longer theoretical.

You can now see consensus form in real time.
