### PR TITLE
feat(c303): add EPICON deterministic runtime evaluator

### DIFF
--- a/lib/epicon/runtime/build-github-check-summary.ts
+++ b/lib/epicon/runtime/build-github-check-summary.ts
@@ -1,0 +1,55 @@
+import type {
+  EpiconGithubCheckSummary,
+  EpiconGovernanceReceipt,
+} from './types';
+
+function formatReasons(reasons: string[]): string {
+  if (reasons.length === 0) return '- no deterministic risk reasons detected';
+
+  return reasons.map((reason) => `- ${reason}`).join('\n');
+}
+
+function statusForReceipt(
+  receipt: EpiconGovernanceReceipt,
+): EpiconGithubCheckSummary['status'] {
+  if (receipt.verdict === 'quarantine') return 'failure';
+  if (receipt.verdict === 'clarify') return 'neutral';
+  return 'success';
+}
+
+export function buildGithubCheckSummary(
+  receipt: EpiconGovernanceReceipt,
+): EpiconGithubCheckSummary {
+  const title = `EPICON ${receipt.verdict.toUpperCase()} · risk ${receipt.risk.toFixed(2)}`;
+
+  const summary = [
+    '## EPICON Runtime Preview',
+    '',
+    `**Verdict:** ${receipt.verdict.toUpperCase()}`,
+    `**Risk:** ${receipt.risk.toFixed(2)}`,
+    `**Severity:** ${receipt.severity}`,
+    `**Governance Version:** ${receipt.governanceVersion}`,
+    `**Enforcement:** ${receipt.enforcement}`,
+    '',
+    '### Event',
+    `- Repo: ${receipt.event.repo}`,
+    `- PR: #${receipt.event.prNumber}`,
+    `- Branch: ${receipt.event.branch}`,
+    `- Author: ${receipt.event.author}`,
+    '',
+    '### Deterministic Reasons',
+    formatReasons(receipt.reasons),
+    '',
+    '### Replay Fingerprint',
+    `\`${receipt.replayFingerprint}\``,
+    '',
+    '> EPICON Runtime Preview is observational only. It does not block merges in this phase.',
+  ].join('\n');
+
+  return {
+    name: 'EPICON Runtime Preview',
+    status: statusForReceipt(receipt),
+    title,
+    summary,
+  };
+}

--- a/lib/epicon/runtime/build-governance-receipt.ts
+++ b/lib/epicon/runtime/build-governance-receipt.ts
@@ -1,0 +1,56 @@
+import crypto from 'node:crypto';
+
+import type {
+  EpiconGovernanceReceipt,
+  EpiconPullRequestEvent,
+  EpiconRuntimeEvaluation,
+} from './types';
+
+function buildReplayFingerprint(
+  event: EpiconPullRequestEvent,
+  evaluation: EpiconRuntimeEvaluation,
+): string {
+  const payload = JSON.stringify({
+    repo: event.repo,
+    prNumber: event.prNumber,
+    branch: event.branch,
+    risk: evaluation.risk,
+    severity: evaluation.severity,
+    reasons: evaluation.reasons,
+  });
+
+  return crypto
+    .createHash('sha256')
+    .update(payload)
+    .digest('hex');
+}
+
+export function buildGovernanceReceipt(
+  event: EpiconPullRequestEvent,
+  evaluation: EpiconRuntimeEvaluation,
+): EpiconGovernanceReceipt {
+  const verdict =
+    evaluation.severity === 'high'
+      ? 'quarantine'
+      : evaluation.severity === 'medium'
+        ? 'clarify'
+        : 'pass';
+
+  return {
+    verdict,
+    risk: evaluation.risk,
+    severity: evaluation.severity,
+    consensus: null,
+    replayFingerprint: buildReplayFingerprint(event, evaluation),
+    governanceVersion: 'EPICON-03',
+    timestamp: new Date().toISOString(),
+    event: {
+      repo: event.repo,
+      prNumber: event.prNumber,
+      branch: event.branch,
+      author: event.author,
+    },
+    reasons: evaluation.reasons,
+    enforcement: 'disabled',
+  };
+}

--- a/lib/epicon/runtime/evaluate-pr-risk.ts
+++ b/lib/epicon/runtime/evaluate-pr-risk.ts
@@ -1,0 +1,83 @@
+import { EPICON_RUNTIME_THRESHOLDS } from './risk-thresholds';
+import { normalizePrSignal } from './normalize-pr-signal';
+import type {
+  EpiconPrSignalInput,
+  EpiconRuntimeEvaluation,
+} from './types';
+
+function clampRisk(value: number): number {
+  return Math.max(0, Math.min(1, Number(value.toFixed(2))));
+}
+
+export function evaluatePrRisk(
+  input: EpiconPrSignalInput,
+): EpiconRuntimeEvaluation {
+  const normalized = normalizePrSignal(input);
+
+  let risk = 0;
+  const reasons: string[] = [];
+
+  risk += normalized.deletions * 0.002;
+  risk += normalized.sensitivePathCount * 0.25;
+  risk += normalized.replaySignals * 0.15;
+
+  if (normalized.scopeMismatch) {
+    risk += 0.2;
+    reasons.push('scope mismatch detected');
+  }
+
+  if (
+    normalized.filesChanged >
+    EPICON_RUNTIME_THRESHOLDS.largeDiffFiles
+  ) {
+    risk += 0.15;
+    reasons.push('large diff footprint');
+  }
+
+  if (
+    normalized.deletions >
+    EPICON_RUNTIME_THRESHOLDS.largeDeletionCount
+  ) {
+    risk += 0.2;
+    reasons.push('high deletion count');
+  }
+
+  if (normalized.sensitivePathCount > 0) {
+    reasons.push('sensitive paths modified');
+  }
+
+  if (normalized.docsOnly) {
+    risk = Math.max(0, risk - 0.25);
+    reasons.push('documentation-only mutation');
+  }
+
+  risk = clampRisk(risk);
+
+  const severity =
+    risk >= EPICON_RUNTIME_THRESHOLDS.highRisk
+      ? 'high'
+      : risk >= EPICON_RUNTIME_THRESHOLDS.mediumRisk
+        ? 'medium'
+        : 'low';
+
+  const recommendedAction =
+    severity === 'high'
+      ? 'clarify'
+      : severity === 'medium'
+        ? 'clarify'
+        : 'pass';
+
+  return {
+    pass: severity !== 'high',
+    risk,
+    severity,
+    recommendedAction,
+    reasons,
+    normalized,
+    meta: {
+      evaluator: 'epicon-runtime-layer-0',
+      enforcement: 'disabled',
+      deterministic: true,
+    },
+  };
+}

--- a/lib/epicon/runtime/normalize-pr-signal.ts
+++ b/lib/epicon/runtime/normalize-pr-signal.ts
@@ -1,0 +1,24 @@
+import type {
+  EpiconNormalizedPrSignal,
+  EpiconPrSignalInput,
+} from './types';
+
+export function normalizePrSignal(
+  input: EpiconPrSignalInput,
+): EpiconNormalizedPrSignal {
+  const totalChanges = input.additions + input.deletions;
+
+  const changeVolume =
+    totalChanges > 500
+      ? 'large'
+      : totalChanges > 100
+        ? 'medium'
+        : 'small';
+
+  return {
+    ...input,
+    totalChanges,
+    changeVolume,
+    sensitivePathCount: input.sensitivePaths.length,
+  };
+}

--- a/lib/epicon/runtime/normalize-pull-request-event.ts
+++ b/lib/epicon/runtime/normalize-pull-request-event.ts
@@ -1,0 +1,48 @@
+import type { EpiconPullRequestEvent } from './types';
+
+type GithubPullRequestLike = {
+  number?: number;
+  title?: string | null;
+  body?: string | null;
+  additions?: number | null;
+  deletions?: number | null;
+  changed_files?: number | null;
+  head?: {
+    ref?: string | null;
+  } | null;
+  user?: {
+    login?: string | null;
+  } | null;
+};
+
+type GithubRepositoryLike = {
+  full_name?: string | null;
+};
+
+type GithubPullRequestWebhookLike = {
+  pull_request?: GithubPullRequestLike | null;
+  repository?: GithubRepositoryLike | null;
+};
+
+export function normalizePullRequestEvent(
+  payload: GithubPullRequestWebhookLike,
+  changedFilenames: string[] = [],
+  timestamp = new Date().toISOString(),
+): EpiconPullRequestEvent {
+  const pullRequest = payload.pull_request;
+  const repository = payload.repository;
+
+  return {
+    repo: repository?.full_name ?? 'unknown/unknown',
+    prNumber: pullRequest?.number ?? 0,
+    title: pullRequest?.title ?? '',
+    body: pullRequest?.body ?? '',
+    branch: pullRequest?.head?.ref ?? 'unknown',
+    author: pullRequest?.user?.login ?? 'unknown',
+    additions: pullRequest?.additions ?? 0,
+    deletions: pullRequest?.deletions ?? 0,
+    changedFiles: pullRequest?.changed_files ?? changedFilenames.length,
+    changedFilenames,
+    timestamp,
+  };
+}

--- a/lib/epicon/runtime/policies/types.ts
+++ b/lib/epicon/runtime/policies/types.ts
@@ -1,0 +1,15 @@
+import type { EpiconPullRequestEvent } from '../types';
+
+export type RuntimePolicySeverity = 'low' | 'medium' | 'high' | 'critical';
+
+export type RuntimePolicyHit = {
+  id: string;
+  severity: RuntimePolicySeverity;
+  confidence: number;
+  note: string;
+};
+
+export type RuntimePolicy = {
+  id: string;
+  evaluate(event: EpiconPullRequestEvent): RuntimePolicyHit | null;
+};

--- a/lib/epicon/runtime/risk-thresholds.ts
+++ b/lib/epicon/runtime/risk-thresholds.ts
@@ -1,0 +1,17 @@
+export const EPICON_RUNTIME_THRESHOLDS = {
+  mediumRisk: 0.35,
+  highRisk: 0.7,
+  largeDiffFiles: 25,
+  largeDeletionCount: 200,
+} as const;
+
+export const EPICON_SENSITIVE_PATH_PATTERNS = [
+  'auth',
+  'middleware',
+  'secret',
+  'token',
+  '.env',
+  'permissions',
+  'vault',
+  'ledger',
+] as const;

--- a/lib/epicon/runtime/types.ts
+++ b/lib/epicon/runtime/types.ts
@@ -1,0 +1,33 @@
+export type EpiconRuntimeSeverity = 'low' | 'medium' | 'high';
+
+export type EpiconRecommendedAction = 'pass' | 'clarify' | 'quarantine';
+
+export type EpiconPrSignalInput = {
+  filesChanged: number;
+  additions: number;
+  deletions: number;
+  sensitivePaths: string[];
+  replaySignals: number;
+  scopeMismatch: boolean;
+  docsOnly?: boolean;
+};
+
+export type EpiconNormalizedPrSignal = EpiconPrSignalInput & {
+  totalChanges: number;
+  changeVolume: 'small' | 'medium' | 'large';
+  sensitivePathCount: number;
+};
+
+export type EpiconRuntimeEvaluation = {
+  pass: boolean;
+  risk: number;
+  severity: EpiconRuntimeSeverity;
+  recommendedAction: EpiconRecommendedAction;
+  reasons: string[];
+  normalized: EpiconNormalizedPrSignal;
+  meta: {
+    evaluator: 'epicon-runtime-layer-0';
+    enforcement: 'disabled';
+    deterministic: true;
+  };
+};

--- a/lib/epicon/runtime/types.ts
+++ b/lib/epicon/runtime/types.ts
@@ -2,6 +2,8 @@ export type EpiconRuntimeSeverity = 'low' | 'medium' | 'high';
 
 export type EpiconRecommendedAction = 'pass' | 'clarify' | 'quarantine';
 
+export type EpiconGovernanceVerdict = 'pass' | 'clarify' | 'quarantine';
+
 export type EpiconPrSignalInput = {
   filesChanged: number;
   additions: number;
@@ -30,4 +32,38 @@ export type EpiconRuntimeEvaluation = {
     enforcement: 'disabled';
     deterministic: true;
   };
+};
+
+export type EpiconPullRequestEvent = {
+  repo: string;
+  prNumber: number;
+  title: string;
+  body: string;
+  branch: string;
+  author: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  changedFilenames: string[];
+  timestamp: string;
+};
+
+export type EpiconGovernanceReceipt = {
+  verdict: EpiconGovernanceVerdict;
+  risk: number;
+  severity: EpiconRuntimeSeverity;
+  consensus: null;
+  replayFingerprint: string;
+  governanceVersion: 'EPICON-03';
+  timestamp: string;
+  event: Pick<EpiconPullRequestEvent, 'repo' | 'prNumber' | 'branch' | 'author'>;
+  reasons: string[];
+  enforcement: 'disabled';
+};
+
+export type EpiconGithubCheckSummary = {
+  name: 'EPICON Runtime Preview';
+  status: 'success' | 'neutral' | 'failure';
+  title: string;
+  summary: string;
 };


### PR DESCRIPTION
## Phase
C-303 Phase 2 — EPICON Runtime Layer

## Scope
Additive deterministic governance runtime evaluator.

## Purpose
Introduce Layer 0 deterministic governance scoring before quorum-based EPICON enforcement.

## Files Planned
- lib/epicon/runtime/types.ts
- lib/epicon/runtime/risk-thresholds.ts
- lib/epicon/runtime/normalize-pr-signal.ts
- lib/epicon/runtime/evaluate-pr-risk.ts
- app/api/epicon/runtime-preview/route.ts

## Runtime Inputs
- filesChanged
- additions
- deletions
- sensitivePaths
- replaySignals
- scopeMismatch

## Runtime Outputs
- pass
- risk
- severity
- recommendedAction
- reasons

## NOT Touching
- vault logic
- replay engine
- DAL mutation paths
- ledger persistence
- merge enforcement
- quorum systems

## Architecture Rule
observe → calibrate → compare → score → enforce later

NOT:
score → instantly block

## Validation Plan
- pnpm exec tsc --noEmit
- pnpm build
- pnpm lint