### PR TITLE
fix(c320): globe WebGL — replace CDN Three.js loader with npm package

### DIFF
--- a/components/terminal/chambers/GlobeView3D.tsx
+++ b/components/terminal/chambers/GlobeView3D.tsx
@@ -20,26 +20,6 @@ type SentimentDomain = {
   score: number | null;
   status: 'nominal' | 'stressed' | 'critical' | 'unknown';
 };
-const THREE_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js';
-function loadThreeScript(): Promise<void> {
-  if (typeof window === 'undefined') return Promise.resolve();
-  const w = window as unknown as { THREE?: any };
-  if (w.THREE) return Promise.resolve();
-  return new Promise((resolve, reject) => {
-    const existing = document.querySelector(`script[src="${THREE_CDN}"]`);
-    if (existing) {
-      existing.addEventListener('load', () => resolve(), { once: true });
-      existing.addEventListener('error', () => reject(new Error('Three.js load failed')), { once: true });
-      return;
-    }
-    const s = document.createElement('script');
-    s.src = THREE_CDN;
-    s.async = true;
-    s.onload = () => resolve();
-    s.onerror = () => reject(new Error('Three.js load failed'));
-    document.head.appendChild(s);
-  });
-}
 function latLngToXYZ(THREE: any, lat: number, lng: number, r = 1.015) {
   const phi = (90 - lat) * (Math.PI / 180);
   const theta = (lng + 180) * (Math.PI / 180);
@@ -126,8 +106,9 @@ export default function GlobeView3D({
     if (!host) return;
     let disposed = false;
     async function boot() {
+      let THREE: any;
       try {
-        await loadThreeScript();
+        THREE = await import('three');
       } catch {
         if (!disposed) setLoadError('Globe requires WebGL and Three.js');
         return;
@@ -135,12 +116,6 @@ export default function GlobeView3D({
       if (disposed) return;
       const el = containerRef.current;
       if (!el) return;
-      const w = window as unknown as { THREE: any };
-      const THREE = w.THREE;
-      if (!THREE) {
-        setLoadError('Three.js unavailable');
-        return;
-      }
       const width = el.clientWidth || 800;
       const height = el.clientHeight || 420;
       const scene = new THREE.Scene();

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
+        "@types/three": "^0.128.0",
         "@types/topojson-client": "^3.1.5",
         "@types/topojson-specification": "^1.0.5",
         "autoprefixer": "^10.4.20",
@@ -1054,6 +1055,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/three": {
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.128.0.tgz",
+      "integrity": "sha512-Jwq5XYUkzAcPTo34hlGAQGUyAI0b2F3aCCFWG/v7ZhJBEG5HGcusMSr70GhDlT8Gs0f02QnSPZ2RCA1MrCOa/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/topojson-client": {
       "version": "3.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mobius-civic-ai-terminal",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.95.1",
         "@modelcontextprotocol/sdk": "1.26.0",
         "@upstash/redis": "^1.37.0",
         "@vercel/kv": "^1.0.0",
@@ -23,6 +24,7 @@
         "react-dom": "^19.0.0",
         "recharts": "^2.15.4",
         "tailwind-merge": "^3.3.1",
+        "three": "^0.128.0",
         "topojson-client": "^3.1.0",
         "world-atlas": "^2.0.2",
         "yaml": "2.7.0",
@@ -54,6 +56,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.95.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.95.2.tgz",
+      "integrity": "sha512-Egddwo3sheo1PzUrMkZnH6VkQYwS0h/b/i8vSK8Ta9M45UQipAMeDFH57dYuDAfXMEUUGeKw6CMlremgMZgrSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@auth/core": {
@@ -906,6 +929,12 @@
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -1979,6 +2008,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -2417,6 +2452,19 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -3692,6 +3740,16 @@
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -3831,6 +3889,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.128.0.tgz",
+      "integrity": "sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA==",
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -3925,6 +3989,12 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
     "node_modules/ts-interface-checker": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@types/three": "^0.128.0",
     "@types/topojson-client": "^3.1.5",
     "@types/topojson-specification": "^1.0.5",
     "autoprefixer": "^10.4.20",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^19.0.0",
     "recharts": "^2.15.4",
     "tailwind-merge": "^3.3.1",
+    "three": "^0.128.0",
     "topojson-client": "^3.1.0",
     "world-atlas": "^2.0.2",
     "yaml": "2.7.0",


### PR DESCRIPTION
## Root cause

`GlobeView3D.tsx` loaded Three.js via a dynamically-injected `<script>` tag pointing to `cdnjs.cloudflare.com`. If the CDN is unreachable (network timeout, CSP block, cold environment), the `onerror` handler fires → `catch` block sets `loadError = 'Globe requires WebGL and Three.js'` → the fallback text renders. No server-side log because the failure is entirely in the browser.

The rest of the component was already correct for r128:
- Manual `mousedown/mousemove/mouseup` rotation (no OrbitControls)
- `CylinderGeometry` + `SphereGeometry` for pin stems/heads
- `RingGeometry` for pulse rings (not `CapsuleGeometry`)
- Country border lines via `world-atlas` topojson
- Pin tooltip + inspection panel

Only the loading mechanism was broken.

## Change

- **`package.json` / `package-lock.json`**: add `three@^0.128.0` as a proper npm dependency
- **`components/terminal/chambers/GlobeView3D.tsx`**: remove `loadThreeScript()` function and `THREE_CDN` constant; replace with `import('three')` dynamic import

`import('three')` is bundled by Next.js — no external network request, no CSP risk from injected `<script>` tags, no race condition on script load event.

`GlobeChamber.tsx` and `app/api/chambers/globe/route.ts` are unchanged — both were already correct.

## Test plan

- [ ] Globe tab renders 3D globe without "Globe requires WebGL and Three.js" error
- [ ] Globe auto-rotates; pauses on drag; resumes after ~4s
- [ ] Signal pins render (cylinder stems + sphere heads)
- [ ] Elevated/critical pins show pulse rings
- [ ] Country border lines load asynchronously
- [ ] Pin tooltip appears on hover; inspection panel opens on click
- [ ] 2D Map / 3D Globe toggle still works on desktop and mobile
- [ ] No console errors from Three.js initialization

No env vars required for this fix.

Fixes: C-320-GLOBE-WEBGL
Cycle: C-320

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrCGLj89xvAD7fPnJKmhK)_