### PR TITLE
C-300 Phase 11 — EPICON Dry-Run Gate (Pre-Enforcement Layer)

### DIFF
--- a/docs/epicon/EPICON_PHASE11_GATE.md
+++ b/docs/epicon/EPICON_PHASE11_GATE.md
@@ -1,0 +1,15 @@
+# EPICON Phase 11 — Dry Run Gate
+
+## Purpose
+Introduce a non-blocking EPICON gate that evaluates mutations before they are committed.
+
+## Behavior
+- Calls /api/epicon/check
+- Returns PASS / NEEDS_CLARIFICATION / FAIL
+- Does NOT block execution yet
+
+## Next Step
+Phase 12 will enforce blocking on FAIL states.
+
+## Principle
+Observe → Verify → THEN Enforce

--- a/lib/epicon/gate.ts
+++ b/lib/epicon/gate.ts
@@ -1,0 +1,29 @@
+export type EpiconGateResult = {
+  decision: 'PASS' | 'NEEDS_CLARIFICATION' | 'FAIL'
+  reason?: string
+  epicon_hash?: string
+}
+
+export async function runEpiconGateDryRun(payload: any): Promise<EpiconGateResult> {
+  try {
+    const res = await fetch('/api/epicon/check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+
+    if (!res.ok) {
+      return { decision: 'FAIL', reason: 'epicon_check_failed' }
+    }
+
+    const data = await res.json()
+
+    return {
+      decision: data.decision ?? 'NEEDS_CLARIFICATION',
+      reason: data.reason,
+      epicon_hash: data.hash,
+    }
+  } catch (err) {
+    return { decision: 'FAIL', reason: 'epicon_runtime_error' }
+  }
+}


### PR DESCRIPTION
# 🧠 C-300 — Phase 11: EPICON Dry-Run Gate

## Phase
Phase 2.5 — Parallel Logic (Non-blocking Gate)

## Scope
Introduce EPICON gate logic that evaluates mutations BEFORE execution, but does not yet block them.

## Files Added
- lib/epicon/gate.ts
- docs/epicon/EPICON_PHASE11_GATE.md

## NOT touching
- cron mutation logic
- ledger write pipeline
- enforcement/blocking

## Change Type
Additive / Parallel Logic

## What This Does
- Introduces a reusable EPICON gate runner
- Calls /api/epicon/check before mutations
- Returns PASS / NEEDS_CLARIFICATION / FAIL
- Enables pre-enforcement visibility

## Why This Matters
Mobius principle:
> You must observe truth BEFORE enforcing truth

## Next Phase (C-301)
- Block mutations on FAIL
- Attach epicon_hash to ledger writes
- Enforce EPICON-03 multi-sig gate
