### PR TITLE
C-314: Journal chamber readability (feed first, collapsed pipeline)

### DIFF
--- a/app/api/chambers/journal/route.ts
+++ b/app/api/chambers/journal/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { GET as getJournal } from '@/app/api/agents/journal/route';
 import { chamberSavepointKey, resolveChamberSavepoint } from '@/lib/chambers/savepoint-cache';
+import { deriveTitleFromSummary } from '@/lib/journal/deriveTitle';
 import { kvLrange } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
@@ -174,6 +175,16 @@ async function respondWithSavepoint(payload: JournalChamberPayload, scope: Recor
   });
 }
 
+function enrichJournalEntryForDisplay(entry: unknown): unknown {
+  const row = entry as Record<string, unknown>;
+  const obs = typeof row.observation === 'string' ? row.observation : '';
+  const inf = typeof row.inference === 'string' ? row.inference : '';
+  const summarySource = [obs, inf].filter((s) => s.trim().length > 0).join('\n\n');
+  const existing = typeof row.title === 'string' ? row.title.trim() : '';
+  const title = existing.length > 0 ? existing : deriveTitleFromSummary(summarySource);
+  return { ...row, title };
+}
+
 function clampWindowHours(input: string | null): number {
   const parsed = Number(input ?? String(WINDOW_HOURS_DEFAULT));
   if (!Number.isFinite(parsed) || parsed <= 0) return WINDOW_HOURS_DEFAULT;
@@ -216,11 +227,16 @@ export async function GET(request: NextRequest) {
       [key: string]: unknown;
     };
     const agentSet = new Set(requestedAgents);
-    let entries = (json.entries ?? []).filter((entry) => entryIsInAgents(entry, agentSet)).slice(0, limit);
+    let entries = (json.entries ?? [])
+      .filter((entry) => entryIsInAgents(entry, agentSet))
+      .slice(0, limit)
+      .map(enrichJournalEntryForDisplay);
     let usedKvFallback = false;
 
     if (entries.length === 0 && mode !== 'canon') {
-      entries = await loadKvHotJournalEntries({ requestedAgents, cycle, windowHours, limit });
+      entries = (await loadKvHotJournalEntries({ requestedAgents, cycle, windowHours, limit })).map(
+        enrichJournalEntryForDisplay,
+      );
       usedKvFallback = entries.length > 0;
     }
 
@@ -256,9 +272,10 @@ export async function GET(request: NextRequest) {
     };
     return respondWithSavepoint(payload, savepointScope);
   } catch (error) {
-    const fallbackEntries = mode !== 'canon'
+    const rawFallback = mode !== 'canon'
       ? await loadKvHotJournalEntries({ requestedAgents, cycle, windowHours, limit })
       : [];
+    const fallbackEntries = rawFallback.map(enrichJournalEntryForDisplay);
     return respondWithSavepoint(
       {
         ok: true,

--- a/app/terminal/journal/JournalPageClient.tsx
+++ b/app/terminal/journal/JournalPageClient.tsx
@@ -1,27 +1,25 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import JournalEntryCard from '@/components/terminal/journal/JournalEntryCard';
+import { JournalFeed } from '@/components/journal/JournalFeed';
+import { JournalHeader } from '@/components/journal/JournalHeader';
+import { JournalPipelinePanel } from '@/components/journal/JournalPipelinePanel';
+import { JournalToolbar, type SortMode, type ViewMode } from '@/components/journal/JournalToolbar';
+import type { JournalFeedCardEntry } from '@/components/journal/types';
 import ChamberEmptyState from '@/components/terminal/ChamberEmptyState';
 import ChamberSkeleton from '@/components/terminal/ChamberSkeleton';
 import { useJournalChamber, type DvaTier } from '@/hooks/useJournalChamber';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
-import type { JournalDisplayEntry, JournalDisplaySeverity, JournalDisplayStatus } from '@/lib/journal/types';
+import { deriveTitleFromSummary } from '@/lib/journal/deriveTitle';
+import {
+  sortJournalByAgent,
+  sortJournalByCycle,
+  sortJournalChronological,
+  sortJournalOperatorFirst,
+} from '@/lib/journal/operatorSort';
+import type { JournalDisplayEntry, JournalDisplaySeverity } from '@/lib/journal/types';
 
 const AGENTS = ['ATLAS', 'ZEUS', 'EVE', 'AUREA', 'HERMES', 'JADE', 'DAEDALUS', 'ECHO'] as const;
-const AGENT_FILTER_ORDER = ['ALL', 'EVE', 'ATLAS', 'ZEUS', 'HERMES', 'JADE', 'AUREA', 'DAEDALUS', 'ECHO'] as const;
-
-const AGENT_PILL_STYLE: Record<string, { border: string; activeBg: string; text: string }> = {
-  ALL: { border: 'border-slate-600', activeBg: 'bg-slate-700/40', text: 'text-slate-100' },
-  ATLAS: { border: 'border-cyan-600/50', activeBg: 'bg-cyan-500/15', text: 'text-cyan-100' },
-  EVE: { border: 'border-rose-500/50', activeBg: 'bg-rose-500/15', text: 'text-rose-100' },
-  ZEUS: { border: 'border-amber-600/50', activeBg: 'bg-amber-600/15', text: 'text-amber-100' },
-  JADE: { border: 'border-emerald-600/50', activeBg: 'bg-emerald-600/15', text: 'text-emerald-100' },
-  HERMES: { border: 'border-orange-600/50', activeBg: 'bg-orange-600/15', text: 'text-orange-100' },
-  AUREA: { border: 'border-amber-500/50', activeBg: 'bg-amber-500/15', text: 'text-amber-50' },
-  DAEDALUS: { border: 'border-amber-900/60', activeBg: 'bg-amber-950/40', text: 'text-amber-200' },
-  ECHO: { border: 'border-slate-500/50', activeBg: 'bg-slate-600/20', text: 'text-slate-100' },
-};
 
 const DVA_TIERS: Array<{ id: DvaTier; label: string; desc: string; color: string; border: string; activeBg: string }> = [
   { id: 'ALL', label: 'ALL', desc: 'All agents', color: 'text-slate-100', border: 'border-slate-600', activeBg: 'bg-slate-700/40' },
@@ -56,22 +54,32 @@ type EpiconItem = {
 function normalizeAgentName(value: unknown): string {
   return typeof value === 'string' ? value.trim().toUpperCase() : '';
 }
+
 function resolveDvaTierAgents(tier: DvaTier): readonly string[] {
   return tier === 'ALL' ? [] : DVA_TIER_AGENT_MAP[tier] ?? [];
 }
+
 function journalEntryAgent(entry: JournalDisplayEntry): string {
   const candidate = entry as JournalDisplayEntry & { agentOrigin?: string; sourceAgent?: string; author?: string };
-  return normalizeAgentName(candidate.agentOrigin) || normalizeAgentName(candidate.agent) || normalizeAgentName(candidate.sourceAgent) || normalizeAgentName(candidate.author);
+  return (
+    normalizeAgentName(candidate.agentOrigin)
+    || normalizeAgentName(candidate.agent)
+    || normalizeAgentName(candidate.sourceAgent)
+    || normalizeAgentName(candidate.author)
+  );
 }
+
 function entryMatchesDvaTier(entry: JournalDisplayEntry, tier: DvaTier): boolean {
   const allowed = resolveDvaTierAgents(tier);
   if (allowed.length === 0) return true;
   const agent = journalEntryAgent(entry);
   return agent.length > 0 && allowed.includes(agent);
 }
+
 function isDerivableEpiconItem(item: EpiconItem): boolean {
   return item.type === 'zeus-verify' || item.author === 'cursor-agent' || item.author === 'mobius-bot' || item.type === 'heartbeat';
 }
+
 function deriveAgent(item: EpiconItem): string {
   const tags = (item.tags ?? []).map((tag) => tag.toLowerCase());
   if (item.type === 'zeus-verify') return 'ZEUS';
@@ -80,20 +88,26 @@ function deriveAgent(item: EpiconItem): string {
   if (item.author === 'mobius-bot') return 'ECHO';
   return 'ATLAS';
 }
+
 function epiconSeverityToJournal(sev: string): JournalDisplaySeverity {
   const s = sev.toLowerCase();
   if (s === 'critical' || s === 'high') return 'critical';
   if (s === 'elevated' || s === 'medium') return 'elevated';
   return 'nominal';
 }
+
 function toDerivedEntry(item: EpiconItem, cycle: string): JournalDisplayEntry {
+  const observation = item.title;
+  const inference = `${item.type} observed via EPICON ${item.source}.`;
+  const summaryBlob = [observation, inference].join('\n\n');
   return {
     id: `derived-${item.id}`,
     agent: deriveAgent(item),
     cycle,
+    title: deriveTitleFromSummary(summaryBlob),
     category: item.type,
-    observation: item.title,
-    inference: `${item.type} observed via EPICON ${item.source}.`,
+    observation,
+    inference,
     recommendation: 'Continue monitoring until native substrate journals are online.',
     source: 'epicon-derived',
     timestamp: item.timestamp,
@@ -101,54 +115,42 @@ function toDerivedEntry(item: EpiconItem, cycle: string): JournalDisplayEntry {
     severity: epiconSeverityToJournal(item.severity ?? 'nominal'),
   };
 }
-function parseCycleOrdinal(cycle: string | undefined): number {
-  const c = cycle?.trim() ?? '';
-  const n = parseInt(c.replace(/\D/g, ''), 10);
-  return Number.isFinite(n) ? n : 0;
-}
-function statusRank(s: JournalDisplayStatus | undefined): number {
-  if (s === 'verified') return 4;
-  if (s === 'committed') return 3;
-  if (s === 'contested') return 2;
-  if (s === 'draft') return 1;
-  return 2;
-}
-function severityRank(s: JournalDisplaySeverity | undefined): number {
-  if (s === 'critical') return 3;
-  if (s === 'elevated') return 2;
-  if (s === 'nominal') return 1;
-  return 0;
-}
-function sortJournalOperatorFirst(rows: JournalDisplayEntry[], focusCycleId: string): JournalDisplayEntry[] {
-  const focus = focusCycleId.trim();
-  return [...rows].sort((a, b) => {
-    const aCurrent = (a.cycle?.trim() ?? '') === focus ? 1 : 0;
-    const bCurrent = (b.cycle?.trim() ?? '') === focus ? 1 : 0;
-    if (aCurrent !== bCurrent) return bCurrent - aCurrent;
-    const cycA = parseCycleOrdinal(a.cycle);
-    const cycB = parseCycleOrdinal(b.cycle);
-    if (cycA !== cycB) return cycB - cycA;
-    const stA = statusRank(a.status);
-    const stB = statusRank(b.status);
-    if (stA !== stB) return stB - stA;
-    const sevA = severityRank(a.severity);
-    const sevB = severityRank(b.severity);
-    if (sevA !== sevB) return sevB - sevA;
-    const confA = typeof a.confidence === 'number' && Number.isFinite(a.confidence) ? a.confidence : -1;
-    const confB = typeof b.confidence === 'number' && Number.isFinite(b.confidence) ? b.confidence : -1;
-    if (confA !== confB) return confB - confA;
-    return new Date(b.timestamp ?? 0).getTime() - new Date(a.timestamp ?? 0).getTime();
-  });
+
+function toFeedCard(entry: JournalDisplayEntry, readMode: 'hot' | 'canon' | 'merged'): JournalFeedCardEntry {
+  const agent = journalEntryAgent(entry);
+  const obs = entry.observation ?? '';
+  const inf = entry.inference ?? '';
+  const rec = (entry.recommendation ?? '').trim();
+  const summary = [obs, inf, rec && rec !== inf ? rec : ''].filter(Boolean).join('\n\n') || '—';
+  const title = (entry.title ?? '').trim() || deriveTitleFromSummary(summary);
+  const lane: JournalFeedCardEntry['lane'] = readMode === 'hot' ? 'HOT' : readMode === 'canon' ? 'CANON' : 'SHAPE';
+  return {
+    id: entry.id,
+    agent,
+    cycle: entry.cycle?.trim() || '—',
+    lane,
+    title,
+    summary,
+    timestamp: entry.timestamp ?? '',
+    gi_at_time: entry.confidence ?? null,
+    event_type: entry.category,
+    tags: [],
+    raw: { ...entry, title },
+  };
 }
 
 export default function JournalPageClient() {
   const [currentCycle, setCurrentCycle] = useState(() => currentCycleId());
   const [entries, setEntries] = useState<JournalDisplayEntry[] | null>(null);
-  const [agent, setAgent] = useState('ALL');
-  const [cycleTab, setCycleTab] = useState<string>('All');
   const [derivedMode, setDerivedMode] = useState(false);
   const [readMode, setReadMode] = useState<'hot' | 'canon' | 'merged'>('hot');
   const [dvaTier, setDvaTier] = useState<DvaTier>('ALL');
+  const [sort, setSort] = useState<SortMode>('newest');
+  const [view, setView] = useState<ViewMode>('feed');
+  const [search, setSearch] = useState('');
+  const [activeAgents, setActiveAgents] = useState<Set<string>>(() => new Set());
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
+
   const journal = useJournalChamber(true, readMode, 100, dvaTier);
   const journalEntries = useMemo(() => (journal.data?.entries ?? []) as JournalDisplayEntry[], [journal.data?.entries]);
   const activeTier = useMemo(() => DVA_TIERS.find((tier) => tier.id === dvaTier), [dvaTier]);
@@ -157,10 +159,11 @@ export default function JournalPageClient() {
   const missingRelatedTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
-    const refreshCurrentCycle = () => setCurrentCycle((previous) => {
-      const next = currentCycleId();
-      return previous === next ? previous : next;
-    });
+    const refreshCurrentCycle = () =>
+      setCurrentCycle((previous) => {
+        const next = currentCycleId();
+        return previous === next ? previous : next;
+      });
     refreshCurrentCycle();
     const timerId = window.setInterval(refreshCurrentCycle, CURRENT_CYCLE_REFRESH_MS);
     return () => window.clearInterval(timerId);
@@ -172,25 +175,31 @@ export default function JournalPageClient() {
       missingRelatedTimerRef.current = null;
     }
   }, []);
+
   useEffect(() => clearMissingRelatedTimer, [clearMissingRelatedTimer]);
+
   const registerAnchor = useCallback((id: string, el: HTMLElement | null) => {
     if (el) anchorsRef.current.set(id, el);
     else anchorsRef.current.delete(id);
   }, []);
-  const onRelatedClick = useCallback((journalEntryId: string) => {
-    clearMissingRelatedTimer();
-    const el = anchorsRef.current.get(journalEntryId);
-    if (el) {
-      setMissingRelatedId(null);
-      el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-      return;
-    }
-    setMissingRelatedId(journalEntryId);
-    missingRelatedTimerRef.current = window.setTimeout(() => {
-      setMissingRelatedId(null);
-      missingRelatedTimerRef.current = null;
-    }, 5000);
-  }, [clearMissingRelatedTimer]);
+
+  const onRelatedClick = useCallback(
+    (journalEntryId: string) => {
+      clearMissingRelatedTimer();
+      const el = anchorsRef.current.get(journalEntryId);
+      if (el) {
+        setMissingRelatedId(null);
+        el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        return;
+      }
+      setMissingRelatedId(journalEntryId);
+      missingRelatedTimerRef.current = window.setTimeout(() => {
+        setMissingRelatedId(null);
+        missingRelatedTimerRef.current = null;
+      }, 5000);
+    },
+    [clearMissingRelatedTimer],
+  );
 
   useEffect(() => {
     let mounted = true;
@@ -227,84 +236,264 @@ export default function JournalPageClient() {
     };
   }, [journalEntries, dvaTier, journal.loading, journal.error, journal.status, currentCycle]);
 
-  const currentCycleCount = useMemo(() => (entries ?? []).filter((entry) => (entry.cycle?.trim() ?? '') === currentCycle).length, [entries, currentCycle]);
-  const latestEntryCycle = useMemo(() => sortJournalOperatorFirst(entries ?? [], currentCycle)[0]?.cycle?.trim() || null, [entries, currentCycle]);
+  const currentCycleCount = useMemo(
+    () => (entries ?? []).filter((entry) => (entry.cycle?.trim() ?? '') === currentCycle).length,
+    [entries, currentCycle],
+  );
+  const latestEntryCycle = useMemo(
+    () => sortJournalOperatorFirst(entries ?? [], currentCycle)[0]?.cycle?.trim() || null,
+    [entries, currentCycle],
+  );
   const shouldShowGlobalHotCycleLag = readMode === 'hot' && dvaTier === 'ALL';
   const cycleLagging = shouldShowGlobalHotCycleLag && (entries?.length ?? 0) > 0 && currentCycleCount === 0;
 
-  const agentCounts = useMemo(() => {
-    const m = new Map<string, number>();
-    for (const e of entries ?? []) {
-      const a = (e.agent ?? '').trim() || 'UNKNOWN';
-      m.set(a, (m.get(a) ?? 0) + 1);
-    }
-    return m;
-  }, [entries]);
-  const agentPills = useMemo(() => AGENT_FILTER_ORDER.map((name) => ({ name, count: name === 'ALL' ? (entries?.length ?? 0) : agentCounts.get(name) ?? 0 })), [entries, agentCounts]);
-  const cycleOptions = useMemo(() => {
-    const set = new Set<string>();
-    for (const e of entries ?? []) {
-      const c = e.cycle?.trim();
-      if (c) set.add(c);
-    }
-    const list = Array.from(set).sort((a, b) => {
-      const na = parseInt(a.replace(/\D/g, ''), 10);
-      const nb = parseInt(b.replace(/\D/g, ''), 10);
-      if (Number.isFinite(na) && Number.isFinite(nb) && na !== nb) return nb - na;
-      return b.localeCompare(a);
-    });
-    if (!list.includes(currentCycle)) list.unshift(currentCycle);
-    return ['All', ...list];
+  const stats = useMemo(() => {
+    const list = entries ?? [];
+    const agents = new Set(list.map((e) => journalEntryAgent(e)).filter(Boolean));
+    const canonCount = list.filter(
+      (e) => Boolean((e as JournalDisplayEntry & { canonical_path?: string }).canonical_path) || e.source_mode === 'substrate',
+    ).length;
+    return {
+      total: list.length,
+      agentCount: agents.size,
+      currentCycle,
+      canonCount,
+    };
   }, [entries, currentCycle]);
-  useEffect(() => {
-    if (entries && cycleTab !== 'All' && !cycleOptions.includes(cycleTab)) setCycleTab(currentCycle);
-  }, [cycleOptions, currentCycle, cycleTab, entries]);
-  const cycleCounts = useMemo(() => {
-    const m = new Map<string, number>();
-    for (const e of entries ?? []) {
-      const c = e.cycle?.trim();
-      if (c) m.set(c, (m.get(c) ?? 0) + 1);
+
+  const readerRows = useMemo(() => {
+    const list = entries ?? [];
+    const q = search.trim().toLowerCase();
+    let rows = list.filter((e) => {
+      if (activeAgents.size === 0) return true;
+      return activeAgents.has(journalEntryAgent(e));
+    });
+    if (q) {
+      rows = rows.filter((e) => {
+        const obs = (e.observation ?? '').toLowerCase();
+        const inf = (e.inference ?? '').toLowerCase();
+        const ag = journalEntryAgent(e).toLowerCase();
+        const cyc = (e.cycle ?? '').toLowerCase();
+        const tit = (e.title ?? '').toLowerCase();
+        return obs.includes(q) || inf.includes(q) || ag.includes(q) || cyc.includes(q) || tit.includes(q);
+      });
     }
-    return m;
-  }, [entries]);
-  const filtered = useMemo(() => {
-    let rows = entries ?? [];
-    if (cycleTab !== 'All') rows = rows.filter((e) => (e.cycle?.trim() ?? '') === cycleTab);
-    if (agent !== 'ALL') rows = rows.filter((e) => e.agent === agent);
-    return sortJournalOperatorFirst(rows, currentCycle);
-  }, [entries, agent, cycleTab, currentCycle]);
+
+    let sorted: JournalDisplayEntry[];
+    switch (sort) {
+      case 'oldest':
+        sorted = sortJournalChronological(rows, 'asc');
+        break;
+      case 'agent':
+        sorted = sortJournalByAgent(rows);
+        break;
+      case 'cycle':
+        sorted = sortJournalByCycle(rows);
+        break;
+      case 'operator':
+        sorted = sortJournalOperatorFirst(rows, currentCycle);
+        break;
+      default:
+        sorted = sortJournalChronological(rows, 'desc');
+    }
+    return sorted.map((e) => toFeedCard(e, readMode));
+  }, [entries, search, activeAgents, sort, currentCycle, readMode]);
+
+  function toggleAgent(agent: string) {
+    if (agent === 'ALL') {
+      setActiveAgents(new Set());
+      return;
+    }
+    setActiveAgents((prev) => {
+      const next = new Set(prev);
+      if (next.has(agent)) next.delete(agent);
+      else next.add(agent);
+      return next;
+    });
+  }
+
+  function toggleExpand(id: string) {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
 
   if (entries === null) return <ChamberSkeleton blocks={8} />;
 
   return (
-    <div className="h-full overflow-y-auto p-4">
-      {derivedMode ? <div className="mb-3 rounded border border-amber-500/40 bg-amber-950/20 px-3 py-2 text-xs text-amber-100">Derived from EPICON feed · {dvaTier === 'ALL' ? 'all-agent fallback' : 'tier-scoped fallback'} · Native journals pending SUBSTRATE_GITHUB_TOKEN</div> : null}
-      {journal.preview && !journal.full ? <div className="mb-3 rounded border border-cyan-500/40 bg-cyan-950/20 px-3 py-2 text-xs text-cyan-100">Preview from snapshot · chamber enrichment in progress</div> : null}
-      {cycleLagging ? <div className="mb-3 rounded border border-violet-500/40 bg-violet-950/20 px-3 py-2 text-xs text-violet-100">Current cycle active · <span className="font-mono">{currentCycle}</span> has no HOT entries yet. Showing latest available cycle <span className="font-mono">{latestEntryCycle ?? '—'}</span> until the next automation write.</div> : null}
-      {journal.data?.scoped ? <div className="mb-3 rounded border border-slate-700/60 bg-slate-950/40 px-3 py-2 text-[11px] text-slate-300">Tier scope active · {(journal.data.tier_agents ?? []).join(' + ') || activeTier?.label || 'selected agents'}</div> : null}
-      {journal.error ? <div className="mb-3 rounded border border-amber-500/40 bg-amber-950/20 px-3 py-2 text-xs text-amber-100">Journal chamber degraded · showing snapshot/derived preview</div> : null}
-      {!journal.error && dvaTier !== 'ALL' && (journal.data as { fallback_reason?: string } | null)?.fallback_reason ? <div className="mb-3 rounded border border-slate-700/50 bg-slate-900/40 px-3 py-2 text-xs text-slate-400">{(journal.data as { fallback_reason?: string } | null)?.fallback_reason} · <button type="button" onClick={() => setDvaTier('ALL')} className="underline hover:text-slate-300">Show all agents</button></div> : null}
-      {journal.stabilizationActive ? <div className="mb-3 rounded border border-amber-700/50 bg-amber-950/30 px-3 py-2 text-xs text-amber-100">⚠ Predictive Stabilization Active · Preview state prioritized due to integrity drift</div> : null}
+    <div className="mx-auto h-full max-w-4xl overflow-y-auto p-4">
+      {derivedMode ? (
+        <div className="mb-3 rounded border border-amber-500/40 bg-amber-950/20 px-3 py-2 text-xs text-amber-100">
+          Derived from EPICON feed · {dvaTier === 'ALL' ? 'all-agent fallback' : 'tier-scoped fallback'} · Native journals
+          pending SUBSTRATE_GITHUB_TOKEN
+        </div>
+      ) : null}
+      {journal.preview && !journal.full ? (
+        <div className="mb-3 rounded border border-cyan-500/40 bg-cyan-950/20 px-3 py-2 text-xs text-cyan-100">
+          Preview from snapshot · chamber enrichment in progress
+        </div>
+      ) : null}
+      {cycleLagging ? (
+        <div className="mb-3 rounded border border-violet-500/40 bg-violet-950/20 px-3 py-2 text-xs text-violet-100">
+          Current cycle active · <span className="font-mono">{currentCycle}</span> has no HOT entries yet. Showing latest
+          available cycle <span className="font-mono">{latestEntryCycle ?? '—'}</span> until the next automation write.
+        </div>
+      ) : null}
+      {journal.data?.scoped ? (
+        <div className="mb-3 rounded border border-slate-700/60 bg-slate-950/40 px-3 py-2 text-[11px] text-slate-300">
+          Tier scope active · {(journal.data.tier_agents ?? []).join(' + ') || activeTier?.label || 'selected agents'}
+        </div>
+      ) : null}
+      {journal.error ? (
+        <div className="mb-3 rounded border border-amber-500/40 bg-amber-950/20 px-3 py-2 text-xs text-amber-100">
+          Journal chamber degraded · showing snapshot/derived preview
+        </div>
+      ) : null}
+      {!journal.error && dvaTier !== 'ALL' && (journal.data as { fallback_reason?: string } | null)?.fallback_reason ? (
+        <div className="mb-3 rounded border border-slate-700/50 bg-slate-900/40 px-3 py-2 text-xs text-slate-400">
+          {(journal.data as { fallback_reason?: string } | null)?.fallback_reason} ·{' '}
+          <button type="button" onClick={() => setDvaTier('ALL')} className="underline hover:text-slate-300">
+            Show all agents
+          </button>
+        </div>
+      ) : null}
+      {journal.stabilizationActive ? (
+        <div className="mb-3 rounded border border-amber-700/50 bg-amber-950/30 px-3 py-2 text-xs text-amber-100">
+          Predictive Stabilization Active · Preview state prioritized due to integrity drift
+        </div>
+      ) : null}
 
-      <div className="mb-3 rounded border border-slate-800/60 bg-slate-950/40 p-2">
-        <div className="mb-1.5 flex items-center justify-between"><span className="text-[9px] font-mono uppercase tracking-[0.18em] text-slate-500">DVA Tier · Agent Layer</span><span className="text-[9px] text-slate-600">{activeTier?.desc ?? ''}</span></div>
-        <div className="flex flex-wrap gap-1.5">{DVA_TIERS.map((tier) => { const active = dvaTier === tier.id; return <button key={tier.id} type="button" aria-pressed={active} onClick={() => { setDvaTier(tier.id); setAgent('ALL'); }} className={`rounded border px-2 py-1 text-[10px] font-mono tracking-[0.12em] transition ${active ? `${tier.border} ${tier.activeBg} ${tier.color}` : 'border-slate-800 text-slate-500 hover:border-slate-600 hover:text-slate-400'}`}>{tier.label}</button>; })}</div>
-      </div>
+      <JournalHeader stats={stats} />
 
-      <div className="mb-3 flex items-center gap-2 text-[11px] font-mono"><span className="text-slate-500">Journal mode</span>{(['hot', 'canon', 'merged'] as const).map((mode) => <button key={mode} type="button" aria-pressed={readMode === mode} onClick={() => setReadMode(mode)} className={`rounded border px-2 py-1 uppercase tracking-[0.14em] ${readMode === mode ? 'border-cyan-400/60 bg-cyan-500/10 text-cyan-200' : 'border-slate-700 text-slate-400 hover:border-slate-500'}`}>{mode}</button>)}</div>
+      <JournalToolbar
+        sortValue={sort}
+        onSortChange={setSort}
+        viewValue={view}
+        onViewChange={setView}
+        searchValue={search}
+        onSearchChange={setSearch}
+        activeAgents={activeAgents}
+        onAgentToggle={toggleAgent}
+      />
 
       {entries.length === 0 && dvaTier !== 'ALL' ? (
-        <div className="space-y-3"><div className="rounded border border-slate-800 bg-slate-900/60 p-3 text-xs text-slate-400"><div className="mb-2 font-semibold text-slate-300">No entries for <span className="font-mono">{DVA_TIERS.find((t) => t.id === dvaTier)?.label ?? dvaTier}</span> in this view</div><p className="mb-3">The current cycle cron may not have written yet, or there are no entries matching this tier in the active window. Switch to ALL to see all available entries.</p><button type="button" onClick={() => { setDvaTier('ALL'); setCycleTab('All'); }} className="rounded border border-slate-600 px-3 py-1.5 text-slate-200 hover:border-slate-400">Show all agents · all cycles</button></div></div>
+        <div className="space-y-3">
+          <div className="rounded border border-slate-800 bg-slate-900/60 p-3 text-xs text-slate-400">
+            <div className="mb-2 font-semibold text-slate-300">
+              No entries for <span className="font-mono">{DVA_TIERS.find((t) => t.id === dvaTier)?.label ?? dvaTier}</span>{' '}
+              in this view
+            </div>
+            <p className="mb-3">
+              The current cycle cron may not have written yet, or there are no entries matching this tier in the active
+              window. Switch to ALL to see all available entries.
+            </p>
+            <button
+              type="button"
+              onClick={() => setDvaTier('ALL')}
+              className="rounded border border-slate-600 px-3 py-1.5 text-slate-200 hover:border-slate-400"
+            >
+              Show all agents · all cycles
+            </button>
+          </div>
+        </div>
       ) : entries.length === 0 ? (
-        <div className="space-y-4"><ChamberEmptyState title={`No journal entries yet for ${currentCycle}`} reason="Agent journals initialize when automations run." action="To activate: set SUBSTRATE_GITHUB_TOKEN in Vercel" actionDetail="Use a fine-grained PAT for kaizencycle/Mobius-Substrate with Contents read + write permissions." /><div className="space-y-2 rounded border border-slate-800 bg-slate-900/60 p-3"><div className="text-xs text-slate-500">Journals write to Mobius-Substrate/journals/ via GitHub API on each automation cycle.</div>{AGENTS.map((agentName) => <div key={agentName} className="flex items-center justify-between rounded border border-slate-800 px-2 py-1.5 text-xs"><span className="rounded border border-slate-700 px-1.5 py-0.5 font-mono text-slate-300">{agentName}</span><span className="text-slate-600">Awaiting first entry</span></div>)}</div></div>
+        <div className="space-y-4">
+          <ChamberEmptyState
+            title={`No journal entries yet for ${currentCycle}`}
+            reason="Agent journals initialize when automations run."
+            action="To activate: set SUBSTRATE_GITHUB_TOKEN in Vercel"
+            actionDetail="Use a fine-grained PAT for kaizencycle/Mobius-Substrate with Contents read + write permissions."
+          />
+          <div className="space-y-2 rounded border border-slate-800 bg-slate-900/60 p-3">
+            <div className="text-xs text-slate-500">
+              Journals write to Mobius-Substrate/journals/ via GitHub API on each automation cycle.
+            </div>
+            {AGENTS.map((agentName) => (
+              <div key={agentName} className="flex items-center justify-between rounded border border-slate-800 px-2 py-1.5 text-xs">
+                <span className="rounded border border-slate-700 px-1.5 py-0.5 font-mono text-slate-300">{agentName}</span>
+                <span className="text-slate-600">Awaiting first entry</span>
+              </div>
+            ))}
+          </div>
+        </div>
       ) : (
         <>
-          <div className="mb-2 flex gap-2 overflow-x-auto pb-1">{cycleOptions.map((c) => { const count = c === 'All' ? (entries?.length ?? 0) : (cycleCounts.get(c) ?? 0); const label = c === 'All' ? `All (${count})` : `${c} (${count})`; const isCurrent = c === currentCycle; return <button key={c} type="button" aria-pressed={cycleTab === c} onClick={() => setCycleTab(c)} className={`whitespace-nowrap rounded border px-2 py-1 text-xs ${cycleTab === c ? 'border-violet-400/60 bg-violet-500/10 text-violet-100' : isCurrent ? 'border-cyan-500/40 text-cyan-200' : 'border-slate-700 text-slate-400'}`}>{label}{isCurrent ? ' · current' : ''}</button>; })}</div>
-          <div className="mb-3 flex gap-2 overflow-x-auto pb-1">{agentPills.map(({ name, count }) => { const st = AGENT_PILL_STYLE[name] ?? AGENT_PILL_STYLE.ALL; const active = agent === name; const disabled = name !== 'ALL' && count === 0; return <button key={name} type="button" aria-pressed={active} disabled={disabled} onClick={() => setAgent(name)} className={`whitespace-nowrap rounded border px-2 py-1 text-xs transition ${active ? `${st.border} ${st.activeBg} ${st.text}` : 'border-slate-700 text-slate-500'} ${disabled ? 'cursor-not-allowed opacity-50' : 'hover:border-slate-500'}`}>{name} ({count})</button>; })}</div>
-          {missingRelatedId ? <div className="mb-2 rounded border border-amber-500/35 bg-amber-950/25 px-3 py-2 text-[11px] text-amber-100">Source not in current window: <span className="font-mono text-amber-50">{missingRelatedId}</span></div> : null}
-          <div className="space-y-2">{filtered.map((entry) => <JournalEntryCard key={entry.id} entry={entry} onRelatedClick={onRelatedClick} registerAnchor={registerAnchor} />)}</div>
+          {missingRelatedId ? (
+            <div className="mb-2 rounded border border-amber-500/35 bg-amber-950/25 px-3 py-2 text-[11px] text-amber-100">
+              Source not in current window: <span className="font-mono text-amber-50">{missingRelatedId}</span>
+            </div>
+          ) : null}
+          <JournalFeed
+            entries={readerRows}
+            view={view}
+            expandedIds={expandedIds}
+            onToggleExpand={toggleExpand}
+            onRelatedClick={onRelatedClick}
+            registerAnchor={registerAnchor}
+          />
         </>
       )}
+
+      <details className="mt-6 rounded-xl border border-slate-800 bg-slate-950/40 dark:border-slate-700">
+        <summary className="cursor-pointer select-none px-4 py-3 text-xs text-slate-500 hover:text-slate-400">
+          Pipeline & operator controls
+        </summary>
+        <div className="space-y-4 border-t border-slate-800 px-4 pb-4 pt-3 dark:border-slate-800">
+          <div>
+            <div className="mb-1.5 flex items-center justify-between">
+              <span className="text-[9px] font-mono uppercase tracking-[0.18em] text-slate-500">DVA Tier · Agent Layer</span>
+              <span className="text-[9px] text-slate-600">{activeTier?.desc ?? ''}</span>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {DVA_TIERS.map((tier) => {
+                const active = dvaTier === tier.id;
+                return (
+                  <button
+                    key={tier.id}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={() => {
+                      setDvaTier(tier.id);
+                      setActiveAgents(new Set());
+                    }}
+                    className={`rounded border px-2 py-1 text-[10px] font-mono tracking-[0.12em] transition ${
+                      active
+                        ? `${tier.border} ${tier.activeBg} ${tier.color}`
+                        : 'border-slate-800 text-slate-500 hover:border-slate-600 hover:text-slate-400'
+                    }`}
+                  >
+                    {tier.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2 text-[11px] font-mono">
+            <span className="text-slate-500">Journal mode</span>
+            {(['hot', 'canon', 'merged'] as const).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                aria-pressed={readMode === mode}
+                onClick={() => setReadMode(mode)}
+                className={`rounded border px-2 py-1 uppercase tracking-[0.14em] ${
+                  readMode === mode
+                    ? 'border-cyan-400/60 bg-cyan-500/10 text-cyan-200'
+                    : 'border-slate-700 text-slate-400 hover:border-slate-500'
+                }`}
+              >
+                {mode}
+              </button>
+            ))}
+          </div>
+
+          <JournalPipelinePanel />
+        </div>
+      </details>
     </div>
   );
 }

--- a/app/terminal/journal/JournalPageClient.tsx
+++ b/app/terminal/journal/JournalPageClient.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ChevronRight } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { JournalFeed } from '@/components/journal/JournalFeed';
 import { JournalHeader } from '@/components/journal/JournalHeader';
@@ -437,8 +438,12 @@ export default function JournalPageClient() {
         </>
       )}
 
-      <details className="mt-6 rounded-xl border border-slate-800 bg-slate-950/40 dark:border-slate-700">
-        <summary className="cursor-pointer select-none px-4 py-3 text-xs text-slate-500 hover:text-slate-400">
+      <details className="group mt-6 rounded-xl border border-slate-800 bg-slate-950/40 dark:border-slate-700">
+        <summary className="flex cursor-pointer list-none select-none items-center gap-2 px-4 py-3 text-xs text-slate-500 hover:text-slate-400 [&::-webkit-details-marker]:hidden">
+          <ChevronRight
+            aria-hidden
+            className="h-3.5 w-3.5 shrink-0 text-slate-500 transition-transform duration-200 ease-out group-open:rotate-90"
+          />
           Pipeline & operator controls
         </summary>
         <div className="space-y-4 border-t border-slate-800 px-4 pb-4 pt-3 dark:border-slate-800">

--- a/components/journal/JournalEntryCard.tsx
+++ b/components/journal/JournalEntryCard.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import DerivedFromChain from '@/components/terminal/journal/DerivedFromChain';
+import type { JournalFeedCardEntry } from '@/components/journal/types';
+import { JOURNAL_AGENT_COLORS } from '@/components/journal/JournalToolbar';
+
+const LANE_STYLES = {
+  HOT: { bg: 'bg-red-950/40', text: 'text-red-300', label: 'HOT' },
+  CANON: { bg: 'bg-emerald-950/40', text: 'text-emerald-300', label: 'CANON' },
+  SHAPE: { bg: 'bg-amber-950/40', text: 'text-amber-300', label: 'SHAPE' },
+} as const;
+
+function formatRelativeTime(iso: string): string {
+  if (!iso) return '—';
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return '—';
+  const sec = Math.max(0, Math.round((Date.now() - t) / 1000));
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const h = Math.round(min / 60);
+  if (h < 48) return `${h}h ago`;
+  return iso.slice(0, 10);
+}
+
+export type JournalEntryCardProps = {
+  entry: JournalFeedCardEntry;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  onRelatedClick?: (journalEntryId: string) => void;
+  registerAnchor?: (id: string, el: HTMLElement | null) => void;
+};
+
+export function JournalEntryCard({
+  entry,
+  expanded,
+  onToggleExpand,
+  onRelatedClick,
+  registerAnchor,
+}: JournalEntryCardProps) {
+  const rootRef = useRef<HTMLElement | null>(null);
+  const agentColor = JOURNAL_AGENT_COLORS[entry.agent] ?? '#94a3b8';
+  const laneStyle = LANE_STYLES[entry.lane] ?? LANE_STYLES.SHAPE;
+  const preview =
+    expanded || !entry.summary
+      ? entry.summary
+      : entry.summary.length > 120
+        ? `${entry.summary.slice(0, 120)}…`
+        : entry.summary;
+
+  useEffect(() => {
+    registerAnchor?.(entry.id, rootRef.current);
+    return () => {
+      registerAnchor?.(entry.id, null);
+    };
+  }, [entry.id, registerAnchor]);
+
+  function handleRootClick(e: React.MouseEvent) {
+    const el = e.target as HTMLElement;
+    if (el.closest('button') || el.closest('a')) return;
+    onToggleExpand();
+  }
+
+  return (
+    <article
+      ref={(n) => {
+        rootRef.current = n;
+      }}
+      data-journal-entry-id={entry.id}
+      role="button"
+      tabIndex={0}
+      onClick={handleRootClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onToggleExpand();
+        }
+      }}
+      className={`mb-2 cursor-pointer rounded-xl border bg-slate-900/60 p-3 transition-all dark:bg-slate-900/80 ${
+        expanded
+          ? 'border-l-[3px] border-slate-600 border-l-transparent'
+          : 'border-slate-800 hover:border-slate-600 dark:border-slate-700'
+      }`}
+      style={expanded ? { borderLeftColor: agentColor } : undefined}
+    >
+      <div className="mb-1.5 flex items-center gap-2">
+        <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: agentColor }} />
+        <span className="text-[11px] font-medium tracking-wide" style={{ color: agentColor }}>
+          {entry.agent}
+        </span>
+        <span className="rounded-full bg-slate-800 px-1.5 py-0.5 text-[10px] text-slate-400">{entry.cycle}</span>
+        <span className={`rounded-full px-1.5 py-0.5 text-[10px] ${laneStyle.bg} ${laneStyle.text}`}>{laneStyle.label}</span>
+        <span className="ml-auto text-[10px] text-slate-500">{formatRelativeTime(entry.timestamp)}</span>
+      </div>
+
+      <h3 className="mb-1 text-[13px] font-medium leading-snug text-slate-100">
+        {entry.title || entry.summary?.slice(0, 80) || 'Journal entry'}
+      </h3>
+
+      <p className="text-[12px] leading-relaxed text-slate-400">{preview}</p>
+
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <span className="rounded-full bg-amber-950/50 px-1.5 py-0.5 font-mono text-[10px] text-amber-300">
+          GI {entry.gi_at_time != null && Number.isFinite(entry.gi_at_time) ? entry.gi_at_time.toFixed(2) : '—'}
+        </span>
+        <span className="rounded-full bg-slate-800 px-1.5 py-0.5 text-[10px] text-slate-500">
+          {entry.event_type ?? 'observation'}
+        </span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleExpand();
+          }}
+          className="ml-auto flex items-center gap-1 text-[10px] text-slate-500 hover:text-slate-300"
+        >
+          {expanded ? (
+            <>
+              <ChevronUp className="h-3 w-3" /> collapse
+            </>
+          ) : (
+            <>
+              <ChevronDown className="h-3 w-3" /> expand
+            </>
+          )}
+        </button>
+      </div>
+
+      {expanded ? (
+        <div className="mt-3 border-t border-slate-800 pt-3 dark:border-slate-800">
+          <div className="whitespace-pre-wrap font-mono text-[11px] leading-relaxed text-slate-500">
+            {entry.summary}
+            {'\n\n'}
+            Entry: {entry.id}
+            {'\n'}
+            Agent: {entry.agent}
+            {'\n'}
+            Cycle: {entry.cycle} · Lane: {entry.lane}
+            {'\n'}
+            GI: {entry.gi_at_time != null && Number.isFinite(entry.gi_at_time) ? entry.gi_at_time.toFixed(3) : '—'}
+            {entry.tags?.length ? `\nTags: ${entry.tags.join(', ')}` : ''}
+          </div>
+          <DerivedFromChain items={entry.raw.derivedFrom} onJournalRefClick={onRelatedClick} />
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/components/journal/JournalFeed.tsx
+++ b/components/journal/JournalFeed.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { JournalFeedCardEntry } from '@/components/journal/types';
+import type { ViewMode } from '@/components/journal/JournalToolbar';
+import { JOURNAL_AGENT_COLORS } from '@/components/journal/JournalToolbar';
+import { JournalEntryCard } from '@/components/journal/JournalEntryCard';
+
+export type JournalFeedProps = {
+  entries: JournalFeedCardEntry[];
+  view: ViewMode;
+  expandedIds: Set<string>;
+  onToggleExpand: (id: string) => void;
+  onRelatedClick?: (journalEntryId: string) => void;
+  registerAnchor?: (id: string, el: HTMLElement | null) => void;
+};
+
+function groupBy<T>(arr: T[], key: keyof T): Record<string, T[]> {
+  return arr.reduce(
+    (acc, item) => {
+      const k = String(item[key]);
+      (acc[k] ??= []).push(item);
+      return acc;
+    },
+    {} as Record<string, T[]>,
+  );
+}
+
+export function JournalFeed({
+  entries,
+  view,
+  expandedIds,
+  onToggleExpand,
+  onRelatedClick,
+  registerAnchor,
+}: JournalFeedProps) {
+  const sorted = useMemo(() => [...entries], [entries]);
+
+  if (sorted.length === 0) {
+    return <div className="py-16 text-center text-sm text-slate-500">No entries match the current filter.</div>;
+  }
+
+  if (view === 'feed') {
+    return (
+      <>
+        {sorted.map((e) => (
+          <JournalEntryCard
+            key={e.id}
+            entry={e}
+            expanded={expandedIds.has(e.id)}
+            onToggleExpand={() => onToggleExpand(e.id)}
+            onRelatedClick={onRelatedClick}
+            registerAnchor={registerAnchor}
+          />
+        ))}
+      </>
+    );
+  }
+
+  if (view === 'by-cycle') {
+    const byCycle = groupBy(sorted, 'cycle');
+    return (
+      <>
+        {Object.entries(byCycle)
+          .sort(([a], [b]) => b.localeCompare(a))
+          .map(([cycle, ents]) => (
+            <div key={cycle} className="mb-5">
+              <div className="mb-2 flex items-center gap-2 border-b border-slate-800 pb-1.5 dark:border-slate-700">
+                <span className="text-xs font-medium text-slate-300">{cycle}</span>
+                <span className="text-xs text-slate-500">{ents.length} entries</span>
+              </div>
+              {ents.map((e) => (
+                <JournalEntryCard
+                  key={e.id}
+                  entry={e}
+                  expanded={expandedIds.has(e.id)}
+                  onToggleExpand={() => onToggleExpand(e.id)}
+                  onRelatedClick={onRelatedClick}
+                  registerAnchor={registerAnchor}
+                />
+              ))}
+            </div>
+          ))}
+      </>
+    );
+  }
+
+  if (view === 'by-agent') {
+    const byAgent = groupBy(sorted, 'agent');
+    return (
+      <>
+        {Object.entries(byAgent)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([agent, ents]) => {
+            const color = JOURNAL_AGENT_COLORS[agent] ?? '#888';
+            return (
+              <div key={agent} className="mb-5">
+                <div
+                  className="mb-2 flex items-center gap-2 pb-1.5"
+                  style={{ borderBottom: `1px solid ${color}33` }}
+                >
+                  <span className="h-2 w-2 rounded-full" style={{ background: color }} />
+                  <span className="text-xs font-medium" style={{ color }}>
+                    {agent}
+                  </span>
+                  <span className="text-xs text-slate-500">{ents.length} entries</span>
+                </div>
+                {ents.map((e) => (
+                  <JournalEntryCard
+                    key={e.id}
+                    entry={e}
+                    expanded={expandedIds.has(e.id)}
+                    onToggleExpand={() => onToggleExpand(e.id)}
+                    onRelatedClick={onRelatedClick}
+                    registerAnchor={registerAnchor}
+                  />
+                ))}
+              </div>
+            );
+          })}
+      </>
+    );
+  }
+
+  return null;
+}

--- a/components/journal/JournalHeader.tsx
+++ b/components/journal/JournalHeader.tsx
@@ -1,0 +1,29 @@
+export interface JournalStats {
+  total: number;
+  agentCount: number;
+  currentCycle: string;
+  canonCount: number;
+}
+
+export function JournalHeader({ stats }: { stats: JournalStats }) {
+  const cells = [
+    { label: 'Total entries', value: stats.total },
+    { label: 'Active agents', value: stats.agentCount },
+    { label: 'Current cycle', value: stats.currentCycle },
+    { label: 'Canon entries', value: stats.canonCount },
+  ] as const;
+
+  return (
+    <div className="mb-4 grid grid-cols-2 gap-2 sm:grid-cols-4">
+      {cells.map(({ label, value }) => (
+        <div
+          key={label}
+          className="rounded-lg border border-slate-800/80 bg-slate-900/50 p-2.5 dark:border-slate-700 dark:bg-slate-900/70"
+        >
+          <div className="text-base font-medium text-slate-100">{value}</div>
+          <div className="mt-0.5 text-[11px] text-slate-500">{label}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/journal/JournalPipelinePanel.tsx
+++ b/components/journal/JournalPipelinePanel.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import DataflowCommandSpine from '@/components/terminal/DataflowCommandSpine';
+import { useShellSnapshot } from '@/hooks/useShellSnapshot';
+import { useLaneDiagnosticsChamber } from '@/hooks/useLaneDiagnosticsChamber';
+
+/** Compact pipeline readout for the Journal chamber footer (C-314). */
+export function JournalPipelinePanel() {
+  const { shell } = useShellSnapshot();
+  const laneDiagnostics = useLaneDiagnosticsChamber(true);
+  return <DataflowCommandSpine shell={shell} diagnostics={laneDiagnostics.data} visible compact />;
+}

--- a/components/journal/JournalToolbar.tsx
+++ b/components/journal/JournalToolbar.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { Search } from 'lucide-react';
+
+export type SortMode = 'newest' | 'oldest' | 'agent' | 'cycle' | 'operator';
+export type ViewMode = 'feed' | 'by-cycle' | 'by-agent';
+
+const AGENTS = ['ATLAS', 'ZEUS', 'EVE', 'JADE', 'AUREA', 'HERMES', 'ECHO', 'DAEDALUS'] as const;
+
+export const JOURNAL_AGENT_COLORS: Record<string, string> = {
+  ATLAS: '#60a5fa',
+  ZEUS: '#fbbf24',
+  EVE: '#34d399',
+  JADE: '#a78bfa',
+  AUREA: '#f59e0b',
+  HERMES: '#f87171',
+  ECHO: '#22d3ee',
+  DAEDALUS: '#94a3b8',
+};
+
+export type JournalToolbarProps = {
+  sortValue: SortMode;
+  onSortChange: (v: SortMode) => void;
+  viewValue: ViewMode;
+  onViewChange: (v: ViewMode) => void;
+  searchValue: string;
+  onSearchChange: (v: string) => void;
+  activeAgents: Set<string>;
+  onAgentToggle: (agent: string) => void;
+};
+
+export function JournalToolbar({
+  sortValue,
+  onSortChange,
+  viewValue,
+  onViewChange,
+  searchValue,
+  onSearchChange,
+  activeAgents,
+  onAgentToggle,
+}: JournalToolbarProps) {
+  return (
+    <div className="mb-4 space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-36 flex-1">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-slate-500" />
+          <input
+            type="text"
+            value={searchValue}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search entries…"
+            className="w-full rounded-lg border border-slate-700 bg-slate-950 py-1.5 pl-8 pr-3 text-xs text-slate-100 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-900"
+          />
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <label className="text-xs text-slate-500">Sort</label>
+          <select
+            value={sortValue}
+            onChange={(e) => onSortChange(e.target.value as SortMode)}
+            className="rounded-lg border border-slate-700 bg-slate-950 px-2 py-1.5 text-xs text-slate-100 dark:border-slate-600 dark:bg-slate-900"
+          >
+            <option value="newest">Newest first</option>
+            <option value="oldest">Oldest first</option>
+            <option value="agent">By agent</option>
+            <option value="cycle">By cycle</option>
+            <option value="operator">Operator priority</option>
+          </select>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <label className="text-xs text-slate-500">View</label>
+          <select
+            value={viewValue}
+            onChange={(e) => onViewChange(e.target.value as ViewMode)}
+            className="rounded-lg border border-slate-700 bg-slate-950 px-2 py-1.5 text-xs text-slate-100 dark:border-slate-600 dark:bg-slate-900"
+          >
+            <option value="feed">Feed</option>
+            <option value="by-cycle">By cycle</option>
+            <option value="by-agent">By agent</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        <button
+          type="button"
+          onClick={() => onAgentToggle('ALL')}
+          className={`rounded-full border px-2.5 py-1 text-[11px] transition-colors ${
+            activeAgents.size === 0
+              ? 'border-slate-100 bg-slate-100 text-slate-900 dark:border-white dark:bg-white dark:text-slate-900'
+              : 'border-slate-700 text-slate-500 hover:border-slate-500 hover:text-slate-300'
+          }`}
+        >
+          All agents
+        </button>
+        {AGENTS.map((agent) => {
+          const active = activeAgents.has(agent);
+          const color = JOURNAL_AGENT_COLORS[agent] ?? '#888';
+          return (
+            <button
+              key={agent}
+              type="button"
+              onClick={() => onAgentToggle(agent)}
+              className="flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] transition-all"
+              style={
+                active
+                  ? {
+                      borderColor: color,
+                      color,
+                      background: `${color}18`,
+                      borderWidth: '1.5px',
+                      fontWeight: 500,
+                    }
+                  : { borderColor: 'rgba(51,65,85,0.9)', color: '#94a3b8' }
+              }
+            >
+              <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full" style={{ background: color }} />
+              {agent}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/journal/types.ts
+++ b/components/journal/types.ts
@@ -1,0 +1,16 @@
+import type { JournalDisplayEntry } from '@/lib/journal/types';
+
+/** Normalized row for readability feed (C-314). */
+export type JournalFeedCardEntry = {
+  id: string;
+  agent: string;
+  cycle: string;
+  lane: 'HOT' | 'CANON' | 'SHAPE';
+  title: string;
+  summary: string;
+  timestamp: string;
+  gi_at_time?: number | null;
+  event_type?: string;
+  tags?: string[];
+  raw: JournalDisplayEntry;
+};

--- a/components/terminal/DataflowCommandSpine.tsx
+++ b/components/terminal/DataflowCommandSpine.tsx
@@ -115,10 +115,12 @@ export default function DataflowCommandSpine({
   shell,
   diagnostics,
   visible,
+  compact = false,
 }: {
   shell: ShellSnapshot | null;
   diagnostics: LaneDiagnosticsPayload | null | undefined;
   visible: boolean;
+  compact?: boolean;
 }) {
   if (!visible) return null;
 
@@ -213,6 +215,32 @@ export default function DataflowCommandSpine({
   ];
 
   const packetMode = shell?.source === 'fallback' || diagnostics?.fallback ? 'preview/fallback' : shell ? 'live packet' : 'awaiting shell';
+
+  if (compact) {
+    return (
+      <section className="rounded-lg border border-slate-800/80 bg-slate-950/90 px-3 py-2.5" aria-label="Dataflow command compact">
+        <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] font-mono text-slate-400">
+          <span className="text-slate-300">{shell?.cycle ?? 'C-—'}</span>
+          <span className="text-violet-300/90">{packetMode}</span>
+          <span>
+            journal {journalState === 'unknown' ? '—' : badgeLabel(journalState)}
+          </span>
+          <span>ledger {ledgerState === 'unknown' ? '—' : badgeLabel(ledgerState)}</span>
+          <span>tripwires {shell?.tripwire?.count ?? 0}</span>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {budgets.map((budget) => (
+            <div
+              key={`${budget.label}-${budget.agent}`}
+              className={cn('rounded border px-2 py-1 text-[9px] font-mono uppercase tracking-[0.1em]', flowBudgetClass(budget.state))}
+            >
+              {budget.label} · {budget.metric}
+            </div>
+          ))}
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="border-b border-cyan-950/60 bg-slate-950/85 px-3 py-2 md:px-4" aria-label="Dataflow command spine">

--- a/components/terminal/TerminalShell.tsx
+++ b/components/terminal/TerminalShell.tsx
@@ -38,6 +38,7 @@ function runtimeBadgeClass(runtime: 'online' | 'degraded' | 'offline') {
 export default function TerminalShell({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const currentPath = pathname ?? '';
+  const flowSpineSuppressed = currentPath.startsWith('/terminal/journal');
   const [clock, setClock] = useState('—');
   const [showLaneDiagnostics, setShowLaneDiagnostics] = useState(false);
   const [showDataflowCommand, setShowDataflowCommand] = useState(true);
@@ -138,9 +139,18 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
         <div className="flex items-center justify-between gap-1.5 md:gap-2">
           <ChamberSwitcher />
           <div className="flex shrink-0 items-center gap-1.5">
-            <button type="button" onClick={() => setShowDataflowCommand((current) => !current)} className={cn('rounded border px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-[0.12em] md:px-2 md:py-1 md:text-[10px]', showDataflowCommand ? 'border-violet-500/60 text-violet-200' : 'border-slate-700 text-slate-400')}>
-              Flow
-            </button>
+            {!flowSpineSuppressed ? (
+              <button
+                type="button"
+                onClick={() => setShowDataflowCommand((current) => !current)}
+                className={cn(
+                  'rounded border px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-[0.12em] md:px-2 md:py-1 md:text-[10px]',
+                  showDataflowCommand ? 'border-violet-500/60 text-violet-200' : 'border-slate-700 text-slate-400',
+                )}
+              >
+                Flow
+              </button>
+            ) : null}
             <button type="button" onClick={() => setShowLaneDiagnostics((current) => !current)} className={cn('rounded border px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-[0.12em] md:px-2 md:py-1 md:text-[10px]', showLaneDiagnostics ? 'border-cyan-500/60 text-cyan-200' : 'border-slate-700 text-slate-400')}>
               Lane diag
             </button>
@@ -150,7 +160,7 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
 
       <DegradedBanner memoryMode={null} />
 
-      <DataflowCommandSpine shell={shell} diagnostics={laneDiagnostics.data} visible={showDataflowCommand} />
+      <DataflowCommandSpine shell={shell} diagnostics={laneDiagnostics.data} visible={showDataflowCommand && !flowSpineSuppressed} />
 
       {showLaneDiagnostics ? (
         <div className="border-b border-slate-800 bg-slate-950/80 px-3 py-2 md:px-4">

--- a/lib/journal/deriveTitle.ts
+++ b/lib/journal/deriveTitle.ts
@@ -1,0 +1,7 @@
+/** First sentence / line for journal entry titles (C-314 readability). */
+export function deriveTitleFromSummary(summary?: string): string {
+  if (!summary?.trim()) return 'Journal entry';
+  const firstSentence = summary.split(/[.!?]/u)[0]?.trim() ?? summary.trim();
+  if (firstSentence.length > 60) return `${firstSentence.slice(0, 57)}…`;
+  return firstSentence.length > 0 ? firstSentence : 'Journal entry';
+}

--- a/lib/journal/operatorSort.ts
+++ b/lib/journal/operatorSort.ts
@@ -1,0 +1,69 @@
+import type { JournalDisplayEntry, JournalDisplaySeverity, JournalDisplayStatus } from '@/lib/journal/types';
+
+function parseCycleOrdinal(cycle: string | undefined): number {
+  const c = cycle?.trim() ?? '';
+  const n = parseInt(c.replace(/\D/g, ''), 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function statusRank(s: JournalDisplayStatus | undefined): number {
+  if (s === 'verified') return 4;
+  if (s === 'committed') return 3;
+  if (s === 'contested') return 2;
+  if (s === 'draft') return 1;
+  return 2;
+}
+
+function severityRank(s: JournalDisplaySeverity | undefined): number {
+  if (s === 'critical') return 3;
+  if (s === 'elevated') return 2;
+  if (s === 'nominal') return 1;
+  return 0;
+}
+
+/** Mobius operator ordering: current cycle, cycle ordinal, status, severity, confidence, time. */
+export function sortJournalOperatorFirst(rows: JournalDisplayEntry[], focusCycleId: string): JournalDisplayEntry[] {
+  const focus = focusCycleId.trim();
+  return [...rows].sort((a, b) => {
+    const aCurrent = (a.cycle?.trim() ?? '') === focus ? 1 : 0;
+    const bCurrent = (b.cycle?.trim() ?? '') === focus ? 1 : 0;
+    if (aCurrent !== bCurrent) return bCurrent - aCurrent;
+    const cycA = parseCycleOrdinal(a.cycle);
+    const cycB = parseCycleOrdinal(b.cycle);
+    if (cycA !== cycB) return cycB - cycA;
+    const stA = statusRank(a.status);
+    const stB = statusRank(b.status);
+    if (stA !== stB) return stB - stA;
+    const sevA = severityRank(a.severity);
+    const sevB = severityRank(b.severity);
+    if (sevA !== sevB) return sevB - sevA;
+    const confA = typeof a.confidence === 'number' && Number.isFinite(a.confidence) ? a.confidence : -1;
+    const confB = typeof b.confidence === 'number' && Number.isFinite(b.confidence) ? b.confidence : -1;
+    if (confA !== confB) return confB - confA;
+    return new Date(b.timestamp ?? 0).getTime() - new Date(a.timestamp ?? 0).getTime();
+  });
+}
+
+export function sortJournalChronological(rows: JournalDisplayEntry[], order: 'asc' | 'desc'): JournalDisplayEntry[] {
+  return [...rows].sort((a, b) => {
+    const ta = new Date(a.timestamp ?? 0).getTime();
+    const tb = new Date(b.timestamp ?? 0).getTime();
+    return order === 'desc' ? tb - ta : ta - tb;
+  });
+}
+
+export function sortJournalByAgent(rows: JournalDisplayEntry[]): JournalDisplayEntry[] {
+  return [...rows].sort((a, b) => {
+    const cmp = (a.agent ?? '').localeCompare(b.agent ?? '');
+    if (cmp !== 0) return cmp;
+    return new Date(b.timestamp ?? 0).getTime() - new Date(a.timestamp ?? 0).getTime();
+  });
+}
+
+export function sortJournalByCycle(rows: JournalDisplayEntry[]): JournalDisplayEntry[] {
+  return [...rows].sort((a, b) => {
+    const cmp = (b.cycle ?? '').localeCompare(a.cycle ?? '');
+    if (cmp !== 0) return cmp;
+    return new Date(b.timestamp ?? 0).getTime() - new Date(a.timestamp ?? 0).getTime();
+  });
+}

--- a/lib/journal/types.ts
+++ b/lib/journal/types.ts
@@ -10,6 +10,8 @@ export type JournalDisplaySeverity = 'nominal' | 'elevated' | 'critical';
 export type JournalDisplayEntry = {
   id: string;
   agent: string;
+  /** Reader-facing headline; may be set by API from summary (C-314). */
+  title?: string;
   cycle?: string;
   category?: string;
   observation?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## C-314 — Journal readability

**Reader-first layout:** stats header, toolbar (search / sort / view / agent pills), expandable entry cards, grouped feed modes. **Operator surface** (DVA tier, journal read mode, dataflow pipeline) lives in a **collapsed `<details>`** at the bottom so lane vocabulary is not the first thing a reader sees.

### Follow-up in this revision
- Pipeline **`<details>`** summary includes a **ChevronRight** with **`group-open:rotate-90`** transition (Tailwind `group` on `<details>`).

### Branch note
Cloud agent convention: `cursor/c314-journal-ui-readability-6622` (not `feat/c314-journal-ui`).

### Validation
- `pnpm exec tsc --noEmit` — pass
- `pnpm build` — pass
- `pnpm lint` — **fails**: Next.js 16 deprecation opens interactive ESLint setup wizard; no `eslint.config` in repo. Next build still runs its integrated lint/type pass.

### Not in scope
- `/terminal/journal/[agent]` chamber page unchanged (main journal client only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

