### PR TITLE
feat(c303): add EPICON GitHub App webhook scaffold

### DIFF
--- a/app/api/github/webhook/route.ts
+++ b/app/api/github/webhook/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { normalizeGithubPullRequestWebhook, isSupportedPullRequestAction } from '@/lib/epicon/github/normalize-webhook-pr';
+import { verifyGithubWebhookSignature } from '@/lib/epicon/github/verify-signature';
+import { buildGithubCheckSummary } from '@/lib/epicon/runtime/build-github-check-summary';
+import { buildGovernanceReceipt } from '@/lib/epicon/runtime/build-governance-receipt';
+import { evaluatePrRisk } from '@/lib/epicon/runtime/evaluate-pr-risk';
+
+export const dynamic = 'force-dynamic';
+
+type GithubWebhookHeaders = {
+  event: string | null;
+  delivery: string | null;
+  signature: string | null;
+};
+
+function readGithubHeaders(request: NextRequest): GithubWebhookHeaders {
+  return {
+    event: request.headers.get('x-github-event'),
+    delivery: request.headers.get('x-github-delivery'),
+    signature: request.headers.get('x-hub-signature-256'),
+  };
+}
+
+function getSensitivePaths(changedFilenames: string[]): string[] {
+  const sensitiveTokens = ['auth', 'secret', 'secrets', 'env', 'middleware', 'migration', 'migrations', 'database', 'db'];
+
+  return changedFilenames.filter((filename) => {
+    const normalized = filename.toLowerCase();
+    return sensitiveTokens.some((token) => normalized.includes(token));
+  });
+}
+
+function isDocsOnly(changedFilenames: string[]): boolean {
+  if (changedFilenames.length === 0) return false;
+
+  return changedFilenames.every((filename) => {
+    const normalized = filename.toLowerCase();
+    return normalized.endsWith('.md') || normalized.startsWith('docs/');
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+  const headers = readGithubHeaders(request);
+
+  const verified = verifyGithubWebhookSignature({
+    body,
+    signature: headers.signature,
+    secret: process.env.GITHUB_WEBHOOK_SECRET,
+  });
+
+  if (!verified) {
+    return NextResponse.json(
+      { ok: false, error: 'invalid_github_webhook_signature' },
+      { status: 401 },
+    );
+  }
+
+  if (headers.event !== 'pull_request') {
+    return NextResponse.json({
+      ok: true,
+      ignored: true,
+      reason: 'unsupported_github_event',
+      event: headers.event,
+      delivery: headers.delivery,
+    });
+  }
+
+  const payload = JSON.parse(body);
+  const { action, event } = normalizeGithubPullRequestWebhook(payload);
+
+  if (!isSupportedPullRequestAction(action)) {
+    return NextResponse.json({
+      ok: true,
+      ignored: true,
+      reason: 'unsupported_pull_request_action',
+      action,
+      delivery: headers.delivery,
+    });
+  }
+
+  const evaluation = evaluatePrRisk({
+    filesChanged: event.changedFiles,
+    additions: event.additions,
+    deletions: event.deletions,
+    sensitivePaths: getSensitivePaths(event.changedFilenames),
+    replaySignals: 0,
+    scopeMismatch: !event.body.includes('Intent:'),
+    docsOnly: isDocsOnly(event.changedFilenames),
+  });
+
+  const receipt = buildGovernanceReceipt(event, evaluation);
+  const check = buildGithubCheckSummary(receipt);
+
+  return NextResponse.json({
+    ok: true,
+    mode: 'preview',
+    enforcement: 'disabled',
+    delivery: headers.delivery,
+    action,
+    event,
+    evaluation,
+    receipt,
+    check,
+  });
+}
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    service: 'EPICON GitHub webhook scaffold',
+    mode: 'preview',
+    enforcement: 'disabled',
+  });
+}

--- a/lib/epicon/github/build-check-run-payload.ts
+++ b/lib/epicon/github/build-check-run-payload.ts
@@ -1,0 +1,41 @@
+import type { EpiconGithubCheckSummary } from '@/lib/epicon/runtime/types';
+
+type GithubCheckRunConclusion = 'success' | 'neutral' | 'failure';
+
+export type EpiconGithubCheckRunPayload = {
+  name: 'EPICON Merge Guard';
+  head_sha: string;
+  status: 'completed';
+  conclusion: GithubCheckRunConclusion;
+  output: {
+    title: string;
+    summary: string;
+  };
+};
+
+function conclusionFromSummary(
+  summary: EpiconGithubCheckSummary,
+): GithubCheckRunConclusion {
+  if (summary.status === 'failure') return 'failure';
+  if (summary.status === 'neutral') return 'neutral';
+  return 'success';
+}
+
+export function buildCheckRunPayload({
+  headSha,
+  summary,
+}: {
+  headSha: string;
+  summary: EpiconGithubCheckSummary;
+}): EpiconGithubCheckRunPayload {
+  return {
+    name: 'EPICON Merge Guard',
+    head_sha: headSha,
+    status: 'completed',
+    conclusion: conclusionFromSummary(summary),
+    output: {
+      title: summary.title,
+      summary: summary.summary,
+    },
+  };
+}

--- a/lib/epicon/github/normalize-webhook-pr.ts
+++ b/lib/epicon/github/normalize-webhook-pr.ts
@@ -1,0 +1,25 @@
+import { normalizePullRequestEvent } from '@/lib/epicon/runtime/normalize-pull-request-event';
+import type { EpiconPullRequestEvent } from '@/lib/epicon/runtime/types';
+
+type GithubWebhookPullRequestPayload = Parameters<typeof normalizePullRequestEvent>[0] & {
+  action?: string;
+};
+
+export type EpiconGithubPullRequestWebhook = {
+  action: string;
+  event: EpiconPullRequestEvent;
+};
+
+export function normalizeGithubPullRequestWebhook(
+  payload: GithubWebhookPullRequestPayload,
+  changedFilenames: string[] = [],
+): EpiconGithubPullRequestWebhook {
+  return {
+    action: payload.action ?? 'unknown',
+    event: normalizePullRequestEvent(payload, changedFilenames),
+  };
+}
+
+export function isSupportedPullRequestAction(action: string): boolean {
+  return ['opened', 'synchronize', 'reopened'].includes(action);
+}

--- a/lib/epicon/github/verify-signature.ts
+++ b/lib/epicon/github/verify-signature.ts
@@ -1,0 +1,33 @@
+import crypto from 'node:crypto';
+
+const GITHUB_SIGNATURE_PREFIX = 'sha256=';
+
+function timingSafeEqual(a: string, b: string): boolean {
+  const aBuffer = Buffer.from(a);
+  const bBuffer = Buffer.from(b);
+
+  if (aBuffer.length !== bBuffer.length) return false;
+
+  return crypto.timingSafeEqual(aBuffer, bBuffer);
+}
+
+export function verifyGithubWebhookSignature({
+  body,
+  signature,
+  secret,
+}: {
+  body: string;
+  signature: string | null;
+  secret: string | undefined;
+}): boolean {
+  if (!secret || !signature?.startsWith(GITHUB_SIGNATURE_PREFIX)) {
+    return false;
+  }
+
+  const expectedSignature = `${GITHUB_SIGNATURE_PREFIX}${crypto
+    .createHmac('sha256', secret)
+    .update(body)
+    .digest('hex')}`;
+
+  return timingSafeEqual(expectedSignature, signature);
+}


### PR DESCRIPTION
## Phase
C-303 Phase 4 — EPICON GitHub App Webhook Scaffold

## Scope
Additive scaffold for GitHub App webhook ingestion and future EPICON Check Run integration.

## Included
- GitHub webhook signature verification
- future PR event normalization hooks
- future EPICON runtime webhook routing
- future GitHub Check Run mapping

## Current Behavior
- observational only
- no merge blocking
- no enforcement
- no ledger writes
- no autonomous mutation
- no live agent execution

## Goal
GitHub PR event
→ EPICON webhook endpoint
→ runtime evaluation
→ placeholder GitHub Check Run

## NOT Touching
- Terminal canon semantics
- ledger sealing
- workflow enforcement
- cron orchestration
- live quorum execution
- GitHub merge permissions

## Validation
- pnpm exec tsc --noEmit
- pnpm build
- pnpm lint