### PR TITLE
feat(c303): add snapshot parallel-read route

### DIFF
--- a/app/api/terminal/parallel-read/snapshot/route.ts
+++ b/app/api/terminal/parallel-read/snapshot/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { GET as getLegacySnapshot } from '@/app/api/terminal/snapshot/route';
+import { buildTerminalDalSnapshot } from '@/lib/dal/snapshot';
+
+export const dynamic = 'force-dynamic';
+
+type ParallelReadStatus = 'matched' | 'mismatch' | 'legacy_only' | 'dal_degraded';
+
+type SnapshotParity = {
+  cycle_match: boolean;
+  degraded_match: boolean;
+  vault_ok_match: boolean;
+  timestamp_present: boolean;
+};
+
+function safeRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function getLegacyVaultOk(legacy: Record<string, unknown>): boolean | null {
+  const vaultLeaf = safeRecord(legacy.vault);
+  if (typeof vaultLeaf.ok === 'boolean') return vaultLeaf.ok;
+
+  const vaultData = safeRecord(vaultLeaf.data);
+  if (typeof vaultData.ok === 'boolean') return vaultData.ok;
+
+  return null;
+}
+
+function getStatus(parity: SnapshotParity, dalOk: boolean): ParallelReadStatus {
+  if (!dalOk) return 'dal_degraded';
+  const values = Object.values(parity);
+  if (values.every(Boolean)) return 'matched';
+  if (values.every((value) => value === false)) return 'legacy_only';
+  return 'mismatch';
+}
+
+/**
+ * C-303 Phase 2C — Snapshot parallel read route.
+ *
+ * This is not a cutover. /api/terminal/snapshot remains authoritative.
+ * The DAL snapshot is returned beside it so operators and agents can observe parity.
+ */
+export async function GET(request: NextRequest) {
+  const startedAt = Date.now();
+  const baseUrl = request.nextUrl.origin;
+  const cycle = request.nextUrl.searchParams.get('cycle')?.trim();
+  const legacyRequestUrl = new URL('/api/terminal/snapshot', baseUrl);
+  if (cycle) legacyRequestUrl.searchParams.set('cycle', cycle);
+
+  const legacyRequest = new NextRequest(legacyRequestUrl);
+  const legacyResponse = await getLegacySnapshot(legacyRequest);
+  const legacyPayload = await legacyResponse.json().catch(() => null);
+  const legacy = safeRecord(legacyPayload);
+  const legacyCycle = typeof legacy.cycle === 'string' ? legacy.cycle : cycle ?? 'C-303';
+  const legacyVaultOk = getLegacyVaultOk(legacy);
+
+  const dalResult = await buildTerminalDalSnapshot(legacyCycle);
+  const dal = dalResult.data ?? null;
+
+  const parity: SnapshotParity = {
+    cycle_match: dal ? legacyCycle === dal.cycle : false,
+    degraded_match: dal ? Boolean(legacy.degraded) === dal.degraded : false,
+    vault_ok_match: dal && legacyVaultOk !== null ? legacyVaultOk === dal.vault.ok : false,
+    timestamp_present: Boolean(legacy.timestamp) && Boolean(dal?.generated_at),
+  };
+
+  const status = getStatus(parity, dalResult.ok);
+
+  return NextResponse.json(
+    {
+      ok: legacyResponse.ok && status !== 'mismatch' && status !== 'dal_degraded',
+      mode: 'parallel_read_snapshot',
+      phase: 'C-303 Phase 2C',
+      authority: {
+        authoritative_source: 'legacy_snapshot_runtime',
+        dal_authority: 'shadow_only',
+        cutover_enabled: false,
+      },
+      status,
+      legacy: {
+        ok: legacy.ok ?? legacyResponse.ok,
+        cycle: legacyCycle,
+        gi: typeof legacy.gi === 'number' ? legacy.gi : null,
+        effective_gi: typeof legacy.effective_gi === 'number' ? legacy.effective_gi : null,
+        degraded: typeof legacy.degraded === 'boolean' ? legacy.degraded : null,
+        terminal_status: typeof legacy.terminal_status === 'string' ? legacy.terminal_status : null,
+        vault_ok: legacyVaultOk,
+        timestamp: typeof legacy.timestamp === 'string' ? legacy.timestamp : null,
+        lanes_count: Array.isArray(legacy.lanes) ? legacy.lanes.length : null,
+      },
+      dal: {
+        ok: dalResult.ok,
+        degraded: dalResult.degraded ?? !dalResult.ok,
+        cycle: dal?.cycle ?? null,
+        snapshot_degraded: dal?.degraded ?? null,
+        vault_ok: dal?.vault.ok ?? null,
+        vault_headline: dal?.vault.headline ?? null,
+        generated_at: dal?.generated_at ?? null,
+        provenance: dalResult.provenance,
+        error: dalResult.error ?? null,
+      },
+      parity,
+      meta: {
+        elapsed_ms: Date.now() - startedAt,
+        canonical_warning: 'Parallel read only. /api/terminal/snapshot remains authoritative.',
+      },
+    },
+    {
+      headers: {
+        'Cache-Control': 'no-store',
+        'X-Mobius-Source': 'terminal-parallel-read-snapshot',
+      },
+    },
+  );
+}

--- a/app/api/terminal/parallel-read/snapshot/route.ts
+++ b/app/api/terminal/parallel-read/snapshot/route.ts
@@ -54,6 +54,7 @@ export async function GET(request: NextRequest) {
   const legacyResponse = await getLegacySnapshot(legacyRequest);
   const legacyPayload = await legacyResponse.json().catch(() => null);
   const legacy = safeRecord(legacyPayload);
+  const legacyPayloadOk = typeof legacy.ok === 'boolean' ? legacy.ok : legacyResponse.ok;
   const legacyCycle = typeof legacy.cycle === 'string' ? legacy.cycle : cycle ?? 'C-303';
   const legacyVaultOk = getLegacyVaultOk(legacy);
 
@@ -71,7 +72,7 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json(
     {
-      ok: legacyResponse.ok && status !== 'mismatch' && status !== 'dal_degraded',
+      ok: legacyPayloadOk && status !== 'mismatch' && status !== 'dal_degraded',
       mode: 'parallel_read_snapshot',
       phase: 'C-303 Phase 2C',
       authority: {
@@ -81,7 +82,7 @@ export async function GET(request: NextRequest) {
       },
       status,
       legacy: {
-        ok: legacy.ok ?? legacyResponse.ok,
+        ok: legacyPayloadOk,
         cycle: legacyCycle,
         gi: typeof legacy.gi === 'number' ? legacy.gi : null,
         effective_gi: typeof legacy.effective_gi === 'number' ? legacy.effective_gi : null,


### PR DESCRIPTION
## Phase
C-303 Phase 2C — Parallel Read Routing: Snapshot

## Scope
Adds a diagnostic-only snapshot parallel-read endpoint that reads the live legacy Terminal snapshot beside the DAL snapshot shadow state.

## Files touched
- `app/api/terminal/parallel-read/snapshot/route.ts`

## NOT touching
- No existing `/api/terminal/snapshot` replacement
- No Terminal UI replacement
- No DAL cutover
- No mutation path
- No ledger write path
- No cron orchestration
- No replay, vault, or EPICON feed logic

## Change type
Additive / parallel-read only.

## Operator guarantee
`/api/terminal/snapshot` remains authoritative. DAL is returned as `shadow_only` with explicit parity diagnostics and no cutover authority.

## Expected current behavior
The DAL snapshot is intentionally smaller than the live snapshot right now. This route may report `mismatch` or `dal_degraded` until later phases stabilize parity. That is expected and should remain visible to operators.

## Response modes
- `matched`
- `mismatch`
- `legacy_only`
- `dal_degraded`

## Validation plan
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `pnpm lint`
- Hit `/api/terminal/parallel-read/snapshot` and verify:
  - `authority.authoritative_source === "legacy_snapshot_runtime"`
  - `authority.dal_authority === "shadow_only"`
  - `authority.cutover_enabled === false`
  - response includes `legacy`, `dal`, `parity`, and `meta`

## Notes
This continues the Phase 2 parallel-read sequence after PR #496 tripwire and PR #497 integrity. It observes snapshot drift before any migration or authority swap.