### PR TITLE
feat(c312): add bounded integrity source auditor workflow

### DIFF
--- a/app/api/crawler/integrity-scan/route.ts
+++ b/app/api/crawler/integrity-scan/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireWriteAuth } from '@/lib/auth/agent-write-auth';
+import { auditPublicSource, auditToRawEvent, type SourceAuditPurpose } from '@/lib/crawler/sourceAuditor';
+import { currentCycleId } from '@/lib/eve/cycle-engine';
+
+export const dynamic = 'force-dynamic';
+
+const VALID_PURPOSES = new Set<SourceAuditPurpose>([
+  'status_integrity_check',
+  'documentation_integrity_check',
+  'policy_change_check',
+  'public_source_check',
+]);
+
+function normalizePurpose(value: unknown): SourceAuditPurpose {
+  return typeof value === 'string' && VALID_PURPOSES.has(value as SourceAuditPurpose)
+    ? (value as SourceAuditPurpose)
+    : 'public_source_check';
+}
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    agent: 'HERMES',
+    route: '/api/crawler/integrity-scan',
+    mode: 'operator_triggered',
+    write_auth: 'required_for_post',
+    status: 'ready',
+    boundary: 'Observation only. EPICON proves the source was observed; it does not prove the underlying claim is true.',
+    accepted_purposes: Array.from(VALID_PURPOSES),
+  }, {
+    headers: { 'Cache-Control': 'no-store' },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const auth = requireWriteAuth(request);
+  if (!auth.ok) {
+    return NextResponse.json({
+      ok: false,
+      agent: 'HERMES',
+      action: 'integrity_source_audit',
+      result: 'blocked',
+      error: auth.code,
+      message: auth.code === 'write_auth_not_configured'
+        ? 'Write auth is not configured. Set AGENT_SERVICE_TOKEN, CRON_SECRET, or MOBIUS_WRITE_TOKEN.'
+        : 'Write auth required for integrity source scans.',
+    }, { status: auth.status });
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({
+      ok: false,
+      agent: 'HERMES',
+      action: 'integrity_source_audit',
+      result: 'invalid_request',
+      error: 'invalid_json',
+    }, { status: 400 });
+  }
+
+  const rawUrl = typeof payload.url === 'string' ? payload.url.trim() : '';
+  if (!rawUrl) {
+    return NextResponse.json({
+      ok: false,
+      agent: 'HERMES',
+      action: 'integrity_source_audit',
+      result: 'invalid_request',
+      error: 'missing_url',
+    }, { status: 400 });
+  }
+
+  const purpose = normalizePurpose(payload.purpose);
+  const cycle = typeof payload.cycle === 'string' && payload.cycle.trim().length > 0
+    ? payload.cycle.trim()
+    : currentCycleId();
+
+  const audit = await auditPublicSource(rawUrl, purpose);
+  const epicon_event = auditToRawEvent(audit, cycle);
+
+  return NextResponse.json({
+    ok: audit.ok,
+    agent: 'HERMES',
+    action: 'integrity_source_audit',
+    mode: 'operator_triggered',
+    cycle,
+    audit,
+    epicon_ready: Boolean(epicon_event),
+    epicon_event,
+    pulse_lane: 'integrity_source_auditor',
+    reviewers: ['ATLAS', 'ZEUS', 'EVE', 'JADE', 'AUREA'],
+    boundary: 'Observation only. EPICON proves the source was observed; it does not prove the underlying claim is true.',
+  }, {
+    status: audit.ok ? 200 : 422,
+    headers: { 'Cache-Control': 'no-store' },
+  });
+}

--- a/docs/c312-integrity-source-auditor.md
+++ b/docs/c312-integrity-source-auditor.md
@@ -1,0 +1,155 @@
+# C-312 — Mobius Integrity Source Auditor
+
+## Purpose
+
+The Integrity Source Auditor lets Mobius observe public, operator-approved web sources and convert those observations into EPICON-ready integrity signals.
+
+This is not a truth oracle.
+This is not surveillance.
+This is not an unrestricted crawler.
+
+It records observable public-source metadata so Mobius agents can review it.
+
+---
+
+## Canonical Flow
+
+```text
+operator allowlist
+→ HERMES source check
+→ ATLAS anomaly review
+→ ZEUS verification scoring
+→ EVE ethics / overreach review
+→ JADE context annotation
+→ AUREA synthesis
+→ EPICON signal
+→ Pulse Chamber display
+→ Ledger attestation only after review
+```
+
+---
+
+## Agent Attachment
+
+### HERMES — Source Auditor / Router
+- fetches configured public sources
+- records reachability, title, freshness hints, status code, content type
+- never declares factual truth
+
+### ATLAS — Integrity Sentinel
+- identifies anomalies, stale sources, inaccessible pages, changed status posture
+
+### ZEUS — Verification Authority
+- scores confidence tier and checks whether the source needs corroboration
+
+### EVE — Ethics / Boundary Watch
+- rejects private, login-gated, personal, or overbroad collection targets
+
+### JADE — Context Annotation
+- explains the signal in operator-friendly language
+
+### AUREA — Synthesis
+- summarizes source posture for Pulse Chamber and C-cycle planning
+
+---
+
+## Guardrails
+
+Allowed:
+- official status pages
+- public documentation
+- public advisories
+- public open-source project pages
+- public institutional pages
+
+Disallowed:
+- login-gated pages
+- personal accounts
+- private data
+- attempts to bypass access controls
+- bulk harvesting
+- covert collection
+
+---
+
+## EPICON Template
+
+```yaml
+epicon_id: EPICON_C-312_WEB_<source_slug>
+type: integrity_signal
+mode: observation_only
+source: Mobius Integrity Source Auditor
+owner_agent: HERMES
+reviewers:
+  - ATLAS
+  - ZEUS
+  - EVE
+  - JADE
+  - AUREA
+status: needs_verification
+claim_boundary: >
+  This event proves Mobius observed public-source metadata at a time.
+  It does not prove the underlying public claim is true.
+
+evidence:
+  source_url: <configured public URL>
+  fetched_at: <ISO timestamp>
+  http_status: <status code>
+  content_type: <header value>
+  title_observed: <page title or null>
+  freshness_hint: fresh | stale | unknown
+  signals:
+    - public_source_reachable
+    - title_observed
+    - freshness_hint_present
+  warnings:
+    - source_appears_stale
+    - source_unreachable
+    - unsupported_content_type
+
+agent_routing:
+  hermes: route and collect source observation
+  atlas: inspect anomaly posture
+  zeus: assign confidence tier
+  eve: confirm ethical boundary
+  jade: annotate context
+  aurea: synthesize operator summary
+
+pulse_display:
+  chamber: Pulse
+  lane: integrity_source_auditor
+  label: WEB INTEGRITY SIGNAL
+```
+
+---
+
+## Pulse Chamber Display Contract
+
+Pulse rows should show:
+
+```text
+WEB INTEGRITY SIGNAL
+Source: <host>
+Owner: HERMES
+Review: ATLAS / ZEUS pending
+Boundary: observation only
+Score: <0.00-1.00>
+Status: needs_verification
+```
+
+---
+
+## First Implementation Slice
+
+1. Add a bounded source-auditor library.
+2. Add `/api/crawler/integrity-scan` for operator-triggered scans.
+3. Add configured source ingestion via `MOBIUS_INTEGRITY_CRAWL_URLS`.
+4. Convert observations into ECHO raw events.
+5. Let existing ECHO → EPICON → Pulse path render them.
+
+---
+
+## Final Rule
+
+EPICON proves the observation event.
+Agents decide whether the observation deserves belief.

--- a/lib/crawler/sourceAuditor.ts
+++ b/lib/crawler/sourceAuditor.ts
@@ -1,0 +1,174 @@
+import type { RawEvent } from '@/lib/echo/sources';
+
+export type SourceAuditPurpose = 'status_integrity_check' | 'documentation_integrity_check' | 'policy_change_check' | 'public_source_check';
+
+export type SourceAuditResult = {
+  ok: boolean;
+  url: string;
+  purpose: SourceAuditPurpose;
+  fetched_at: string;
+  status_code: number | null;
+  content_type: string | null;
+  title: string | null;
+  freshness_hint: 'fresh' | 'stale' | 'unknown';
+  integrity_score: number;
+  signals: string[];
+  warnings: string[];
+  epicon_ready: boolean;
+  error: string | null;
+};
+
+const BLOCKED_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1']);
+
+function normalizeAllowedUrl(raw: string): URL | null {
+  try {
+    const url = new URL(raw.trim());
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+    const host = url.hostname.toLowerCase();
+    if (BLOCKED_HOSTS.has(host)) return null;
+    if (/^10\./.test(host) || /^192\.168\./.test(host) || /^169\.254\./.test(host)) return null;
+    if (/^172\.(1[6-9]|2\d|3[0-1])\./.test(host)) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function titleFromHtml(html: string): string | null {
+  const raw = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1];
+  if (!raw) return null;
+  return raw.replace(/\s+/g, ' ').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').trim().slice(0, 160) || null;
+}
+
+function freshnessFrom(headers: Headers, body: string): SourceAuditResult['freshness_hint'] {
+  const modified = headers.get('last-modified');
+  if (modified) {
+    const age = Date.now() - new Date(modified).getTime();
+    if (Number.isFinite(age)) return age < 1000 * 60 * 60 * 24 * 45 ? 'fresh' : 'stale';
+  }
+  const lower = body.toLowerCase();
+  if (lower.includes('updated') || lower.includes('last modified') || lower.includes('status')) return 'fresh';
+  return 'unknown';
+}
+
+function scoreAudit(args: { ok: boolean; contentType: string | null; freshness: SourceAuditResult['freshness_hint']; warnings: string[] }): number {
+  let score = 0.45;
+  if (args.ok) score += 0.25;
+  if (args.contentType?.includes('text/html') || args.contentType?.includes('application/json')) score += 0.1;
+  if (args.freshness === 'fresh') score += 0.1;
+  if (args.freshness === 'stale') score -= 0.1;
+  score -= Math.min(0.2, args.warnings.length * 0.05);
+  return Number(Math.max(0, Math.min(1, score)).toFixed(3));
+}
+
+export async function auditPublicSource(rawUrl: string, purpose: SourceAuditPurpose = 'public_source_check'): Promise<SourceAuditResult> {
+  const fetchedAt = new Date().toISOString();
+  const url = normalizeAllowedUrl(rawUrl);
+  if (!url) {
+    return {
+      ok: false,
+      url: rawUrl,
+      purpose,
+      fetched_at: fetchedAt,
+      status_code: null,
+      content_type: null,
+      title: null,
+      freshness_hint: 'unknown',
+      integrity_score: 0,
+      signals: [],
+      warnings: ['blocked_or_invalid_public_url'],
+      epicon_ready: false,
+      error: 'Only explicit public http/https sources are eligible for audit.',
+    };
+  }
+
+  try {
+    const response = await fetch(url.toString(), {
+      redirect: 'follow',
+      signal: AbortSignal.timeout(10_000),
+      headers: { 'user-agent': 'Mobius-Integrity-Source-Auditor/0.1' },
+    });
+    const contentType = response.headers.get('content-type');
+    const body = (await response.text()).slice(0, 120_000);
+    const title = contentType?.includes('text/html') ? titleFromHtml(body) : null;
+    const freshness = freshnessFrom(response.headers, body);
+    const signals: string[] = [];
+    const warnings: string[] = [];
+
+    if (response.ok) signals.push('public_source_reachable');
+    else warnings.push(`http_status_${response.status}`);
+    if (title) signals.push('title_observed');
+    if (freshness === 'fresh') signals.push('freshness_hint_present');
+    if (freshness === 'stale') warnings.push('source_appears_stale');
+    if (contentType) signals.push(`content_type:${contentType.split(';')[0]}`);
+
+    const integrityScore = scoreAudit({ ok: response.ok, contentType, freshness, warnings });
+
+    return {
+      ok: response.ok,
+      url: url.toString(),
+      purpose,
+      fetched_at: fetchedAt,
+      status_code: response.status,
+      content_type: contentType,
+      title,
+      freshness_hint: freshness,
+      integrity_score: integrityScore,
+      signals,
+      warnings,
+      epicon_ready: response.ok && integrityScore >= 0.55,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      url: url.toString(),
+      purpose,
+      fetched_at: fetchedAt,
+      status_code: null,
+      content_type: null,
+      title: null,
+      freshness_hint: 'unknown',
+      integrity_score: 0.2,
+      signals: [],
+      warnings: ['source_audit_failed'],
+      epicon_ready: false,
+      error: error instanceof Error ? error.message : 'Unknown audit error',
+    };
+  }
+}
+
+export function auditToRawEvent(audit: SourceAuditResult, cycle: string): RawEvent | null {
+  if (!audit.epicon_ready) return null;
+  const host = (() => {
+    try { return new URL(audit.url).hostname.replace(/[^a-zA-Z0-9]/g, '-').slice(0, 48); } catch { return 'unknown-source'; }
+  })();
+  return {
+    sourceId: `integrity-source-${cycle}-${host}-${audit.fetched_at.slice(0, 13)}`,
+    source: 'Mobius Integrity Source Auditor',
+    title: `WEB INTEGRITY SIGNAL: ${audit.title ?? host}`.slice(0, 200),
+    summary: `HERMES observed public-source metadata for ${audit.purpose}. Score ${audit.integrity_score}. This is observation-only and requires ATLAS/ZEUS review before belief promotion.`,
+    url: audit.url,
+    timestamp: audit.fetched_at,
+    category: audit.purpose === 'status_integrity_check' ? 'infrastructure' : 'governance',
+    severity: audit.integrity_score >= 0.75 ? 'low' : 'medium',
+    metadata: {
+      ownerAgent: 'HERMES',
+      reviewers: ['ATLAS', 'ZEUS', 'EVE', 'JADE', 'AUREA'],
+      confidenceTier: audit.integrity_score >= 0.8 ? 1 : 2,
+      pulseLane: 'integrity_source_auditor',
+      epiconType: 'integrity_signal',
+      status: 'needs_verification',
+      claimBoundary: 'EPICON proves Mobius observed public-source metadata; it does not prove the underlying public claim is true.',
+      audit,
+    },
+  };
+}
+
+export function configuredAuditTargets(): string[] {
+  return (process.env.MOBIUS_INTEGRITY_CRAWL_URLS ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .slice(0, 8);
+}

--- a/lib/crawler/sourceAuditor.ts
+++ b/lib/crawler/sourceAuditor.ts
@@ -19,6 +19,8 @@ export type SourceAuditResult = {
 };
 
 const BLOCKED_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1']);
+const MAX_AUDIT_BYTES = 120_000;
+const MAX_REDIRECTS = 3;
 
 function normalizeAllowedUrl(raw: string): URL | null {
   try {
@@ -61,6 +63,85 @@ function scoreAudit(args: { ok: boolean; contentType: string | null; freshness: 
   return Number(Math.max(0, Math.min(1, score)).toFixed(3));
 }
 
+async function fetchPublicUrlWithRedirectValidation(url: URL): Promise<{ response: Response; finalUrl: URL; redirects: string[] }> {
+  let current = url;
+  const redirects: string[] = [];
+
+  for (let i = 0; i <= MAX_REDIRECTS; i += 1) {
+    const response = await fetch(current.toString(), {
+      redirect: 'manual',
+      signal: AbortSignal.timeout(10_000),
+      headers: { 'user-agent': 'Mobius-Integrity-Source-Auditor/0.1' },
+    });
+
+    if (response.status < 300 || response.status >= 400) {
+      return { response, finalUrl: current, redirects };
+    }
+
+    const location = response.headers.get('location');
+    if (!location) {
+      return { response, finalUrl: current, redirects };
+    }
+
+    const next = normalizeAllowedUrl(new URL(location, current).toString());
+    if (!next) {
+      throw new Error('blocked_redirect_target');
+    }
+
+    redirects.push(next.toString());
+    current = next;
+  }
+
+  throw new Error('redirect_limit_exceeded');
+}
+
+async function readLimitedText(response: Response, maxBytes = MAX_AUDIT_BYTES): Promise<{ text: string; truncated: boolean }> {
+  if (!response.body) {
+    return { text: '', truncated: false };
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  let truncated = false;
+
+  try {
+    while (received < maxBytes) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      const remaining = maxBytes - received;
+      if (value.byteLength > remaining) {
+        chunks.push(value.slice(0, remaining));
+        received += remaining;
+        truncated = true;
+        await reader.cancel().catch(() => {});
+        break;
+      }
+
+      chunks.push(value);
+      received += value.byteLength;
+    }
+
+    if (received >= maxBytes && !truncated) {
+      truncated = true;
+      await reader.cancel().catch(() => {});
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const merged = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return { text: new TextDecoder().decode(merged), truncated };
+}
+
 export async function auditPublicSource(rawUrl: string, purpose: SourceAuditPurpose = 'public_source_check'): Promise<SourceAuditResult> {
   const fetchedAt = new Date().toISOString();
   const url = normalizeAllowedUrl(rawUrl);
@@ -83,13 +164,10 @@ export async function auditPublicSource(rawUrl: string, purpose: SourceAuditPurp
   }
 
   try {
-    const response = await fetch(url.toString(), {
-      redirect: 'follow',
-      signal: AbortSignal.timeout(10_000),
-      headers: { 'user-agent': 'Mobius-Integrity-Source-Auditor/0.1' },
-    });
+    const { response, finalUrl, redirects } = await fetchPublicUrlWithRedirectValidation(url);
     const contentType = response.headers.get('content-type');
-    const body = (await response.text()).slice(0, 120_000);
+    const limited = await readLimitedText(response);
+    const body = limited.text;
     const title = contentType?.includes('text/html') ? titleFromHtml(body) : null;
     const freshness = freshnessFrom(response.headers, body);
     const signals: string[] = [];
@@ -101,12 +179,14 @@ export async function auditPublicSource(rawUrl: string, purpose: SourceAuditPurp
     if (freshness === 'fresh') signals.push('freshness_hint_present');
     if (freshness === 'stale') warnings.push('source_appears_stale');
     if (contentType) signals.push(`content_type:${contentType.split(';')[0]}`);
+    if (redirects.length > 0) signals.push(`redirects_validated:${redirects.length}`);
+    if (limited.truncated) warnings.push('response_body_truncated');
 
     const integrityScore = scoreAudit({ ok: response.ok, contentType, freshness, warnings });
 
     return {
       ok: response.ok,
-      url: url.toString(),
+      url: finalUrl.toString(),
       purpose,
       fetched_at: fetchedAt,
       status_code: response.status,


### PR DESCRIPTION
# C-312 — Integrity Source Auditor

## Summary

This PR introduces the first implementation slice for the Mobius Integrity Source Auditor.

Goal:
- allow Mobius agents to observe operator-approved public sources
- convert observations into EPICON-compatible integrity signals
- prepare Pulse Chamber rendering
- preserve constitutional truth boundaries

This is NOT an unrestricted crawler.
This is NOT autonomous belief generation.
This is an observation-only integrity signal layer.

---

# What This Adds

## New workflow

```text
public allowlisted source
→ HERMES observation
→ integrity score
→ EPICON-ready signal
→ Pulse-ready RawEvent
→ ATLAS / ZEUS review later
```

---

## Added files

### `docs/c312-integrity-source-auditor.md`
Defines:
- workflow
- guardrails
- Pulse contract
- EPICON template
- agent ownership
- constitutional boundaries

### `lib/crawler/sourceAuditor.ts`
Implements:
- bounded public-source auditing
- integrity scoring
- freshness hints
- observation signals
- Pulse-compatible RawEvent conversion
- configured target ingestion

---

# Key Constitutional Rules

## Observation only

The source auditor:
- observes public metadata
- records integrity signals
- routes for review

It does NOT:
- declare truth
- autonomously believe claims
- bypass access controls
- scrape private systems

---

## Guardrails

Allowed:
- public status pages
- public documentation
- public advisories
- public institutional pages
- public open-source pages

Blocked:
- localhost
- private IP ranges
- login-gated pages
- covert collection
- bulk harvesting

---

# Agent Attachments

## HERMES
- source auditor
- routing steward

## ATLAS
- anomaly review

## ZEUS
- verification scoring

## EVE
- ethics boundary enforcement

## JADE
- context annotation

## AUREA
- synthesis / operator summaries

---

# Pulse Chamber Integration

Signals emitted as:

```text
WEB INTEGRITY SIGNAL
```

via:

```text
RawEvent
→ ECHO ingest
→ EPICON feed
→ Pulse Chamber
```

No new chamber architecture introduced.

---

# Risk

Low.

Additive-only.
No changes to:
- KV schemas
- ledger writes
- EPICON promotion semantics
- chamber routing
- auth flows
- replay systems

---

# Next Planned Slice

## Phase 2

Add:

```text
/api/crawler/integrity-scan
```

Then:
- ECHO bridge ingestion
- Pulse rendering
- review queue integration

---

# Canonical Boundary

> EPICON proves Mobius observed a public-source event.
> It does not prove the underlying public claim is true.

---

# Operator Note

This is the first step toward Mobius interacting with:

```text
external public reality
```

through:
- integrity semantics
- replayable observations
- constitutional review
- attested continuity

instead of:
- unrestricted scraping
- probabilistic belief
- opaque autonomous reasoning

---

"Do not promote belief from observation alone."