### PR TITLE
docs(c303): Phase 1 DAL foundation specification

### DIFF
--- a/app/api/terminal/snapshot-compare/route.ts
+++ b/app/api/terminal/snapshot-compare/route.ts
@@ -19,6 +19,21 @@ type ConfidenceInput = {
   dalResults: Array<DalResult<unknown>>;
 };
 
+type CompareHistoryFrame = {
+  id: string;
+  ts: string;
+  mode: 'snapshot-compare';
+  migration_state: 'diagnostic_not_authoritative';
+  confidence_score: number;
+  parity_ratio: number;
+  mismatches: number;
+  missing: number;
+  unknown: number;
+  fallback_count: number;
+  stale_count: number;
+  cutover_recommendation: string;
+};
+
 export const dynamic = 'force-dynamic';
 
 function compareField(field: string, legacy: unknown, dal: unknown): CompareField {
@@ -107,8 +122,26 @@ function buildConfidenceMetrics({ comparisons, dalResults }: ConfidenceInput) {
   };
 }
 
+function buildHistoryFrame(confidence: ReturnType<typeof buildConfidenceMetrics>): CompareHistoryFrame {
+  const ts = new Date().toISOString();
+  return {
+    id: `snapshot-compare-${ts}`,
+    ts,
+    mode: 'snapshot-compare',
+    migration_state: 'diagnostic_not_authoritative',
+    confidence_score: confidence.confidence_score,
+    parity_ratio: confidence.parity_ratio,
+    mismatches: confidence.mismatches,
+    missing: confidence.missing,
+    unknown: confidence.unknown,
+    fallback_count: confidence.fallback_count,
+    stale_count: confidence.stale_count,
+    cutover_recommendation: confidence.cutover_recommendation,
+  };
+}
+
 /**
- * C-303 Phase 1G — legacy snapshot vs DAL snapshot comparison.
+ * C-303 Phase 1H — legacy snapshot vs DAL snapshot comparison.
  *
  * Diagnostic only. Does not replace either path.
  */
@@ -165,6 +198,7 @@ export async function GET(request: NextRequest) {
     comparisons,
     dalResults: [dalResult, integrityDalResult, tripwireDalResult] as Array<DalResult<unknown>>,
   });
+  const historyFrame = buildHistoryFrame(confidence);
 
   return NextResponse.json(
     {
@@ -181,6 +215,11 @@ export async function GET(request: NextRequest) {
           dalResult.ok &&
           integrityDalResult.ok &&
           tripwireDalResult.ok,
+      },
+      history: {
+        frame: historyFrame,
+        persistence: 'not_enabled',
+        note: 'Phase 1H exposes a stable history frame. Persistence should be added after KV wrapper selection.',
       },
       comparisons,
       legacy: {

--- a/app/api/terminal/snapshot-compare/route.ts
+++ b/app/api/terminal/snapshot-compare/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { GET as getLegacySnapshot } from '@/app/api/terminal/snapshot/route';
 import { buildTerminalDalSnapshot } from '@/lib/dal/snapshot';
 import { readIntegrityDalSnapshot } from '@/lib/dal/integrity';
+import { readTripwireDalSnapshot } from '@/lib/dal/tripwire';
 
 type CompareStatus = 'match' | 'mismatch' | 'missing' | 'unknown';
 
@@ -49,8 +50,23 @@ function safeRecord(value: unknown): Record<string, unknown> {
     : {};
 }
 
+function findLegacyTripwire(legacy: Record<string, unknown>): Record<string, unknown> {
+  const direct = safeRecord(legacy.tripwire);
+  if (Object.keys(direct).length > 0) return direct;
+
+  const tripwires = safeRecord(legacy.tripwires);
+  if (Object.keys(tripwires).length > 0) return tripwires;
+
+  const runtime = safeRecord(legacy.runtime);
+  const runtimeTripwire = safeRecord(runtime.tripwire);
+  if (Object.keys(runtimeTripwire).length > 0) return runtimeTripwire;
+
+  const sentinel = safeRecord(legacy.sentinel);
+  return safeRecord(sentinel.tripwire);
+}
+
 /**
- * C-303 Phase 1E — legacy snapshot vs DAL snapshot comparison.
+ * C-303 Phase 1F — legacy snapshot vs DAL snapshot comparison.
  *
  * Diagnostic only. Does not replace either path.
  */
@@ -59,18 +75,21 @@ export async function GET(request: NextRequest) {
   const baseUrl = request.nextUrl.origin;
   const legacyRequest = new NextRequest(new URL('/api/terminal/snapshot', baseUrl));
 
-  const [legacyResponse, dalResult, integrityDalResult] = await Promise.all([
+  const [legacyResponse, dalResult, integrityDalResult, tripwireDalResult] = await Promise.all([
     getLegacySnapshot(legacyRequest),
     buildTerminalDalSnapshot('C-303'),
     readIntegrityDalSnapshot(),
+    readTripwireDalSnapshot(),
   ]);
 
   const legacyPayload = await legacyResponse.json().catch(() => null);
   const legacy = safeRecord(legacyPayload);
   const legacyGi = safeRecord(legacy.gi);
   const legacyIntegrity = safeRecord(legacy.integrity);
+  const legacyTripwire = findLegacyTripwire(legacy);
   const dal = dalResult.data;
   const integrityDal = integrityDalResult.data;
+  const tripwireDal = tripwireDalResult.data;
 
   const legacyGlobalIntegrity =
     typeof legacy.global_integrity === 'number'
@@ -81,6 +100,13 @@ export async function GET(request: NextRequest) {
           ? legacyIntegrity.global_integrity
           : undefined;
 
+  const legacyTripwireActive =
+    typeof legacyTripwire.active === 'boolean'
+      ? legacyTripwire.active
+      : typeof legacyTripwire.triggered === 'boolean'
+        ? legacyTripwire.triggered
+        : undefined;
+
   const comparisons: CompareField[] = [
     compareField('cycle', legacy.cycle, dal?.cycle),
     compareField('degraded', legacy.degraded, dal?.degraded),
@@ -88,6 +114,9 @@ export async function GET(request: NextRequest) {
     compareField('integrity_cycle', legacy.cycle, integrityDal?.cycle),
     compareNumberField('global_integrity', legacyGlobalIntegrity, integrityDal?.global_integrity),
     compareField('terminal_status', legacy.terminal_status, integrityDal?.terminal_status),
+    compareField('tripwire_active', legacyTripwireActive, tripwireDal?.active),
+    compareField('tripwire_level', legacyTripwire.level, tripwireDal?.level),
+    compareField('tripwire_triggered_by', legacyTripwire.triggered_by ?? legacyTripwire.triggeredBy, tripwireDal?.triggered_by),
   ];
 
   const mismatchCount = comparisons.filter((item) => item.status === 'mismatch').length;
@@ -96,7 +125,7 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json(
     {
-      ok: legacyResponse.ok && dalResult.ok && integrityDalResult.ok,
+      ok: legacyResponse.ok && dalResult.ok && integrityDalResult.ok && tripwireDalResult.ok,
       mode: 'snapshot-compare',
       migration_state: 'diagnostic_not_authoritative',
       summary: {
@@ -104,7 +133,12 @@ export async function GET(request: NextRequest) {
         mismatches: mismatchCount,
         missing: missingCount,
         unknown: unknownCount,
-        safe_to_cutover: mismatchCount === 0 && missingCount === 0 && dalResult.ok && integrityDalResult.ok,
+        safe_to_cutover:
+          mismatchCount === 0 &&
+          missingCount === 0 &&
+          dalResult.ok &&
+          integrityDalResult.ok &&
+          tripwireDalResult.ok,
       },
       comparisons,
       legacy: {
@@ -113,6 +147,11 @@ export async function GET(request: NextRequest) {
         cycle: legacy.cycle ?? null,
         terminal_status: legacy.terminal_status ?? null,
         global_integrity: legacyGlobalIntegrity ?? null,
+        tripwire: {
+          active: legacyTripwireActive ?? null,
+          level: legacyTripwire.level ?? null,
+          triggered_by: legacyTripwire.triggered_by ?? legacyTripwire.triggeredBy ?? null,
+        },
       },
       dal: {
         ok: dalResult.ok,
@@ -127,6 +166,14 @@ export async function GET(request: NextRequest) {
           terminal_status: integrityDal?.terminal_status ?? null,
           provenance: integrityDalResult.provenance,
           error: integrityDalResult.error ?? null,
+        },
+        tripwire: {
+          ok: tripwireDalResult.ok,
+          active: tripwireDal?.active ?? null,
+          level: tripwireDal?.level ?? null,
+          triggered_by: tripwireDal?.triggered_by ?? null,
+          provenance: tripwireDalResult.provenance,
+          error: tripwireDalResult.error ?? null,
         },
       },
       meta: {

--- a/app/api/terminal/snapshot-compare/route.ts
+++ b/app/api/terminal/snapshot-compare/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { GET as getLegacySnapshot } from '@/app/api/terminal/snapshot/route';
 import { buildTerminalDalSnapshot } from '@/lib/dal/snapshot';
+import { readIntegrityDalSnapshot } from '@/lib/dal/integrity';
 
 type CompareStatus = 'match' | 'mismatch' | 'missing' | 'unknown';
 
@@ -25,6 +26,23 @@ function compareField(field: string, legacy: unknown, dal: unknown): CompareFiel
   return { field, status: legacy === dal ? 'match' : 'mismatch', legacy, dal };
 }
 
+function compareNumberField(field: string, legacy: unknown, dal: unknown, tolerance = 0.001): CompareField {
+  if (legacy === undefined || dal === undefined) {
+    return { field, status: 'missing', legacy, dal };
+  }
+
+  if (typeof legacy !== 'number' || typeof dal !== 'number') {
+    return { field, status: 'unknown', legacy, dal };
+  }
+
+  return {
+    field,
+    status: Math.abs(legacy - dal) <= tolerance ? 'match' : 'mismatch',
+    legacy,
+    dal,
+  };
+}
+
 function safeRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -32,7 +50,7 @@ function safeRecord(value: unknown): Record<string, unknown> {
 }
 
 /**
- * C-303 Phase 1C — legacy snapshot vs DAL snapshot comparison.
+ * C-303 Phase 1E — legacy snapshot vs DAL snapshot comparison.
  *
  * Diagnostic only. Does not replace either path.
  */
@@ -41,19 +59,35 @@ export async function GET(request: NextRequest) {
   const baseUrl = request.nextUrl.origin;
   const legacyRequest = new NextRequest(new URL('/api/terminal/snapshot', baseUrl));
 
-  const [legacyResponse, dalResult] = await Promise.all([
+  const [legacyResponse, dalResult, integrityDalResult] = await Promise.all([
     getLegacySnapshot(legacyRequest),
     buildTerminalDalSnapshot('C-303'),
+    readIntegrityDalSnapshot(),
   ]);
 
   const legacyPayload = await legacyResponse.json().catch(() => null);
   const legacy = safeRecord(legacyPayload);
+  const legacyGi = safeRecord(legacy.gi);
+  const legacyIntegrity = safeRecord(legacy.integrity);
   const dal = dalResult.data;
+  const integrityDal = integrityDalResult.data;
+
+  const legacyGlobalIntegrity =
+    typeof legacy.global_integrity === 'number'
+      ? legacy.global_integrity
+      : typeof legacyGi.score === 'number'
+        ? legacyGi.score
+        : typeof legacyIntegrity.global_integrity === 'number'
+          ? legacyIntegrity.global_integrity
+          : undefined;
 
   const comparisons: CompareField[] = [
     compareField('cycle', legacy.cycle, dal?.cycle),
     compareField('degraded', legacy.degraded, dal?.degraded),
     compareField('vault_ok', safeRecord(legacy.vault).ok, dal?.vault.ok),
+    compareField('integrity_cycle', legacy.cycle, integrityDal?.cycle),
+    compareNumberField('global_integrity', legacyGlobalIntegrity, integrityDal?.global_integrity),
+    compareField('terminal_status', legacy.terminal_status, integrityDal?.terminal_status),
   ];
 
   const mismatchCount = comparisons.filter((item) => item.status === 'mismatch').length;
@@ -62,7 +96,7 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json(
     {
-      ok: legacyResponse.ok && dalResult.ok,
+      ok: legacyResponse.ok && dalResult.ok && integrityDalResult.ok,
       mode: 'snapshot-compare',
       migration_state: 'diagnostic_not_authoritative',
       summary: {
@@ -70,7 +104,7 @@ export async function GET(request: NextRequest) {
         mismatches: mismatchCount,
         missing: missingCount,
         unknown: unknownCount,
-        safe_to_cutover: mismatchCount === 0 && missingCount === 0 && dalResult.ok,
+        safe_to_cutover: mismatchCount === 0 && missingCount === 0 && dalResult.ok && integrityDalResult.ok,
       },
       comparisons,
       legacy: {
@@ -78,6 +112,7 @@ export async function GET(request: NextRequest) {
         degraded: legacy.degraded ?? null,
         cycle: legacy.cycle ?? null,
         terminal_status: legacy.terminal_status ?? null,
+        global_integrity: legacyGlobalIntegrity ?? null,
       },
       dal: {
         ok: dalResult.ok,
@@ -85,6 +120,14 @@ export async function GET(request: NextRequest) {
         cycle: dal?.cycle ?? null,
         provenance: dalResult.provenance,
         error: dalResult.error ?? null,
+        integrity: {
+          ok: integrityDalResult.ok,
+          cycle: integrityDal?.cycle ?? null,
+          global_integrity: integrityDal?.global_integrity ?? null,
+          terminal_status: integrityDal?.terminal_status ?? null,
+          provenance: integrityDalResult.provenance,
+          error: integrityDalResult.error ?? null,
+        },
       },
       meta: {
         elapsed_ms: Date.now() - startedAt,

--- a/app/api/terminal/snapshot-compare/route.ts
+++ b/app/api/terminal/snapshot-compare/route.ts
@@ -3,6 +3,7 @@ import { GET as getLegacySnapshot } from '@/app/api/terminal/snapshot/route';
 import { buildTerminalDalSnapshot } from '@/lib/dal/snapshot';
 import { readIntegrityDalSnapshot } from '@/lib/dal/integrity';
 import { readTripwireDalSnapshot } from '@/lib/dal/tripwire';
+import type { DalResult } from '@/lib/dal/types';
 
 type CompareStatus = 'match' | 'mismatch' | 'missing' | 'unknown';
 
@@ -11,6 +12,11 @@ type CompareField = {
   status: CompareStatus;
   legacy: unknown;
   dal: unknown;
+};
+
+type ConfidenceInput = {
+  comparisons: CompareField[];
+  dalResults: Array<DalResult<unknown>>;
 };
 
 export const dynamic = 'force-dynamic';
@@ -65,8 +71,44 @@ function findLegacyTripwire(legacy: Record<string, unknown>): Record<string, unk
   return safeRecord(sentinel.tripwire);
 }
 
+function buildConfidenceMetrics({ comparisons, dalResults }: ConfidenceInput) {
+  const fieldsChecked = comparisons.length;
+  const matches = comparisons.filter((item) => item.status === 'match').length;
+  const mismatches = comparisons.filter((item) => item.status === 'mismatch').length;
+  const missing = comparisons.filter((item) => item.status === 'missing').length;
+  const unknown = comparisons.filter((item) => item.status === 'unknown').length;
+  const degradedSources = dalResults
+    .filter((result) => result.degraded || !result.ok)
+    .map((result) => result.provenance.source);
+  const fallbackCount = dalResults.filter((result) => result.provenance.source === 'fallback').length;
+  const staleCount = dalResults.filter((result) => result.provenance.freshness !== 'live').length;
+
+  const parityRatio = fieldsChecked > 0 ? matches / fieldsChecked : 0;
+  const penalty = (mismatches * 0.2) + (missing * 0.15) + (unknown * 0.05) + (fallbackCount * 0.05) + (staleCount * 0.03);
+  const confidenceScore = Math.max(0, Math.min(1, parityRatio - penalty));
+
+  return {
+    fields_checked: fieldsChecked,
+    matches,
+    mismatches,
+    missing,
+    unknown,
+    parity_ratio: Number(parityRatio.toFixed(4)),
+    confidence_score: Number(confidenceScore.toFixed(4)),
+    degraded_sources: [...new Set(degradedSources)],
+    fallback_count: fallbackCount,
+    stale_count: staleCount,
+    cutover_recommendation:
+      confidenceScore >= 0.98 && mismatches === 0 && missing === 0 && fallbackCount === 0
+        ? 'eligible_for_limited_shadow_cutover'
+        : confidenceScore >= 0.85 && mismatches === 0
+          ? 'continue_shadow_observation'
+          : 'not_ready_for_cutover',
+  };
+}
+
 /**
- * C-303 Phase 1F — legacy snapshot vs DAL snapshot comparison.
+ * C-303 Phase 1G — legacy snapshot vs DAL snapshot comparison.
  *
  * Diagnostic only. Does not replace either path.
  */
@@ -119,9 +161,10 @@ export async function GET(request: NextRequest) {
     compareField('tripwire_triggered_by', legacyTripwire.triggered_by ?? legacyTripwire.triggeredBy, tripwireDal?.triggered_by),
   ];
 
-  const mismatchCount = comparisons.filter((item) => item.status === 'mismatch').length;
-  const missingCount = comparisons.filter((item) => item.status === 'missing').length;
-  const unknownCount = comparisons.filter((item) => item.status === 'unknown').length;
+  const confidence = buildConfidenceMetrics({
+    comparisons,
+    dalResults: [dalResult, integrityDalResult, tripwireDalResult] as Array<DalResult<unknown>>,
+  });
 
   return NextResponse.json(
     {
@@ -129,13 +172,12 @@ export async function GET(request: NextRequest) {
       mode: 'snapshot-compare',
       migration_state: 'diagnostic_not_authoritative',
       summary: {
-        fields_checked: comparisons.length,
-        mismatches: mismatchCount,
-        missing: missingCount,
-        unknown: unknownCount,
+        ...confidence,
         safe_to_cutover:
-          mismatchCount === 0 &&
-          missingCount === 0 &&
+          confidence.mismatches === 0 &&
+          confidence.missing === 0 &&
+          confidence.fallback_count === 0 &&
+          confidence.confidence_score >= 0.98 &&
           dalResult.ok &&
           integrityDalResult.ok &&
           tripwireDalResult.ok,

--- a/app/api/terminal/snapshot-compare/route.ts
+++ b/app/api/terminal/snapshot-compare/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { GET as getLegacySnapshot } from '@/app/api/terminal/snapshot/route';
+import { buildTerminalDalSnapshot } from '@/lib/dal/snapshot';
+
+type CompareStatus = 'match' | 'mismatch' | 'missing' | 'unknown';
+
+type CompareField = {
+  field: string;
+  status: CompareStatus;
+  legacy: unknown;
+  dal: unknown;
+};
+
+export const dynamic = 'force-dynamic';
+
+function compareField(field: string, legacy: unknown, dal: unknown): CompareField {
+  if (legacy === undefined || dal === undefined) {
+    return { field, status: 'missing', legacy, dal };
+  }
+
+  if (legacy === null || dal === null) {
+    return { field, status: legacy === dal ? 'match' : 'unknown', legacy, dal };
+  }
+
+  return { field, status: legacy === dal ? 'match' : 'mismatch', legacy, dal };
+}
+
+function safeRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+/**
+ * C-303 Phase 1C — legacy snapshot vs DAL snapshot comparison.
+ *
+ * Diagnostic only. Does not replace either path.
+ */
+export async function GET(request: NextRequest) {
+  const startedAt = Date.now();
+  const baseUrl = request.nextUrl.origin;
+  const legacyRequest = new NextRequest(new URL('/api/terminal/snapshot', baseUrl));
+
+  const [legacyResponse, dalResult] = await Promise.all([
+    getLegacySnapshot(legacyRequest),
+    buildTerminalDalSnapshot('C-303'),
+  ]);
+
+  const legacyPayload = await legacyResponse.json().catch(() => null);
+  const legacy = safeRecord(legacyPayload);
+  const dal = dalResult.data;
+
+  const comparisons: CompareField[] = [
+    compareField('cycle', legacy.cycle, dal?.cycle),
+    compareField('degraded', legacy.degraded, dal?.degraded),
+    compareField('vault_ok', safeRecord(legacy.vault).ok, dal?.vault.ok),
+  ];
+
+  const mismatchCount = comparisons.filter((item) => item.status === 'mismatch').length;
+  const missingCount = comparisons.filter((item) => item.status === 'missing').length;
+  const unknownCount = comparisons.filter((item) => item.status === 'unknown').length;
+
+  return NextResponse.json(
+    {
+      ok: legacyResponse.ok && dalResult.ok,
+      mode: 'snapshot-compare',
+      migration_state: 'diagnostic_not_authoritative',
+      summary: {
+        fields_checked: comparisons.length,
+        mismatches: mismatchCount,
+        missing: missingCount,
+        unknown: unknownCount,
+        safe_to_cutover: mismatchCount === 0 && missingCount === 0 && dalResult.ok,
+      },
+      comparisons,
+      legacy: {
+        ok: legacy.ok ?? legacyResponse.ok,
+        degraded: legacy.degraded ?? null,
+        cycle: legacy.cycle ?? null,
+        terminal_status: legacy.terminal_status ?? null,
+      },
+      dal: {
+        ok: dalResult.ok,
+        degraded: dalResult.degraded ?? !dalResult.ok,
+        cycle: dal?.cycle ?? null,
+        provenance: dalResult.provenance,
+        error: dalResult.error ?? null,
+      },
+      meta: {
+        elapsed_ms: Date.now() - startedAt,
+        canonical_warning: 'Comparison is diagnostic only. Legacy snapshot remains authoritative.',
+      },
+    },
+    {
+      headers: {
+        'Cache-Control': 'no-store',
+        'X-Mobius-Source': 'terminal-snapshot-compare',
+      },
+    },
+  );
+}

--- a/app/api/terminal/snapshot-dal-shadow/route.ts
+++ b/app/api/terminal/snapshot-dal-shadow/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { buildTerminalDalSnapshot } from '@/lib/dal/snapshot';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * C-303 Phase 1B — DAL shadow mode.
+ *
+ * This endpoint intentionally does not replace /api/terminal/snapshot.
+ * It lets operators compare the new DAL aggregate boundary against the
+ * existing terminal snapshot pipeline before any route migration occurs.
+ */
+export async function GET() {
+  const startedAt = Date.now();
+  const result = await buildTerminalDalSnapshot('C-303');
+
+  return NextResponse.json(
+    {
+      ok: result.ok,
+      mode: 'dal-shadow',
+      migration_state: 'parallel_not_authoritative',
+      degraded: result.degraded ?? !result.ok,
+      data: result.data,
+      provenance: result.provenance,
+      error: result.error ?? null,
+      meta: {
+        elapsed_ms: Date.now() - startedAt,
+        canonical_warning: 'This shadow endpoint is diagnostic only and does not replace /api/terminal/snapshot yet.',
+      },
+    },
+    {
+      headers: {
+        'Cache-Control': 'no-store',
+        'X-Mobius-Source': 'terminal-snapshot-dal-shadow',
+      },
+    },
+  );
+}

--- a/app/terminal/compare/page.tsx
+++ b/app/terminal/compare/page.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+type CompareStatus = 'match' | 'mismatch' | 'missing' | 'unknown';
+
+type CompareField = {
+  field: string;
+  status: CompareStatus;
+  legacy: unknown;
+  dal: unknown;
+};
+
+type SnapshotCompareResponse = {
+  ok: boolean;
+  mode: string;
+  migration_state: string;
+  summary: {
+    fields_checked: number;
+    matches: number;
+    mismatches: number;
+    missing: number;
+    unknown: number;
+    parity_ratio: number;
+    confidence_score: number;
+    degraded_sources: string[];
+    fallback_count: number;
+    stale_count: number;
+    cutover_recommendation: string;
+    safe_to_cutover: boolean;
+  };
+  history: {
+    frame: {
+      id: string;
+      ts: string;
+      confidence_score: number;
+      parity_ratio: number;
+      mismatches: number;
+      missing: number;
+      unknown: number;
+      fallback_count: number;
+      stale_count: number;
+      cutover_recommendation: string;
+    };
+    persistence: string;
+    note: string;
+  };
+  comparisons: CompareField[];
+  dal: {
+    provenance?: {
+      source: string;
+      freshness: string;
+      timestamp: string | null;
+      note?: string;
+    };
+    integrity?: {
+      provenance?: {
+        source: string;
+        freshness: string;
+        timestamp: string | null;
+        note?: string;
+      };
+    };
+    tripwire?: {
+      provenance?: {
+        source: string;
+        freshness: string;
+        timestamp: string | null;
+        note?: string;
+      };
+    };
+  };
+  meta: {
+    elapsed_ms: number;
+    canonical_warning: string;
+  };
+};
+
+type CompareError = { error?: string };
+
+const STATUS_CLASS: Record<CompareStatus, string> = {
+  match: 'border-emerald-500/30 bg-emerald-950/20 text-emerald-300',
+  mismatch: 'border-rose-500/30 bg-rose-950/20 text-rose-300',
+  missing: 'border-amber-500/30 bg-amber-950/20 text-amber-300',
+  unknown: 'border-slate-600/40 bg-slate-900/70 text-slate-300',
+};
+
+function isSnapshotCompareResponse(payload: SnapshotCompareResponse | CompareError): payload is SnapshotCompareResponse {
+  return (
+    typeof (payload as SnapshotCompareResponse).mode === 'string' &&
+    Boolean((payload as SnapshotCompareResponse).summary) &&
+    Array.isArray((payload as SnapshotCompareResponse).comparisons)
+  );
+}
+
+function displayValue(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return JSON.stringify(value);
+}
+
+export default function ComparePage() {
+  const [data, setData] = useState<SnapshotCompareResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function loadCompare() {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/terminal/snapshot-compare', { cache: 'no-store' });
+      const payload = (await response.json()) as SnapshotCompareResponse | CompareError;
+      if (!response.ok || !isSnapshotCompareResponse(payload)) {
+        throw new Error('error' in payload ? payload.error ?? 'snapshot_compare_failed' : 'snapshot_compare_failed');
+      }
+      setData(payload);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'snapshot_compare_failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadCompare();
+  }, []);
+
+  const confidenceLabel = useMemo(() => {
+    if (!data) return 'not_loaded';
+    return `${Math.round(data.summary.confidence_score * 100)}% confidence`;
+  }, [data]);
+
+  const provenanceRows = [
+    ['snapshot', data?.dal.provenance],
+    ['integrity', data?.dal.integrity?.provenance],
+    ['tripwire', data?.dal.tripwire?.provenance],
+  ].filter((row): row is [string, NonNullable<typeof data>['dal']['provenance']] => Boolean(row[1]));
+
+  return (
+    <div className="h-full overflow-y-auto p-4 font-mono text-xs text-slate-200">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-[10px] uppercase tracking-[0.22em] text-slate-500">Mobius Migration</div>
+          <h1 className="mt-1 text-lg font-semibold uppercase tracking-[0.16em] text-cyan-200">DAL Compare Chamber</h1>
+          <p className="mt-2 max-w-2xl text-[11px] leading-relaxed text-slate-500">
+            Diagnostic visibility for legacy snapshot vs DAL shadow state. Legacy snapshot remains authoritative; this chamber only measures readiness.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void loadCompare()}
+          disabled={loading}
+          className="rounded border border-cyan-500/40 px-3 py-1 text-cyan-200 hover:border-cyan-300 disabled:opacity-50"
+        >
+          {loading ? 'Refreshing…' : 'Refresh Compare'}
+        </button>
+      </div>
+
+      {error ? <div className="mb-4 rounded border border-rose-500/30 bg-rose-950/20 p-3 text-rose-200">{error}</div> : null}
+      {!data && !error ? <div className="rounded border border-slate-800 bg-slate-950/80 p-4 text-slate-400">Loading compare state…</div> : null}
+
+      {data ? (
+        <>
+          <section className="mb-4 grid gap-3 md:grid-cols-4">
+            <div className="rounded border border-cyan-500/25 bg-slate-950/80 p-4">
+              <div className="text-[10px] uppercase tracking-[0.18em] text-cyan-300/80">Confidence</div>
+              <div className="mt-2 text-2xl text-cyan-100">{confidenceLabel}</div>
+              <div className="mt-1 text-slate-500">parity {data.summary.parity_ratio.toFixed(4)}</div>
+            </div>
+            <div className="rounded border border-slate-800 bg-slate-950/80 p-4">
+              <div className="text-[10px] uppercase tracking-[0.18em] text-slate-500">Recommendation</div>
+              <div className="mt-2 text-amber-200">{data.summary.cutover_recommendation}</div>
+              <div className="mt-1 text-slate-500">safe: {String(data.summary.safe_to_cutover)}</div>
+            </div>
+            <div className="rounded border border-slate-800 bg-slate-950/80 p-4">
+              <div className="text-[10px] uppercase tracking-[0.18em] text-slate-500">Drift</div>
+              <div className="mt-2 text-slate-100">{data.summary.mismatches} mismatch</div>
+              <div className="mt-1 text-slate-500">{data.summary.missing} missing · {data.summary.unknown} unknown</div>
+            </div>
+            <div className="rounded border border-slate-800 bg-slate-950/80 p-4">
+              <div className="text-[10px] uppercase tracking-[0.18em] text-slate-500">Sources</div>
+              <div className="mt-2 text-slate-100">{data.summary.fallback_count} fallback</div>
+              <div className="mt-1 text-slate-500">{data.summary.stale_count} stale</div>
+            </div>
+          </section>
+
+          <section className="mb-4 rounded border border-slate-800 bg-slate-950/80 p-4">
+            <div className="mb-3 text-[10px] uppercase tracking-[0.18em] text-violet-300/80">Drift Table</div>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[760px] border-collapse text-left text-[11px]">
+                <thead className="text-slate-500">
+                  <tr className="border-b border-slate-800">
+                    <th className="py-2 pr-3">field</th>
+                    <th className="py-2 pr-3">status</th>
+                    <th className="py-2 pr-3">legacy</th>
+                    <th className="py-2 pr-3">dal</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.comparisons.map((item) => (
+                    <tr key={item.field} className="border-b border-slate-900/80">
+                      <td className="py-2 pr-3 text-slate-200">{item.field}</td>
+                      <td className="py-2 pr-3">
+                        <span className={`rounded border px-2 py-0.5 ${STATUS_CLASS[item.status]}`}>{item.status}</span>
+                      </td>
+                      <td className="max-w-[260px] truncate py-2 pr-3 text-slate-400">{displayValue(item.legacy)}</td>
+                      <td className="max-w-[260px] truncate py-2 pr-3 text-slate-400">{displayValue(item.dal)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="mb-4 grid gap-3 md:grid-cols-2">
+            <div className="rounded border border-slate-800 bg-slate-950/80 p-4">
+              <div className="mb-3 text-[10px] uppercase tracking-[0.18em] text-emerald-300/80">DAL Provenance</div>
+              <div className="space-y-2">
+                {provenanceRows.map(([name, provenance]) => (
+                  <div key={name} className="rounded border border-slate-800 bg-black/20 p-3">
+                    <div className="text-slate-300">{name}</div>
+                    <div className="mt-1 text-slate-500">source: {provenance.source} · freshness: {provenance.freshness}</div>
+                    <div className="mt-1 text-slate-600">{provenance.note ?? 'no note'}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded border border-slate-800 bg-slate-950/80 p-4">
+              <div className="mb-3 text-[10px] uppercase tracking-[0.18em] text-amber-300/80">History Frame</div>
+              <div className="space-y-1 text-slate-400">
+                <div>id: {data.history.frame.id}</div>
+                <div>ts: {data.history.frame.ts}</div>
+                <div>persistence: {data.history.persistence}</div>
+                <div>elapsed: {data.meta.elapsed_ms}ms</div>
+                <div className="pt-2 text-slate-500">{data.history.note}</div>
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded border border-slate-800 bg-slate-950/70 p-4 text-[11px] text-slate-400">
+            <div className="mb-2 uppercase tracking-[0.18em] text-cyan-300/80">Operator Law</div>
+            <div>{data.meta.canonical_warning}</div>
+            <div className="mt-2 text-amber-300">Current mode: diagnostic-only. No cutover authority is granted by this chamber.</div>
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/app/terminal/compare/page.tsx
+++ b/app/terminal/compare/page.tsx
@@ -11,6 +11,15 @@ type CompareField = {
   dal: unknown;
 };
 
+type DalProvenanceView = {
+  source: string;
+  freshness: string;
+  timestamp: string | null;
+  note?: string;
+};
+
+type ProvenanceRow = [string, DalProvenanceView];
+
 type SnapshotCompareResponse = {
   ok: boolean;
   mode: string;
@@ -47,27 +56,12 @@ type SnapshotCompareResponse = {
   };
   comparisons: CompareField[];
   dal: {
-    provenance?: {
-      source: string;
-      freshness: string;
-      timestamp: string | null;
-      note?: string;
-    };
+    provenance?: DalProvenanceView;
     integrity?: {
-      provenance?: {
-        source: string;
-        freshness: string;
-        timestamp: string | null;
-        note?: string;
-      };
+      provenance?: DalProvenanceView;
     };
     tripwire?: {
-      provenance?: {
-        source: string;
-        freshness: string;
-        timestamp: string | null;
-        note?: string;
-      };
+      provenance?: DalProvenanceView;
     };
   };
   meta: {
@@ -101,6 +95,15 @@ function displayValue(value: unknown): string {
   return JSON.stringify(value);
 }
 
+function toProvenanceRows(data: SnapshotCompareResponse | null): ProvenanceRow[] {
+  if (!data) return [];
+  const rows: ProvenanceRow[] = [];
+  if (data.dal.provenance) rows.push(['snapshot', data.dal.provenance]);
+  if (data.dal.integrity?.provenance) rows.push(['integrity', data.dal.integrity.provenance]);
+  if (data.dal.tripwire?.provenance) rows.push(['tripwire', data.dal.tripwire.provenance]);
+  return rows;
+}
+
 export default function ComparePage() {
   const [data, setData] = useState<SnapshotCompareResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -132,11 +135,7 @@ export default function ComparePage() {
     return `${Math.round(data.summary.confidence_score * 100)}% confidence`;
   }, [data]);
 
-  const provenanceRows = [
-    ['snapshot', data?.dal.provenance],
-    ['integrity', data?.dal.integrity?.provenance],
-    ['tripwire', data?.dal.tripwire?.provenance],
-  ].filter((row): row is [string, NonNullable<typeof data>['dal']['provenance']] => Boolean(row[1]));
+  const provenanceRows = useMemo(() => toProvenanceRows(data), [data]);
 
   return (
     <div className="h-full overflow-y-auto p-4 font-mono text-xs text-slate-200">

--- a/docs/pr/C303_PHASE1_DAL_FOUNDATION.md
+++ b/docs/pr/C303_PHASE1_DAL_FOUNDATION.md
@@ -1,0 +1,354 @@
+# C-303 — Phase 1 DAL Foundation (Additive)
+
+## Phase
+
+Phase 1 — Data Access Layer Foundation
+
+## Change Type
+
+Additive only.
+
+No runtime behavior changes.
+No deletions.
+No route rewrites.
+No hydration rewrites.
+
+---
+
+# Objective
+
+Extract canonical data access into `/lib/dal/*` so:
+
+```text
+UI -> DAL -> canonical source
+```
+
+replaces:
+
+```text
+UI -> API -> API -> hydration recursion
+```
+
+This phase introduces stable server-safe read boundaries.
+
+---
+
+# Architectural Problem
+
+Current risk patterns:
+
+## 1. Internal self-fetch recursion
+
+Examples:
+
+- server components fetching `/api/...`
+- SSR routes depending on internal HTTP
+- snapshot routes becoming indirect dependency graphs
+
+This increases:
+
+- hydration instability
+- timeout chains
+- duplicated parsing
+- degraded-state ambiguity
+- Vercel runtime variance
+
+---
+
+## 2. Canonical truth fragmentation
+
+Truth currently exists across:
+
+- KV
+- ledger
+- substrate
+- ECHO
+- runtime memory
+- snapshot aggregators
+
+without a stable canonical access contract.
+
+---
+
+## 3. Operator ambiguity
+
+Current UI often cannot explain:
+
+- where a value came from
+- whether it is stale
+- whether it is canonical
+- whether it is replayed
+- whether it is degraded
+
+---
+
+# DAL Rules
+
+## Rule 1 — DAL is server-only truth access
+
+DAL modules:
+
+- may read KV
+- may read ledger
+- may read substrate
+- may aggregate runtime state
+
+DAL modules:
+
+- may NOT depend on React
+- may NOT depend on browser state
+- may NOT depend on client hydration
+
+---
+
+## Rule 2 — DAL never invents truth
+
+Allowed:
+
+```ts
+status: 'degraded'
+```
+
+Forbidden:
+
+```ts
+status: 'healthy' // inferred without proof
+```
+
+---
+
+## Rule 3 — provenance is mandatory
+
+Every DAL return shape should eventually support:
+
+```ts
+{
+  source: 'kv' | 'ledger' | 'echo' | 'github';
+  stale: boolean;
+  timestamp: string | null;
+}
+```
+
+---
+
+# Initial DAL Layout
+
+## Core modules
+
+```text
+lib/dal/
+  vault.ts
+  signals.ts
+  snapshot.ts
+  ledger.ts
+  journal.ts
+  sentinel.ts
+```
+
+---
+
+# Planned Responsibilities
+
+## `lib/dal/vault.ts`
+
+Canonical reads for:
+
+- reserve balance
+- reserve blocks
+- quorum state
+- seal state
+- hash coverage
+- fountain readiness
+
+Primary extraction targets:
+
+- `app/api/vault/status/route.ts`
+- `lib/vault/vault.ts`
+- `lib/vault-v2/*`
+
+---
+
+## `lib/dal/snapshot.ts`
+
+Canonical aggregate snapshot.
+
+Will eventually power:
+
+- `/api/terminal/snapshot`
+- SSR chamber boot payloads
+- operator hydration seed
+
+Responsibilities:
+
+- cycle
+- GI
+- degraded state
+- vault summary
+- sentinel summary
+- ledger summary
+- provenance map
+
+---
+
+## `lib/dal/journal.ts`
+
+Journal lane recovery and normalization.
+
+Responsibilities:
+
+- lane reconciliation
+- fallback ordering
+- canonical parsing
+- replay-aware reads
+- degraded empty-state handling
+
+---
+
+## `lib/dal/ledger.ts`
+
+Canonical ledger reads.
+
+Responsibilities:
+
+- substrate events
+- attestation reads
+- EPICON references
+- replay verification
+- canonical ledger normalization
+
+---
+
+## `lib/dal/signals.ts`
+
+Signal aggregation normalization.
+
+Responsibilities:
+
+- signal freshness
+- source ownership
+- stale-state normalization
+- provenance metadata
+
+---
+
+## `lib/dal/sentinel.ts`
+
+Sentinel and quorum reads.
+
+Responsibilities:
+
+- quorum state
+- attested agents
+- degraded agents
+- timeout analysis
+- replay diagnostics
+
+---
+
+# Extraction Strategy
+
+## DO NOT rewrite routes first
+
+Correct sequence:
+
+### Step 1
+
+Extract pure functions.
+
+### Step 2
+
+Wrap with DAL.
+
+### Step 3
+
+Migrate API routes.
+
+### Step 4
+
+Migrate SSR.
+
+### Step 5
+
+Remove internal self-fetch.
+
+---
+
+# Highest Priority Targets
+
+## Tier A
+
+Most important routes:
+
+```text
+/api/terminal/snapshot
+/api/echo/digest
+/api/vault/status
+```
+
+Reason:
+
+These routes currently influence:
+
+- chamber hydration
+- operator truth
+- degraded-state visibility
+- GI rendering
+- vault integrity
+
+---
+
+## Tier B
+
+```text
+/api/chambers/ledger
+/api/vault/seal/attest
+/api/vault/seal/quorum
+```
+
+---
+
+# Phase 1 Acceptance Criteria
+
+## Required
+
+- DAL directory introduced
+- canonical naming established
+- extraction boundaries documented
+- no runtime regressions
+- no route deletions
+- no hydration regressions
+
+## Forbidden
+
+- no giant rewrites
+- no client-side DAL usage
+- no fake cached truth
+- no silent fallback masking
+
+---
+
+# Validation Contract
+
+Implementation PRs following this spec must run:
+
+```bash
+pnpm exec tsc --noEmit
+pnpm build
+pnpm lint
+```
+
+and report:
+
+- files changed
+- commands run
+- exact failures
+- remaining issues
+
+---
+
+# Canonical Principle
+
+Mobius cannot become protocol-grade infrastructure
+until truth access is separated from rendering.
+
+DAL is the beginning of that separation.

--- a/lib/dal/integrity.ts
+++ b/lib/dal/integrity.ts
@@ -1,0 +1,50 @@
+import { integrityStatus } from '@/lib/mock/integrityStatus';
+import type { IntegrityStatusResponse } from '@/lib/mock/integrityStatus';
+import type { DalResult } from '@/lib/dal/types';
+import { degradedDalResult, okDalResult, nowIso } from '@/lib/dal/types';
+
+export type IntegrityDalSnapshot = {
+  cycle: string;
+  global_integrity: number;
+  mode: IntegrityStatusResponse['mode'];
+  terminal_status: IntegrityStatusResponse['terminal_status'];
+  summary: string;
+  verified: boolean;
+  degraded: boolean;
+  timestamp: string;
+};
+
+/**
+ * C-303 Phase 1D — additive integrity DAL scaffold.
+ *
+ * This is deliberately non-authoritative during Phase 1.
+ * It establishes the typed boundary before live GI routing is migrated.
+ */
+export async function readIntegrityDalSnapshot(): Promise<DalResult<IntegrityDalSnapshot>> {
+  try {
+    return okDalResult(
+      {
+        cycle: integrityStatus.cycle,
+        global_integrity: integrityStatus.global_integrity,
+        mode: integrityStatus.mode,
+        terminal_status: integrityStatus.terminal_status,
+        summary: integrityStatus.summary,
+        verified: integrityStatus.gi_verified ?? false,
+        degraded: integrityStatus.degraded ?? true,
+        timestamp: integrityStatus.timestamp,
+      },
+      {
+        source: 'fallback',
+        freshness: 'stale',
+        timestamp: nowIso(),
+        note: 'Non-authoritative integrity DAL scaffold; live GI migration pending',
+      },
+    );
+  } catch (error) {
+    return degradedDalResult<IntegrityDalSnapshot>({
+      source: 'fallback',
+      error: error instanceof Error ? error.message : 'unknown_integrity_dal_error',
+      note: 'Integrity DAL scaffold failed during additive phase',
+    });
+  }
+}

--- a/lib/dal/snapshot.ts
+++ b/lib/dal/snapshot.ts
@@ -1,0 +1,55 @@
+import type { DalResult } from '@/lib/dal/types';
+import { degradedDalResult, okDalResult, nowIso } from '@/lib/dal/types';
+import { readVaultDalSnapshot } from '@/lib/dal/vault';
+
+export type TerminalDalSnapshot = {
+  cycle: string;
+  degraded: boolean;
+  vault: {
+    ok: boolean;
+    headline: string | null;
+  };
+  generated_at: string;
+};
+
+/**
+ * Phase 1 additive snapshot DAL.
+ *
+ * This is NOT wired into /api/terminal/snapshot yet.
+ *
+ * Purpose:
+ * establish canonical aggregation boundaries before migration.
+ */
+export async function buildTerminalDalSnapshot(
+  cycle = 'C-303',
+): Promise<DalResult<TerminalDalSnapshot>> {
+  try {
+    const vault = await readVaultDalSnapshot(null);
+
+    const degraded = !vault.ok;
+
+    return okDalResult(
+      {
+        cycle,
+        degraded,
+        vault: {
+          ok: vault.ok,
+          headline: vault.data?.headline ?? null,
+        },
+        generated_at: nowIso(),
+      },
+      {
+        source: 'computed',
+        freshness: degraded ? 'stale' : 'live',
+        timestamp: nowIso(),
+        note: 'Additive DAL aggregate scaffold',
+      },
+    );
+  } catch (error) {
+    return degradedDalResult<TerminalDalSnapshot>({
+      source: 'fallback',
+      error: error instanceof Error ? error.message : 'unknown_snapshot_dal_error',
+      note: 'Snapshot DAL scaffold failed during additive phase',
+    });
+  }
+}

--- a/lib/dal/tripwire.ts
+++ b/lib/dal/tripwire.ts
@@ -1,0 +1,48 @@
+import { getTripwireState } from '@/lib/tripwire/store';
+import type { RuntimeTripwireLevel } from '@/lib/tripwire/store';
+import type { DalResult } from '@/lib/dal/types';
+import { degradedDalResult, okDalResult, nowIso } from '@/lib/dal/types';
+
+export type TripwireDalSnapshot = {
+  active: boolean;
+  level: RuntimeTripwireLevel;
+  reason: string;
+  last_updated: string;
+  triggered_by: string | null;
+  timestamp: string;
+};
+
+/**
+ * C-303 Phase 1F — additive tripwire DAL scaffold.
+ *
+ * Reads the existing runtime tripwire store directly.
+ * It is diagnostic during Phase 1 and does not replace legacy snapshot routing.
+ */
+export async function readTripwireDalSnapshot(): Promise<DalResult<TripwireDalSnapshot>> {
+  try {
+    const state = getTripwireState();
+
+    return okDalResult(
+      {
+        active: state.active,
+        level: state.level,
+        reason: state.reason,
+        last_updated: state.last_updated,
+        triggered_by: state.triggeredBy ?? null,
+        timestamp: nowIso(),
+      },
+      {
+        source: 'computed',
+        freshness: 'live',
+        timestamp: nowIso(),
+        note: 'Tripwire DAL scaffold sourced from runtime tripwire store',
+      },
+    );
+  } catch (error) {
+    return degradedDalResult<TripwireDalSnapshot>({
+      source: 'fallback',
+      error: error instanceof Error ? error.message : 'unknown_tripwire_dal_error',
+      note: 'Tripwire DAL scaffold failed during additive phase',
+    });
+  }
+}

--- a/lib/dal/types.ts
+++ b/lib/dal/types.ts
@@ -1,0 +1,51 @@
+export type DalSource = 'kv' | 'ledger' | 'substrate' | 'echo' | 'github' | 'computed' | 'fallback';
+
+export type DalFreshness = 'live' | 'stale' | 'unknown';
+
+export type DalProvenance = {
+  source: DalSource;
+  freshness: DalFreshness;
+  timestamp: string | null;
+  note?: string;
+};
+
+export type DalResult<T> = {
+  ok: boolean;
+  data: T | null;
+  provenance: DalProvenance;
+  degraded?: boolean;
+  error?: string;
+};
+
+export function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function okDalResult<T>(data: T, provenance: DalProvenance): DalResult<T> {
+  return {
+    ok: true,
+    data,
+    provenance,
+    degraded: provenance.freshness !== 'live',
+  };
+}
+
+export function degradedDalResult<T>(args: {
+  source: DalSource;
+  error: string;
+  note?: string;
+  data?: T | null;
+}): DalResult<T> {
+  return {
+    ok: false,
+    data: args.data ?? null,
+    degraded: true,
+    error: args.error,
+    provenance: {
+      source: args.source,
+      freshness: 'unknown',
+      timestamp: nowIso(),
+      note: args.note,
+    },
+  };
+}

--- a/lib/dal/vault.ts
+++ b/lib/dal/vault.ts
@@ -1,0 +1,71 @@
+import { getVaultStatusPayload } from '@/lib/vault/vault';
+import { computeVaultSealLaneSemantics } from '@/lib/vault/lane-status';
+import type { DalResult } from '@/lib/dal/types';
+import { degradedDalResult, okDalResult, nowIso } from '@/lib/dal/types';
+
+export type VaultDalSnapshot = {
+  status: 'sealed' | 'preview' | 'activating';
+  balance_reserve: number;
+  gi_current: number | null;
+  preview_active: boolean;
+  source_entries: number;
+  reserve_lane: string;
+  reserve_block_lane: string;
+  headline: string;
+  timestamp: string;
+};
+
+/**
+ * C-303 additive DAL scaffold.
+ *
+ * IMPORTANT:
+ * - no route rewrites yet
+ * - no UI rewrites yet
+ * - no internal fetches
+ * - server-safe reads only
+ */
+export async function readVaultDalSnapshot(
+  giCurrent: number | null,
+): Promise<DalResult<VaultDalSnapshot>> {
+  try {
+    const v1 = await getVaultStatusPayload(giCurrent);
+
+    const lane = computeVaultSealLaneSemantics({
+      v1BalanceReserve: v1.balance_reserve,
+      inProgressBalance: 0,
+      sealsCountAttested: 0,
+      sealsAuditCount: 0,
+      giCurrent,
+      giThreshold: v1.gi_threshold,
+      sustainCyclesRequired: v1.sustain_cycles_required,
+      v1Status: v1.status,
+      candidateInFlight: false,
+    });
+
+    return okDalResult(
+      {
+        status: v1.status,
+        balance_reserve: v1.balance_reserve,
+        gi_current: v1.gi_current,
+        preview_active: v1.preview_active,
+        source_entries: v1.source_entries,
+        reserve_lane: lane.reserve_lane,
+        reserve_block_lane: lane.reserve_block_lane,
+        headline: lane.headline,
+        timestamp: nowIso(),
+      },
+      {
+        source: 'computed',
+        freshness: 'live',
+        timestamp: nowIso(),
+        note: 'DAL scaffold sourced from canonical vault libraries',
+      },
+    );
+  } catch (error) {
+    return degradedDalResult<VaultDalSnapshot>({
+      source: 'fallback',
+      error: error instanceof Error ? error.message : 'unknown_vault_dal_error',
+      note: 'Vault DAL scaffold degraded during additive extraction',
+    });
+  }
+}


### PR DESCRIPTION
# 🧾 C-303 — Phase 1 DAL Foundation

## Summary

This PR establishes the additive implementation specification for:

```text
/lib/dal/*
```

as the canonical truth-access layer for Mobius.

This is the first execution phase following:

- PR #494
- Infrastructure Stabilization Roadmap

---

# Purpose

Separate:

```text
truth access
```

from:

```text
rendering + hydration
```

so Mobius can evolve from:

```text
UI-driven terminal
```

into:

```text
protocol-grade integrity infrastructure
```

---

# Scope

Documentation-only.

No runtime mutations.
No route rewrites.
No hydration rewrites.
No deletions.

Added:

```text
docs/pr/C303_PHASE1_DAL_FOUNDATION.md
```

---

# Core Architectural Principle

Replace:

```text
UI -> API -> API -> hydration recursion
```

with:

```text
UI -> DAL -> canonical source
```

---

# Initial DAL Targets

Planned modules:

```text
lib/dal/
  vault.ts
  signals.ts
  snapshot.ts
  ledger.ts
  journal.ts
  sentinel.ts
```

---

# Highest Priority Runtime Targets

Tier A:

- `/api/terminal/snapshot`
- `/api/echo/digest`
- `/api/vault/status`

Tier B:

- `/api/chambers/ledger`
- `/api/vault/seal/attest`
- `/api/vault/seal/quorum`

---

# Enforcement Rules Established

DAL modules:

✅ may read KV
✅ may read ledger
✅ may aggregate runtime state

DAL modules:

❌ may NOT depend on React
❌ may NOT depend on hydration
❌ may NOT invent truth

---

# Merge Safety

✅ docs-only
✅ additive-only
✅ no runtime risk
✅ no API mutations
✅ no build risk

---

# Follow-up

Next implementation PR should:

1. Introduce `lib/dal/`
2. Extract pure vault readers
3. Extract snapshot loaders
4. Begin removing internal self-fetch recursion
