### PR TITLE
C-305 PR-508: Pulse — heartbeat rail + full-height EPICON feed

### DIFF
--- a/app/api/health/heartbeats/route.ts
+++ b/app/api/health/heartbeats/route.ts
@@ -9,17 +9,22 @@ export const dynamic = 'force-dynamic';
 export async function GET() {
   const [journalRaw, runtimeRaw, vaultTs, promoteTs] = await Promise.allSettled([
     kvGetRaw<{ lastWrite?: string; lastCycle?: string }>('journal:heartbeat'),
-    kvGet<string>(KV_KEYS.HEARTBEAT),
+    kvGet<string | { timestamp?: string }>(KV_KEYS.HEARTBEAT),
     kvGet<number>('vault-attestation:lastRun'),
     kvGet<string>('LAST_PROMOTION_RUN_AT'),
   ]);
 
   const journal = journalRaw.status === 'fulfilled' ? (journalRaw.value?.lastWrite ?? null) : null;
 
+  // kvGet(KV_KEYS.HEARTBEAT) returns the stored JSON string under primary Redis,
+  // but backup Redis and the OAA bridge may return an already-parsed object.
+  // Handle both shapes so runtime heartbeat is never falsely null during KV failover.
   let runtime: string | null = null;
-  if (runtimeRaw.status === 'fulfilled' && runtimeRaw.value) {
+  if (runtimeRaw.status === 'fulfilled' && runtimeRaw.value != null) {
     try {
-      const parsed = JSON.parse(runtimeRaw.value) as { timestamp?: string };
+      const val = runtimeRaw.value;
+      const parsed: { timestamp?: string } =
+        typeof val === 'string' ? (JSON.parse(val) as { timestamp?: string }) : val;
       runtime = parsed.timestamp ?? null;
     } catch {
       runtime = null;

--- a/app/api/health/heartbeats/route.ts
+++ b/app/api/health/heartbeats/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { kvGet, kvGetRaw, KV_KEYS } from '@/lib/kv/store';
+
+export const dynamic = 'force-dynamic';
+
+// journal:heartbeat is written via kvSetRawKey (no prefix) by /api/journal
+// heartbeat:last, vault-attestation:lastRun, LAST_PROMOTION_RUN_AT are written via kvSet (mobius prefix)
+
+export async function GET() {
+  const [journalRaw, runtimeRaw, vaultTs, promoteTs] = await Promise.allSettled([
+    kvGetRaw<{ lastWrite?: string; lastCycle?: string }>('journal:heartbeat'),
+    kvGet<string>(KV_KEYS.HEARTBEAT),
+    kvGet<number>('vault-attestation:lastRun'),
+    kvGet<string>('LAST_PROMOTION_RUN_AT'),
+  ]);
+
+  const journal = journalRaw.status === 'fulfilled' ? (journalRaw.value?.lastWrite ?? null) : null;
+
+  let runtime: string | null = null;
+  if (runtimeRaw.status === 'fulfilled' && runtimeRaw.value) {
+    try {
+      const parsed = JSON.parse(runtimeRaw.value) as { timestamp?: string };
+      runtime = parsed.timestamp ?? null;
+    } catch {
+      runtime = null;
+    }
+  }
+
+  const vault = vaultTs.status === 'fulfilled' && vaultTs.value
+    ? new Date(vaultTs.value).toISOString()
+    : null;
+
+  const promote = promoteTs.status === 'fulfilled' ? (promoteTs.value ?? null) : null;
+
+  return NextResponse.json({
+    journal,
+    runtime,
+    vault,
+    promote,
+    timestamp: new Date().toISOString(),
+  }, {
+    headers: { 'Cache-Control': 'public, s-maxage=15, stale-while-revalidate=30' },
+  });
+}

--- a/app/terminal/pulse/PulsePageClient.tsx
+++ b/app/terminal/pulse/PulsePageClient.tsx
@@ -1,286 +1,201 @@
 'use client';
 
-/**
- * C-305 FIX-507-08: Pulse chamber client — unified data wiring.
- * Fetches from /api/chambers/pulse (single aggregated request) and maps
- * all 9 data sources to their display panels. Replaces N-fetch pattern.
- * Refresh interval: 15s to match the aggregator KV cache TTL.
- */
-
 import { useState, useEffect, useCallback } from 'react';
-import type { PulsePayload } from '@/app/api/chambers/pulse/route';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface Heartbeats {
+  journal:  string | null;
+  runtime:  string | null;
+  vault:    string | null;
+  promote:  string | null;
+  timestamp?: string;
+}
+
+interface EpiconItem {
+  id?:          string | number;
+  title?:       string;
+  summary?:     string;
+  agent?:       string;
+  author?:      string;
+  confidence?:  number;
+  mii_score?:   number;
+  tags?:        string[];
+  timestamp?:   string;
+  createdAt?:   string;
+}
+
+interface EpiconResponse {
+  ok?:    boolean;
+  items?: EpiconItem[];
+  count?: number;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function ageLabel(iso: string | null): string {
+  if (!iso) return '—';
+  const diffMs = Date.now() - new Date(iso).getTime();
+  if (diffMs < 0) return 'now';
+  const s = Math.floor(diffMs / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  return `${h}h ago`;
+}
+
+function heartbeatDot(iso: string | null): string {
+  if (!iso) return 'bg-slate-700';
+  const ageMin = (Date.now() - new Date(iso).getTime()) / 60_000;
+  if (ageMin < 6)  return 'bg-emerald-400';
+  if (ageMin < 15) return 'bg-amber-400';
+  return 'bg-red-500';
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
 
 export default function PulsePageClient() {
-  const [pulse, setPulse] = useState<PulsePayload | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [lastFetch, setLastFetch] = useState<number>(0);
+  const [heartbeats, setHeartbeats] = useState<Heartbeats | null>(null);
+  const [epicon, setEpicon]         = useState<EpiconItem[]>([]);
+  const [epiconCount, setEpiconCount] = useState<number>(0);
+  const [loading, setLoading]       = useState(true);
 
-  const loadPulse = useCallback(async () => {
+  const loadHeartbeats = useCallback(async () => {
     try {
-      const res = await fetch('/api/chambers/pulse');
-      if (!res.ok) return;
-      const data = (await res.json()) as PulsePayload;
-      setPulse(data);
-      setLastFetch(Date.now());
+      const res = await fetch('/api/health/heartbeats');
+      if (res.ok) setHeartbeats(await res.json() as Heartbeats);
     } catch (e) {
-      console.warn('[pulse] fetch failed:', e);
+      console.warn('[pulse] heartbeats fetch failed:', e);
+    }
+  }, []);
+
+  const loadEpicon = useCallback(async () => {
+    try {
+      const res = await fetch('/api/epicon/feed?limit=50');
+      if (!res.ok) return;
+      const data = await res.json() as EpiconResponse;
+      setEpicon(data.items ?? []);
+      setEpiconCount(data.count ?? data.items?.length ?? 0);
+    } catch (e) {
+      console.warn('[pulse] epicon fetch failed:', e);
     } finally {
       setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    void loadPulse();
-    const interval = setInterval(() => void loadPulse(), 15_000);
-    return () => clearInterval(interval);
-  }, [loadPulse]);
+    void loadHeartbeats();
+    void loadEpicon();
+    const hbInterval  = setInterval(() => void loadHeartbeats(), 30_000);
+    const epInterval  = setInterval(() => void loadEpicon(),     15_000);
+    return () => { clearInterval(hbInterval); clearInterval(epInterval); };
+  }, [loadHeartbeats, loadEpicon]);
 
-  // ── Derived values ──────────────────────────────────────────────────
-  const snap     = pulse?.snapshot as Record<string, unknown> | null ?? null;
-  const gi       = (pulse?.integrityStatus as Record<string, unknown> | null)?.gi as number | null
-                   ?? (snap?.gi as number | null)
-                   ?? null;
-  const cycle    = pulse?._meta?.cycle ?? (snap?.cycle as string | null) ?? '—';
-  const epiconRaw = pulse?.epicon as Record<string, unknown> | null;
-  const epicon   = ((epiconRaw?.items ?? epiconRaw) as unknown[] | null) ?? [];
-  // /api/agents/journal returns { entries: [...] } — unwrap the envelope
-  const agentJournalRaw = pulse?.agentJournal as { entries?: unknown[] } | unknown[] | null;
-  const agents   = (Array.isArray(agentJournalRaw)
-    ? agentJournalRaw
-    : (agentJournalRaw as { entries?: unknown[] } | null)?.entries ?? []);
-  const miiRaw   = pulse?.mii as Record<string, unknown> | null;
-  const miiScore = (miiRaw?.composite ?? miiRaw?.score) as number | null ?? null;
-  const vaultRaw = pulse?.vaultStatus as Record<string, unknown> | null;
-  const vaultSeals   = (vaultRaw?.seals as unknown[] | null) ?? [];
-  const vaultSustain = vaultRaw?.sustain as number | null ?? null;
-  // /api/chambers/lane-diagnostics returns lanes as an object map { name: state }
-  // Convert to array for rendering; handle both object and legacy array shapes.
-  const lanesRaw = pulse?.laneDiagnostics as Record<string, unknown> | null;
-  const lanesObj = lanesRaw?.lanes;
-  const lanes: Array<{ name: string; state?: unknown; ok?: unknown }> =
-    Array.isArray(lanesObj)
-      ? (lanesObj as Array<{ name: string; state?: unknown }>)
-      : lanesObj && typeof lanesObj === 'object'
-        ? Object.entries(lanesObj as Record<string, unknown>).map(([name, val]) =>
-            val && typeof val === 'object'
-              ? { name, ...(val as Record<string, unknown>) }
-              : { name, state: val }
-          )
-        : [];
-  const echoRaw  = pulse?.echoDigest as Record<string, unknown> | null;
-  const canon    = pulse?.substrateCanon as Record<string, unknown> | null;
-  const freshMs  = lastFetch ? Date.now() - lastFetch : null;
-
-  const giColor  = gi == null ? 'text-slate-500'
-    : gi >= 0.85 ? 'text-emerald-400'
-    : gi >= 0.70 ? 'text-amber-400'
-    : 'text-red-400';
+  const hbRail: Array<{ label: string; ts: string | null }> = [
+    { label: 'Journal', ts: heartbeats?.journal  ?? null },
+    { label: 'Runtime', ts: heartbeats?.runtime  ?? null },
+    { label: 'Vault',   ts: heartbeats?.vault    ?? null },
+    { label: 'Promote', ts: heartbeats?.promote  ?? null },
+  ];
 
   return (
-    <div className="flex h-full flex-col gap-3 overflow-y-auto p-3 md:p-4">
+    <div className="flex h-full flex-col overflow-hidden">
 
-      {/* ── Meta bar ── */}
-      <div className="flex items-center justify-between rounded border border-slate-800 bg-slate-950/60 px-3 py-1.5 font-mono text-[10px] uppercase tracking-widest text-slate-400">
-        <span>Pulse · {cycle}</span>
-        <span className="flex items-center gap-2">
-          <span className={giColor}>
-            GI {gi != null ? gi.toFixed(3) : '—'}
+      {/* ── Heartbeat rail (sticky) ── */}
+      <div className="shrink-0 border-b border-slate-800 bg-slate-950/80 px-3 py-2">
+        <div className="mb-1 font-mono text-[8px] uppercase tracking-[0.2em] text-slate-600">
+          Cron heartbeats
+        </div>
+        <div className="flex flex-wrap gap-x-4 gap-y-1">
+          {hbRail.map(({ label, ts }) => (
+            <div key={label} className="flex items-center gap-1.5">
+              <span className={`h-1.5 w-1.5 rounded-full ${heartbeatDot(ts)}`} />
+              <span className="font-mono text-[9px] uppercase tracking-wide text-slate-400">
+                {label}
+              </span>
+              <span className="font-mono text-[9px] text-slate-600">
+                {ageLabel(ts)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ── EPICON feed (scrollable) ── */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="flex items-center justify-between border-b border-slate-800/60 px-3 py-1.5">
+          <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">
+            EPICON feed
           </span>
-          <span className="text-slate-600">·</span>
-          <span className={freshMs != null && freshMs < 20_000 ? 'text-emerald-500' : 'text-amber-400'}>
-            {freshMs != null ? `${Math.floor(freshMs / 1000)}s ago` : 'syncing'}
+          <span className="font-mono text-[9px] text-slate-600">
+            {epiconCount} events
+            {loading && <span className="ml-1 animate-pulse text-slate-700">↻</span>}
           </span>
-          {loading && <span className="animate-pulse text-slate-600">↻</span>}
-        </span>
-      </div>
-
-      {/* ── Row 1: GI · MII · Vault sustain ── */}
-      <div className="grid grid-cols-3 gap-2">
-        <MetricTile
-          label="GI"
-          value={gi?.toFixed(3)}
-          status={gi == null ? 'unknown' : gi >= 0.85 ? 'nominal' : gi >= 0.70 ? 'stressed' : 'critical'}
-        />
-        <MetricTile
-          label="MII"
-          value={miiScore?.toFixed(3)}
-          status={miiScore == null ? 'unknown' : miiScore >= 0.75 ? 'nominal' : 'stressed'}
-        />
-        <MetricTile
-          label="Vault sustain"
-          value={vaultSustain != null ? `${vaultSustain}/5` : '—'}
-          status={vaultSustain == null ? 'unknown' : vaultSustain >= 5 ? 'nominal' : vaultSustain >= 3 ? 'stressed' : 'critical'}
-        />
-      </div>
-
-      {/* ── Row 2: Lane diagnostics ── */}
-      <section className="rounded border border-slate-800 bg-slate-950/60 px-3 py-2">
-        <div className="mb-2 font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">Lane diagnostics</div>
-        <div className="grid grid-cols-2 gap-1 md:grid-cols-3">
-          {lanes.length === 0
-            ? <p className="col-span-3 text-[10px] text-slate-600">No lane data</p>
-            : (lanes as Array<Record<string, unknown>>).map((lane) => (
-              <div key={String(lane.name ?? lane.key ?? '')} className="flex items-center justify-between rounded bg-slate-900/60 px-2 py-1">
-                <span className="font-mono text-[9px] uppercase tracking-wide text-slate-400">
-                  {String(lane.name ?? lane.key ?? '—')}
-                </span>
-                <span className={`font-mono text-[10px] ${
-                  lane.state === 'ok' || lane.ok === true ? 'text-emerald-400'
-                  : lane.state === 'stale' ? 'text-amber-400'
-                  : 'text-red-400'
-                }`}>
-                  {String(lane.state ?? (lane.ok ? 'ok' : 'err'))}
-                </span>
-              </div>
-            ))
-          }
         </div>
-      </section>
 
-      {/* ── Row 3: EPICON feed ── */}
-      <section className="flex-1 rounded border border-slate-800 bg-slate-950/60 px-3 py-2">
-        <div className="mb-2 flex items-center justify-between">
-          <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">EPICON feed</span>
-          <span className="font-mono text-[9px] text-slate-600">{epicon.length} events</span>
-        </div>
-        <div className="max-h-48 space-y-1 overflow-y-auto">
-          {epicon.length === 0
-            ? <p className="text-[10px] text-slate-600">No EPICON events in current cycle</p>
-            : (epicon as Array<Record<string, unknown>>).slice(0, 30).map((ev, i) => {
-                const conf = (ev.confidence ?? ev.mii_score) as number | null ?? null;
-                return (
-                  <div key={String(ev.id ?? i)} className="flex items-start gap-2 rounded bg-slate-900/40 px-2 py-1">
-                    {conf != null && (
-                      <span className={`mt-0.5 shrink-0 rounded px-1 font-mono text-[8px] uppercase ${
-                        conf >= 0.9 ? 'bg-emerald-900/40 text-emerald-400'
-                        : conf >= 0.7 ? 'bg-amber-900/40 text-amber-400'
-                        : 'bg-slate-800 text-slate-500'
-                      }`}>{Math.round(conf * 100)}%</span>
-                    )}
-                    <span className="min-w-0 truncate font-mono text-[10px] text-slate-300">
-                      {String(ev.title ?? ev.summary ?? ev.id ?? '—')}
-                    </span>
-                    <span className="shrink-0 font-mono text-[9px] text-slate-600">
-                      {String(ev.agent ?? ev.author ?? '—')}
-                    </span>
-                  </div>
-                );
-              })
-          }
-        </div>
-      </section>
+        <div className="flex-1 overflow-y-auto">
+          {epicon.length === 0 && !loading && (
+            <p className="px-3 py-4 font-mono text-[10px] text-slate-600">
+              No EPICON events in current cycle
+            </p>
+          )}
+          {epicon.map((ev, i) => {
+            const conf    = (ev.confidence ?? ev.mii_score) as number | null ?? null;
+            const confPct = conf != null ? Math.round(conf * 100) : null;
+            const confColor =
+              conf == null ? '' :
+              conf >= 0.9  ? 'bg-emerald-900/40 text-emerald-400' :
+              conf >= 0.7  ? 'bg-amber-900/40 text-amber-400' :
+              'bg-slate-800 text-slate-500';
+            const tags = Array.isArray(ev.tags) ? ev.tags : [];
 
-      {/* ── Row 4: Agent journal · Echo digest ── */}
-      <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
-        <section className="rounded border border-slate-800 bg-slate-950/60 px-3 py-2">
-          <div className="mb-2 font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">Agent journal</div>
-          <div className="max-h-32 space-y-1 overflow-y-auto">
-            {agents.length === 0
-              ? <p className="text-[10px] text-slate-600">No journal entries</p>
-              : (agents as Array<Record<string, unknown>>).slice(0, 10).map((e, i) => (
-                <div key={String(e.id ?? i)} className="flex items-center gap-2">
-                  <span className="w-16 shrink-0 font-mono text-[9px] uppercase text-slate-500">
-                    {String(e.agent ?? '—')}
+            return (
+              <div
+                key={String(ev.id ?? i)}
+                className="flex items-start gap-2 border-b border-slate-800/40 px-3 py-2 hover:bg-slate-900/30"
+              >
+                {/* Confidence badge */}
+                {confPct != null && (
+                  <span className={`mt-0.5 shrink-0 rounded px-1 font-mono text-[8px] uppercase ${confColor}`}>
+                    {confPct}%
                   </span>
-                  <span className="min-w-0 truncate text-[10px] text-slate-300">
-                    {String(e.message ?? e.observation ?? e.summary ?? '—')}
-                  </span>
-                </div>
-              ))
-            }
-          </div>
-        </section>
+                )}
 
-        <section className="rounded border border-slate-800 bg-slate-950/60 px-3 py-2">
-          <div className="mb-2 font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">ECHO digest</div>
-          {echoRaw
-            ? (
-              <div className="space-y-1 font-mono text-[10px]">
-                <div className="flex justify-between">
-                  <span className="text-slate-500">Hash</span>
-                  <span className="text-cyan-400">{String(echoRaw.hash ?? '—').slice(0, 12)}…</span>
+                {/* Title + tags */}
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-mono text-[10px] text-slate-200">
+                    {String(ev.title ?? ev.summary ?? ev.id ?? '—')}
+                  </p>
+                  {tags.length > 0 && (
+                    <div className="mt-0.5 flex flex-wrap gap-1">
+                      {tags.slice(0, 4).map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded bg-slate-800 px-1 font-mono text-[7px] uppercase text-slate-500"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
                 </div>
-                <div className="flex justify-between">
-                  <span className="text-slate-500">Age</span>
-                  <span className="text-slate-300">{String(echoRaw.age ?? '—')}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-slate-500">Entries</span>
-                  <span className="text-slate-300">{String(echoRaw.count ?? '—')}</span>
+
+                {/* Agent + time */}
+                <div className="shrink-0 text-right">
+                  <p className="font-mono text-[9px] text-slate-500">
+                    {String(ev.agent ?? ev.author ?? '—')}
+                  </p>
+                  <p className="font-mono text-[8px] text-slate-700">
+                    {ageLabel(ev.timestamp ?? ev.createdAt ?? null)}
+                  </p>
                 </div>
               </div>
-            )
-            : <p className="text-[10px] text-slate-600">Digest unavailable</p>
-          }
-        </section>
+            );
+          })}
+        </div>
       </div>
 
-      {/* ── Row 5: Vault seals · Substrate canon ── */}
-      <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
-        <section className="rounded border border-slate-800 bg-slate-950/60 px-3 py-2">
-          <div className="mb-2 font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">Vault seals</div>
-          {vaultSeals.length === 0
-            ? <p className="text-[10px] text-slate-600">No seals in current cycle</p>
-            : (vaultSeals as Array<Record<string, unknown>>).slice(0, 8).map((s) => (
-              <div key={String(s.seal_id ?? s.sealId ?? '')} className="flex items-center justify-between py-0.5">
-                <span className="font-mono text-[9px] text-slate-400">
-                  {String(s.seal_id ?? s.sealId ?? '—')}
-                </span>
-                <span className={`font-mono text-[9px] ${
-                  s.status === 'attested' || s.status === 'promoted' ? 'text-emerald-400'
-                  : s.status === 'quarantined' ? 'text-red-400'
-                  : 'text-amber-400'
-                }`}>
-                  {String(s.status ?? '—')}
-                </span>
-              </div>
-            ))
-          }
-        </section>
-
-        <section className="rounded border border-slate-800 bg-slate-950/60 px-3 py-2">
-          <div className="mb-2 font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">Substrate canon</div>
-          {canon
-            ? (
-              <div className="space-y-1 font-mono text-[10px]">
-                <div className="flex justify-between">
-                  <span className="text-slate-500">Head</span>
-                  <span className="text-violet-400">{String(canon.head ?? '—').slice(0, 10)}…</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-slate-500">Cycle</span>
-                  <span className="text-slate-300">{String(canon.cycle ?? '—')}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-slate-500">Entries</span>
-                  <span className="text-slate-300">{String(canon.entryCount ?? canon.count ?? '—')}</span>
-                </div>
-              </div>
-            )
-            : <p className="text-[10px] text-slate-600">Canon unavailable</p>
-          }
-        </section>
-      </div>
-
-    </div>
-  );
-}
-
-// ── Shared metric tile ───────────────────────────────────────────────────────
-function MetricTile({ label, value, status }: {
-  label: string;
-  value: string | undefined;
-  status: 'nominal' | 'stressed' | 'critical' | 'unknown';
-}) {
-  const color =
-    status === 'nominal'  ? 'border-emerald-700/50 text-emerald-300' :
-    status === 'stressed' ? 'border-amber-700/50 text-amber-300' :
-    status === 'critical' ? 'border-red-700/50 text-red-400' :
-    'border-slate-700 text-slate-500';
-  return (
-    <div className={`rounded border px-3 py-2 ${color}`}>
-      <div className="font-mono text-[9px] uppercase tracking-[0.18em] opacity-60">{label}</div>
-      <div className="mt-1 font-mono text-xl">{value ?? '—'}</div>
     </div>
   );
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **New endpoint** `/api/health/heartbeats` — reads 4 existing KV keys and normalises them to ISO timestamps for the heartbeat rail:
  - `journal:heartbeat` (raw key, written by `/api/journal`) → `{ lastWrite }` shape
  - `heartbeat:last` (prefixed, written by fleet heartbeat cron) → JSON payload, extracts `timestamp`
  - `vault-attestation:lastRun` (prefixed, written by vault-attestation cron) → numeric `Date.now()`, converted to ISO
  - `LAST_PROMOTION_RUN_AT` (prefixed, written by promote cron) → already ISO string
  - Response cached `s-maxage=15, stale-while-revalidate=30`

- **PulsePageClient rewrite** — replaces the 9-source aggregator layout (PR-507) with a focused two-section view:
  - Sticky **cron heartbeat rail** (Journal / Runtime / Vault / Promote) with colored dot (green < 6m, amber < 15m, red ≥ 15m) and age label
  - Full-height scrollable **EPICON feed** fetching `/api/epicon/feed?limit=50`, sourcing `d.items` (not `d.events`) to match actual API response shape
  - Two independent poll intervals: heartbeats every 30s, EPICON every 15s

## Test plan

- [ ] Heartbeat rail shows four labeled entries with correct dot colors after crons have run
- [ ] EPICON feed populates with events, confidence badge renders correctly
- [ ] Tag chips render for events that include `tags` array
- [ ] `—` shown gracefully when any KV key has no data (e.g. first deploy before crons fire)
- [ ] No fan-out: single EPICON fetch per 15s interval, CDN cache serves repeat tab opens
- [ ] Heartbeat dots turn amber then red as crons age past 6m / 15m thresholds

https://claude.ai/code/session_019CJ7Eexf1bTaZ73Q9cqP5p
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019CJ7Eexf1bTaZ73Q9cqP5p)_