### PR TITLE
C-314: Fix Signals 6/40 display, snapshot stream coalesce, pulse WRONGTYPE

### DIFF
--- a/app/api/cron/promote/route.ts
+++ b/app/api/cron/promote/route.ts
@@ -32,6 +32,18 @@ export async function GET(request: NextRequest) {
         ? `Bearer ${cronMat}`
         : serviceAuthorizationHeaderValue();
 
+  if (!authHeader) {
+    console.warn(
+      '[promote] skipped: no SUBSTRATE_TOKEN, CRON_SECRET, or outbound service bearer — configure env to run scheduled promotion',
+    );
+    return NextResponse.json({
+      ok: false,
+      skipped: true,
+      reason: 'no_promote_auth_material',
+      timestamp: new Date().toISOString(),
+    });
+  }
+
   try {
     // FIX-507-02: write heartbeat unconditionally so promotion-status never shows stale
     // when the promote fetch times out or returns a transient non-OK (Render cold-start).

--- a/app/api/cron/swarm/route.ts
+++ b/app/api/cron/swarm/route.ts
@@ -69,7 +69,7 @@ async function loadSwarmSignals(): Promise<SwarmSignals> {
     errors?: number;
     instrumentCount?: number;
     fallbacksUsed?: number;
-  }>('signals:micro:cache');
+  }>('signals:micro:cache:v2');
 
   const microData = (micro as { data?: { errors?: number; instrumentCount?: number; fallbacksUsed?: number } } | null)?.data ?? micro;
 

--- a/app/api/pulse/search/route.ts
+++ b/app/api/pulse/search/route.ts
@@ -58,7 +58,16 @@ export async function GET(req: NextRequest) {
       ]);
       const allKeys = [...new Set([...rawKeys, ...prefixedKeys])];
       const entries = await Promise.all(
-        allKeys.slice(0, 100).map(k => redis.get<Record<string, unknown>>(k))
+        allKeys.slice(0, 100).map(async (k) => {
+          try {
+            return await redis.get<Record<string, unknown>>(k);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (msg.includes('WRONGTYPE')) return null;
+            console.warn('[pulse/search] KV journal key read failed:', k, err);
+            return null;
+          }
+        }),
       );
       for (const entry of entries) {
         if (!entry) continue;

--- a/app/api/signals/micro/route.ts
+++ b/app/api/signals/micro/route.ts
@@ -10,7 +10,7 @@ import { kvGet, kvSet } from '@/lib/kv/store';
 
 export const dynamic = 'force-dynamic';
 
-const CACHE_KEY = 'signals:micro:cache';
+const CACHE_KEY = 'signals:micro:cache:v2';
 const CACHE_TTL_MS = 60_000;
 const CACHE_TTL_SEC = 90;
 

--- a/app/api/terminal/snapshot/route.ts
+++ b/app/api/terminal/snapshot/route.ts
@@ -34,7 +34,8 @@ export const dynamic = 'force-dynamic';
 // FIX-510-05: coalesce parallel snapshot requests — only one Render fan-out per 20s window.
 const SNAPSHOT_COALESCE_KEY = 'snapshot:coalesce';
 const SNAPSHOT_COALESCE_MS = 20_000;
-let snapshotInFlight: Promise<NextResponse> | null = null;
+/** Serialized snapshot bytes — each waiter builds its own `NextResponse` so body streams are never shared (fixes ERR_INVALID_STATE / locked stream). */
+let snapshotInFlight: Promise<{ status: number; body: string }> | null = null;
 let snapshotInFlightStarted = 0;
 
 // C-293 OPT-1: echo + promotion lanes persistently hit the 5s budget.
@@ -462,25 +463,45 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       }
     }
 
-    // Coalesce: if a build is already in flight, share it
+    // Coalesce: if a build is already in flight, await the same serialized payload (each caller gets a fresh Response)
     if (snapshotInFlight && now - snapshotInFlightStarted < SNAPSHOT_COALESCE_MS) {
-      return snapshotInFlight;
+      const { status, body } = await snapshotInFlight;
+      return new NextResponse(body, {
+        status,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'public, s-maxage=20, stale-while-revalidate=60',
+          'X-Mobius-Source': 'terminal-snapshot',
+          'X-Cache': 'COALESCE',
+        },
+      });
     }
 
     snapshotInFlightStarted = now;
-    snapshotInFlight = buildSnapshotResponse(request).then(async (res) => {
+    const work = (async (): Promise<{ status: number; body: string }> => {
       try {
-        const clone = res.clone();
-        const body = await clone.text();
-        kvSet(SNAPSHOT_COALESCE_KEY, { builtAt: now, body }, 25).catch(() => {});
-      } catch {
-        // non-fatal
+        const res = await buildSnapshotResponse(request);
+        const status = res.status;
+        const body = await res.text();
+        const builtAt = snapshotInFlightStarted;
+        void kvSet(SNAPSHOT_COALESCE_KEY, { builtAt, body }, 25).catch(() => {});
+        return { status, body };
+      } finally {
+        snapshotInFlight = null;
       }
-      snapshotInFlight = null;
-      return res;
-    });
+    })();
+    snapshotInFlight = work;
 
-    return snapshotInFlight;
+    const { status, body } = await work;
+    return new NextResponse(body, {
+      status,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, s-maxage=20, stale-while-revalidate=60',
+        'X-Mobius-Source': 'terminal-snapshot',
+        'X-Cache': 'MISS',
+      },
+    });
   }
 
   return buildSnapshotResponse(request);

--- a/app/terminal/signals/SignalsPageClient.tsx
+++ b/app/terminal/signals/SignalsPageClient.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react';
 import ChamberSkeleton from '@/components/terminal/ChamberSkeleton';
 import { useSignalsChamber } from '@/hooks/useSignalsChamber';
+import { INSTRUMENT_COUNT } from '@/lib/signals/registry';
 
 type SignalEntry = {
   agentName: string;
@@ -328,7 +329,14 @@ export default function SignalsPageClient() {
 
   if (loading && !data) return <ChamberSkeleton blocks={4} />;
 
-  const expected = payload.instrumentCount ?? agents.length;
+  const instrumentSlotsFilled =
+    Array.isArray(payload.instruments) && payload.instruments.length > 0
+      ? payload.instruments.length
+      : typeof payload.instrumentCount === 'number'
+        ? payload.instrumentCount
+        : 0;
+  const agentLanes = agents.length;
+  const sweepPartial = instrumentSlotsFilled > 0 && instrumentSlotsFilled < INSTRUMENT_COUNT;
   const sweepOk = payload.ok !== false && signalsLeaf?.ok !== false;
 
   return (
@@ -340,11 +348,22 @@ export default function SignalsPageClient() {
       ) : null}
       <div className="flex shrink-0 flex-wrap items-center justify-between gap-2">
         <div className="text-[11px] text-slate-400">
-          <span className="font-mono text-slate-200">{agents.length}</span>
-          {expected && agents.length !== expected ? (
-            <span className="text-amber-400/90"> / {expected} instruments</span>
-          ) : expected ? (
-            <span> micro instruments</span>
+          <span className="font-mono text-slate-200">{instrumentSlotsFilled}</span>
+          <span className="text-slate-500"> / {INSTRUMENT_COUNT}</span>
+          <span> instruments</span>
+          {agentLanes > 0 ? (
+            <span className="text-slate-600">
+              {' '}
+              · <span className="font-mono text-slate-400">{agentLanes}</span> agent lanes
+            </span>
+          ) : null}
+          {sweepPartial ? (
+            <span
+              className="ml-2 text-amber-400/90"
+              title="Fewer instruments than registry size — upstream timeouts, blocks, or KV cache from an older sweep shape"
+            >
+              · partial registry sweep
+            </span>
           ) : null}
           {typeof payload.composite === 'number' && sweepOk ? (
             <span className="ml-2 text-slate-500">· sweep composite {payload.composite.toFixed(3)}</span>
@@ -418,7 +437,7 @@ export default function SignalsPageClient() {
               <section className="rounded border border-slate-800 bg-slate-950/60 px-3 py-2">
                 <div className="mb-2 flex items-center justify-between">
                   <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">
-                    Instrument grid · {payload.instruments.length}/40
+                    Instrument grid · {(payload.instruments?.length ?? instrumentSlotsFilled)} / {INSTRUMENT_COUNT}
                   </span>
                   <div className="flex gap-3 font-mono text-[9px] text-slate-600">
                     <span><span className="text-emerald-400">●</span> primary</span>

--- a/lib/signals/fetcher.ts
+++ b/lib/signals/fetcher.ts
@@ -33,10 +33,16 @@ async function tryUrl(
     clearTimeout(timer);
     if (!res.ok) return null;
 
-    const ct = res.headers.get('content-type') ?? '';
-    const data = ct.includes('xml')
-      ? await res.text()
-      : await res.json().catch(() => res.text());
+    const ct = (res.headers.get('content-type') ?? '').toLowerCase();
+    const text = await res.text();
+    let data: unknown = text;
+    if (!ct.includes('xml') && !text.trimStart().startsWith('<')) {
+      try {
+        data = JSON.parse(text) as unknown;
+      } catch {
+        data = text;
+      }
+    }
 
     const raw = inst.normalize(data);
     const score = parseFloat(Math.min(Math.max(raw, 0), 1).toFixed(3));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## C-314 — Signals / snapshot / pulse hardening

### What you saw: **6 / 40** on Signals
That was a **UI bug**, not “only six APIs work.” The header compared **agent lane count** (6 micro-agent families in the registry sweep) to **`instrumentCount`** (40). The sweep was already returning 40 instrument slots; the label made it look broken.

### Code fixes
- **`/api/terminal/snapshot`**: Concurrent coalesced requests no longer share one `NextResponse` instance (fixes production `ERR_INVALID_STATE` / **ReadableStream is locked** when multiple clients hit snapshot during the 20s coalesce window).
- **`SignalsPageClient`**: Header shows **instruments filled / registry total** plus **agent lanes** separately; instrument grid uses `INSTRUMENT_COUNT` from `lib/signals/registry`.
- **`lib/signals/fetcher`**: Single `text()` read then JSON parse — avoids invalid double-read paths on odd content-types.
- **`/api/pulse/search`**: Per-key `get` wrapped so **WRONGTYPE** keys (journal namespace collision) are skipped instead of failing the whole journal scan.
- **`/api/cron/promote`**: If there is **no** SUBSTRATE_TOKEN / CRON_SECRET / outbound bearer material, the cron **skips** the internal promote POST (stops pointless 401 spam when auth is genuinely unset).
- **`signals:micro:cache` → `v2`**: Bumps KV cache key so old cached shapes roll off; **`/api/cron/swarm`** reads the new key.

### Still operator / env (not fixed by this PR)
- **401 promote** when a token *is* set but wrong → fix **Vercel env** / ledger alignment.
- **GitHub PAT 403**, **TERMINAL_API_BASE / TERMINAL_ID** (ledger 400), **Anthropic balance**, **treasury 404**, **ZEUS 401** → credentials / upstream services.

### Validation
- `pnpm exec tsc --noEmit` — pass  
- `pnpm build` — pass  
- `pnpm lint` — not run (Next.js interactive ESLint wizard in this repo)

Branch: `cursor/c314-signals-snapshot-pulse-fixes-6622`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

