### PR TITLE
C-301 Phase 12 — 5 bug fixes + 5 optimizations

### DIFF
--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -513,7 +513,12 @@ export async function GET(request: NextRequest) {
         substrate: substrateEntries.length,
       },
       merged_from_archive: mode === 'merged' && substrateEntries.length > 0,
-      canonical_source: substrateEntries.length === 0 && kvForSources.length > 0 ? 'kv-fallback' : 'substrate',
+      canonical_source:
+        substrateEntries.length > 0
+          ? 'substrate'
+          : kvForSources.length > 0
+          ? 'kv-fallback'
+          : 'kv-empty',
       archive_error: substrateError,
       archive_fetched_count: substrateEntries.length,
       archive_stale: archiveStale,

--- a/app/api/cron/journal-canonize/route.ts
+++ b/app/api/cron/journal-canonize/route.ts
@@ -37,9 +37,21 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ ok: false, error: 'Cron-only endpoint' }, { status: 403 });
   }
 
-  const repoUrl = process.env.JOURNAL_CANON_SUBSTRATE_TARGET ?? process.env.SUBSTRATE_GITHUB_REPO ?? process.env.GITHUB_REPO_URL ?? '(not configured)';
+  const repoUrl =
+    process.env.JOURNAL_CANON_SUBSTRATE_TARGET ??
+    process.env.SUBSTRATE_GITHUB_REPO ??
+    process.env.GITHUB_REPO_URL ??
+    null;
+  const substrateConfigured = Boolean(repoUrl);
+  if (!substrateConfigured) {
+    console.warn(
+      '[journal-canonize] substrate write target not configured — journal entries will not canonize to Substrate. ' +
+      'Set JOURNAL_CANON_SUBSTRATE_TARGET=<github-repo-url> (or SUBSTRATE_GITHUB_REPO / GITHUB_REPO_URL) in Vercel environment variables.',
+    );
+  }
   console.log('[journal-canonize] running', {
-    substrate_target: repoUrl
+    substrate_target: repoUrl ?? '(not configured)',
+    substrate_configured: substrateConfigured,
   });
 
   // Ensure SUBSTRATE_RETRY_QUEUE key exists in KV (resolves D1 key-missing snapshot flag).

--- a/app/api/cron/reattest-seals/route.ts
+++ b/app/api/cron/reattest-seals/route.ts
@@ -53,11 +53,18 @@ export async function GET(req: NextRequest) {
   }
 
   const quarantined = allSeals.filter((s) => s.status === 'quarantined');
+  // Track seals where all agents already attested in prior runs but the seal is still
+  // quarantined — the inner loop's `continue` guard skips them all, leaving them stuck.
+  const fullyAttestedButStuck: string[] = [];
 
   for (const seal of quarantined) {
-    for (const agent of SENTINEL_AGENTS) {
-      if (seal.attestations[agent]) continue; // already attested
+    const agentsPending = SENTINEL_AGENTS.filter((a) => !seal.attestations[a]);
+    if (agentsPending.length === 0) {
+      fullyAttestedButStuck.push(seal.seal_id);
+      continue;
+    }
 
+    for (const agent of agentsPending) {
       try {
         const r = await backAttestSeal({
           seal_id: seal.seal_id,
@@ -88,6 +95,35 @@ export async function GET(req: NextRequest) {
     }
   }
 
+  // Force re-evaluation for seals where all agents attested in prior runs but the seal
+  // never transitioned out of quarantine. Re-attest via ATLAS (idempotent) to trigger
+  // quorum re-check inside backAttestSeal.
+  for (const seal_id of fullyAttestedButStuck) {
+    try {
+      console.warn('[reattest-seals] fully-attested-but-stuck seal — forcing re-evaluation', { seal_id });
+      const r = await backAttestSeal({
+        seal_id,
+        agent: 'ATLAS',
+        verdict: 'pass',
+        rationale: buildBackAttestRationale('ATLAS', seal_id) + ' [forced-re-eval: all agents already attested]',
+      });
+      results.push({
+        seal_id,
+        agent: 'ATLAS',
+        ok: r.ok,
+        transition: r.ok ? r.transition : undefined,
+        error: !r.ok ? r.reason : undefined,
+      });
+      if (r.ok && r.transition === 'attested') {
+        void releaseReplayPressureForAttestedSeal().catch(() => {});
+        console.info('[reattest-seals] stuck seal cleared → attested', { seal_id });
+      }
+    } catch (e) {
+      const msg = `[forced-re-eval] ${seal_id}: ${e instanceof Error ? e.message : String(e)}`;
+      errors.push(msg);
+    }
+  }
+
   const attested = results.filter((r) => r.transition === 'attested').length;
   const recorded = results.filter((r) => r.transition === 'recorded').length;
 
@@ -96,6 +132,7 @@ export async function GET(req: NextRequest) {
     at: new Date().toISOString(),
     duration_ms: Date.now() - started,
     quarantined_found: quarantined.length,
+    stuck_fully_attested: fullyAttestedButStuck.length,
     attestations_attempted: results.length,
     attested_transitions: attested,
     recorded_transitions: recorded,

--- a/app/api/cron/sweep/route.ts
+++ b/app/api/cron/sweep/route.ts
@@ -20,11 +20,22 @@ async function run(req: NextRequest) {
   const authErr = getEveSynthesisAuthError(req);
   if (authErr) return authErr;
   
-  // C-300 FIX: Validate required config before proceeding with substrate attestation
-  const substrateBase = process.env.NEXT_PUBLIC_SUBSTRATE_API_BASE;
-  if (!substrateBase) {
-    console.warn('[cron/sweep] substrate attestation disabled: missing NEXT_PUBLIC_SUBSTRATE_API_BASE');
-    // Continue with sweep but note that attestation will be skipped gracefully
+  // C-301 FIX: Check the *write-path* substrate vars, not the public UI base URL.
+  // NEXT_PUBLIC_SUBSTRATE_API_BASE is a browser-facing env used by the UI only.
+  // Journal canonize and substrate writes use JOURNAL_CANON_SUBSTRATE_TARGET
+  // (or SUBSTRATE_GITHUB_REPO / GITHUB_REPO_URL as fallbacks).
+  const substrateWriteTarget =
+    process.env.JOURNAL_CANON_SUBSTRATE_TARGET ??
+    process.env.SUBSTRATE_GITHUB_REPO ??
+    process.env.GITHUB_REPO_URL ??
+    null;
+  const substrateConfigured = Boolean(substrateWriteTarget);
+  if (!substrateConfigured) {
+    console.warn(
+      '[cron/sweep] substrate write-path not configured: ' +
+      'set JOURNAL_CANON_SUBSTRATE_TARGET (or SUBSTRATE_GITHUB_REPO / GITHUB_REPO_URL) ' +
+      'to enable journal canonize and substrate attestation.',
+    );
   }
   
   try {
@@ -87,6 +98,7 @@ async function run(req: NextRequest) {
         agents: council.entries.map((entry) => entry.agent),
         failedAgents: council.failedAgents,
       },
+      substrate_configured: substrateConfigured,
     });
   } catch (err) {
     console.error('[cron/sweep] failed:', err);

--- a/app/api/echo/digest/route.ts
+++ b/app/api/echo/digest/route.ts
@@ -44,10 +44,10 @@ export async function GET() {
 
     return NextResponse.json(digest, {
       headers: {
-        // OPT-05 (C-296): increased from s-maxage=15 → 30. Digest is rebuilt from
-        // KV/in-memory state on each compute; 30s edge cache cuts ~50% of invocations
-        // (~1,440/day saved) without meaningfully lagging the cron update cadence.
-        'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+        // C-301 OPT: increased from s-maxage=30 → 60 / swr=60 → 120.
+        // 60s edge cache halves invocation cost; prior 30s caused constant STALE
+        // churn with no freshness benefit vs sweep cadence (10m) or echo-ingest (1h).
+        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120',
         'X-Mobius-Source': 'echo-digest',
       },
     });

--- a/app/api/terminal/snapshot/route.ts
+++ b/app/api/terminal/snapshot/route.ts
@@ -304,12 +304,21 @@ export async function GET(request: NextRequest) {
 
   const tripwireLaneState = laneByKey.get('tripwire');
   const tripwireElevated = tripwireLaneState?.state === 'degraded';
+  const integrityMode = typeof integrityData?.mode === 'string' ? integrityData.mode : null;
+  // C-301 FIX: 'yellow' is stressed/watchful (GI 0.5–0.75), NOT degraded.
+  // Only 'red' mode or actual memory/KV degradation should set degraded:true.
   const topDegraded =
     memoryMode?.degraded === true ||
     tripwireElevated ||
     Boolean(trustSnapshot?.elevated) ||
-    Boolean(integrityData?.gi_degraded ?? integrityData?.degraded) ||
-    (typeof integrityData?.mode === 'string' && (integrityData.mode === 'red' || integrityData.mode === 'yellow'));
+    Boolean(integrityData?.gi_degraded) ||
+    integrityMode === 'red';
+
+  const terminalStatus: 'healthy' | 'stressed' | 'degraded' | 'critical' =
+    integrityMode === 'red' || (trustSnapshot?.critical ?? false) ? 'critical'
+    : topDegraded ? 'degraded'
+    : integrityMode === 'yellow' ? 'stressed'
+    : 'healthy';
 
   const trustSummary = trustSnapshot
     ? {
@@ -344,6 +353,7 @@ export async function GET(request: NextRequest) {
       gi: topGi,
       effective_gi: effectiveGi,
       degraded: topDegraded,
+      terminal_status: terminalStatus,
       include_catalog: includeCatalog === 'true',
       journal_mode: journalMode === 'hot' || journalMode === 'canon' || journalMode === 'merged' ? journalMode : 'merged',
       timestamp: new Date().toISOString(),

--- a/vercel.json
+++ b/vercel.json
@@ -22,10 +22,6 @@
       "schedule": "*/5 * * * *"
     },
     {
-      "path": "/api/cron/promote",
-      "schedule": "*/10 * * * *"
-    },
-    {
       "path": "/api/cron/gi-refresh",
       "schedule": "45 0 * * *"
     },
@@ -51,7 +47,7 @@
     },
     {
       "path": "/api/cron/echo-ingest",
-      "schedule": "0 */2 * * *"
+      "schedule": "0 * * * *"
     },
     {
       "path": "/api/vault/block/attest-sweep",
@@ -59,7 +55,7 @@
     },
     {
       "path": "/api/cron/reattest-seals",
-      "schedule": "0 * * * *"
+      "schedule": "*/30 * * * *"
     }
   ],
   "installCommand": "pnpm install --no-frozen-lockfile"


### PR DESCRIPTION
## Summary

- **Fix 1** — `vercel.json`: remove duplicate `/api/cron/promote` at `*/10` (was double-firing every 10 min alongside the `*/5` entry)
- **Fix 2** — `cron/sweep`: fix substrate env-var check — was testing `NEXT_PUBLIC_SUBSTRATE_API_BASE` (browser UI var); now checks the actual write-path vars (`JOURNAL_CANON_SUBSTRATE_TARGET` / `SUBSTRATE_GITHUB_REPO` / `GITHUB_REPO_URL`)
- **Fix 3** — `cron/reattest-seals`: handle quarantined seals where all agents already attested in prior runs (inner loop's `continue` guard skipped them all, leaving 8 seals stuck in quarantine permanently); force ATLAS re-evaluation to trigger quorum transition + report `stuck_fully_attested` in response
- **Fix 4** — `agents/journal`: fix `canonical_source` — was returning `'substrate'` when both KV and substrate returned 0 entries; now returns `'kv-empty'` to distinguish empty-hot-store from empty-substrate
- **Fix 5** — `terminal/snapshot`: fix `degraded` flag — `'yellow'` mode (GI 0.5–0.75, stressed/watchful band) was propagating as `degraded: true`; only `'red'` mode or memory/KV degradation should; add `terminal_status: 'healthy' | 'stressed' | 'degraded' | 'critical'` field for precise UI signal

- **Opt 6** — `vercel.json`: echo-ingest `0 */2` → `0 *` (hourly) to address `novelty: weak (0.164)` and MIC replay pressure
- **Opt 7** — `vercel.json`: reattest-seals `0 *` → `*/30 *` (every 30 min) to drain quarantine queue faster; combined with Fix 3 clears the 8 stuck seals on next run
- **Opt 8** — `cron/sweep`: add `substrate_configured: bool` to response for operator dashboard observability
- **Opt 9** — `echo/digest`: edge cache `s-maxage=30/swr=60` → `s-maxage=60/swr=120`; halves edge invocations, prior 30s TTL caused constant STALE churn with no freshness benefit vs sweep cadence
- **Opt 10** — `cron/journal-canonize`: structured substrate-target warning with exact env var names and expected format instead of silent `(not configured)` log

## Snapshot health impact

| Signal | Before | After |
|---|---|---|
| `degraded` | `true` (yellow mis-classified) | `false` |
| `terminal_status` | _(absent)_ | `'stressed'` (accurate) |
| `canonical_source` | `'substrate'` when journal empty | `'kv-empty'` |
| Quarantined seals | 8 stuck permanently | Cleared on next reattest run |
| Novelty score | `weak (0.164)` | Expected improvement with hourly ingest |
| Replay pressure | Elevated | Expected decay as seals clear + ingest rate increases |

## Test plan

- [ ] Verify `vercel.json` crons: `promote` appears once (`*/5`), `echo-ingest` at `0 *`, `reattest-seals` at `*/30`
- [ ] Trigger `GET /api/cron/reattest-seals` manually — confirm `stuck_fully_attested` count in response and that previously stuck seals transition to `attested`
- [ ] Confirm `GET /api/cron/sweep` response includes `substrate_configured` field
- [ ] Confirm `GET /api/agents/journal` returns `canonical_source: 'kv-empty'` when journal is empty
- [ ] Confirm `GET /api/terminal/snapshot` returns `degraded: false` and `terminal_status: 'stressed'` under yellow GI
- [ ] Confirm `GET /api/echo/digest` response header shows `s-maxage=60, stale-while-revalidate=120`

https://claude.ai/code/session_01MyNwahEpJb7mfrcv5GeCzq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyNwahEpJb7mfrcv5GeCzq)_