### PR TITLE
fix(c305/pr506): substrate repair pack — 5 log-driven fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ JOURNAL_CANON_SUBSTRATE_TARGET=https://civic-protocol-core-ledger.onrender.com/a
 
 # Public site URL (used by MCP bridge server-side fetches to same-origin APIs). Production: https://mobius-civic-ai-terminal.vercel.app
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
+# FIX-506-02/05: Render Civic Ledger routing — terminal canonical URL sent in all substrate attest payloads
+# Without this Render rejects writes with {"detail":"No API base configured for terminal"}
+NEXT_PUBLIC_TERMINAL_URL=https://mobius-civic-ai-terminal.vercel.app
 
 # Decentralization Phase 1–2 (Terminal): optional IPFS HTTP gateway for content-addressed reads.
 # When unset or false, Terminal keeps federated REST-only behavior (no operator illusion).

--- a/app/api/cron/reattest-seals/route.ts
+++ b/app/api/cron/reattest-seals/route.ts
@@ -14,8 +14,9 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { bearerMatchesToken } from '@/lib/vault-v2/auth';
-import { listAllSeals } from '@/lib/vault-v2/store';
+import { listAllSeals, writeSeal } from '@/lib/vault-v2/store';
 import { backAttestSeal, buildBackAttestRationale } from '@/lib/vault-v2/back-attest';
+import { attestReserveBlockToSubstrate } from '@/lib/vault-v2/substrate-attestation';
 import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
 import { releaseReplayPressureForAttestedSeal } from '@/lib/mic/replayPressure';
 import { kvGet, kvSet } from '@/lib/kv/store';
@@ -121,36 +122,50 @@ export async function GET(req: NextRequest) {
     await recordReattestAttempt(seal.seal_id);
   }
 
-  // For fully-attested seals still in quarantine, apply backoff before re-evaluating.
-  // These seals have all agent signatures — the blocker is typically a substrate write
-  // failure. Repeated re-evaluation without backoff hammers the ledger endpoint.
+  // FIX-506-03: fully-attested seals stuck in quarantine have all 5 agent signatures
+  // but substrate_attestation_error is null — meaning a prior write appeared to succeed
+  // (or was never attempted) yet the seal was never promoted. Force a direct substrate
+  // write rather than re-running attestation (which the dedup guard would skip anyway).
   for (const seal_id of fullyAttestedButStuck) {
     if (await shouldSkipRetry(seal_id)) {
-      results.push({ seal_id, agent: 'backoff', ok: true, transition: 'skipped-backoff' });
+      results.push({ seal_id, agent: 'substrate-write', ok: true, transition: 'skipped-backoff' });
       continue;
     }
+    const seal = allSeals.find((s) => s.seal_id === seal_id);
+    if (!seal) { errors.push(`[stuck] ${seal_id}: seal not found in listAllSeals`); continue; }
+
     try {
-      console.warn('[reattest-seals] fully-attested-but-stuck seal — forcing re-evaluation', { seal_id });
-      const r = await backAttestSeal({
-        seal_id,
-        agent: 'ATLAS',
-        verdict: 'pass',
-        rationale: buildBackAttestRationale('ATLAS', seal_id) + ' [forced-re-eval: all agents already attested]',
-      });
+      console.warn('[reattest-seals] fully-attested-but-stuck — forcing substrate write', { seal_id });
+      const substrate = await attestReserveBlockToSubstrate(seal);
+      const substrateError = substrate.ok ? null : (substrate.error ?? 'substrate_write_failed');
+
+      const updatedSeal: Seal = {
+        ...seal,
+        substrate_attestation_id: substrate.ok ? (substrate.entryId ?? null) : seal.substrate_attestation_id,
+        substrate_event_hash: substrate.ok ? (substrate.eventHash ?? substrate.entryId ?? null) : seal.substrate_event_hash,
+        substrate_attested_at: substrate.ok ? (substrate.attestedAt ?? new Date().toISOString()) : seal.substrate_attested_at,
+        substrate_attestation_error: substrateError,
+      };
+      await writeSeal(updatedSeal);
+
       results.push({
         seal_id,
-        agent: 'ATLAS',
-        ok: r.ok,
-        transition: r.ok ? r.transition : undefined,
-        error: !r.ok ? r.reason : undefined,
+        agent: 'substrate-write',
+        ok: substrate.ok,
+        transition: substrate.ok ? 'substrate-written' : undefined,
+        error: substrateError ?? undefined,
       });
-      if (r.ok && r.transition === 'attested') {
+
+      if (substrate.ok) {
         void releaseReplayPressureForAttestedSeal().catch(() => {});
-        console.info('[reattest-seals] stuck seal cleared → attested', { seal_id });
+        console.info('[reattest-seals] stuck seal substrate write ok — seal updated', { seal_id });
+      } else {
+        console.error('[reattest-seals] stuck seal substrate write failed', { seal_id, error: substrateError });
       }
     } catch (e) {
-      const msg = `[forced-re-eval] ${seal_id}: ${e instanceof Error ? e.message : String(e)}`;
+      const msg = `[stuck-substrate] ${seal_id}: ${e instanceof Error ? e.message : String(e)}`;
       errors.push(msg);
+      results.push({ seal_id, agent: 'substrate-write', ok: false, error: msg });
     }
     await recordReattestAttempt(seal_id);
   }

--- a/app/api/cron/reattest-seals/route.ts
+++ b/app/api/cron/reattest-seals/route.ts
@@ -14,7 +14,7 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { bearerMatchesToken } from '@/lib/vault-v2/auth';
-import { listAllSeals, writeSeal } from '@/lib/vault-v2/store';
+import { listAllSeals, writeSeal, appendSealToChain } from '@/lib/vault-v2/store';
 import { backAttestSeal, buildBackAttestRationale } from '@/lib/vault-v2/back-attest';
 import { attestReserveBlockToSubstrate } from '@/lib/vault-v2/substrate-attestation';
 import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
@@ -141,24 +141,32 @@ export async function GET(req: NextRequest) {
 
       const updatedSeal: Seal = {
         ...seal,
+        // P1 fix: promote to attested so fountain/quorum/attested-count flows resolve
+        status: substrate.ok ? 'attested' : seal.status,
         substrate_attestation_id: substrate.ok ? (substrate.entryId ?? null) : seal.substrate_attestation_id,
         substrate_event_hash: substrate.ok ? (substrate.eventHash ?? substrate.entryId ?? null) : seal.substrate_event_hash,
         substrate_attested_at: substrate.ok ? (substrate.attestedAt ?? new Date().toISOString()) : seal.substrate_attested_at,
         substrate_attestation_error: substrateError,
       };
       await writeSeal(updatedSeal);
+      if (substrate.ok) {
+        // Append to attested chain so downstream indexes (fountain, quorum, attested counts) pick it up
+        await appendSealToChain(updatedSeal).catch((err: unknown) => {
+          console.warn('[reattest-seals] appendSealToChain failed (non-fatal):', (err as Error)?.message);
+        });
+      }
 
       results.push({
         seal_id,
         agent: 'substrate-write',
         ok: substrate.ok,
-        transition: substrate.ok ? 'substrate-written' : undefined,
+        transition: substrate.ok ? 'attested' : undefined,
         error: substrateError ?? undefined,
       });
 
       if (substrate.ok) {
         void releaseReplayPressureForAttestedSeal().catch(() => {});
-        console.info('[reattest-seals] stuck seal substrate write ok — seal updated', { seal_id });
+        console.info('[reattest-seals] stuck seal promoted → attested + appended to chain', { seal_id });
       } else {
         console.error('[reattest-seals] stuck seal substrate write failed', { seal_id, error: substrateError });
       }

--- a/app/api/epicon/promotion-status/route.ts
+++ b/app/api/epicon/promotion-status/route.ts
@@ -2,11 +2,14 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getPromotionState, defaultPromotionState, type PromotionStateValue } from '@/lib/epicon/promotion';
 import { getEchoEpicon } from '@/lib/echo/store';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
-import { kvGet } from '@/lib/kv/store';
+import { kvGet, kvSet } from '@/lib/kv/store';
 import type { EpiconItem } from '@/lib/terminal/types';
 
-// Promote cron fires every 5 min; warn in diagnostics if last successful run > 2h ago
+// FIX-506-04: promotion-status stale warning was firing on every snapshot hit (~2m).
+// Debounce to log at most once per 10 min so logs are actionable, not flooded.
 const PROMOTION_STALE_THRESHOLD_MS = 2 * 60 * 60 * 1000;
+const PROMOTION_STALE_WARN_DEBOUNCE_MS = 10 * 60 * 1000;
+const PROMOTION_STALE_WARN_KEY = 'promotion:stale-warn-ts';
 
 export const dynamic = 'force-dynamic';
 
@@ -74,7 +77,12 @@ export async function GET(_request: NextRequest): Promise<NextResponse> {
         : false;
     if (promotionStale) {
       const ageMin = Math.round((Date.now() - new Date(lastPromotionRunAt!).getTime()) / 60000);
-      console.warn(`[promotion-status] stale — last run was ${ageMin}m ago`);
+      // Debounce: emit at most once per 10 min to avoid flooding logs on every snapshot poll
+      const lastWarn = await kvGet<number>(PROMOTION_STALE_WARN_KEY).catch(() => null);
+      if (!lastWarn || Date.now() - lastWarn > PROMOTION_STALE_WARN_DEBOUNCE_MS) {
+        console.warn(`[promotion-status] stale — last run was ${ageMin}m ago`);
+        await kvSet(PROMOTION_STALE_WARN_KEY, Date.now(), 600).catch(() => {});
+      }
     }
 
     return NextResponse.json({

--- a/lib/agents/journalCanonOutbox.ts
+++ b/lib/agents/journalCanonOutbox.ts
@@ -91,8 +91,10 @@ export async function processJournalCanonOutbox(redis: Redis | null, limit = 5) 
       processed += 1;
       // FIX-506-01: try GitHub first; on failure fall back to Render Civic Ledger.
       // GitHub 403 was silently re-queuing forever — Render is the authoritative write target.
+      // P2 fix: no CIVIC_LEDGER_URL gate — attestToLedger() resolves URL itself via
+      // RENDER_LEDGER_URL > CIVIC_LEDGER_URL > hardcoded fallback, so the fallback always runs.
       let result = await writeJournalToSubstrate(item.entry);
-      if (!result.ok && process.env.CIVIC_LEDGER_URL) {
+      if (!result.ok) {
         console.warn('[journal/canon-outbox] GitHub write failed, trying Render fallback:', result.error);
         try {
           const renderResult = await attestToLedger({

--- a/lib/agents/journalCanonOutbox.ts
+++ b/lib/agents/journalCanonOutbox.ts
@@ -1,5 +1,6 @@
 import type { Redis } from '@upstash/redis';
 import { writeJournalToSubstrate, type SubstrateJournalWriteInput } from '@/lib/substrate/github-journal';
+import { attestToLedger } from '@/lib/substrate/client';
 import { bumpTerminalWatermark } from '@/lib/terminal/watermark';
 
 export type JournalCanonStatus = 'canon_pending' | 'canon_written' | 'canon_failed';
@@ -88,7 +89,40 @@ export async function processJournalCanonOutbox(redis: Redis | null, limit = 5) 
       const item = asOutboxItem(await redis.get<unknown>(itemKey(id)));
       if (!item || item.status === 'canon_written') continue;
       processed += 1;
-      const result = await writeJournalToSubstrate(item.entry);
+      // FIX-506-01: try GitHub first; on failure fall back to Render Civic Ledger.
+      // GitHub 403 was silently re-queuing forever — Render is the authoritative write target.
+      let result = await writeJournalToSubstrate(item.entry);
+      if (!result.ok && process.env.CIVIC_LEDGER_URL) {
+        console.warn('[journal/canon-outbox] GitHub write failed, trying Render fallback:', result.error);
+        try {
+          const renderResult = await attestToLedger({
+            id: item.entry.id,
+            agent: item.entry.agent,
+            agentOrigin: item.entry.agentOrigin,
+            cycle: item.entry.cycle,
+            title: `Journal: ${item.entry.scope ?? item.entry.category} — ${item.entry.agent}`,
+            summary: [item.entry.observation, item.entry.inference, item.entry.recommendation]
+              .filter(Boolean).join(' ').slice(0, 500),
+            category: (['market','geopolitical','infrastructure','narrative','governance'] as const)
+              .includes(item.entry.category as never) ? (item.entry.category as 'market'|'geopolitical'|'infrastructure'|'narrative') : 'infrastructure',
+            severity: item.entry.severity as 'nominal' | 'degraded' | 'elevated' | 'critical',
+            source: 'agent-journal',
+            gi_at_time: item.entry.gi_at_time,
+            confidence: item.entry.confidence,
+            verified: false,
+            derivedFrom: item.entry.derivedFrom ?? [],
+            tags: [...(item.entry.tags ?? []), 'journal-canon', `cycle:${item.entry.cycle}`],
+          });
+          if (renderResult.ok) {
+            result = { ok: true, path: `render:${renderResult.entryId ?? 'submitted'}` };
+            console.log('[journal/canon-outbox] Render fallback write ok:', item.entry.id);
+          } else {
+            console.error('[journal/canon-outbox] Render fallback also failed:', renderResult.error);
+          }
+        } catch (renderErr) {
+          console.error('[journal/canon-outbox] Render fallback threw:', renderErr instanceof Error ? renderErr.message : renderErr);
+        }
+      }
       const next: JournalCanonOutboxItem = {
         ...item,
         attempts: item.attempts + 1,

--- a/lib/substrate/client.ts
+++ b/lib/substrate/client.ts
@@ -259,10 +259,20 @@ export async function attestToLedger(entry: SubstrateEntry): Promise<AttestToLed
   const eventId = entry.id ?? `${entry.agentOrigin}-${entry.cycle}-${Date.now()}`;
   const attestTimestamp = new Date().toISOString();
   const ledgerLabSource = toLedgerLabSource(entry.source);
+  // FIX-506-02: Render Civic Ledger requires terminal_base_url/api_base for routing.
+  // Without these fields Render rejects with {"detail":"No API base configured for terminal"}.
+  const terminalBase = (
+    process.env.NEXT_PUBLIC_TERMINAL_URL ??
+    process.env.NEXT_PUBLIC_SITE_URL ??
+    'https://mobius-civic-ai-terminal.vercel.app'
+  ).replace(/\/+$/, '');
+
   const requestBody = {
     event_type: entry.category,
     civic_id: eventId,
     lab_source: ledgerLabSource,
+    terminal_base_url: terminalBase,
+    api_base: terminalBase,
     payload: {
       event_id: eventId,
       title: entry.title,


### PR DESCRIPTION
## C-305 — Substrate Repair Pack (log-driven)

EPICON: C-305 / ATLAS / substrate-repair / log-driven  
Fixes derived directly from live Vercel logs `2026-05-08T14:31–15:31Z`.

---

## Changes

| Fix | File | Error Fixed |
|-----|------|-------------|
| 01 | `lib/agents/journalCanonOutbox.ts` | 403 GitHub PAT — Render fallback on every failed GitHub write |
| 02 | `lib/substrate/client.ts` | 400 "No API base" — add `terminal_base_url`+`api_base` to all Render payloads |
| 03 | `app/api/cron/reattest-seals/route.ts` | 8 seals stuck — force direct `attestReserveBlockToSubstrate` for fully-attested quarantined seals |
| 04 | `app/api/epicon/promotion-status/route.ts` | log flood — debounce stale warning to max once per 10m via KV |
| 05 | `.env.example` | document `NEXT_PUBLIC_TERMINAL_URL` (required by Render routing) |

---

## Root causes

**FIX-01** `journalCanonOutbox` calls `writeJournalToSubstrate` (GitHub). When it 403s, the error was caught and re-queued indefinitely — journal entries never landed anywhere. Fix: on GitHub failure, fall back to `attestToLedger()` (Render) with mapped payload. The 403 path now has a real exit.

**FIX-02** `attestToLedger` in `lib/substrate/client.ts` is the central substrate write function used by sweep, back-attest, and all seal writes. It never included `terminal_base_url`/`api_base` in the request body — Render requires these to route the write. Every substrate write was returning 400. Resolves via `NEXT_PUBLIC_TERMINAL_URL > NEXT_PUBLIC_SITE_URL > hardcoded fallback`.

**FIX-03** 8 seals (C-288–C-298) show `substrate_attestation_error: null` but remain quarantined. Null error means the write returned `ok: true` (possibly via dedup guard) without the entry actually landing. The previous `fullyAttestedButStuck` handler tried to re-run agent attestation — the dedup guard would skip it. Fix: bypass attestation entirely and force a direct `attestReserveBlockToSubstrate()` + `writeSeal()` so the substrate write is retried with the current (corrected) payload including `terminal_base_url`.

**FIX-04** `promotion-status/route.ts` logs `[promotion-status] stale` every time it's called. The snapshot route calls it on every request (~every 2m), causing ~80+ identical log lines per hour. Fix: KV debounce — log at most once per 10 min using `promotion:stale-warn-ts` with 600s TTL.

**FIX-05** `NEXT_PUBLIC_TERMINAL_URL` was not in `.env.example`. The vercel.json promote cron is already `*/5 * * * *` — no schedule change needed.

---

## Env var required in Vercel

Add to project settings if not already set:
```
NEXT_PUBLIC_TERMINAL_URL=https://mobius-civic-ai-terminal.vercel.app
```

---

## Test plan

- [ ] `journal-canonize` cron: logs show Render fallback path when GitHub token missing/expired
- [ ] `sweep` cron: no more 400 from Render; logs show `[substrate] using ledger URL:` with ok result
- [ ] `reattest-seals`: 8 quarantined seals from C-288–C-298 promoted or show explicit error (not null)
- [ ] `/api/terminal/snapshot`: `[promotion-status] stale` logs appear max once per 10m, not every 2m
- [ ] Verify `NEXT_PUBLIC_TERMINAL_URL` is set in Vercel project environment variables

https://claude.ai/code/session_019CJ7Eexf1bTaZ73Q9cqP5p

---
_Generated by [Claude Code](https://claude.ai/code/session_019CJ7Eexf1bTaZ73Q9cqP5p)_