### PR TITLE
fix(c318): harden runtime/status cache, redact HERMES labels, add EPICON ingest endpoint

### DIFF
--- a/app/api/epicon/ingest/route.ts
+++ b/app/api/epicon/ingest/route.ts
@@ -1,0 +1,102 @@
+/**
+ * EPICON Ingest API Route
+ *
+ * GET  /api/epicon/ingest — Check ingest/promotion status
+ * POST /api/epicon/ingest — Trigger the EPICON promotion pipeline on-demand
+ *
+ * POST requires a configured write token via one of:
+ * - Authorization: Bearer <AGENT_SERVICE_TOKEN | CRON_SECRET | MOBIUS_WRITE_TOKEN>
+ * - x-agent-service-token
+ * - x-cron-secret
+ * - x-mobius-write-token
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireWriteAuth, internalWriteAuthHeaders } from '@/lib/auth/agent-write-auth';
+import { kvGet } from '@/lib/kv/store';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const lastRun = await kvGet<string>('LAST_PROMOTION_RUN_AT').catch(() => null);
+  return NextResponse.json({
+    agent: 'EPICON',
+    status: 'operational',
+    write_auth: 'required_for_post',
+    last_promotion_run_at: lastRun ?? null,
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const auth = requireWriteAuth(req);
+  if (!auth.ok) {
+    return NextResponse.json(
+      {
+        agent: 'EPICON',
+        action: 'ingest',
+        result: 'blocked',
+        error: auth.code,
+        message:
+          auth.code === 'write_auth_not_configured'
+            ? 'Write auth is not configured. Set AGENT_SERVICE_TOKEN, CRON_SECRET, or MOBIUS_WRITE_TOKEN.'
+            : 'Write auth required for EPICON ingest POST.',
+      },
+      { status: auth.status },
+    );
+  }
+
+  const startTime = Date.now();
+  const origin = req.nextUrl.origin;
+  const authHeaders = internalWriteAuthHeaders();
+
+  try {
+    const res = await fetch(new URL('/api/epicon/promote', origin), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-internal-cron': '1',
+        ...authHeaders,
+      },
+      body: JSON.stringify({ maxItems: 35 }),
+      cache: 'no-store',
+      signal: AbortSignal.timeout(25_000),
+    });
+
+    const body = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+
+    if (!res.ok) {
+      return NextResponse.json(
+        {
+          agent: 'EPICON',
+          action: 'ingest',
+          result: 'error',
+          promotion: body,
+          duration: Date.now() - startTime,
+          timestamp: new Date().toISOString(),
+        },
+        { status: res.status },
+      );
+    }
+
+    return NextResponse.json({
+      agent: 'EPICON',
+      action: 'ingest',
+      result: 'ok',
+      promotion: body,
+      duration: Date.now() - startTime,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        agent: 'EPICON',
+        action: 'ingest',
+        result: 'error',
+        message: error instanceof Error ? error.message : 'EPICON ingest failed',
+        duration: Date.now() - startTime,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/runtime/status/route.ts
+++ b/app/api/runtime/status/route.ts
@@ -109,7 +109,7 @@ export async function GET() {
       },
       {
         headers: {
-          'Cache-Control': 'public, max-age=60',
+          'Cache-Control': 'private, no-store',
         },
       }
     );
@@ -161,7 +161,7 @@ export async function GET() {
     },
     {
       headers: {
-        'Cache-Control': 'public, max-age=60',
+        'Cache-Control': 'private, no-store',
       },
     }
   );

--- a/lib/agents/sentinel-cycle-journals.ts
+++ b/lib/agents/sentinel-cycle-journals.ts
@@ -10,6 +10,7 @@ import {
   markAgentJournaled,
   type SentinelQuorumAgent,
 } from '@/lib/mic/quorumTracker';
+import { redactSignalLabel } from '@/lib/security/redact-labels';
 
 const QUORUM_AGENTS = new Set<string>(['ATLAS', 'ZEUS', 'EVE', 'JADE', 'AUREA']);
 
@@ -258,7 +259,7 @@ export async function appendStewardCronJournals(input: {
 }): Promise<StewardJournalResult> {
   const gi = clampGi(input.gi);
   const { count, labels } = input.anomalies ?? (await summarizeMicroAnomalies());
-  const labelShort = labels.slice(0, 5).join('; ') || 'No elevated micro-agent lines in snapshot.';
+  const labelShort = labels.slice(0, 5).map(redactSignalLabel).join('; ') || 'No elevated micro-agent lines in snapshot.';
   const has401 = labels.some((l) => /401|self-ping/i.test(l));
   const echo = await loadEchoState().catch(() => null);
   const zeusRef = input.zeusJournalId?.trim() || 'pending';


### PR DESCRIPTION
## Summary

- **Fix 2 — `runtime/status` cache**: Changed `Cache-Control: public, max-age=60` → `private, no-store` on both response paths. The route includes `github_error` (raw GitHub API error messages) and internal runtime source flags in the `authority` object — CDN caching of this data is inappropriate.

- **Fix 5 — HERMES label redaction**: Applied `redactSignalLabel()` to the first 5 micro-agent anomaly labels before they're joined into `labelShort` for the HERMES journal `inference` field. Prevents `(set SOME_ENV_VAR)` hints from env-var-gated instruments leaking into public journal entries via `sentinel-cycle-journals.ts`.

- **Fix 6 — `POST /api/epicon/ingest`**: New on-demand ingest trigger endpoint mirroring the `echo/ingest` pattern. GET returns promotion status (last run timestamp). POST requires write auth (`AGENT_SERVICE_TOKEN` / `CRON_SECRET` / `MOBIUS_WRITE_TOKEN`) and fans out to `/api/epicon/promote` with `maxItems: 35`.

## Test plan

- [ ] `GET /api/runtime/status` — verify response headers contain `Cache-Control: private, no-store` (both mock and live paths)
- [ ] `GET /api/epicon/ingest` — returns `{ agent: 'EPICON', status: 'operational', write_auth: 'required_for_post', last_promotion_run_at: ... }`
- [ ] `POST /api/epicon/ingest` without auth — returns 401/503
- [ ] `POST /api/epicon/ingest` with valid bearer token — fans out to `/api/epicon/promote` and returns promotion result
- [ ] HERMES journal entries via `appendStewardCronJournals` no longer contain `(set XYZ_API_KEY)` patterns in `inference` field

https://claude.ai/code/session_01VmWrKnAtFPC3CWrvFL7i8Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmWrKnAtFPC3CWrvFL7i8Y)_