### PR TITLE
C-314: Terminal gap fixes (ignore-build, promote auth, GI, ZEUS, seals)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+## Automation and commit verification
+
+Commits from Mobius automation (`mobius-bot`, catalog workflows, and sentinel jobs) are typically **unsigned**. GitHub shows these as “Unverified,” which is expected: there is no human GPG key on the bot identity. If branch protection requires verified commits, either configure GPG signing in the relevant workflows using a dedicated bot key stored in repository secrets, or adjust protection rules for automation accounts.

--- a/app/api/cron/journal-canonize/route.ts
+++ b/app/api/cron/journal-canonize/route.ts
@@ -88,10 +88,19 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  const substrateWriteTarget =
+    process.env.JOURNAL_CANON_SUBSTRATE_TARGET ??
+    process.env.SUBSTRATE_GITHUB_REPO ??
+    process.env.GITHUB_REPO_URL ??
+    null;
+  const substrateConfigured = Boolean(substrateWriteTarget);
+  const githubToken = Boolean(process.env.SUBSTRATE_GITHUB_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim());
+  const github_direct_write_configured = !substrateConfigured && githubToken;
+
   console.log('[journal-canonize] running', {
     substrate_target: target.ledgerBase,
-    substrate_configured: true,
-    github_direct_write_configured: Boolean(process.env.SUBSTRATE_GITHUB_TOKEN),
+    substrate_configured: substrateConfigured,
+    github_direct_write_configured,
   });
 
   void ensureRetryQueueExists();

--- a/app/api/cron/promote/route.ts
+++ b/app/api/cron/promote/route.ts
@@ -21,7 +21,24 @@ export async function GET(request: NextRequest) {
   if (authError) return authError;
 
   const origin = request.nextUrl.origin;
-  const authHeader = serviceAuthorizationHeaderValue();
+  // C-314 T-03: /api/epicon/promote validates SUBSTRATE_TOKEN (or CRON_SECRET) when configured.
+  // Prefer SUBSTRATE_TOKEN for this internal hop so we never send MOBIUS_SERVICE_SECRET and get 401.
+  const substrate = process.env.SUBSTRATE_TOKEN?.trim();
+  const cronOnly = process.env.CRON_SECRET?.trim();
+  const bearerMaterial = (() => {
+    if (substrate) {
+      const m = /^Bearer\s+(.+)$/i.exec(substrate);
+      return (m ? m[1] : substrate).trim();
+    }
+    if (cronOnly) {
+      const m = /^Bearer\s+(.+)$/i.exec(cronOnly);
+      return (m ? m[1] : cronOnly).trim();
+    }
+    return null;
+  })();
+  const authHeader = bearerMaterial
+    ? `Bearer ${bearerMaterial}`
+    : serviceAuthorizationHeaderValue();
 
   try {
     // FIX-507-02: write heartbeat unconditionally so promotion-status never shows stale

--- a/app/api/cron/reattest-seals/route.ts
+++ b/app/api/cron/reattest-seals/route.ts
@@ -24,10 +24,46 @@ import { backAttestSeal, buildBackAttestRationale } from '@/lib/vault-v2/back-at
 import { attestReserveBlockToSubstrate, dequeueSubstrateRetry } from '@/lib/vault-v2/substrate-attestation';
 import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
 import { releaseReplayPressureForAttestedSeal } from '@/lib/mic/replayPressure';
-import { kvGet, kvSet } from '@/lib/kv/store';
+import { kvGet, kvSet, kvDel } from '@/lib/kv/store';
 import type { Seal } from '@/lib/vault-v2/types';
 
 export const dynamic = 'force-dynamic';
+
+// C-314 T-07: one-time KV reset for seals that looped before TERMINAL_REGISTRATION was fixed.
+const LEGACY_STUCK_SEALS = [
+  'seal-C-288-001',
+  'seal-C-292-001',
+  'seal-C-293-001',
+  'seal-C-294-001',
+  'seal-C-295-001',
+  'seal-C-296-001',
+  'seal-C-297-001',
+  'seal-C-298-001',
+] as const;
+const C314_REATTEST_MIGRATION_KEY = 'reattest:c314-migration-done';
+
+async function runLegacySealMigration(allSeals: Seal[]): Promise<void> {
+  const done = await kvGet<boolean>(C314_REATTEST_MIGRATION_KEY);
+  if (done) return;
+
+  console.info('[reattest-seals] C-314 migration: clearing stuck quarantine / reattest KV for legacy seal IDs');
+  for (const sealId of LEGACY_STUCK_SEALS) {
+    await kvDel(`seal:${sealId}:reattest_attempts`).catch(() => {});
+    await kvDel(`seal:${sealId}:reattest_last_attempt`).catch(() => {});
+    const seal = allSeals.find((s) => s.seal_id === sealId);
+    if (seal && seal.status === 'permanently-failed') {
+      await writeSeal({
+        ...seal,
+        status: 'quarantined',
+        substrate_attestation_error: null,
+      }).catch((e) => {
+        console.warn(`[reattest-seals] migration: could not reset seal ${sealId}`, e);
+      });
+    }
+    console.info(`[reattest-seals] migration reset keys for ${sealId}`);
+  }
+  await kvSet(C314_REATTEST_MIGRATION_KEY, true, 365 * 24 * 3600).catch(() => {});
+}
 
 // Max reattest attempts before a seal is marked permanently-failed (prevents infinite loops).
 // At 1h cron cadence, 12 attempts ≈ 12 hours of retries before giving up.
@@ -160,6 +196,13 @@ export async function GET(req: NextRequest) {
       ok: false,
       error: `listAllSeals failed: ${e instanceof Error ? e.message : String(e)}`,
     }, { status: 500 });
+  }
+
+  await runLegacySealMigration(allSeals);
+  try {
+    allSeals = await listAllSeals(200);
+  } catch {
+    // keep prior list if refresh fails
   }
 
   const quarantined = allSeals.filter((s) => s.status === 'quarantined');

--- a/app/api/cron/sweep/route.ts
+++ b/app/api/cron/sweep/route.ts
@@ -17,6 +17,35 @@ import { kvGet, kvSet, kvDel, KV_KEYS } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
 
+const ZEUS_LAST_RESOLVED_KEY = 'zeus:last-resolved-status';
+type ZeusSweepResult = 'pass' | 'fail' | 'inconclusive';
+
+async function runZeusVerificationSweep(origin: string): Promise<ZeusSweepResult> {
+  try {
+    const res = await fetch(`${origin}/api/agents/ledger-zeus?limit=50`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(12_000),
+    });
+    if (!res.ok) {
+      console.warn('[cron/sweep] ZEUS verification probe non-OK:', res.status);
+      return 'inconclusive';
+    }
+    const body = (await res.json()) as {
+      evaluated?: Array<{ zeus?: { zeus_verified?: boolean } }>;
+    };
+    const ev = body.evaluated;
+    if (!Array.isArray(ev) || ev.length === 0) {
+      return 'inconclusive';
+    }
+    const allPass = ev.every((row) => row.zeus?.zeus_verified === true);
+    if (allPass) return 'pass';
+    return 'fail';
+  } catch (err) {
+    console.warn('[cron/sweep] ZEUS verification error — inconclusive', err);
+    return 'inconclusive';
+  }
+}
+
 async function run(req: NextRequest) {
   const authErr = getEveSynthesisAuthError(req);
   if (authErr) return authErr;
@@ -44,6 +73,15 @@ async function run(req: NextRequest) {
     const gi = typeof data.composite === 'number' && Number.isFinite(data.composite)
       ? data.composite
       : null;
+
+    const zeusRaw = await runZeusVerificationSweep(req.nextUrl.origin);
+    let zeusResolved: ZeusSweepResult = zeusRaw;
+    if (zeusRaw === 'inconclusive') {
+      const prior = await kvGet<ZeusSweepResult>(ZEUS_LAST_RESOLVED_KEY);
+      zeusResolved = prior ?? 'inconclusive';
+    } else {
+      await kvSet(ZEUS_LAST_RESOLVED_KEY, zeusRaw, 14 * 24 * 3600).catch(() => {});
+    }
 
     let cycle: string;
     try {
@@ -114,6 +152,8 @@ async function run(req: NextRequest) {
       source: 'cron-sweep',
       timestamp: new Date().toISOString(),
       composite: data.composite,
+      zeus_verification: zeusRaw,
+      zeus_verification_resolved: zeusResolved,
       instrumentCount: data.instrumentCount ?? null,
       cycle,
       sustain: sustainResult

--- a/lib/agents/micro/index.ts
+++ b/lib/agents/micro/index.ts
@@ -10,25 +10,26 @@ export { pollDaedalus, DAEDALUS_CONFIG } from './daedalus';
 export { ALL_INSTRUMENT_POLLS } from './instrument-polls';
 
 import { type AgentPollResult, type MicroSignal } from './core';
-import { pollGaia } from './gaia';
-import { pollHermes } from './hermes';
-import { pollThemis } from './themis';
-import { pollDaedalus } from './daedalus';
 import { ALL_INSTRUMENT_POLLS } from './instrument-polls';
 
-function normalizeHermesFallback(signal: MicroSignal | undefined, agentName: string): MicroSignal {
-  if (!signal || signal.value === 0) {
-    return {
-      agentName,
-      source: 'fallback · narrative neutral',
-      timestamp: new Date().toISOString(),
-      value: 0.5,
-      label: `${agentName}: fallback neutral (no live signal)`,
-      severity: 'nominal',
-      raw: { fallback: true },
-    };
+function computeHermesU34Gi(agent: AgentPollResult): number | null {
+  if (!agent.healthy || agent.errors.length > 0) {
+    return null;
   }
-  return signal;
+  if (agent.signals.length === 0) {
+    return null;
+  }
+  const s = agent.signals[0]!;
+  const raw = s.raw as { httpOk?: boolean; quietContext?: boolean; structuralEmpty?: boolean } | undefined;
+  if (raw && raw.httpOk === false && s.value === 0) {
+    return null;
+  }
+  if (raw && raw.structuralEmpty === true && s.value === 0) {
+    return null;
+  }
+  return Number(
+    (agent.signals.reduce((sum, signal) => sum + signal.value, 0) / agent.signals.length).toFixed(3),
+  );
 }
 
 export interface MicroAgentSweepResult {
@@ -61,26 +62,32 @@ async function mapLimit<T, R>(items: T[], limit: number, fn: (item: T) => Promis
 export async function pollAllMicroAgents(): Promise<MicroAgentSweepResult> {
   const results = await mapLimit(ALL_INSTRUMENT_POLLS, CONCURRENCY, (poll) => poll());
 
-  const agents: AgentPollResult[] = results.map((agent) => {
-    if (agent.agentName.startsWith('HERMES-µ3') || agent.agentName.startsWith('HERMES-µ4')) {
-      return {
-        ...agent,
-        signals: [normalizeHermesFallback(agent.signals[0], agent.agentName)],
-      };
-    }
-    return agent;
-  });
+  const agents: AgentPollResult[] = results;
 
   const allSignals = agents.flatMap((a) => a.signals);
 
-  const compositeByAgent = agents.map((agent) => {
-    if (agent.signals.length === 0) return 0.5;
-    return Number((agent.signals.reduce((sum, signal) => sum + signal.value, 0) / agent.signals.length).toFixed(3));
-  });
+  const compositeParts: number[] = [];
+  for (const agent of agents) {
+    const isHermesU34 = agent.agentName.startsWith('HERMES-µ3') || agent.agentName.startsWith('HERMES-µ4');
+    if (isHermesU34) {
+      const h = computeHermesU34Gi(agent);
+      if (h !== null) {
+        compositeParts.push(h);
+      }
+      continue;
+    }
+    if (agent.signals.length === 0) {
+      compositeParts.push(0.5);
+      continue;
+    }
+    compositeParts.push(
+      Number((agent.signals.reduce((sum, signal) => sum + signal.value, 0) / agent.signals.length).toFixed(3)),
+    );
+  }
 
   const composite =
-    compositeByAgent.length > 0
-      ? Number((compositeByAgent.reduce((sum, value) => sum + value, 0) / compositeByAgent.length).toFixed(3))
+    compositeParts.length > 0
+      ? Number((compositeParts.reduce((sum, value) => sum + value, 0) / compositeParts.length).toFixed(3))
       : 0.5;
 
   const anomalies = allSignals.filter((s) => s.severity === 'elevated' || s.severity === 'critical');

--- a/lib/agents/micro/instrument-polls.ts
+++ b/lib/agents/micro/instrument-polls.ts
@@ -383,7 +383,7 @@ export async function pollHermesU3(): Promise<AgentPollResult> {
     for (const q of queries) {
       const url =
         `https://api.gdeltproject.org/api/v2/doc/doc?query=${encodeURIComponent(q)}&mode=artlist&maxrecords=8&format=json&timespan=${span}`;
-      const meta = await safeFetchWithMeta<{ articles?: unknown[] }>(url, 12000);
+      const meta = await safeFetchWithMeta<{ articles?: unknown[] }>(url, 6000);
       lastMeta = meta;
       if (meta.ok && meta.data) {
         n += meta.data.articles?.length ?? 0;
@@ -458,7 +458,7 @@ export async function pollHermesU4(): Promise<AgentPollResult> {
     const url = `https://www.reddit.com/r/${sub}/hot.json?limit=8`;
     const meta = await safeFetchWithMeta<{ data?: { children?: Array<{ data?: { score?: number; title?: string } }> } }>(
       url,
-      12000,
+      6000,
       { headers: { ...UA_HEADERS, Accept: 'application/json' } },
     );
     lastStatus = meta.status;

--- a/lib/ledger.ts
+++ b/lib/ledger.ts
@@ -1,0 +1,18 @@
+/**
+ * C-314 / FIX-03: Terminal identity fields for Civic Protocol ledger payloads.
+ * Spread into outbound bodies so Render never returns "No API base configured for terminal".
+ * Uses getters so reads follow env changes after module load (same contract as getTerminalRegistration).
+ */
+export const TERMINAL_REGISTRATION = {
+  get terminal_id(): string {
+    return process.env.TERMINAL_ID?.trim() || 'mobius-civic-ai-terminal';
+  },
+  get api_base(): string {
+    const raw =
+      process.env.TERMINAL_API_BASE?.trim() ||
+      process.env.NEXT_PUBLIC_TERMINAL_URL?.trim() ||
+      process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+      'https://mobius-civic-ai-terminal.vercel.app';
+    return raw.replace(/\/+$/, '');
+  },
+};

--- a/lib/substrate/client.ts
+++ b/lib/substrate/client.ts
@@ -1,3 +1,5 @@
+import { TERMINAL_REGISTRATION } from '@/lib/ledger';
+
 export type SubstrateServiceKey = 'ledger' | 'gi' | 'mic' | 'broker' | 'oaa';
 
 export type SubstrateServiceStatus = {
@@ -149,13 +151,8 @@ function resolveSubstrateLedgerUrl(): string {
  */
 export function getTerminalRegistration(): { terminal_id: string; api_base: string } {
   return {
-    terminal_id: process.env.TERMINAL_ID ?? 'mobius-civic-ai-terminal',
-    api_base: (
-      process.env.TERMINAL_API_BASE ??
-      process.env.NEXT_PUBLIC_TERMINAL_URL ??
-      process.env.NEXT_PUBLIC_SITE_URL ??
-      'https://mobius-civic-ai-terminal.vercel.app'
-    ).replace(/\/+$/, ''),
+    terminal_id: TERMINAL_REGISTRATION.terminal_id,
+    api_base: TERMINAL_REGISTRATION.api_base,
   };
 }
 
@@ -276,24 +273,16 @@ export async function attestToLedger(entry: SubstrateEntry): Promise<AttestToLed
   const eventId = entry.id ?? `${entry.agentOrigin}-${entry.cycle}-${Date.now()}`;
   const attestTimestamp = new Date().toISOString();
   const ledgerLabSource = toLedgerLabSource(entry.source);
-  // FIX-506-02 / FIX-03: Render Civic Ledger requires terminal_base_url/api_base/terminal_id for routing.
-  // Without these fields Render rejects with {"detail":"No API base configured for terminal"}.
-  // Priority: TERMINAL_API_BASE > NEXT_PUBLIC_TERMINAL_URL > NEXT_PUBLIC_SITE_URL > hardcoded fallback.
-  const terminalBase = (
-    process.env.TERMINAL_API_BASE ??
-    process.env.NEXT_PUBLIC_TERMINAL_URL ??
-    process.env.NEXT_PUBLIC_SITE_URL ??
-    'https://mobius-civic-ai-terminal.vercel.app'
-  ).replace(/\/+$/, '');
-  const terminalId = process.env.TERMINAL_ID ?? 'mobius-civic-ai-terminal';
+  // FIX-506-02 / C-314 T-04: terminal identity via TERMINAL_REGISTRATION (lib/ledger.ts).
+  const { terminal_id, api_base } = TERMINAL_REGISTRATION;
 
   const requestBody = {
     event_type: entry.category,
     civic_id: eventId,
     lab_source: ledgerLabSource,
-    terminal_base_url: terminalBase,
-    api_base: terminalBase,
-    terminal_id: terminalId,
+    terminal_base_url: api_base,
+    api_base,
+    terminal_id,
     payload: {
       event_id: eventId,
       title: entry.title,

--- a/lib/swarm/budget.ts
+++ b/lib/swarm/budget.ts
@@ -85,8 +85,10 @@ export async function recordSpend(tierCosts: number[]): Promise<BudgetState> {
 }
 
 export function dailyLimitUsd(): number {
-  const raw = parseFloat(process.env.DAILY_LLM_BUDGET_USD ?? '0.50');
-  return Number.isFinite(raw) && raw > 0 ? raw : 0.5;
+  const raw = parseFloat(
+    process.env.SWARM_DAILY_BUDGET_USD ?? process.env.DAILY_LLM_BUDGET_USD ?? '1.0',
+  );
+  return Number.isFinite(raw) && raw > 0 ? raw : 1.0;
 }
 
 export function tierCostUsd(tier: number): number {

--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -1,23 +1,59 @@
 #!/usr/bin/env bash
-# C-305 OPT-01: dual-email + name + chore pattern gate — verified complete
+# C-305 OPT-01 + C-314 T-01: Vercel ignoreCommand gate — exit 0 = skip build, exit 1 = build.
+# Prefer VERCEL_GIT_* when present (ignoreCommand runs before full clone in some paths).
 set -euo pipefail
 
-subject="$(git log -1 --format=%s)"
-author_email="$(git log -1 --format=%ae)"
-author_name="$(git log -1 --format=%an)"
+subject="${VERCEL_GIT_COMMIT_MESSAGE:-}"
+author_email="${VERCEL_GIT_COMMIT_AUTHOR_EMAIL:-}"
+author_name="${VERCEL_GIT_COMMIT_AUTHOR_NAME:-}"
+
+if [[ -z "$subject" ]]; then
+  subject="$(git log -1 --format=%s 2>/dev/null || echo "")"
+fi
+if [[ -z "$author_email" ]]; then
+  author_email="$(git log -1 --format=%ae 2>/dev/null || echo "")"
+fi
+if [[ -z "$author_name" ]]; then
+  author_name="$(git log -1 --format=%an 2>/dev/null || echo "")"
+fi
 
 if [[ "$subject" == *"[skip ci]"* ]] || [[ "$subject" == *"[skip deploy]"* ]]; then
   echo "Skipping: skip directive in commit message"
   exit 0
 fi
 
+# Sentinel + catalog bot addresses (explicit + mobius.systems agent inboxes).
+SENTINEL_EMAILS=(
+  "bot@mobius.systems"
+  "bot@mobius.substrate"
+  "atlas@mobius.systems"
+  "zeus@mobius.systems"
+  "eve@mobius.systems"
+  "jade@mobius.systems"
+  "aurea@mobius.systems"
+  "hermes@mobius.systems"
+  "echo@mobius.systems"
+  "daedalus@mobius.systems"
+)
+
+is_listed_sentinel=false
+for em in "${SENTINEL_EMAILS[@]}"; do
+  if [[ "${author_email,,}" == "${em,,}" ]]; then
+    is_listed_sentinel=true
+    break
+  fi
+done
+
 # Match mobius-bot identity (name) and legacy bot emails used on CI / Cursor.
-# Fix 10: expanded to catch github-actions bot and any noreply.github.com identity.
+# C-314: listed sentinel emails + mobius.systems agent pattern + substrate bot domain.
 if [[ "$author_name" == "mobius-bot" ]] \
   || [[ "$author_name" == "github-actions[bot]" ]] \
+  || [[ "$is_listed_sentinel" == true ]] \
   || [[ "$author_email" =~ ^(bot@mobius\.systems|bot@mobius\.substrate|bot@mobius\.internal|cursoragent@cursor\.com)$ ]] \
+  || [[ "$author_email" =~ ^(atlas|zeus|eve|jade|aurea|hermes|echo|daedalus)@mobius\.systems$ ]] \
+  || [[ "$author_email" =~ @mobius\.substrate$ ]] \
   || [[ "$author_email" =~ \.noreply\.github\.com$ ]]; then
-  echo "Skipping: bot commit by $author_name <$author_email>"
+  echo "Skipping: bot/sentinel commit by $author_name <$author_email>"
   exit 0
 fi
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change set addresses the C-314 terminal gap list: Vercel builds canceled by incomplete bot-author filtering, internal promote calls returning 401 when `SUBSTRATE_TOKEN` is enforced, ledger terminal registration drift, HERMES micro-lane behavior dragging GI, ZEUS verification stuck as inconclusive, legacy quarantined seals, swarm budget defaults, journal-canonize logging, and documentation for unsigned bot commits.

## Changes

- **`scripts/ignore-build.sh`**: Prefer `VERCEL_GIT_COMMIT_*` when present; expand skip rules for sentinel inboxes (`*@mobius.systems` agent pattern, `@mobius.substrate`), explicit bot/sentinel list, and case-insensitive email match. Exit semantics unchanged (0 = skip build, 1 = build).
- **`app/api/cron/promote/route.ts`**: Send `Authorization: Bearer …` using `SUBSTRATE_TOKEN` first, then `CRON_SECRET`, then existing `serviceAuthorizationHeaderValue()` so POST `/api/epicon/promote` auth aligns with `SUBSTRATE_TOKEN` when configured.
- **`lib/ledger.ts`** + **`lib/substrate/client.ts`**: Introduce `TERMINAL_REGISTRATION` (getter-based `terminal_id` / `api_base`) and use it in `attestToLedger` so Render ledger payloads always carry terminal routing fields.
- **`lib/agents/micro/index.ts`** + **`instrument-polls.ts`**: HERMES-µ3/µ4 omit dead or empty-lane scores from the GI composite average (instead of neutral 0.5); shorten GDELT/Reddit fetch timeouts to 6s.
- **`app/api/cron/sweep/route.ts`**: Probe `/api/agents/ledger-zeus`; on inconclusive/non-OK/empty journal, fall back to last resolved status in KV (`zeus:last-resolved-status`); expose `zeus_verification` / `zeus_verification_resolved` in JSON.
- **`app/api/cron/reattest-seals/route.ts`**: One-time migration (`reattest:c314-migration-done`) clears reattempt KV keys for the eight legacy seal IDs and resets `permanently-failed` seals back to `quarantined` when present.
- **`lib/swarm/budget.ts`**: Read `SWARM_DAILY_BUDGET_USD` (fallback `DAILY_LLM_BUDGET_USD`), default daily cap **$1.00** when unset. Swarm route already implements Haiku tier fallback when ATLAS credits are exhausted (C-312 FIX-06) — unchanged.
- **`vercel.json`**: `ignoreCommand` already points at `bash scripts/ignore-build.sh` — unchanged.
- **`app/api/cron/journal-canonize/route.ts`**: `github_direct_write_configured` is false when substrate repo targets (`JOURNAL_CANON_SUBSTRATE_TARGET` / `SUBSTRATE_GITHUB_REPO` / `GITHUB_REPO_URL`) are set, even if a GitHub token exists.
- **`CONTRIBUTING.md`**: Notes on expected “Unverified” automation commits and GPG options.

## Ops (Vercel — not in repo)

Set or confirm: `TERMINAL_ID`, `TERMINAL_API_BASE`, `SWARM_DAILY_BUDGET_USD=1.0`, `SUBSTRATE_TOKEN` aligned with `/api/epicon/promote`, `CRON_SECRET`, `JOURNAL_HARD_CAP` as needed.

## Verification

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- `pnpm lint` — **not run** (Next.js 16 migration prompt is interactive in this environment)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

