### PR TITLE
feat(c303): add EPICON quorum escalation runtime

### DIFF
--- a/app/api/epicon/quorum-preview/route.ts
+++ b/app/api/epicon/quorum-preview/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+
+import { buildGovernanceReceipt } from '@/lib/epicon/runtime/build-governance-receipt';
+import { buildQuorumDecision } from '@/lib/epicon/quorum/build-quorum-decision';
+import { buildQuorumPacket } from '@/lib/epicon/quorum/build-quorum-packet';
+import type {
+  EpiconPullRequestEvent,
+  EpiconRuntimeEvaluation,
+} from '@/lib/epicon/runtime/types';
+
+export const dynamic = 'force-dynamic';
+
+const sampleEvent: EpiconPullRequestEvent = {
+  repo: 'kaizencycle/mobius-civic-ai-terminal',
+  prNumber: 501,
+  title: 'feat(c303): add EPICON quorum escalation runtime',
+  body: 'Phase 3 preview packet for observational quorum routing.',
+  branch: 'c303-phase3-quorum-escalation-runtime',
+  author: 'kaizencycle',
+  additions: 127,
+  deletions: 0,
+  changedFiles: 3,
+  changedFilenames: [
+    'lib/epicon/quorum/types.ts',
+    'lib/epicon/quorum/escalation-router.ts',
+    'lib/epicon/quorum/build-quorum-packet.ts',
+  ],
+  timestamp: new Date().toISOString(),
+};
+
+const sampleEvaluation: EpiconRuntimeEvaluation = {
+  pass: false,
+  risk: 0.82,
+  severity: 'high',
+  recommendedAction: 'quarantine',
+  reasons: [
+    'high runtime risk preview',
+    'sensitive governance path modified',
+  ],
+  normalized: {
+    filesChanged: 3,
+    additions: 127,
+    deletions: 0,
+    sensitivePaths: ['lib/epicon/quorum'],
+    replaySignals: 0,
+    scopeMismatch: false,
+    docsOnly: false,
+    totalChanges: 127,
+    changeVolume: 'small',
+    sensitivePathCount: 1,
+  },
+  meta: {
+    evaluator: 'epicon-runtime-layer-0',
+    enforcement: 'disabled',
+    deterministic: true,
+  },
+};
+
+export async function GET() {
+  const receipt = buildGovernanceReceipt(sampleEvent, sampleEvaluation);
+  const packet = buildQuorumPacket(receipt);
+  const decision = buildQuorumDecision(packet);
+
+  return NextResponse.json({
+    ok: true,
+    phase: 'C-303 Phase 3 — Quorum Escalation Runtime',
+    enforcement: 'disabled',
+    receipt,
+    packet,
+    decision,
+  });
+}

--- a/lib/epicon/quorum/build-quorum-decision.ts
+++ b/lib/epicon/quorum/build-quorum-decision.ts
@@ -1,0 +1,38 @@
+import type {
+  EpiconAgentParticipationReceipt,
+  EpiconQuorumDecision,
+  EpiconQuorumPacket,
+} from './types';
+
+function buildPendingParticipation(
+  packet: EpiconQuorumPacket,
+): EpiconAgentParticipationReceipt[] {
+  return packet.requestedAgents.map((agent) => ({
+    agent,
+    status: 'pending',
+    confidence: null,
+    note: null,
+  }));
+}
+
+export function buildQuorumDecision(
+  packet: EpiconQuorumPacket,
+): EpiconQuorumDecision {
+  const requiresOperatorReview = packet.reasons.includes('operator_requested');
+  const requiresQuarantine =
+    packet.reasons.includes('quarantine_recommended') ||
+    packet.reasons.includes('high_runtime_risk');
+
+  return {
+    packetId: packet.packetId,
+    status: requiresOperatorReview ? 'operator_review_required' : 'pending',
+    participatingAgents: buildPendingParticipation(packet),
+    finalRecommendation: requiresOperatorReview
+      ? 'operator_review'
+      : requiresQuarantine
+        ? 'quarantine'
+        : 'clarify',
+    enforcement: 'disabled',
+    decidedAt: new Date().toISOString(),
+  };
+}

--- a/lib/epicon/quorum/build-quorum-packet.ts
+++ b/lib/epicon/quorum/build-quorum-packet.ts
@@ -1,0 +1,34 @@
+import crypto from 'node:crypto';
+
+import type { EpiconGovernanceReceipt } from '../runtime/types';
+import { buildEscalationPreview } from './escalation-router';
+import type { EpiconQuorumPacket } from './types';
+
+function buildPacketId(receipt: EpiconGovernanceReceipt): string {
+  return crypto
+    .createHash('sha256')
+    .update(
+      JSON.stringify({
+        repo: receipt.event.repo,
+        prNumber: receipt.event.prNumber,
+        fingerprint: receipt.replayFingerprint,
+      }),
+    )
+    .digest('hex');
+}
+
+export function buildQuorumPacket(
+  receipt: EpiconGovernanceReceipt,
+): EpiconQuorumPacket {
+  const escalation = buildEscalationPreview(receipt);
+
+  return {
+    packetId: buildPacketId(receipt),
+    tier: escalation.tier,
+    receipt,
+    reasons: escalation.reasons,
+    requestedAgents: escalation.requestedAgents,
+    createdAt: new Date().toISOString(),
+    enforcement: 'disabled',
+  };
+}

--- a/lib/epicon/quorum/build-quorum-summary.ts
+++ b/lib/epicon/quorum/build-quorum-summary.ts
@@ -1,0 +1,38 @@
+import type { EpiconQuorumDecision, EpiconQuorumPacket } from './types';
+
+function formatReasons(packet: EpiconQuorumPacket): string[] {
+  if (packet.reasons.length === 0) return ['- no quorum escalation reasons detected'];
+
+  return packet.reasons.map((reason) => `- ${reason}`);
+}
+
+function formatAgents(decision: EpiconQuorumDecision): string[] {
+  if (decision.participatingAgents.length === 0) return ['- no agents requested'];
+
+  return decision.participatingAgents.map(
+    (agent) => `- ${agent.agent}: ${agent.status}`,
+  );
+}
+
+export function buildQuorumSummary(
+  packet: EpiconQuorumPacket,
+  decision: EpiconQuorumDecision,
+): string {
+  return [
+    '## EPICON Quorum Preview',
+    '',
+    `**Packet:** ${packet.packetId}`,
+    `**Tier:** ${packet.tier}`,
+    `**Decision Status:** ${decision.status}`,
+    `**Recommendation:** ${decision.finalRecommendation}`,
+    `**Enforcement:** ${decision.enforcement}`,
+    '',
+    '### Escalation Reasons',
+    ...formatReasons(packet),
+    '',
+    '### Requested Agents',
+    ...formatAgents(decision),
+    '',
+    '> Quorum Preview is observational only. It does not execute agents, write to the ledger, or block merges.',
+  ].join('\n');
+}

--- a/lib/epicon/quorum/escalation-router.ts
+++ b/lib/epicon/quorum/escalation-router.ts
@@ -1,0 +1,55 @@
+import type { EpiconGovernanceReceipt } from '../runtime/types';
+import type {
+  EpiconQuorumEscalationReason,
+  EpiconQuorumPacket,
+} from './types';
+
+function determineReasons(
+  receipt: EpiconGovernanceReceipt,
+): EpiconQuorumEscalationReason[] {
+  const reasons: EpiconQuorumEscalationReason[] = [];
+
+  if (receipt.severity === 'high') {
+    reasons.push('high_runtime_risk');
+  }
+
+  if (receipt.verdict === 'quarantine') {
+    reasons.push('quarantine_recommended');
+  }
+
+  const hasReplayRisk = receipt.policyHits?.some(
+    (hit) => hit.id === 'replay-risk',
+  );
+
+  if (hasReplayRisk) {
+    reasons.push('replay_risk');
+  }
+
+  const hasSensitivePolicyHit = receipt.policyHits?.some(
+    (hit) => hit.id === 'sensitive-paths',
+  );
+
+  if (hasSensitivePolicyHit) {
+    reasons.push('sensitive_policy_hit');
+  }
+
+  return reasons;
+}
+
+export function shouldEscalateToQuorum(
+  receipt: EpiconGovernanceReceipt,
+): boolean {
+  return determineReasons(receipt).length > 0;
+}
+
+export function buildEscalationPreview(
+  receipt: EpiconGovernanceReceipt,
+): Pick<EpiconQuorumPacket, 'tier' | 'reasons' | 'requestedAgents'> {
+  const reasons = determineReasons(receipt);
+
+  return {
+    tier: 'tier_2_agent_quorum',
+    reasons,
+    requestedAgents: ['ATLAS', 'AUREA', 'EVE'],
+  };
+}

--- a/lib/epicon/quorum/escalation-router.ts
+++ b/lib/epicon/quorum/escalation-router.ts
@@ -17,19 +17,25 @@ function determineReasons(
     reasons.push('quarantine_recommended');
   }
 
-  const hasReplayRisk = receipt.policyHits?.some(
-    (hit) => hit.id === 'replay-risk',
+  const hasReplayReason = receipt.reasons.some((reason) =>
+    reason.toLowerCase().includes('replay'),
   );
 
-  if (hasReplayRisk) {
+  if (hasReplayReason) {
     reasons.push('replay_risk');
   }
 
-  const hasSensitivePolicyHit = receipt.policyHits?.some(
-    (hit) => hit.id === 'sensitive-paths',
-  );
+  const hasSensitiveReason = receipt.reasons.some((reason) => {
+    const normalizedReason = reason.toLowerCase();
+    return (
+      normalizedReason.includes('sensitive') ||
+      normalizedReason.includes('auth') ||
+      normalizedReason.includes('secret') ||
+      normalizedReason.includes('middleware')
+    );
+  });
 
-  if (hasSensitivePolicyHit) {
+  if (hasSensitiveReason) {
     reasons.push('sensitive_policy_hit');
   }
 

--- a/lib/epicon/quorum/types.ts
+++ b/lib/epicon/quorum/types.ts
@@ -1,0 +1,38 @@
+import type { EpiconGovernanceReceipt } from '../runtime/types';
+
+export type EpiconQuorumTier = 'tier_2_agent_quorum' | 'tier_3_operator_review';
+
+export type EpiconQuorumAgentId = 'ATLAS' | 'AUREA' | 'EVE' | 'JADE' | 'HERMES';
+
+export type EpiconQuorumEscalationReason =
+  | 'high_runtime_risk'
+  | 'quarantine_recommended'
+  | 'sensitive_policy_hit'
+  | 'replay_risk'
+  | 'operator_requested';
+
+export type EpiconQuorumPacket = {
+  packetId: string;
+  tier: EpiconQuorumTier;
+  receipt: EpiconGovernanceReceipt;
+  reasons: EpiconQuorumEscalationReason[];
+  requestedAgents: EpiconQuorumAgentId[];
+  createdAt: string;
+  enforcement: 'disabled';
+};
+
+export type EpiconAgentParticipationReceipt = {
+  agent: EpiconQuorumAgentId;
+  status: 'pending' | 'accepted' | 'declined' | 'timed_out';
+  confidence: number | null;
+  note: string | null;
+};
+
+export type EpiconQuorumDecision = {
+  packetId: string;
+  status: 'not_required' | 'pending' | 'quorum_ready' | 'timed_out' | 'operator_review_required';
+  participatingAgents: EpiconAgentParticipationReceipt[];
+  finalRecommendation: 'pass' | 'clarify' | 'quarantine' | 'operator_review';
+  enforcement: 'disabled';
+  decidedAt: string;
+};


### PR DESCRIPTION
## Phase
C-303 Phase 3 — Quorum Escalation Runtime

## Initial Scope (Safe Additive Scaffolding)
This PR introduces the first additive quorum escalation layer for EPICON.

Included in this PR:
- quorum packet types
- escalation routing logic
- quorum packet builder

## Purpose
Bridge deterministic EPICON runtime evaluation into future Mobius Agent quorum review.

## Current Behavior
- observational only
- enforcement disabled
- no autonomous mutation
- no merge blocking
- no ledger writes

## Architecture
Tier 0 → static checks
Tier 1 → deterministic EPICON runtime
Tier 2 → agent quorum escalation
Tier 3 → operator escalation

## Initial Requested Agents
- ATLAS
- AUREA
- EVE

## NOT Touching
- Substrate canon semantics
- existing runtime evaluator behavior
- Terminal truth flow
- ledger sealing
- cron orchestration
- workflow enforcement

## Validation
- pnpm exec tsc --noEmit
- pnpm build
- pnpm lint