### PR TITLE
C-314: Vault substrate burst, fountain sweep, GI carry-forward

### DIFF
--- a/app/api/cron/reattest-seals/route.ts
+++ b/app/api/cron/reattest-seals/route.ts
@@ -24,13 +24,14 @@ import { backAttestSeal, buildBackAttestRationale } from '@/lib/vault-v2/back-at
 import { attestReserveBlockToSubstrate, dequeueSubstrateRetry } from '@/lib/vault-v2/substrate-attestation';
 import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
 import { releaseReplayPressureForAttestedSeal } from '@/lib/mic/replayPressure';
-import { kvGet, kvSet, kvDel } from '@/lib/kv/store';
+import { kvGet, kvSet, kvDel, isRedisAvailable } from '@/lib/kv/store';
 import type { Seal } from '@/lib/vault-v2/types';
 
 export const dynamic = 'force-dynamic';
 
 // C-314 T-07: one-time KV reset for seals that looped before TERMINAL_REGISTRATION was fixed.
-const LEGACY_STUCK_SEALS = [
+// Expanded list: legacy v1 parcel IDs (C-288 … C-307-041) that share the same reattest backoff keys.
+const LEGACY_SEAL_KV_RESET_IDS = [
   'seal-C-288-001',
   'seal-C-292-001',
   'seal-C-293-001',
@@ -39,30 +40,97 @@ const LEGACY_STUCK_SEALS = [
   'seal-C-296-001',
   'seal-C-297-001',
   'seal-C-298-001',
+  'seal-C-299-001',
+  'seal-C-300-002',
+  'seal-C-300-003',
+  'seal-C-300-004',
+  'seal-C-301-005',
+  'seal-C-301-006',
+  'seal-C-301-007',
+  'seal-C-302-008',
+  'seal-C-302-009',
+  'seal-C-302-010',
+  'seal-C-302-011',
+  'seal-C-303-012',
+  'seal-C-303-013',
+  'seal-C-303-014',
+  'seal-C-303-015',
+  'seal-C-303-016',
+  'seal-C-304-017',
+  'seal-C-304-018',
+  'seal-C-304-019',
+  'seal-C-304-020',
+  'seal-C-304-021',
+  'seal-C-304-022',
+  'seal-C-304-023',
+  'seal-C-305-024',
+  'seal-C-305-025',
+  'seal-C-305-026',
+  'seal-C-305-027',
+  'seal-C-305-028',
+  'seal-C-306-029',
+  'seal-C-306-030',
+  'seal-C-306-031',
+  'seal-C-306-032',
+  'seal-C-306-033',
+  'seal-C-306-034',
+  'seal-C-306-035',
+  'seal-C-307-036',
+  'seal-C-307-037',
+  'seal-C-307-038',
+  'seal-C-307-039',
+  'seal-C-307-040',
+  'seal-C-307-041',
 ] as const;
+
 const C314_REATTEST_MIGRATION_KEY = 'reattest:c314-migration-done';
+/** One-time burst repair after TERMINAL_ID / TERMINAL_API_BASE + ledger client fix (C-314). */
+const SUBSTRATE_FIX_C314_KEY = 'reattest:substrate-fix-c314-done';
 
 async function runLegacySealMigration(allSeals: Seal[]): Promise<void> {
+  if (!isRedisAvailable()) {
+    console.warn('[reattest-seals] C-314 legacy migration skipped — KV not configured');
+    return;
+  }
+
   const done = await kvGet<boolean>(C314_REATTEST_MIGRATION_KEY);
   if (done) return;
 
   console.info('[reattest-seals] C-314 migration: clearing stuck quarantine / reattest KV for legacy seal IDs');
-  for (const sealId of LEGACY_STUCK_SEALS) {
-    await kvDel(`seal:${sealId}:reattest_attempts`).catch(() => {});
-    await kvDel(`seal:${sealId}:reattest_last_attempt`).catch(() => {});
+  let migrationOk = true;
+
+  for (const sealId of LEGACY_SEAL_KV_RESET_IDS) {
+    const delAttempts = await kvDel(`seal:${sealId}:reattest_attempts`);
+    const delLast = await kvDel(`seal:${sealId}:reattest_last_attempt`);
+    if (!delAttempts && !delLast) {
+      // Keys may be absent; kvDel returns false when Redis unavailable (already guarded).
+    }
+
     const seal = allSeals.find((s) => s.seal_id === sealId);
     if (seal && seal.status === 'permanently-failed') {
-      await writeSeal({
-        ...seal,
-        status: 'quarantined',
-        substrate_attestation_error: null,
-      }).catch((e) => {
+      try {
+        await writeSeal({
+          ...seal,
+          status: 'quarantined',
+          substrate_attestation_error: null,
+        });
+      } catch (e) {
+        migrationOk = false;
         console.warn(`[reattest-seals] migration: could not reset seal ${sealId}`, e);
-      });
+      }
     }
     console.info(`[reattest-seals] migration reset keys for ${sealId}`);
   }
-  await kvSet(C314_REATTEST_MIGRATION_KEY, true, 365 * 24 * 3600).catch(() => {});
+
+  if (!migrationOk) {
+    console.error('[reattest-seals] C-314 legacy migration incomplete — not marking migration key');
+    return;
+  }
+
+  const setOk = await kvSet(C314_REATTEST_MIGRATION_KEY, true, 365 * 24 * 3600);
+  if (!setOk) {
+    console.error('[reattest-seals] C-314 legacy migration: failed to persist migration key');
+  }
 }
 
 // Max reattest attempts before a seal is marked permanently-failed (prevents infinite loops).
@@ -103,21 +171,34 @@ function needsSubstratePointerRepair(seal: Seal): boolean {
   );
 }
 
+type SubstrateRetryOpts = {
+  /** When true, ignore exponential backoff (C-314 burst migration). */
+  skipBackoff?: boolean;
+  /** When true, only record attempts on failure (burst should not penalize successes). */
+  burstMode?: boolean;
+};
+
 async function retrySubstratePointer(
   seal: Seal,
   results: Array<{ seal_id: string; agent: string; ok: boolean; transition?: string; error?: string }>,
   errors: string[],
   reason: 'stuck-quarantined' | 'stale-substrate-pointer',
+  opts?: SubstrateRetryOpts,
 ): Promise<void> {
-  if (await shouldSkipRetry(seal.seal_id)) {
+  if (!opts?.skipBackoff && (await shouldSkipRetry(seal.seal_id))) {
     results.push({ seal_id: seal.seal_id, agent: 'substrate-write', ok: true, transition: 'skipped-backoff' });
     return;
   }
+
+  let recordAttempt = !opts?.burstMode;
 
   try {
     console.warn('[reattest-seals] forcing substrate write', { seal_id: seal.seal_id, reason });
     const substrate = await attestReserveBlockToSubstrate(seal);
     const substrateError = substrate.ok ? null : (substrate.error ?? 'substrate_write_failed');
+    if (opts?.burstMode) {
+      recordAttempt = !substrate.ok;
+    }
 
     const updatedSeal: Seal = {
       ...seal,
@@ -160,12 +241,73 @@ async function retrySubstratePointer(
       error: substrateError ?? undefined,
     });
   } catch (e) {
+    recordAttempt = true;
     const msg = `[substrate-retry:${reason}] ${seal.seal_id}: ${e instanceof Error ? e.message : String(e)}`;
     errors.push(msg);
     results.push({ seal_id: seal.seal_id, agent: 'substrate-write', ok: false, error: msg });
   }
 
-  await recordReattestAttempt(seal.seal_id);
+  if (recordAttempt) {
+    await recordReattestAttempt(seal.seal_id);
+  }
+}
+
+async function runSubstrateFixBurstC314(
+  seals: Seal[],
+  results: Array<{ seal_id: string; agent: string; ok: boolean; transition?: string; error?: string }>,
+  errors: string[],
+): Promise<{ ranBurst: boolean; targets: number; remainingAfter: number }> {
+  const already = await kvGet<boolean>(SUBSTRATE_FIX_C314_KEY);
+  if (already) {
+    return { ranBurst: false, targets: 0, remainingAfter: 0 };
+  }
+  if (!isRedisAvailable()) {
+    console.warn('[reattest-seals] C-314 substrate burst skipped — KV not configured');
+    return { ranBurst: false, targets: 0, remainingAfter: 0 };
+  }
+
+  const targets = seals.filter(needsSubstratePointerRepair);
+  if (targets.length === 0) {
+    const setOk = await kvSet(SUBSTRATE_FIX_C314_KEY, true, 365 * 24 * 3600);
+    if (!setOk) {
+      console.error('[reattest-seals] C-314 substrate burst: could not set completion key (nothing to repair)');
+    }
+    return { ranBurst: true, targets: 0, remainingAfter: 0 };
+  }
+
+  console.info(`[reattest-seals] C-314 substrate burst migration: ${targets.length} seals (no backoff)`);
+
+  for (const seal of targets) {
+    await kvDel(`seal:${seal.seal_id}:reattest_attempts`);
+    await kvDel(`seal:${seal.seal_id}:reattest_last_attempt`);
+    await retrySubstratePointer(seal, results, errors, 'stale-substrate-pointer', {
+      skipBackoff: true,
+      burstMode: true,
+    });
+  }
+
+  let remainingAfter = targets.length;
+  try {
+    const refreshed = await listAllSeals(500);
+    remainingAfter = refreshed.filter(needsSubstratePointerRepair).length;
+  } catch {
+    remainingAfter = targets.length;
+  }
+
+  if (remainingAfter === 0) {
+    const setOk = await kvSet(SUBSTRATE_FIX_C314_KEY, true, 365 * 24 * 3600);
+    if (!setOk) {
+      console.error('[reattest-seals] C-314 substrate burst: completion KV SET failed — will retry next cron');
+    } else {
+      console.info('[reattest-seals] C-314 substrate burst migration complete — all targets repaired');
+    }
+  } else {
+    console.warn('[reattest-seals] C-314 substrate burst incomplete — completion key not set', {
+      remainingAfter,
+    });
+  }
+
+  return { ranBurst: true, targets: targets.length, remainingAfter };
 }
 
 export async function GET(req: NextRequest) {
@@ -190,7 +332,7 @@ export async function GET(req: NextRequest) {
 
   let allSeals: Seal[] = [];
   try {
-    allSeals = await listAllSeals(200);
+    allSeals = await listAllSeals(500);
   } catch (e) {
     return NextResponse.json({
       ok: false,
@@ -200,9 +342,18 @@ export async function GET(req: NextRequest) {
 
   await runLegacySealMigration(allSeals);
   try {
-    allSeals = await listAllSeals(200);
+    allSeals = await listAllSeals(500);
   } catch {
     // keep prior list if refresh fails
+  }
+
+  const substrateBurst = await runSubstrateFixBurstC314(allSeals, results, errors);
+  if (substrateBurst.ranBurst) {
+    try {
+      allSeals = await listAllSeals(500);
+    } catch {
+      // keep prior list if refresh fails
+    }
   }
 
   const quarantined = allSeals.filter((s) => s.status === 'quarantined');
@@ -318,6 +469,7 @@ export async function GET(req: NextRequest) {
     ok: errors.length === 0,
     at: new Date().toISOString(),
     duration_ms: Date.now() - started,
+    c314_substrate_burst: substrateBurst,
     quarantined_found: quarantined.length,
     stuck_fully_attested: fullyAttestedButStuck.length,
     stale_substrate_pointers: staleSubstratePointers.length,

--- a/app/api/cron/vault-attestation/route.ts
+++ b/app/api/cron/vault-attestation/route.ts
@@ -30,6 +30,7 @@ import {
   getInProgressBalance,
   listAllSeals,
   listSeals,
+  writeSeal,
 } from '@/lib/vault-v2/store';
 import { evaluateQuorum, finalizeSeal, injectTimeouts } from '@/lib/vault-v2/seal';
 import { tryFormNextCandidate } from '@/lib/vault-v2/deposit';
@@ -57,6 +58,8 @@ export const dynamic = 'force-dynamic';
 // double-trigger (sweeper + cron) doesn't cause redundant Render round-trips.
 const MIN_RUN_INTERVAL_MS = 4 * 60 * 1000;
 const VAULT_ATTEST_LAST_RUN_KEY = 'vault-attestation:lastRun';
+const SUBSTRATE_FIX_C314_KEY = 'reattest:substrate-fix-c314-done';
+const FOUNTAIN_SWEEP_C314_KEY = 'vault:fountain-sweep-c314-done';
 
 type CandidateState =
   | 'none'
@@ -95,6 +98,8 @@ type Report = {
   seals_quarantined_total: number;
   quarantined_needing_reattestation: QuarantinedSealDigest[];
   fountain_pending_count: number;
+  /** C-314: one-time sweep pending → activating after substrate repair. */
+  fountain_c314_sweep: { transitioned: number; skipped: string | null } | null;
   errors: string[];
 };
 
@@ -106,6 +111,51 @@ function readAttestationConfidence(attestation: unknown): number {
   const maybe = attestation as { confidence?: unknown } | null;
   const confidence = typeof maybe?.confidence === 'number' ? maybe.confidence : 0.75;
   return Math.max(0, Math.min(1, confidence));
+}
+
+function sealHasCompleteQuorum(seal: Seal): boolean {
+  return SENTINEL_AGENTS.every((agent) => Boolean(seal.attestations[agent]));
+}
+
+/**
+ * C-314 FIX-5: after substrate burst marks complete, advance fountain from `pending`
+ * to `activating` for attested seals that now have a valid substrate pointer.
+ */
+async function runFountainSweepC314(): Promise<{ transitioned: number; skipped: string | null }> {
+  const done = await kvGet<boolean>(FOUNTAIN_SWEEP_C314_KEY);
+  if (done) {
+    return { transitioned: 0, skipped: 'already_done' };
+  }
+
+  const substrateDone = await kvGet<boolean>(SUBSTRATE_FIX_C314_KEY);
+  if (!substrateDone) {
+    console.info('[vault-attestation] C-314 fountain sweep deferred — substrate burst not complete');
+    return { transitioned: 0, skipped: 'substrate_incomplete' };
+  }
+
+  const seals = await listAllSeals(500);
+  let transitioned = 0;
+
+  for (const seal of seals) {
+    if (seal.status !== 'attested') continue;
+    if (seal.fountain_status !== 'pending') continue;
+    if (!seal.substrate_attestation_id || !seal.substrate_event_hash) continue;
+    if (seal.substrate_attestation_error) continue;
+    if (!sealHasCompleteQuorum(seal)) continue;
+
+    await writeSeal({
+      ...seal,
+      fountain_status: 'activating',
+    });
+    transitioned += 1;
+  }
+
+  const setOk = await kvSet(FOUNTAIN_SWEEP_C314_KEY, true, 365 * 24 * 3600);
+  if (!setOk) {
+    console.error('[vault-attestation] C-314 fountain sweep: could not persist completion key');
+  }
+  console.info('[vault-attestation] C-314 fountain sweep complete', { transitioned });
+  return { transitioned, skipped: null };
 }
 
 export async function GET(req: NextRequest) {
@@ -303,6 +353,7 @@ export async function GET(req: NextRequest) {
   // The idle fast-path now only skips the fountain/attested count reads; the
   // quarantined-seal scan always runs so back-attestation can clear the backlog.
   let fountain_pending_count = 0;
+  let fountain_c314_sweep: Report['fountain_c314_sweep'] = null;
   let seals_total = 0;
   let seals_attested_total = 0;
   let seals_audit_total = 0;
@@ -321,7 +372,7 @@ export async function GET(req: NextRequest) {
 
     try {
       // allSeals always fetched so quarantined back-attestation runs even when idle.
-      const allSeals = await listAllSeals(200);
+      const allSeals = await listAllSeals(500);
       const quarantined = allSeals.filter((s: Seal) => s.status === 'quarantined');
       seals_quarantined_total = quarantined.length;
       quarantined_needing_reattestation = quarantined.map((s: Seal) => ({
@@ -333,7 +384,7 @@ export async function GET(req: NextRequest) {
       // Full attested/fountain counts only when not idle (KV read budget).
       if (shouldScanAll) {
         const [seals, attestedCount, auditCount] = await Promise.all([
-          listSeals(200),
+          listSeals(500),
           countSeals(),
           countAllSeals(),
         ]);
@@ -382,6 +433,12 @@ export async function GET(req: NextRequest) {
     }
   }
 
+  try {
+    fountain_c314_sweep = await runFountainSweepC314();
+  } catch (e) {
+    errors.push(`fountain-sweep-c314: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
   const report: Report = {
     ok: errors.length === 0,
     at: new Date().toISOString(),
@@ -403,6 +460,7 @@ export async function GET(req: NextRequest) {
     seals_quarantined_total,
     quarantined_needing_reattestation,
     fountain_pending_count,
+    fountain_c314_sweep,
     errors,
   };
 

--- a/app/api/vault/migrate-v1/route.ts
+++ b/app/api/vault/migrate-v1/route.ts
@@ -5,6 +5,7 @@
 import { NextResponse } from 'next/server';
 import { createHash } from 'crypto';
 import { kvGetRaw, kvSetRawKey, kvDel, kvInspectSamples } from '@/lib/kv/store';
+import { TERMINAL_REGISTRATION } from '@/lib/ledger';
 
 export const dynamic = 'force-dynamic';
 
@@ -67,8 +68,9 @@ export async function POST(req: Request) {
     migration_cycle: cycle,
     operatorNote: operatorNote ?? null,
     source: 'terminal-migrate-v1',
-    terminal_base_url:
-      process.env.NEXT_PUBLIC_TERMINAL_URL ?? 'https://mobius-civic-ai-terminal.vercel.app',
+    terminal_base_url: TERMINAL_REGISTRATION.api_base,
+    terminal_id: TERMINAL_REGISTRATION.terminal_id,
+    api_base: TERMINAL_REGISTRATION.api_base,
   };
 
   await kvSetRawKey(v1Key, v2Seal);

--- a/lib/agents/micro/index.ts
+++ b/lib/agents/micro/index.ts
@@ -37,6 +37,8 @@ export interface MicroAgentSweepResult {
   agents: AgentPollResult[];
   allSignals: MicroSignal[];
   composite: number;
+  /** Agents that contributed a numeric slice to `composite` (C-314: excludes failed / empty polls). */
+  compositeContributorCount: number;
   anomalies: MicroSignal[];
   healthy: boolean;
   instrumentCount: number;
@@ -76,6 +78,10 @@ export async function pollAllMicroAgents(): Promise<MicroAgentSweepResult> {
       }
       continue;
     }
+    // C-314 FIX-7: do not average in "0" scores from failed / unhealthy polls — exclude them.
+    if (!agent.healthy || agent.errors.length > 0) {
+      continue;
+    }
     if (agent.signals.length === 0) {
       compositeParts.push(0.5);
       continue;
@@ -88,7 +94,7 @@ export async function pollAllMicroAgents(): Promise<MicroAgentSweepResult> {
   const composite =
     compositeParts.length > 0
       ? Number((compositeParts.reduce((sum, value) => sum + value, 0) / compositeParts.length).toFixed(3))
-      : 0.5;
+      : 0.75;
 
   const anomalies = allSignals.filter((s) => s.severity === 'elevated' || s.severity === 'critical');
 
@@ -97,6 +103,7 @@ export async function pollAllMicroAgents(): Promise<MicroAgentSweepResult> {
     agents,
     allSignals,
     composite,
+    compositeContributorCount: compositeParts.length,
     anomalies,
     healthy: agents.some((a) => a.healthy),
     instrumentCount: ALL_INSTRUMENT_POLLS.length,

--- a/lib/signals/runMicroSweep.ts
+++ b/lib/signals/runMicroSweep.ts
@@ -6,6 +6,7 @@ import { pollAllMicroAgents } from '@/lib/agents/micro';
 import {
   saveSignalSnapshot,
   isRedisAvailable,
+  kvGet,
   kvSet,
   KV_KEYS,
   KV_TTL_SECONDS,
@@ -18,6 +19,8 @@ import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
 
 let lastLedgerPushMs = 0;
 const LEDGER_PUSH_INTERVAL_MS = 10 * 60 * 1000;
+/** C-314 FIX-7: when no micro agents contribute, carry forward last valid GI instead of a synthetic floor. */
+const GI_LAST_VALID_KEY = 'gi:last-valid';
 
 export type MicroSweepResult = Awaited<ReturnType<typeof pollAllMicroAgents>>;
 
@@ -25,7 +28,17 @@ export type MicroSweepResult = Awaited<ReturnType<typeof pollAllMicroAgents>>;
  * Runs full instrument poll and persists GI, signals, heartbeat, system pulse, sustain.
  */
 export async function runMicroSweepPipeline(now = Date.now()): Promise<MicroSweepResult> {
-  const result = await pollAllMicroAgents();
+  const polled = await pollAllMicroAgents();
+
+  let composite = polled.composite;
+  if (isRedisAvailable() && polled.compositeContributorCount === 0) {
+    const last = await kvGet<number>(GI_LAST_VALID_KEY);
+    if (typeof last === 'number' && Number.isFinite(last)) {
+      composite = Math.max(0, Math.min(1, last));
+    }
+  }
+
+  const result: MicroSweepResult = { ...polled, composite };
 
   const signalQuality =
     result.allSignals.length > 0
@@ -46,10 +59,19 @@ export async function runMicroSweepPipeline(now = Date.now()): Promise<MicroSwee
       gi_verification_method = `multi-source-consensus(${withinBand.length}/${highConf.length})`;
     }
   }
-  await saveGiStateFromMicroSweep({ composite: result.composite, signalQuality, preloadedGi: preGi, gi_verified, gi_verification_method });
+  await saveGiStateFromMicroSweep({
+    composite: result.composite,
+    signalQuality,
+    preloadedGi: preGi,
+    gi_verified,
+    gi_verification_method,
+  });
   await updateSustainTrackingFromGi(result.composite);
 
   if (isRedisAvailable()) {
+    if (result.compositeContributorCount > 0) {
+      void kvSet(GI_LAST_VALID_KEY, result.composite, 7 * 24 * 3600).catch(() => {});
+    }
     await saveSignalSnapshot({
       composite: result.composite,
       anomalies: result.anomalies?.length ?? 0,

--- a/lib/substrate/client.ts
+++ b/lib/substrate/client.ts
@@ -354,6 +354,12 @@ export async function attestToLedger(entry: SubstrateEntry): Promise<AttestToLed
     }
     const data = (await res.json()) as { id?: string; event_id?: string };
     const entryId = data.event_id ?? data.id ?? eventId;
+    console.info('[substrate] ledger attest confirmed', {
+      civic_id: requestBody.civic_id,
+      entry_id: entryId,
+      terminal_id,
+      api_base: api_base,
+    });
     void markSubmitted(entryId);
 
     const MIC_URL = (process.env.MIC_WALLET_URL ?? process.env.RENDER_MIC_URL ?? '').trim();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the remaining **code-side** items from the C-314 vault substrate recovery spec: a one-time **burst reattestation** for all attested seals with missing or errored substrate pointers, a **fountain lane sweep** once substrate repair completes, **GI composite** behavior that excludes failed micro polls (plus `gi:last-valid` carry-forward), **success logging** on ledger attest, **`migrate-v1`** terminal identity fields aligned with `TERMINAL_REGISTRATION`, and raises vault seal list reads to **500** so the full reserve backlog fits one pass.

**FIX-1 (Vercel env):** Operators must still set `TERMINAL_ID` and `TERMINAL_API_BASE` in Vercel Production — this PR does not replace that.

## Details

- **`reattest:substrate-fix-c314-done`**: Hourly cron runs `runSubstrateFixBurstC314` once until every `needsSubstratePointerRepair` seal clears; clears backoff keys per seal; uses burst mode on `retrySubstratePointer` (no backoff, no attempt increment on success). JSON adds `c314_substrate_burst`.
- **`reattest:c314-migration-done`**: Legacy seal list expanded to the full C-288…C-307-041 set; migration key is only set when Redis is available and the migration loop completes without write failures.
- **`vault:fountain-sweep-c314-done`**: After substrate key is set, `vault-attestation` transitions eligible seals from `fountain_status: pending` → `activating` when substrate pointer + quorum are valid. Report field `fountain_c314_sweep`.
- **GI**: `pollAllMicroAgents` skips unhealthy / errored agents for composite; empty contributor set uses **0.75** prior; `runMicroSweepPipeline` applies `gi:last-valid` KV carry-forward when no instruments contributed.
- **`attestToLedger`**: `console.info` on successful attest with `civic_id`, `entry_id`, `terminal_id`, `api_base`.

## Tests

- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass (includes typecheck in Next build)  
- `pnpm lint` — **not run to completion** (Next.js ESLint migration interactive prompt)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

