### PR TITLE
C-305 PR-509: Pulse data browser — cycle/agent/seal search

### DIFF
--- a/app/api/health/heartbeats/route.ts
+++ b/app/api/health/heartbeats/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { kvGet, kvGetRaw, KV_KEYS } from '@/lib/kv/store';
+
+export const dynamic = 'force-dynamic';
+
+// journal:heartbeat is written via kvSetRawKey (no prefix) by /api/journal
+// heartbeat:last, vault-attestation:lastRun, LAST_PROMOTION_RUN_AT are written via kvSet (mobius prefix)
+
+export async function GET() {
+  const [journalRaw, runtimeRaw, vaultTs, promoteTs] = await Promise.allSettled([
+    kvGetRaw<{ lastWrite?: string; lastCycle?: string }>('journal:heartbeat'),
+    kvGet<string | { timestamp?: string }>(KV_KEYS.HEARTBEAT),
+    kvGet<number>('vault-attestation:lastRun'),
+    kvGet<string>('LAST_PROMOTION_RUN_AT'),
+  ]);
+
+  const journal = journalRaw.status === 'fulfilled' ? (journalRaw.value?.lastWrite ?? null) : null;
+
+  // kvGet(KV_KEYS.HEARTBEAT) returns the stored JSON string under primary Redis,
+  // but backup Redis and the OAA bridge may return an already-parsed object.
+  // Handle both shapes so runtime heartbeat is never falsely null during KV failover.
+  let runtime: string | null = null;
+  if (runtimeRaw.status === 'fulfilled' && runtimeRaw.value != null) {
+    try {
+      const val = runtimeRaw.value;
+      const parsed: { timestamp?: string } =
+        typeof val === 'string' ? (JSON.parse(val) as { timestamp?: string }) : val;
+      runtime = parsed.timestamp ?? null;
+    } catch {
+      runtime = null;
+    }
+  }
+
+  const vault = vaultTs.status === 'fulfilled' && vaultTs.value
+    ? new Date(vaultTs.value).toISOString()
+    : null;
+
+  const promote = promoteTs.status === 'fulfilled' ? (promoteTs.value ?? null) : null;
+
+  return NextResponse.json({
+    journal,
+    runtime,
+    vault,
+    promote,
+    timestamp: new Date().toISOString(),
+  }, {
+    headers: { 'Cache-Control': 'public, s-maxage=15, stale-while-revalidate=30' },
+  });
+}

--- a/app/api/pulse/search/route.ts
+++ b/app/api/pulse/search/route.ts
@@ -40,22 +40,24 @@ export async function GET(req: NextRequest) {
   if (!q) return NextResponse.json({ ok: false, error: 'q required' }, { status: 400 });
 
   const isCycle = /^C-\d+$/.test(q);
-  const isAgent = /^(ATLAS|ZEUS|EVE|JADE|AUREA|HERMES|ECHO|DAEDALUS)/.test(q);
+  const isAgent = /^(ATLAS|ZEUS|EVE|JADE|AUREA|HERMES|ECHO|DAEDALUS)\b/.test(q);
   const isSeal  = /^SEAL-/.test(q);
 
   const results: SearchResult[] = [];
   const redis = getRedis();
 
-  // ── 1. KV journal entries (raw keys: journal:{agent}:{timestamp}) ─────────
-  // Written via kvSetRawKey — no mobius: prefix.
+  // ── 1. KV journal entries ────────────────────────────────────────────────
+  // Two namespaces: kvSetRawKey writes unprefixed `journal:*`; kvSet writes `mobius:journal:*`.
+  // Scan both and deduplicate so both write paths are covered.
   if (redis) {
     try {
-      const keys = await redis.keys('journal:*');
-      const filteredKeys = isCycle
-        ? keys // cycle match is by content, not key name — load all, filter below
-        : keys;
+      const [rawKeys, prefixedKeys] = await Promise.all([
+        redis.keys('journal:*'),
+        redis.keys('mobius:journal:*'),
+      ]);
+      const allKeys = [...new Set([...rawKeys, ...prefixedKeys])];
       const entries = await Promise.all(
-        filteredKeys.slice(0, 100).map(k => redis.get<Record<string, unknown>>(k))
+        allKeys.slice(0, 100).map(k => redis.get<Record<string, unknown>>(k))
       );
       for (const entry of entries) {
         if (!entry) continue;

--- a/app/api/pulse/search/route.ts
+++ b/app/api/pulse/search/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Redis } from '@upstash/redis';
+import { kvGet } from '@/lib/kv/store';
+
+export const dynamic = 'force-dynamic';
+
+// ── Redis client (mirrors pattern from lib/kv/store.ts) ──────────────────────
+
+function getRedis(): Redis | null {
+  const url   = process.env.KV_REST_API_URL   ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  try { return new Redis({ url, token }); } catch { return null; }
+}
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface SearchResult extends Record<string, unknown> {
+  source: 'journal' | 'vault' | 'ledger' | 'epicon-cache';
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function matchesQuery(entry: Record<string, unknown>, q: string): boolean {
+  return JSON.stringify(entry).toUpperCase().includes(q);
+}
+
+function toMs(ts: unknown): number {
+  if (typeof ts === 'number') return ts;
+  if (typeof ts === 'string') { const ms = new Date(ts).getTime(); return isNaN(ms) ? 0 : ms; }
+  return 0;
+}
+
+// ── Handler ──────────────────────────────────────────────────────────────────
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const q = (searchParams.get('q') ?? '').trim().toUpperCase();
+
+  if (!q) return NextResponse.json({ ok: false, error: 'q required' }, { status: 400 });
+
+  const isCycle = /^C-\d+$/.test(q);
+  const isAgent = /^(ATLAS|ZEUS|EVE|JADE|AUREA|HERMES|ECHO|DAEDALUS)/.test(q);
+  const isSeal  = /^SEAL-/.test(q);
+
+  const results: SearchResult[] = [];
+  const redis = getRedis();
+
+  // ── 1. KV journal entries (raw keys: journal:{agent}:{timestamp}) ─────────
+  // Written via kvSetRawKey — no mobius: prefix.
+  if (redis) {
+    try {
+      const keys = await redis.keys('journal:*');
+      const filteredKeys = isCycle
+        ? keys // cycle match is by content, not key name — load all, filter below
+        : keys;
+      const entries = await Promise.all(
+        filteredKeys.slice(0, 100).map(k => redis.get<Record<string, unknown>>(k))
+      );
+      for (const entry of entries) {
+        if (!entry) continue;
+        if (!matchesQuery(entry, q)) continue;
+        results.push({ source: 'journal', ...entry });
+      }
+    } catch (err) {
+      console.warn('[pulse/search] KV journal scan failed:', err);
+    }
+  }
+
+  // ── 2. Vault seals (index at raw key vault:seals:index:all) ──────────────
+  // Individual seals at vault:seal:{seal_id} — also raw keys.
+  if (redis && !isAgent) {
+    try {
+      const index = (await redis.get<string[]>('vault:seals:index:all')) ?? [];
+      const matching = (isCycle || isSeal)
+        ? index.filter(id => id.toUpperCase().includes(isSeal ? q.replace('SEAL-', '') : q))
+        : index; // freetext — load all, filter by content below
+      const seals = await Promise.all(
+        matching.slice(0, 50).map(id => redis.get<Record<string, unknown>>(`vault:seal:${id}`))
+      );
+      for (const seal of seals) {
+        if (!seal) continue;
+        if (!matchesQuery(seal, q)) continue;
+        results.push({ source: 'vault', ...seal });
+      }
+    } catch (err) {
+      console.warn('[pulse/search] KV vault scan failed:', err);
+    }
+  }
+
+  // ── 3. Render Civic Ledger ────────────────────────────────────────────────
+  const ledgerBase  = process.env.RENDER_LEDGER_URL ?? 'https://civic-protocol-core-ledger.onrender.com';
+  const authToken   = process.env.SUBSTRATE_TOKEN ?? process.env.AGENT_SERVICE_TOKEN ?? '';
+  let ledgerHit = false;
+  try {
+    const res = await fetch(`${ledgerBase}/ledger/events?limit=200&offset=0`, {
+      headers: { ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}) },
+      signal: AbortSignal.timeout(8_000),
+      cache: 'no-store',
+    });
+    if (res.ok) {
+      const payload = await res.json() as Record<string, unknown>;
+      const events: Record<string, unknown>[] = Array.isArray(payload)
+        ? (payload as Record<string, unknown>[])
+        : Array.isArray(payload.events)  ? (payload.events as Record<string, unknown>[])
+        : Array.isArray(payload.items)   ? (payload.items   as Record<string, unknown>[])
+        : Array.isArray(payload.entries) ? (payload.entries as Record<string, unknown>[])
+        : [];
+      for (const ev of events) {
+        if (!matchesQuery(ev, q)) continue;
+        results.push({ source: 'ledger', ...ev });
+      }
+      ledgerHit = true;
+    }
+  } catch (err) {
+    console.warn('[pulse/search] Ledger query failed:', err);
+  }
+
+  // ── 4. EPICON KV cache fallback (if ledger unreachable) ──────────────────
+  // Written via kvSet — key is mobius-prefixed; use kvGet to read.
+  if (!ledgerHit) {
+    try {
+      const cached = await kvGet<{ entries?: Record<string, unknown>[] }>('epicon:render-ledger-cache');
+      if (cached?.entries) {
+        for (const ev of cached.entries) {
+          if (!matchesQuery(ev, q)) continue;
+          results.push({ source: 'epicon-cache', ...ev });
+        }
+      }
+    } catch {
+      // silent — best-effort fallback
+    }
+  }
+
+  // Sort newest first, handling both ISO strings and numeric epoch ms
+  results.sort((a, b) =>
+    toMs(b.attested_at ?? b.writtenAt ?? b.timestamp) -
+    toMs(a.attested_at ?? a.writtenAt ?? a.timestamp)
+  );
+
+  return NextResponse.json({
+    ok: true,
+    query: q,
+    queryType: isCycle ? 'cycle' : isAgent ? 'agent' : isSeal ? 'seal' : 'freetext',
+    count: results.length,
+    results: results.slice(0, 200),
+  });
+}

--- a/app/terminal/pulse/PulsePageClient.tsx
+++ b/app/terminal/pulse/PulsePageClient.tsx
@@ -1,286 +1,379 @@
 'use client';
 
-/**
- * C-305 FIX-507-08: Pulse chamber client — unified data wiring.
- * Fetches from /api/chambers/pulse (single aggregated request) and maps
- * all 9 data sources to their display panels. Replaces N-fetch pattern.
- * Refresh interval: 15s to match the aggregator KV cache TTL.
- */
+import { useState, useEffect, useCallback, useRef } from 'react';
 
-import { useState, useEffect, useCallback } from 'react';
-import type { PulsePayload } from '@/app/api/chambers/pulse/route';
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface Heartbeats {
+  journal:  string | null;
+  runtime:  string | null;
+  vault:    string | null;
+  promote:  string | null;
+}
+
+interface EpiconItem {
+  id?:         string | number;
+  title?:      string;
+  summary?:    string;
+  agent?:      string;
+  author?:     string;
+  confidence?: number;
+  mii_score?:  number;
+  tags?:       string[];
+  timestamp?:  string;
+  createdAt?:  string;
+}
+
+interface EpiconResponse {
+  items?: EpiconItem[];
+  count?: number;
+}
+
+interface SearchResult {
+  source:      'journal' | 'vault' | 'ledger' | 'epicon-cache';
+  event_id?:   string;
+  title?:      string;
+  summary?:    string;
+  message?:    string;
+  agent?:      string;
+  cycle?:      string;
+  confidence?: number;
+  severity?:   string;
+  tags?:       string[];
+  attested_at?: number;
+  writtenAt?:  string;
+  timestamp?:  string;
+  status?:     string;
+  sealId?:     string;
+  seal_id?:    string;
+  [key: string]: unknown;
+}
+
+interface SearchState {
+  query:     string;
+  loading:   boolean;
+  results:   SearchResult[];
+  count:     number;
+  queryType: string;
+  error:     string | null;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function ageLabel(ts: string | number | null | undefined): string {
+  if (ts == null) return '—';
+  const ms = typeof ts === 'number' ? ts : new Date(ts).getTime();
+  if (isNaN(ms)) return '—';
+  const diffMs = Date.now() - ms;
+  if (diffMs < 0) return 'now';
+  const s = Math.floor(diffMs / 1000);
+  if (s < 60)  return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60)  return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  return `${h}h ago`;
+}
+
+function heartbeatDot(iso: string | null): string {
+  if (!iso) return 'bg-slate-700';
+  const ageMin = (Date.now() - new Date(iso).getTime()) / 60_000;
+  if (ageMin < 6)  return 'bg-emerald-400';
+  if (ageMin < 15) return 'bg-amber-400';
+  return 'bg-red-500';
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+const EMPTY_SEARCH: SearchState = {
+  query: '', loading: false, results: [], count: 0, queryType: '', error: null,
+};
 
 export default function PulsePageClient() {
-  const [pulse, setPulse] = useState<PulsePayload | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [lastFetch, setLastFetch] = useState<number>(0);
+  const [heartbeats, setHeartbeats] = useState<Heartbeats | null>(null);
+  const [epicon,     setEpicon]     = useState<EpiconItem[]>([]);
+  const [epiconCount, setEpiconCount] = useState<number>(0);
+  const [feedLoading, setFeedLoading] = useState(true);
+  const [search,     setSearch]     = useState<SearchState>(EMPTY_SEARCH);
+  const [inputVal,   setInputVal]   = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  const loadPulse = useCallback(async () => {
+  // ── Data fetchers ─────────────────────────────────────────────────────────
+
+  const loadHeartbeats = useCallback(async () => {
     try {
-      const res = await fetch('/api/chambers/pulse');
-      if (!res.ok) return;
-      const data = (await res.json()) as PulsePayload;
-      setPulse(data);
-      setLastFetch(Date.now());
+      const res = await fetch('/api/health/heartbeats');
+      if (res.ok) setHeartbeats(await res.json() as Heartbeats);
     } catch (e) {
-      console.warn('[pulse] fetch failed:', e);
+      console.warn('[pulse] heartbeats fetch failed:', e);
+    }
+  }, []);
+
+  const loadEpicon = useCallback(async () => {
+    try {
+      const res = await fetch('/api/epicon/feed?limit=50');
+      if (!res.ok) return;
+      const data = await res.json() as EpiconResponse;
+      setEpicon(data.items ?? []);
+      setEpiconCount(data.count ?? data.items?.length ?? 0);
+    } catch (e) {
+      console.warn('[pulse] epicon fetch failed:', e);
     } finally {
-      setLoading(false);
+      setFeedLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    void loadPulse();
-    const interval = setInterval(() => void loadPulse(), 15_000);
-    return () => clearInterval(interval);
-  }, [loadPulse]);
+    void loadHeartbeats();
+    void loadEpicon();
+    const hbInterval = setInterval(() => void loadHeartbeats(), 30_000);
+    const epInterval = setInterval(() => void loadEpicon(),     15_000);
+    return () => { clearInterval(hbInterval); clearInterval(epInterval); };
+  }, [loadHeartbeats, loadEpicon]);
 
-  // ── Derived values ──────────────────────────────────────────────────
-  const snap     = pulse?.snapshot as Record<string, unknown> | null ?? null;
-  const gi       = (pulse?.integrityStatus as Record<string, unknown> | null)?.gi as number | null
-                   ?? (snap?.gi as number | null)
-                   ?? null;
-  const cycle    = pulse?._meta?.cycle ?? (snap?.cycle as string | null) ?? '—';
-  const epiconRaw = pulse?.epicon as Record<string, unknown> | null;
-  const epicon   = ((epiconRaw?.items ?? epiconRaw) as unknown[] | null) ?? [];
-  // /api/agents/journal returns { entries: [...] } — unwrap the envelope
-  const agentJournalRaw = pulse?.agentJournal as { entries?: unknown[] } | unknown[] | null;
-  const agents   = (Array.isArray(agentJournalRaw)
-    ? agentJournalRaw
-    : (agentJournalRaw as { entries?: unknown[] } | null)?.entries ?? []);
-  const miiRaw   = pulse?.mii as Record<string, unknown> | null;
-  const miiScore = (miiRaw?.composite ?? miiRaw?.score) as number | null ?? null;
-  const vaultRaw = pulse?.vaultStatus as Record<string, unknown> | null;
-  const vaultSeals   = (vaultRaw?.seals as unknown[] | null) ?? [];
-  const vaultSustain = vaultRaw?.sustain as number | null ?? null;
-  // /api/chambers/lane-diagnostics returns lanes as an object map { name: state }
-  // Convert to array for rendering; handle both object and legacy array shapes.
-  const lanesRaw = pulse?.laneDiagnostics as Record<string, unknown> | null;
-  const lanesObj = lanesRaw?.lanes;
-  const lanes: Array<{ name: string; state?: unknown; ok?: unknown }> =
-    Array.isArray(lanesObj)
-      ? (lanesObj as Array<{ name: string; state?: unknown }>)
-      : lanesObj && typeof lanesObj === 'object'
-        ? Object.entries(lanesObj as Record<string, unknown>).map(([name, val]) =>
-            val && typeof val === 'object'
-              ? { name, ...(val as Record<string, unknown>) }
-              : { name, state: val }
-          )
-        : [];
-  const echoRaw  = pulse?.echoDigest as Record<string, unknown> | null;
-  const canon    = pulse?.substrateCanon as Record<string, unknown> | null;
-  const freshMs  = lastFetch ? Date.now() - lastFetch : null;
+  // ── Search ────────────────────────────────────────────────────────────────
 
-  const giColor  = gi == null ? 'text-slate-500'
-    : gi >= 0.85 ? 'text-emerald-400'
-    : gi >= 0.70 ? 'text-amber-400'
-    : 'text-red-400';
+  async function runSearch(q: string) {
+    const trimmed = q.trim();
+    if (!trimmed) { clearSearch(); return; }
+    setSearch(s => ({ ...s, query: trimmed, loading: true, error: null }));
+    try {
+      const res  = await fetch(`/api/pulse/search?q=${encodeURIComponent(trimmed)}`);
+      const data = await res.json() as { ok?: boolean; error?: string; results?: SearchResult[]; count?: number; queryType?: string };
+      if (!res.ok) throw new Error(data.error ?? 'Search failed');
+      setSearch({
+        query:     trimmed,
+        loading:   false,
+        results:   data.results   ?? [],
+        count:     data.count     ?? 0,
+        queryType: data.queryType ?? '',
+        error:     null,
+      });
+    } catch (err) {
+      setSearch(s => ({ ...s, loading: false, error: String(err) }));
+    }
+  }
+
+  function clearSearch() {
+    setSearch(EMPTY_SEARCH);
+    setInputVal('');
+    inputRef.current?.focus();
+  }
+
+  const inSearchMode = search.query.length > 0;
+
+  // ── Heartbeat rail data ───────────────────────────────────────────────────
+
+  const hbRail: Array<{ label: string; ts: string | null }> = [
+    { label: 'Journal', ts: heartbeats?.journal ?? null },
+    { label: 'Runtime', ts: heartbeats?.runtime ?? null },
+    { label: 'Vault',   ts: heartbeats?.vault   ?? null },
+    { label: 'Promote', ts: heartbeats?.promote ?? null },
+  ];
 
   return (
-    <div className="flex h-full flex-col gap-3 overflow-y-auto p-3 md:p-4">
+    <div className="flex h-full flex-col overflow-hidden">
 
-      {/* ── Meta bar ── */}
-      <div className="flex items-center justify-between rounded border border-slate-800 bg-slate-950/60 px-3 py-1.5 font-mono text-[10px] uppercase tracking-widest text-slate-400">
-        <span>Pulse · {cycle}</span>
-        <span className="flex items-center gap-2">
-          <span className={giColor}>
-            GI {gi != null ? gi.toFixed(3) : '—'}
-          </span>
-          <span className="text-slate-600">·</span>
-          <span className={freshMs != null && freshMs < 20_000 ? 'text-emerald-500' : 'text-amber-400'}>
-            {freshMs != null ? `${Math.floor(freshMs / 1000)}s ago` : 'syncing'}
-          </span>
-          {loading && <span className="animate-pulse text-slate-600">↻</span>}
-        </span>
+      {/* ── Heartbeat rail (sticky) ── */}
+      <div className="shrink-0 border-b border-slate-800 bg-slate-950/80 px-3 py-2">
+        <div className="mb-1 font-mono text-[8px] uppercase tracking-[0.2em] text-slate-600">
+          Cron heartbeats
+        </div>
+        <div className="flex flex-wrap gap-x-4 gap-y-1">
+          {hbRail.map(({ label, ts }) => (
+            <div key={label} className="flex items-center gap-1.5">
+              <span className={`h-1.5 w-1.5 rounded-full ${heartbeatDot(ts)}`} />
+              <span className="font-mono text-[9px] uppercase tracking-wide text-slate-400">
+                {label}
+              </span>
+              <span className="font-mono text-[9px] text-slate-600">
+                {ageLabel(ts)}
+              </span>
+            </div>
+          ))}
+        </div>
       </div>
 
-      {/* ── Row 1: GI · MII · Vault sustain ── */}
-      <div className="grid grid-cols-3 gap-2">
-        <MetricTile
-          label="GI"
-          value={gi?.toFixed(3)}
-          status={gi == null ? 'unknown' : gi >= 0.85 ? 'nominal' : gi >= 0.70 ? 'stressed' : 'critical'}
-        />
-        <MetricTile
-          label="MII"
-          value={miiScore?.toFixed(3)}
-          status={miiScore == null ? 'unknown' : miiScore >= 0.75 ? 'nominal' : 'stressed'}
-        />
-        <MetricTile
-          label="Vault sustain"
-          value={vaultSustain != null ? `${vaultSustain}/5` : '—'}
-          status={vaultSustain == null ? 'unknown' : vaultSustain >= 5 ? 'nominal' : vaultSustain >= 3 ? 'stressed' : 'critical'}
-        />
+      {/* ── Search bar ── */}
+      <div className="shrink-0 border-b border-slate-800/60 bg-slate-950/90 px-3 py-2">
+        <div className="flex items-center gap-2">
+          <span className="shrink-0 font-mono text-[10px] text-slate-600">⌕</span>
+          <input
+            ref={inputRef}
+            value={inputVal}
+            onChange={e => setInputVal(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') void runSearch(inputVal);
+              if (e.key === 'Escape') clearSearch();
+            }}
+            placeholder="C-298  ·  ATLAS  ·  seal-C-298-001  ·  any tag or event ID"
+            className="flex-1 bg-transparent font-mono text-[11px] text-sky-300 outline-none placeholder:text-slate-700"
+          />
+          {inputVal && !inSearchMode && (
+            <button
+              onClick={() => void runSearch(inputVal)}
+              className="shrink-0 rounded border border-slate-700 px-2 py-0.5 font-mono text-[9px] uppercase tracking-wide text-slate-400 hover:border-slate-500 hover:text-slate-200"
+            >
+              Search
+            </button>
+          )}
+          {inSearchMode && (
+            <button
+              onClick={clearSearch}
+              className="shrink-0 rounded border border-slate-700 px-2 py-0.5 font-mono text-[9px] uppercase tracking-wide text-slate-400 hover:border-red-700 hover:text-red-300"
+            >
+              ✕ Clear
+            </button>
+          )}
+        </div>
       </div>
 
-      {/* ── Row 2: Lane diagnostics ── */}
-      <section className="rounded border border-slate-800 bg-slate-950/60 px-3 py-2">
-        <div className="mb-2 font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">Lane diagnostics</div>
-        <div className="grid grid-cols-2 gap-1 md:grid-cols-3">
-          {lanes.length === 0
-            ? <p className="col-span-3 text-[10px] text-slate-600">No lane data</p>
-            : (lanes as Array<Record<string, unknown>>).map((lane) => (
-              <div key={String(lane.name ?? lane.key ?? '')} className="flex items-center justify-between rounded bg-slate-900/60 px-2 py-1">
-                <span className="font-mono text-[9px] uppercase tracking-wide text-slate-400">
-                  {String(lane.name ?? lane.key ?? '—')}
+      {/* ── Feed area ── */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+
+        {/* ── Search results mode ── */}
+        {inSearchMode && (
+          <>
+            <div className="sticky top-0 z-10 border-b border-slate-800/60 bg-slate-950/95 px-3 py-1.5 backdrop-blur-sm">
+              <div className="flex items-center justify-between">
+                <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">
+                  {search.loading
+                    ? 'Searching…'
+                    : `${search.count} results · ${search.query}`}
                 </span>
-                <span className={`font-mono text-[10px] ${
-                  lane.state === 'ok' || lane.ok === true ? 'text-emerald-400'
-                  : lane.state === 'stale' ? 'text-amber-400'
-                  : 'text-red-400'
-                }`}>
-                  {String(lane.state ?? (lane.ok ? 'ok' : 'err'))}
+                <span className="font-mono text-[9px] capitalize text-slate-600">
+                  {search.queryType}
                 </span>
               </div>
-            ))
-          }
-        </div>
-      </section>
+            </div>
 
-      {/* ── Row 3: EPICON feed ── */}
-      <section className="flex-1 rounded border border-slate-800 bg-slate-950/60 px-3 py-2">
-        <div className="mb-2 flex items-center justify-between">
-          <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">EPICON feed</span>
-          <span className="font-mono text-[9px] text-slate-600">{epicon.length} events</span>
-        </div>
-        <div className="max-h-48 space-y-1 overflow-y-auto">
-          {epicon.length === 0
-            ? <p className="text-[10px] text-slate-600">No EPICON events in current cycle</p>
-            : (epicon as Array<Record<string, unknown>>).slice(0, 30).map((ev, i) => {
-                const conf = (ev.confidence ?? ev.mii_score) as number | null ?? null;
+            {search.error && (
+              <p className="px-3 py-3 font-mono text-[10px] text-red-400">{search.error}</p>
+            )}
+
+            {!search.loading && search.results.length === 0 && !search.error && (
+              <p className="px-3 py-4 font-mono text-[10px] text-slate-600">
+                No records found for{' '}
+                <span className="text-slate-400">{search.query}</span>
+              </p>
+            )}
+
+            <div className="divide-y divide-slate-800/40 pb-28 md:pb-8">
+              {search.results.map((r, i) => {
+                const sourceColor =
+                  r.source === 'ledger'       ? 'text-cyan-500'   :
+                  r.source === 'journal'      ? 'text-violet-400' :
+                  r.source === 'vault'        ? 'text-amber-400'  :
+                  'text-slate-500';
+                const conf = typeof r.confidence === 'number' ? r.confidence : null;
+                const ts   = r.attested_at ?? r.writtenAt ?? r.timestamp ?? null;
+                const tags = Array.isArray(r.tags) ? (r.tags as string[]) : [];
                 return (
-                  <div key={String(ev.id ?? i)} className="flex items-start gap-2 rounded bg-slate-900/40 px-2 py-1">
-                    {conf != null && (
-                      <span className={`mt-0.5 shrink-0 rounded px-1 font-mono text-[8px] uppercase ${
-                        conf >= 0.9 ? 'bg-emerald-900/40 text-emerald-400'
-                        : conf >= 0.7 ? 'bg-amber-900/40 text-amber-400'
-                        : 'bg-slate-800 text-slate-500'
-                      }`}>{Math.round(conf * 100)}%</span>
-                    )}
-                    <span className="min-w-0 truncate font-mono text-[10px] text-slate-300">
-                      {String(ev.title ?? ev.summary ?? ev.id ?? '—')}
+                  <div
+                    key={String(r.event_id ?? r.seal_id ?? r.sealId ?? i)}
+                    className="grid grid-cols-[auto_1fr_auto] items-start gap-x-2 px-3 py-2 hover:bg-white/[0.02]"
+                  >
+                    <span className={`mt-0.5 shrink-0 font-mono text-[8px] uppercase ${sourceColor}`}>
+                      {r.source === 'epicon-cache' ? 'epicon' : r.source}
                     </span>
-                    <span className="shrink-0 font-mono text-[9px] text-slate-600">
-                      {String(ev.agent ?? ev.author ?? '—')}
-                    </span>
+                    <div className="min-w-0">
+                      <p className="truncate font-mono text-[11px] text-slate-200">
+                        {String(r.title ?? r.summary ?? r.message ?? r.event_id ?? r.seal_id ?? r.sealId ?? '—')}
+                      </p>
+                      <p className="mt-0.5 font-mono text-[9px] text-slate-600">
+                        {[r.cycle, r.agent, r.status].filter(Boolean).join(' · ')}
+                        {tags.length > 0 && ` · ${tags.join(' ')}`}
+                      </p>
+                    </div>
+                    <div className="shrink-0 text-right">
+                      {conf != null && (
+                        <p className={`font-mono text-[9px] ${
+                          conf >= 0.9 ? 'text-emerald-400' :
+                          conf >= 0.7 ? 'text-amber-400'   :
+                          'text-slate-500'
+                        }`}>
+                          {(conf * 100).toFixed(0)}%
+                        </p>
+                      )}
+                      <p className="font-mono text-[9px] text-slate-700">{ageLabel(ts)}</p>
+                    </div>
                   </div>
                 );
-              })
-          }
-        </div>
-      </section>
+              })}
+            </div>
+          </>
+        )}
 
-      {/* ── Row 4: Agent journal · Echo digest ── */}
-      <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
-        <section className="rounded border border-slate-800 bg-slate-950/60 px-3 py-2">
-          <div className="mb-2 font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">Agent journal</div>
-          <div className="max-h-32 space-y-1 overflow-y-auto">
-            {agents.length === 0
-              ? <p className="text-[10px] text-slate-600">No journal entries</p>
-              : (agents as Array<Record<string, unknown>>).slice(0, 10).map((e, i) => (
-                <div key={String(e.id ?? i)} className="flex items-center gap-2">
-                  <span className="w-16 shrink-0 font-mono text-[9px] uppercase text-slate-500">
-                    {String(e.agent ?? '—')}
-                  </span>
-                  <span className="min-w-0 truncate text-[10px] text-slate-300">
-                    {String(e.message ?? e.observation ?? e.summary ?? '—')}
-                  </span>
-                </div>
-              ))
-            }
-          </div>
-        </section>
-
-        <section className="rounded border border-slate-800 bg-slate-950/60 px-3 py-2">
-          <div className="mb-2 font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">ECHO digest</div>
-          {echoRaw
-            ? (
-              <div className="space-y-1 font-mono text-[10px]">
-                <div className="flex justify-between">
-                  <span className="text-slate-500">Hash</span>
-                  <span className="text-cyan-400">{String(echoRaw.hash ?? '—').slice(0, 12)}…</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-slate-500">Age</span>
-                  <span className="text-slate-300">{String(echoRaw.age ?? '—')}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-slate-500">Entries</span>
-                  <span className="text-slate-300">{String(echoRaw.count ?? '—')}</span>
-                </div>
-              </div>
-            )
-            : <p className="text-[10px] text-slate-600">Digest unavailable</p>
-          }
-        </section>
-      </div>
-
-      {/* ── Row 5: Vault seals · Substrate canon ── */}
-      <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
-        <section className="rounded border border-slate-800 bg-slate-950/60 px-3 py-2">
-          <div className="mb-2 font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">Vault seals</div>
-          {vaultSeals.length === 0
-            ? <p className="text-[10px] text-slate-600">No seals in current cycle</p>
-            : (vaultSeals as Array<Record<string, unknown>>).slice(0, 8).map((s) => (
-              <div key={String(s.seal_id ?? s.sealId ?? '')} className="flex items-center justify-between py-0.5">
-                <span className="font-mono text-[9px] text-slate-400">
-                  {String(s.seal_id ?? s.sealId ?? '—')}
+        {/* ── Live EPICON feed — shown when not in search mode ── */}
+        {!inSearchMode && (
+          <>
+            <div className="sticky top-0 z-10 border-b border-slate-800/60 bg-slate-950/95 px-3 py-1.5 backdrop-blur-sm">
+              <div className="flex items-center justify-between">
+                <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400">
+                  EPICON feed
                 </span>
-                <span className={`font-mono text-[9px] ${
-                  s.status === 'attested' || s.status === 'promoted' ? 'text-emerald-400'
-                  : s.status === 'quarantined' ? 'text-red-400'
-                  : 'text-amber-400'
-                }`}>
-                  {String(s.status ?? '—')}
+                <span className="font-mono text-[9px] text-slate-600">
+                  {feedLoading ? 'syncing…' : `${epiconCount} events`}
                 </span>
               </div>
-            ))
-          }
-        </section>
+            </div>
 
-        <section className="rounded border border-slate-800 bg-slate-950/60 px-3 py-2">
-          <div className="mb-2 font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">Substrate canon</div>
-          {canon
-            ? (
-              <div className="space-y-1 font-mono text-[10px]">
-                <div className="flex justify-between">
-                  <span className="text-slate-500">Head</span>
-                  <span className="text-violet-400">{String(canon.head ?? '—').slice(0, 10)}…</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-slate-500">Cycle</span>
-                  <span className="text-slate-300">{String(canon.cycle ?? '—')}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-slate-500">Entries</span>
-                  <span className="text-slate-300">{String(canon.entryCount ?? canon.count ?? '—')}</span>
-                </div>
-              </div>
-            )
-            : <p className="text-[10px] text-slate-600">Canon unavailable</p>
-          }
-        </section>
+            {epicon.length === 0 && !feedLoading && (
+              <p className="px-3 py-4 font-mono text-[10px] text-slate-600">
+                No EPICON events in current cycle
+              </p>
+            )}
+
+            <div className="divide-y divide-slate-800/40 pb-28 md:pb-8">
+              {epicon.map((ev, i) => {
+                const conf    = (ev.confidence ?? ev.mii_score) ?? null;
+                const confPct = conf != null ? Math.round(conf * 100) : null;
+                const confColor =
+                  conf == null ? '' :
+                  conf >= 0.9  ? 'bg-emerald-900/40 text-emerald-400' :
+                  conf >= 0.7  ? 'bg-amber-900/40 text-amber-400'     :
+                  'bg-slate-800 text-slate-500';
+                const tags = Array.isArray(ev.tags) ? ev.tags : [];
+
+                return (
+                  <div
+                    key={String(ev.id ?? i)}
+                    className="flex items-start gap-2 px-3 py-2 hover:bg-slate-900/30"
+                  >
+                    {confPct != null && (
+                      <span className={`mt-0.5 shrink-0 rounded px-1 font-mono text-[8px] uppercase ${confColor}`}>
+                        {confPct}%
+                      </span>
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-mono text-[10px] text-slate-200">
+                        {String(ev.title ?? ev.summary ?? ev.id ?? '—')}
+                      </p>
+                      {tags.length > 0 && (
+                        <div className="mt-0.5 flex flex-wrap gap-1">
+                          {tags.slice(0, 4).map(tag => (
+                            <span key={tag} className="rounded bg-slate-800 px-1 font-mono text-[7px] uppercase text-slate-500">
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                    <div className="shrink-0 text-right">
+                      <p className="font-mono text-[9px] text-slate-500">
+                        {String(ev.agent ?? ev.author ?? '—')}
+                      </p>
+                      <p className="font-mono text-[8px] text-slate-700">
+                        {ageLabel(ev.timestamp ?? ev.createdAt)}
+                      </p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+
       </div>
-
-    </div>
-  );
-}
-
-// ── Shared metric tile ───────────────────────────────────────────────────────
-function MetricTile({ label, value, status }: {
-  label: string;
-  value: string | undefined;
-  status: 'nominal' | 'stressed' | 'critical' | 'unknown';
-}) {
-  const color =
-    status === 'nominal'  ? 'border-emerald-700/50 text-emerald-300' :
-    status === 'stressed' ? 'border-amber-700/50 text-amber-300' :
-    status === 'critical' ? 'border-red-700/50 text-red-400' :
-    'border-slate-700 text-slate-500';
-  return (
-    <div className={`rounded border px-3 py-2 ${color}`}>
-      <div className="font-mono text-[9px] uppercase tracking-[0.18em] opacity-60">{label}</div>
-      <div className="mt-1 font-mono text-xl">{value ?? '—'}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **New endpoint** `/api/pulse/search` — fans out to KV + Render ledger, returns up to 200 sorted results:
  - KV journal entries: raw key scan (`journal:*`) via Upstash Redis `keys()`, content-filtered
  - Vault seals: reads `vault:seals:index:all` index then loads matching `vault:seal:{id}` records
  - Render Civic Ledger: `GET RENDER_LEDGER_URL/ledger/events?limit=200`, text-filtered; auth via `SUBSTRATE_TOKEN`
  - EPICON KV cache fallback (`epicon:render-ledger-cache`) when ledger unreachable
  - Detects query type: `C-NNN` cycle IDs, agent names (ATLAS/ZEUS/EVE/…), `SEAL-` prefixes, free text
  - Results sorted newest-first; handles ISO strings and numeric epoch ms timestamps

- **PulsePageClient** (includes PR-508 base layout):
  - Sticky cron heartbeat rail (Journal / Runtime / Vault / Promote) with dot color + age label
  - Search bar between rail and feed — Enter to search, Esc or Clear button to reset
  - Search results mode: sticky header with result count + queryType badge, source-colored rows (ledger=cyan, journal=violet, vault=amber)
  - Live EPICON feed when not searching (15s poll, `d.items` key, 50 items)

- **Codex P1 fix** also included: `kvGet(KV_KEYS.HEARTBEAT)` may return a pre-parsed object under backup KV / OAA bridge — handle both string and object shapes in the heartbeats endpoint

## Test plan

- [ ] `C-298` → results include journal entries and vault seals containing that cycle ID, plus filtered ledger events
- [ ] `ATLAS` → results show all ATLAS agent events across sources
- [ ] Free text (e.g. a tag name) → JSON string scan across KV cache returns matching entries
- [ ] Esc / Clear returns immediately to live EPICON feed
- [ ] No results: empty state message with the query echoed
- [ ] Ledger timeout: graceful fallback to `epicon:render-ledger-cache` with source badge `epicon`
- [ ] Heartbeat rail Runtime dot still green during primary KV outage (backup-KV path)

https://claude.ai/code/session_019CJ7Eexf1bTaZ73Q9cqP5p

---
_Generated by [Claude Code](https://claude.ai/code/session_019CJ7Eexf1bTaZ73Q9cqP5p)_