### PR TITLE
fix(journal): excise GitHub PAT write path — ledger-only substrate (C-317)

### DIFF
--- a/app/api/agents/journal/route.ts
+++ b/app/api/agents/journal/route.ts
@@ -5,11 +5,7 @@ import { writeToSubstrate } from '@/lib/substrate/client';
 import { kvLrange, kvGet } from '@/lib/kv/store';
 import { scanKeys } from '@/lib/kv/scan';
 import { getOperatorSession } from '@/lib/auth/session';
-import {
-  writeJournalToSubstrate,
-  type SubstrateJournalEntry,
-  type SubstrateJournalWriteInput,
-} from '@/lib/substrate/github-journal';
+import type { SubstrateJournalEntry } from '@/lib/substrate/github-journal';
 import { readAgentJournals } from '@/lib/substrate/github-reader';
 import { checkProvenanceBreak, checkTemporalCoherence } from '@/lib/tripwire/archiveChecks';
 import { checkJournalQualityDrift } from '@/lib/tripwire/journalQuality';
@@ -641,32 +637,30 @@ export async function POST(request: NextRequest) {
       ? input.gi_snapshot
       : undefined;
 
-  const substratePayload: SubstrateJournalWriteInput = {
+  // GitHub PAT write path removed in C-317 (PAT lacks contents:write scope → 403 → 502).
+  // All journal writes route through Civic Protocol Core Ledger exclusively.
+  const ledgerResult = await writeToSubstrate({
     id: entry.id,
     agent: entry.agent,
     agentOrigin: entry.agentOrigin,
     cycle: entry.cycle,
-    scope: entry.scope,
+    title: entry.inference,
+    summary: entry.observation,
     category: entry.category,
     severity: entry.severity,
-    observation: entry.observation,
-    inference: entry.inference,
-    recommendation: entry.recommendation,
+    source: 'agent-journal',
     confidence: entry.confidence,
     derivedFrom: entry.derivedFrom,
-    source: entry.source,
-    tags: entry.tags ?? [],
+    tags: entry.tags,
     ...(giAt !== undefined ? { gi_at_time: giAt } : {}),
-    status: entry.status,
-  };
+  });
 
-  const substrateResult = await writeJournalToSubstrate(substratePayload);
-  if (!substrateResult.ok) {
+  if (!ledgerResult.ok) {
     return NextResponse.json(
       {
         ok: false,
         canonical: false,
-        error: substrateResult.error ?? 'substrate_write_failed',
+        error: ledgerResult.error ?? 'ledger_write_failed',
         mirrored_to_kv: false,
       },
       { status: 502 },
@@ -686,26 +680,10 @@ export async function POST(request: NextRequest) {
     mirroredToKv = writeResult.written || writeResult.token === 'already_exists';
   }
 
-  void writeToSubstrate({
-    agent: entry.agent,
-    agentOrigin: entry.agentOrigin,
-    cycle: entry.cycle,
-    title: entry.inference,
-    summary: entry.observation,
-    category: entry.category,
-    severity: entry.severity,
-    source: 'agent-journal',
-    confidence: entry.confidence,
-    derivedFrom: entry.derivedFrom,
-    tags: entry.tags,
-  }).catch((error) => {
-    console.error('[ledger] journal attest error', error);
-  });
-
   return NextResponse.json({
     ok: true,
     canonical: true,
-    path: substrateResult.path,
+    path: ledgerResult.entryId,
     mirrored_to_kv: mirroredToKv,
     entryId: entry.id,
     timestamp: entry.timestamp,

--- a/app/api/cron/reattest-seals/route.ts
+++ b/app/api/cron/reattest-seals/route.ts
@@ -281,7 +281,7 @@ async function runSubstrateFixBurstC314(
     return { ranBurst: true, targets: 0, remainingAfter: 0 };
   }
 
-  console.info(`[reattest-seals] C-314 substrate burst migration: ${targets.length} seals (no backoff)`);
+  console.info(`[reattest-seals] C-314 substrate burst migration: ${targets.length} seals — running without backoff`);
 
   for (const seal of targets) {
     await kvDel(`seal:${seal.seal_id}:reattest_attempts`);

--- a/app/api/cron/swarm/route.ts
+++ b/app/api/cron/swarm/route.ts
@@ -141,7 +141,7 @@ async function callAgent(
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.toLowerCase().includes('credit balance')) {
-      console.error(`[swarm] ${agentId} ATLAS credit exhausted — cooldown 1h`);
+      console.warn(`[swarm] ${agentId} credit exhausted — setting 1h cooldown`);
       await markCreditExhausted();
     }
     return {

--- a/lib/agents/journalCanonOutbox.ts
+++ b/lib/agents/journalCanonOutbox.ts
@@ -1,5 +1,5 @@
 import type { Redis } from '@upstash/redis';
-import { writeJournalToSubstrate, type SubstrateJournalWriteInput } from '@/lib/substrate/github-journal';
+import type { SubstrateJournalWriteInput } from '@/lib/substrate/github-journal';
 import { attestToLedger } from '@/lib/substrate/client';
 import { bumpTerminalWatermark } from '@/lib/terminal/watermark';
 
@@ -89,41 +89,38 @@ export async function processJournalCanonOutbox(redis: Redis | null, limit = 5) 
       const item = asOutboxItem(await redis.get<unknown>(itemKey(id)));
       if (!item || item.status === 'canon_written') continue;
       processed += 1;
-      // FIX-506-01: try GitHub first; on failure fall back to Render Civic Ledger.
-      // GitHub 403 was silently re-queuing forever — Render is the authoritative write target.
-      // P2 fix: no CIVIC_LEDGER_URL gate — attestToLedger() resolves URL itself via
-      // RENDER_LEDGER_URL > CIVIC_LEDGER_URL > hardcoded fallback, so the fallback always runs.
-      let result = await writeJournalToSubstrate(item.entry);
-      if (!result.ok) {
-        console.warn('[journal/canon-outbox] GitHub write failed, trying Render fallback:', result.error);
-        try {
-          const renderResult = await attestToLedger({
-            id: item.entry.id,
-            agent: item.entry.agent,
-            agentOrigin: item.entry.agentOrigin,
-            cycle: item.entry.cycle,
-            title: `Journal: ${item.entry.scope ?? item.entry.category} — ${item.entry.agent}`,
-            summary: [item.entry.observation, item.entry.inference, item.entry.recommendation]
-              .filter(Boolean).join(' ').slice(0, 500),
-            category: (['market','geopolitical','infrastructure','narrative','governance'] as const)
-              .includes(item.entry.category as never) ? (item.entry.category as 'market'|'geopolitical'|'infrastructure'|'narrative') : 'infrastructure',
-            severity: item.entry.severity as 'nominal' | 'degraded' | 'elevated' | 'critical',
-            source: 'agent-journal',
-            gi_at_time: item.entry.gi_at_time,
-            confidence: item.entry.confidence,
-            verified: false,
-            derivedFrom: item.entry.derivedFrom ?? [],
-            tags: [...(item.entry.tags ?? []), 'journal-canon', `cycle:${item.entry.cycle}`],
-          });
-          if (renderResult.ok) {
-            result = { ok: true, path: `render:${renderResult.entryId ?? 'submitted'}` };
-            console.log('[journal/canon-outbox] Render fallback write ok:', item.entry.id);
-          } else {
-            console.error('[journal/canon-outbox] Render fallback also failed:', renderResult.error);
-          }
-        } catch (renderErr) {
-          console.error('[journal/canon-outbox] Render fallback threw:', renderErr instanceof Error ? renderErr.message : renderErr);
+      // C-317: GitHub PAT write path removed. Civic Protocol Core Ledger is the only write target.
+      // attestToLedger resolves the URL via RENDER_LEDGER_URL > CIVIC_LEDGER_URL > hardcoded fallback.
+      let result: { ok: boolean; path?: string; error?: string } = { ok: false };
+      try {
+        const ledgerResult = await attestToLedger({
+          id: item.entry.id,
+          agent: item.entry.agent,
+          agentOrigin: item.entry.agentOrigin,
+          cycle: item.entry.cycle,
+          title: `Journal: ${item.entry.scope ?? item.entry.category} — ${item.entry.agent}`,
+          summary: [item.entry.observation, item.entry.inference, item.entry.recommendation]
+            .filter(Boolean).join(' ').slice(0, 500),
+          category: (['market','geopolitical','infrastructure','narrative','governance'] as const)
+            .includes(item.entry.category as never) ? (item.entry.category as 'market'|'geopolitical'|'infrastructure'|'narrative') : 'infrastructure',
+          severity: item.entry.severity as 'nominal' | 'degraded' | 'elevated' | 'critical',
+          source: 'agent-journal',
+          gi_at_time: item.entry.gi_at_time,
+          confidence: item.entry.confidence,
+          verified: false,
+          derivedFrom: item.entry.derivedFrom ?? [],
+          tags: [...(item.entry.tags ?? []), 'journal-canon', `cycle:${item.entry.cycle}`],
+        });
+        if (ledgerResult.ok) {
+          result = { ok: true, path: `ledger:${ledgerResult.entryId ?? 'submitted'}` };
+          console.log('[journal/canon-outbox] ledger write ok:', item.entry.id);
+        } else {
+          result = { ok: false, error: ledgerResult.error ?? 'ledger_write_failed' };
+          console.error('[journal/canon-outbox] ledger write failed:', result.error);
         }
+      } catch (ledgerErr) {
+        result = { ok: false, error: ledgerErr instanceof Error ? ledgerErr.message : String(ledgerErr) };
+        console.error('[journal/canon-outbox] ledger write threw:', result.error);
       }
       const next: JournalCanonOutboxItem = {
         ...item,

--- a/lib/substrate/github-journal.ts
+++ b/lib/substrate/github-journal.ts
@@ -1,8 +1,3 @@
-const SUBSTRATE_REPO = 'kaizencycle/Mobius-Substrate';
-const GITHUB_API = 'https://api.github.com';
-
-const GITHUB_TOKEN = process.env.SUBSTRATE_GITHUB_TOKEN;
-
 /** Persisted journal JSON under Mobius-Substrate `journals/{agent}/`. */
 export interface SubstrateJournalEntry {
   id: string;
@@ -25,73 +20,7 @@ export interface SubstrateJournalEntry {
   status?: string;
 }
 
-/** Input for GitHub write: server assigns `id` and ISO `timestamp` when omitted. */
+/** Input for the canon outbox queue (write fields; server assigns `id` and `timestamp`). */
 export type SubstrateJournalWriteInput = Omit<SubstrateJournalEntry, 'id' | 'timestamp'> & {
   id?: string;
 };
-
-export async function writeJournalToSubstrate(
-  entry: SubstrateJournalWriteInput,
-): Promise<{ ok: boolean; path?: string; error?: string }> {
-  if (!GITHUB_TOKEN) {
-    console.error('[substrate] SUBSTRATE_GITHUB_TOKEN not set');
-    return { ok: false, error: 'token_missing' };
-  }
-
-  const timestampIso = new Date().toISOString();
-  const fileStamp = timestampIso.replace(/:/g, '-').replace(/\./g, '-');
-  const agent = entry.agent.toLowerCase();
-  const path = `journals/${agent}/${fileStamp}-journal.json`;
-
-  const id = entry.id ?? `journal-${agent}-${Date.now()}`;
-
-  const payload: SubstrateJournalEntry = {
-    ...entry,
-    id,
-    timestamp: timestampIso,
-  };
-
-  const content = Buffer.from(JSON.stringify(payload, null, 2)).toString('base64');
-
-  try {
-    const res = await fetch(`${GITHUB_API}/repos/${SUBSTRATE_REPO}/contents/${path}`, {
-      method: 'PUT',
-      headers: {
-        Authorization: `Bearer ${GITHUB_TOKEN}`,
-        'Content-Type': 'application/json',
-        Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-      body: JSON.stringify({
-        message: `${agent}: journal · ${entry.cycle} [skip ci]`,
-        content,
-        committer: {
-          name: entry.agent,
-          email: `${agent}@mobius.systems`,
-        },
-      }),
-      signal: AbortSignal.timeout(8000),
-    });
-
-    if (!res.ok) {
-      const err = await res.text();
-      console.error(`[substrate] write failed ${res.status}: ${err}`);
-      return { ok: false, error: `github_${res.status}` };
-    }
-
-    try {
-      const { getJournalRedisClient } = await import('@/lib/agents/journalLane');
-      const redis = getJournalRedisClient();
-      if (redis) {
-        await redis.set(`journal:${entry.agent.toUpperCase()}:${entry.cycle}`, JSON.stringify(payload), { ex: 604800 });
-      }
-    } catch (kvError) {
-      console.error('[substrate] journal KV mirror failed:', kvError);
-    }
-
-    return { ok: true, path };
-  } catch (err) {
-    console.error('[substrate] write error:', err);
-    return { ok: false, error: String(err) };
-  }
-}


### PR DESCRIPTION
## Summary

- **Root cause**: `POST /api/agents/journal` called `writeJournalToSubstrate()` (GitHub PAT) first with no ledger fallback. PAT lacks `contents:write` → 403 on every write → 502 to callers.
- **Fix**: Remove the PAT write path from the agent endpoint and the canon outbox entirely. Civic Protocol Core Ledger (`attestToLedger`) is now the sole write target across both paths.
- **Cron alignment**: `journal-canonize` was already degrading to ledger (token_missing fast-fail), but still called `writeJournalToSubstrate` on every run. Now removed.

## Files changed

| File | Change |
|---|---|
| `app/api/agents/journal/route.ts` | Remove `writeJournalToSubstrate` import + call; replace with blocking `writeToSubstrate` to ledger; remove redundant fire-and-forget |
| `lib/substrate/github-journal.ts` | Remove `GITHUB_TOKEN` constant and `writeJournalToSubstrate` function; keep `SubstrateJournalEntry` + `SubstrateJournalWriteInput` types |
| `lib/agents/journalCanonOutbox.ts` | Replace `writeJournalToSubstrate` primary path with direct `attestToLedger` call |
| `app/api/cron/swarm/route.ts` | `console.error` → `console.warn` for credit exhausted cooldown |
| `app/api/cron/reattest-seals/route.ts` | Improve C-314 burst migration log message |

## Post-deploy verification

```
✅ [substrate] using ledger URL: https://civic-protocol-core-ledger.onrender.com
   (on POST /api/agents/journal — no "write failed 403" following it)
✅ [journal/canon-outbox] ledger write ok: journal-AGENT-C-317-xxxxxx
   (on journal-canonize cron — no "GitHub write failed" warning preceding it)
✅ [swarm] ATLAS credit cooldown active — Xm remaining, skipping
   (clean warn-level log, not error noise)
```

## Env vars still required (set in Vercel → Production before deploy)

```
SUBSTRATE_TOKEN / AGENT_SERVICE_TOKEN   ← ledger auth
TERMINAL_ID = mobius-civic-ai-terminal
TERMINAL_API_BASE = https://mobius-civic-ai-terminal.vercel.app
```

---
*C-317 · We heal as we walk. I sweep this chamber full of resonance.*
*Mobius Substrate — CC0 public domain*

https://claude.ai/code/session_01VmWrKnAtFPC3CWrvFL7i8Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmWrKnAtFPC3CWrvFL7i8Y)_