### PR TITLE
feat(c321): 10 terminal optimizations — deploy cascade, cold-boot, empty states, ZEUS dispute

### DIFF
--- a/app/api/cron/heartbeat/route.ts
+++ b/app/api/cron/heartbeat/route.ts
@@ -12,7 +12,7 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { getEveSynthesisAuthError } from '@/lib/security/serviceAuth';
 import { writeFleetHeartbeatKV } from '@/lib/runtime/agent-heartbeat-kv';
-import { loadGIState, loadGIStateCarry, appendGiTrend, kvDel } from '@/lib/kv/store';
+import { loadGIState, loadGIStateCarry, appendGiTrend, kvDel, kvSet } from '@/lib/kv/store';
 import { updateSustainTrackingFromGi, seedSustainStateIfMissing } from '@/lib/mic/sustainTracker';
 import { resolveOperatorCycleId } from '@/lib/eve/resolve-operator-cycle';
 
@@ -73,6 +73,18 @@ async function run(req: NextRequest) {
     kvDel('cache:integrity-status'),
     kvDel('cache:lane-diagnostics'),
   ]).catch(() => {});
+
+  // OPT-9 (C-321): persist last-known snapshot so the shell endpoint can serve
+  // real values on cold start instead of all-dashes.
+  if (gi !== null) {
+    const cycle = await resolveOperatorCycleId().catch(() => '');
+    void kvSet('terminal:last-known-snapshot', {
+      gi,
+      cycle: cycle || undefined,
+      runtime: 'ok',
+      ts: Date.now(),
+    }, 86400).catch(() => {});
+  }
 
   return NextResponse.json({
     ok: true,

--- a/app/api/cron/sweep/route.ts
+++ b/app/api/cron/sweep/route.ts
@@ -90,6 +90,18 @@ async function run(req: NextRequest) {
       cycle = currentCycleId();
     }
 
+    // OPT-8 (C-321): surface ZEUS probe failures as a formal dispute in KV so
+    // Sentinel can render an orange banner with cycle, message, and age.
+    if (zeusRaw === 'fail') {
+      await kvSet('zeus:dispute:latest', {
+        cycle,
+        message: 'ZEUS verification probe returned fail. EPICON queue may be blocked; check vault/journal surface health.',
+        ts:      Date.now(),
+      }, 7200).catch(() => {});
+    } else if (zeusRaw === 'pass') {
+      await kvDel('zeus:dispute:latest').catch(() => {});
+    }
+
     // Fix 2: restore missing CURRENT_CYCLE KV key so kvHealth shows it as present
     try {
       const currentCycleKv = await kvGet<string>(KV_KEYS.CURRENT_CYCLE);

--- a/app/api/cron/watchdog/route.ts
+++ b/app/api/cron/watchdog/route.ts
@@ -3,7 +3,7 @@ import { getServiceAuthError, serviceAuthorizationHeaderValue } from '@/lib/secu
 import { appendAgentJournalEntry } from '@/lib/agents/journal';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
 import { pushLedgerEntry } from '@/lib/epicon/ledgerPush';
-import { kvGet, kvSet, kvSetRawKey, KV_KEYS, isRedisAvailable, KV_TTL_SECONDS } from '@/lib/kv/store';
+import { kvGet, kvSet, kvDel, kvSetRawKey, KV_KEYS, isRedisAvailable, KV_TTL_SECONDS } from '@/lib/kv/store';
 import { readAllSubstrateJournals } from '@/lib/substrate/github-reader';
 import { evaluateTrustTripwires } from '@/lib/tripwire/trustTripwires';
 import type { TrustTripwireResult, TrustTripwireSnapshot } from '@/lib/tripwire/types';
@@ -16,6 +16,19 @@ import { runEchoIngest } from '@/app/api/echo/ingest/route';
 import { POST as postEpiconPromote } from '@/app/api/epicon/promote/route';
 
 export const dynamic = 'force-dynamic';
+
+// OPT-10 (C-321): tiered escalation — at 2,276+ failures the watchdog was logging
+// the same flat "threshold breached" message since failure #10. Now escalates proportionally.
+const ESCALATION_TIERS = [
+  { threshold:   50, severity: 'warn'     as const, label: 'EPICON promote degraded'  },
+  { threshold:  300, severity: 'error'    as const, label: 'EPICON promote stuck'     },
+  { threshold:  900, severity: 'critical' as const, label: 'EPICON lane blocked'      },
+  { threshold: 2000, severity: 'alert'    as const, label: 'EPICON multi-day outage'  },
+] as const;
+
+function getEscalationTier(failures: number) {
+  return [...ESCALATION_TIERS].reverse().find((t) => failures >= t.threshold) ?? null;
+}
 
 function emptyTrustSnapshot(timestamp: string): TrustTripwireSnapshot {
   return {
@@ -143,16 +156,27 @@ export async function GET(request: NextRequest) {
   const echoResult = await runAction(() => runEchoIngest(), 30_000);
   actions.push(`echo-ingest:${echoResult.ok ? 'ok' : `fail:${echoResult.status}`}`);
 
-  // FIX-14: alert when promote failures accumulate (threshold = 10 consecutive failures).
+  // OPT-10 (C-321): tiered escalation replaces flat FIX-14 threshold alert.
   const PROMOTE_FAIL_KEY = 'watchdog:promote-fail-count';
-  const PROMOTE_FAIL_THRESHOLD = 10;
   const promoteFailCount = (await kvGet<number>(PROMOTE_FAIL_KEY)) ?? 0;
-  if (promoteFailCount >= PROMOTE_FAIL_THRESHOLD) {
-    console.error(
-      `[watchdog] promote failure threshold breached: ${promoteFailCount} consecutive failures. ` +
-      'Check SUBSTRATE_TOKEN and /api/epicon/promote auth. EPICON promotion lane may be stuck.',
-    );
-    actions.push(`promote-fail-alert:${promoteFailCount}`);
+  const escalationTier = getEscalationTier(promoteFailCount);
+  if (escalationTier) {
+    const logFn = escalationTier.severity === 'warn' ? console.warn : console.error;
+    logFn(`[watchdog] ${escalationTier.label}: ${promoteFailCount} consecutive failures (tier: ${escalationTier.severity})`, {
+      failures: promoteFailCount,
+      severity: escalationTier.severity,
+      threshold: escalationTier.threshold,
+      hint: 'Set SUBSTRATE_TOKEN in Vercel env vars to unblock EPICON promotion.',
+    });
+    actions.push(`promote-fail-alert:${promoteFailCount}:${escalationTier.severity}`);
+    await kvSet('watchdog:epicon:escalation', {
+      failures:  promoteFailCount,
+      severity:  escalationTier.severity,
+      label:     escalationTier.label,
+      ts:        Date.now(),
+    }, 3600).catch(() => {});
+  } else if (promoteFailCount === 0) {
+    await kvDel('watchdog:epicon:escalation').catch(() => {});
   }
 
   const promoteRequest = makeInternalRequest(origin, '/api/epicon/promote', {

--- a/app/api/terminal/shell/route.ts
+++ b/app/api/terminal/shell/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { resolveGiForTerminal } from '@/lib/integrity/resolveGi';
 import { loadMicReadinessSnapshotRaw } from '@/lib/mic/loadReadinessSnapshot';
 import { currentCycleId } from '@/lib/eve/cycle-engine';
-import { loadTripwireState } from '@/lib/kv/store';
+import { loadTripwireState, kvGet } from '@/lib/kv/store';
 import { getHeartbeat, getJournalHeartbeat } from '@/lib/runtime/heartbeat';
 
 export const dynamic = 'force-dynamic';
@@ -50,11 +50,16 @@ export async function GET() {
       },
     });
   } catch {
+    // OPT-9 (C-321): serve last-known snapshot from KV so cold-start console
+    // shows real values (GI, cycle) instead of all-dashes.
+    type LastKnown = { gi?: number; cycle?: string; runtime?: string; ts?: number };
+    const lastKnown = await kvGet<LastKnown>('terminal:last-known-snapshot').catch(() => null);
+    const staleAgeS = lastKnown?.ts ? Math.round((Date.now() - lastKnown.ts) / 1000) : null;
     return NextResponse.json({
       ok: true,
       fallback: true,
-      cycle: currentCycleId(),
-      gi: null,
+      cycle: lastKnown?.cycle ?? currentCycleId(),
+      gi: lastKnown?.gi ?? null,
       mode: 'yellow',
       degraded: true,
       tripwire: { count: 0, elevated: false },
@@ -62,7 +67,9 @@ export async function GET() {
         runtime: getHeartbeat(),
         journal: getJournalHeartbeat(),
       },
-      source: 'fallback',
+      source: lastKnown?.gi != null ? 'last-known' : 'fallback',
+      _stale: lastKnown?.gi != null,
+      _stale_age_s: staleAgeS,
       timestamp,
     });
   }

--- a/app/terminal/sentinel/SentinelPageClient.tsx
+++ b/app/terminal/sentinel/SentinelPageClient.tsx
@@ -8,6 +8,22 @@ import { currentCycleId } from '@/lib/eve/cycle-engine';
 type Agent = { id: string; name: string; role: string; status: string; liveness?: string; lastAction?: string; last_action?: string; last_seen?: string | null; last_journal_at?: string | null; confidence?: number; source_badges?: string[]; tier?: string; mii_avg?: number };
 type JournalEntry = { id: string; observation?: string; cycle?: string };
 type MiiEntry = { agent: string; mii: number; timestamp: string };
+
+// OPT-8 (C-321): ZEUS dispute signal surfaced from sweep cron KV write.
+type ZeusDispute = {
+  cycle: string;
+  message: string;
+  ts: number;
+};
+
+// OPT-10 (C-321): EPICON tiered escalation from watchdog cron KV write.
+type EpiconEscalation = {
+  failures: number;
+  severity: 'warn' | 'error' | 'critical' | 'alert';
+  label: string;
+  ts: number;
+};
+
 type SentinelQuorum = {
   status: string;
   attestations_received: number;
@@ -19,6 +35,7 @@ type SentinelQuorum = {
 
 const CONFIDENCE_FLOOR = 0.65;
 const SENTINEL_TIERS = ['Sentinel', 'Architect'];
+const ALL_AGENTS = ['ATLAS', 'ZEUS', 'EVE', 'JADE', 'AUREA', 'HERMES', 'ECHO', 'DAEDALUS'] as const;
 
 function journalRelTime(ts: string | null | undefined): string {
   if (!ts) return '—';
@@ -87,7 +104,73 @@ const SENTINEL_LAYOUT: Array<{ name: string; x: number; y: number }> = [
   { name: 'DAEDALUS', x: 38, y: 16 },
 ];
 
-export default function SentinelPageClient() {
+// OPT-8 (C-321): orange banner for active ZEUS disputes (< 90 min old).
+function ZeusDisputeBanner({ dispute }: { dispute?: ZeusDispute | null }) {
+  if (!dispute) return null;
+  const ageMs = Date.now() - dispute.ts;
+  if (ageMs > 90 * 60 * 1000) return null;
+  return (
+    <div className="mb-3 rounded border border-orange-500/30 bg-orange-950/20 px-3 py-2 font-mono text-xs">
+      <div className="flex items-center gap-2 text-orange-400">
+        <span>⚡</span>
+        <span>ZEUS dispute · {dispute.cycle}</span>
+        <span className="ml-auto opacity-50">{Math.round(ageMs / 60000)}m ago</span>
+      </div>
+      <p className="mt-1 opacity-60 leading-relaxed">{dispute.message}</p>
+    </div>
+  );
+}
+
+// OPT-10 (C-321): escalation banner matching severity tier from watchdog cron.
+function EpiconEscalationBanner({ escalation }: { escalation?: EpiconEscalation | null }) {
+  if (!escalation) return null;
+  const colorMap: Record<EpiconEscalation['severity'], string> = {
+    warn: 'border-amber-500/30 bg-amber-950/20 text-amber-400',
+    error: 'border-rose-500/30 bg-rose-950/20 text-rose-400',
+    critical: 'border-rose-600/40 bg-rose-950/30 text-rose-300',
+    alert: 'border-red-600/50 bg-red-950/40 text-red-300',
+  };
+  const cls = colorMap[escalation.severity] ?? colorMap.warn;
+  return (
+    <div className={`mb-3 rounded border px-3 py-2 font-mono text-xs ${cls}`}>
+      <div className="flex items-center gap-2">
+        <span>⚠</span>
+        <span>{escalation.label}</span>
+        <span className="ml-auto opacity-50">{escalation.failures.toLocaleString()} failures</span>
+      </div>
+      <p className="mt-1 opacity-60">EPICON promotion lane blocked. Set SUBSTRATE_TOKEN in Vercel env vars to unblock.</p>
+    </div>
+  );
+}
+
+// OPT-6 (C-321): shown when an agent has no KV heartbeat data.
+function AgentFallbackCard({ name }: { name: string }) {
+  return (
+    <div className="group rounded border border-slate-800/60 bg-slate-900/30 p-4 text-left opacity-40">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          <span style={{ color: AGENT_COLORS[name] ?? '#94a3b8' }}>{name}</span>
+          <span className="font-mono text-xs text-slate-500">0.000</span>
+        </div>
+        <div className="flex flex-col items-end gap-0.5 text-[9px] font-mono text-slate-600">
+          <span className="flex items-center gap-1">
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-neutral-600" />
+            offline
+          </span>
+        </div>
+      </div>
+      <div className="mt-1 text-xs text-slate-600">Awaiting first cycle heartbeat</div>
+    </div>
+  );
+}
+
+export default function SentinelPageClient({
+  zeusDispute,
+  epiconEscalation,
+}: {
+  zeusDispute?: ZeusDispute | null;
+  epiconEscalation?: EpiconEscalation | null;
+}) {
   const { snapshot, loading } = useTerminalSnapshot();
   const [expanded, setExpanded] = useState<string | null>(null);
   const [journalByAgent, setJournalByAgent] = useState<Record<string, JournalEntry[]>>({});
@@ -204,6 +287,8 @@ export default function SentinelPageClient() {
 
   return (
     <div className="h-full overflow-y-auto p-4">
+      <ZeusDisputeBanner dispute={zeusDispute} />
+      <EpiconEscalationBanner escalation={epiconEscalation} />
       <div className="mb-3 rounded border border-slate-800/80 bg-slate-950/50 px-3 py-2 text-[10px] font-mono leading-relaxed text-slate-400">
         <span className="text-slate-500">Cycle {currentCycle}</span>
         {' · '}
@@ -284,6 +369,12 @@ export default function SentinelPageClient() {
           ))}
         </div>
       </section>
+      {/* OPT-6 (C-321): no-agents state shows fallback cards for all 8 agents */}
+      {(agents.agents ?? []).length === 0 ? (
+        <div className="mb-3 rounded border border-slate-800/50 bg-slate-950/30 px-3 py-2 text-[10px] font-mono text-slate-500">
+          No agent heartbeats — awaiting first cycle. Cards below show offline state.
+        </div>
+      ) : null}
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
         {(agents.agents ?? []).map((agent) => {
           const rows = journalByAgent[agent.name] ?? [];
@@ -374,6 +465,13 @@ export default function SentinelPageClient() {
           </button>
           );
         })}
+        {/* OPT-6 (C-321): fallback cards for agents absent from the snapshot */}
+        {(() => {
+          const activeNames = new Set((agents.agents ?? []).map((a) => a.name));
+          return ALL_AGENTS
+            .filter((n) => !activeNames.has(n))
+            .map((n) => <AgentFallbackCard key={n} name={n} />);
+        })()}
       </div>
       {expanded ? (
         <div className="mt-4 rounded border border-slate-800 bg-slate-900/60 p-3">

--- a/app/terminal/sentinel/page.tsx
+++ b/app/terminal/sentinel/page.tsx
@@ -9,7 +9,7 @@ export const metadata = chamberMeta(
 );
 
 type ZeusDispute = { cycle: string; message: string; ts: number };
-type EpiconEscalation = { failures: number; severity: string; label: string; ts: number };
+type EpiconEscalation = { failures: number; severity: 'warn' | 'error' | 'critical' | 'alert'; label: string; ts: number };
 
 export default async function SentinelPage() {
   // OPT-8 + OPT-10 (C-321): fetch dispute and escalation state from KV on the

--- a/app/terminal/sentinel/page.tsx
+++ b/app/terminal/sentinel/page.tsx
@@ -1,5 +1,6 @@
 import { chamberMeta } from '../layout';
 import SentinelPageClient from './SentinelPageClient';
+import { kvGet } from '@/lib/kv/store';
 
 export const metadata = chamberMeta(
   'Sentinel',
@@ -7,6 +8,21 @@ export const metadata = chamberMeta(
   'sentinel'
 );
 
-export default function SentinelPage() {
-  return <SentinelPageClient />;
+type ZeusDispute = { cycle: string; message: string; ts: number };
+type EpiconEscalation = { failures: number; severity: string; label: string; ts: number };
+
+export default async function SentinelPage() {
+  // OPT-8 + OPT-10 (C-321): fetch dispute and escalation state from KV on the
+  // server so the page renders with current signal data on first load.
+  const [zeusDispute, epiconEscalation] = await Promise.all([
+    kvGet<ZeusDispute>('zeus:dispute:latest').catch(() => null),
+    kvGet<EpiconEscalation>('watchdog:epicon:escalation').catch(() => null),
+  ]);
+
+  return (
+    <SentinelPageClient
+      zeusDispute={zeusDispute ?? null}
+      epiconEscalation={epiconEscalation ?? null}
+    />
+  );
 }

--- a/app/terminal/vault/VaultPageClient.tsx
+++ b/app/terminal/vault/VaultPageClient.tsx
@@ -193,8 +193,14 @@ export default function VaultPageClient() {
   const focusCycle = currentCycleId();
 
   useEffect(() => {
-    void fetch('/api/vault/status', { cache: 'no-store' })
+    // OPT-4 (C-321): 10s AbortController guard — substrate 404/502 can hold the
+    // lambda open up to 30s, leaving the chamber stuck on "Loading vault…".
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+
+    void fetch('/api/vault/status', { cache: 'no-store', signal: controller.signal })
       .then(async (r) => {
+        clearTimeout(timeout);
         const j = (await r.json()) as VaultPayload & { error?: string };
         if (!r.ok || !j.ok) {
           setErr(j.error ?? `Vault status unavailable (HTTP ${r.status})`);
@@ -203,8 +209,20 @@ export default function VaultPageClient() {
         }
         setData(j);
       })
-      .catch(() => setErr('Unable to load vault status'))
+      .catch((e: unknown) => {
+        clearTimeout(timeout);
+        if (e instanceof DOMException && e.name === 'AbortError') {
+          setErr('Vault status timed out — substrate may be unreachable. Set SUBSTRATE_TOKEN, TERMINAL_ID, TERMINAL_API_BASE in Vercel env vars to restore vault writes.');
+        } else {
+          setErr('Unable to load vault status');
+        }
+      })
       .finally(() => setLoading(false));
+
+    return () => {
+      clearTimeout(timeout);
+      controller.abort();
+    };
   }, []);
 
   useEffect(() => {

--- a/components/terminal/TerminalShell.tsx
+++ b/components/terminal/TerminalShell.tsx
@@ -60,8 +60,21 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
     return typeof seed?.gi === 'number' && Number.isFinite(seed.gi) ? seed.gi : null;
   }, []);
 
-  const gi = shell?.gi ?? seededGi;
-  const cycle = shell?.cycle ?? 'C-—';
+  // OPT-7 (C-321): read last-known from sessionStorage so cold-boot shows GI 63~
+  // instead of GI — when the live fetch is still in flight or failed.
+  const lastKnown = useMemo(() => {
+    try {
+      const raw = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('mobius:shell:last-known') : null;
+      return raw ? (JSON.parse(raw) as { gi?: number | null; cycle?: string | null }) : null;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const giRaw = shell?.gi ?? seededGi ?? lastKnown?.gi ?? null;
+  const isStale = !shell && (seededGi === null) && lastKnown?.gi != null;
+  const gi = giRaw;
+  const cycle = shell?.cycle ?? lastKnown?.cycle ?? 'C-—';
   const mode = shell?.mode?.toLowerCase() ?? null;
 
   const runtime = useMemo<'online' | 'degraded' | 'offline'>(() => {
@@ -125,8 +138,8 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
             <a href={SHELL_URL} target="_blank" rel="noopener noreferrer" className="hidden rounded border border-violet-500/40 bg-violet-500/10 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wider text-violet-300 md:inline-block">Shell</a>
           </div>
           <div className="flex items-center gap-1.5 text-[10px] font-mono md:gap-2 md:text-[11px]">
-            <span className={cn('flex items-center gap-1 rounded border px-1.5 py-0.5 md:px-2 md:py-1', loading ? 'border-slate-700 text-slate-500' : giTone)}>
-              GI {gi === null ? '—' : gi.toFixed(2)}
+            <span className={cn('flex items-center gap-1 rounded border px-1.5 py-0.5 md:px-2 md:py-1', loading && gi === null ? 'border-slate-700 text-slate-500' : giTone)}>
+              GI {gi === null ? '—' : `${gi.toFixed(2)}${isStale ? '~' : ''}`}
             </span>
             <span className={cn('rounded border px-1.5 py-0.5 uppercase md:px-2 md:py-1', loading ? 'border-slate-700 bg-slate-800/40 text-slate-500' : runtimeBadgeClass(runtime))}>
               {loading ? 'boot' : runtime}

--- a/components/terminal/TerminalShell.tsx
+++ b/components/terminal/TerminalShell.tsx
@@ -43,7 +43,7 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
   const [showLaneDiagnostics, setShowLaneDiagnostics] = useState(false);
   const [showDataflowCommand, setShowDataflowCommand] = useState(true);
   const [consoleCollapsed, setConsoleCollapsed] = useState(false);
-  const { shell, loading } = useShellSnapshot();
+  const { shell, loading, stale } = useShellSnapshot();
   const flowTelemetryEnabled = showDataflowCommand || showLaneDiagnostics;
   const laneDiagnostics = useLaneDiagnosticsChamber(flowTelemetryEnabled);
 
@@ -60,21 +60,12 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
     return typeof seed?.gi === 'number' && Number.isFinite(seed.gi) ? seed.gi : null;
   }, []);
 
-  // OPT-7 (C-321): read last-known from sessionStorage so cold-boot shows GI 63~
-  // instead of GI — when the live fetch is still in flight or failed.
-  const lastKnown = useMemo(() => {
-    try {
-      const raw = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('mobius:shell:last-known') : null;
-      return raw ? (JSON.parse(raw) as { gi?: number | null; cycle?: string | null }) : null;
-    } catch {
-      return null;
-    }
-  }, []);
-
-  const giRaw = shell?.gi ?? seededGi ?? lastKnown?.gi ?? null;
-  const isStale = !shell && (seededGi === null) && lastKnown?.gi != null;
-  const gi = giRaw;
-  const cycle = shell?.cycle ?? lastKnown?.cycle ?? 'C-—';
+  // OPT-7 (C-321): isStale comes from the hook — true when shell has a GI value
+  // but no live fetch has confirmed it yet (cached from sessionStorage or SSR seed
+  // that predates the current client session). Shows ~ tilde in the GI badge.
+  const isStale = stale;
+  const gi = shell?.gi ?? seededGi ?? null;
+  const cycle = shell?.cycle ?? 'C-—';
   const mode = shell?.mode?.toLowerCase() ?? null;
 
   const runtime = useMemo<'online' | 'degraded' | 'offline'>(() => {

--- a/hooks/useShellSnapshot.ts
+++ b/hooks/useShellSnapshot.ts
@@ -41,9 +41,17 @@ function saveLastKnown(snapshot: ShellSnapshot) {
 }
 
 export function useShellSnapshot() {
+  // P2 fix (C-321): distinguish live-fresh from cached init. readSeed() is SSR-injected
+  // (live at render time); readLastKnown() is sessionStorage (stale from prior load).
   const [shell, setShell] = useState<ShellSnapshot | null>(() => readSeed() ?? readLastKnown());
   const [loading, setLoading] = useState(shell === null);
   const [error, setError] = useState<string | null>(null);
+  // liveLoaded becomes true after the first successful fetch from the server.
+  // Until then, any value we're showing came from SSR seed or sessionStorage cache.
+  const [liveLoaded, setLiveLoaded] = useState(() => {
+    // SSR seed is live — mark as already-loaded so header doesn't show ~ on first paint.
+    return readSeed() !== null;
+  });
 
   useEffect(() => {
     let mounted = true;
@@ -65,6 +73,7 @@ export function useShellSnapshot() {
           saveLastKnown(json);
         }
         setShell(json);
+        setLiveLoaded(true);
         setError(null);
       } catch (err) {
         if (!mounted) return;
@@ -88,5 +97,8 @@ export function useShellSnapshot() {
     };
   }, []);
 
-  return { shell, loading, error };
+  // stale = we have a GI value but it hasn't been confirmed by a live fetch yet.
+  const stale = !liveLoaded && shell?.gi != null;
+
+  return { shell, loading, error, stale };
 }

--- a/hooks/useShellSnapshot.ts
+++ b/hooks/useShellSnapshot.ts
@@ -16,6 +16,7 @@ export type ShellSnapshot = {
 };
 
 const POLL_MS = 30_000;
+const LAST_KNOWN_KEY = 'mobius:shell:last-known';
 
 function readSeed(): ShellSnapshot | null {
   if (typeof window === 'undefined') return null;
@@ -24,17 +25,33 @@ function readSeed(): ShellSnapshot | null {
   return seed;
 }
 
+function readLastKnown(): ShellSnapshot | null {
+  try {
+    const raw = sessionStorage.getItem(LAST_KNOWN_KEY);
+    return raw ? (JSON.parse(raw) as ShellSnapshot) : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveLastKnown(snapshot: ShellSnapshot) {
+  try {
+    sessionStorage.setItem(LAST_KNOWN_KEY, JSON.stringify(snapshot));
+  } catch {}
+}
+
 export function useShellSnapshot() {
-  const [shell, setShell] = useState<ShellSnapshot | null>(() => readSeed());
+  const [shell, setShell] = useState<ShellSnapshot | null>(() => readSeed() ?? readLastKnown());
   const [loading, setLoading] = useState(shell === null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let mounted = true;
 
-    async function load() {
-      // OPT-12 (C-291): add AbortController timeout so the shell fetch can't
-      // hang indefinitely on slow cold starts, causing the header to freeze at "—".
+    // OPT-3 (C-321): retry with backoff on cold-start failure so a 5s serverless
+    // wake-up doesn't strand the header at "—boot—" for the full session.
+    async function load(attempt = 0): Promise<void> {
+      const RETRY_DELAYS = [0, 600, 1400, 3000];
       const controller = new AbortController();
       const timeoutId = window.setTimeout(() => controller.abort(), 6_000);
       try {
@@ -44,10 +61,18 @@ export function useShellSnapshot() {
         });
         const json = (await res.json()) as ShellSnapshot;
         if (!mounted) return;
+        if (json?.gi !== undefined && json?.gi !== null) {
+          saveLastKnown(json);
+        }
         setShell(json);
         setError(null);
       } catch (err) {
         if (!mounted) return;
+        const nextAttempt = attempt + 1;
+        if (nextAttempt < RETRY_DELAYS.length) {
+          window.setTimeout(() => void load(nextAttempt), RETRY_DELAYS[nextAttempt]);
+          return;
+        }
         setError(err instanceof Error ? err.message : 'Shell snapshot load failed');
       } finally {
         window.clearTimeout(timeoutId);
@@ -56,7 +81,7 @@ export function useShellSnapshot() {
     }
 
     void load();
-    const id = window.setInterval(load, POLL_MS);
+    const id = window.setInterval(() => void load(), POLL_MS);
     return () => {
       mounted = false;
       window.clearInterval(id);

--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -64,10 +64,15 @@ if [[ "$subject" =~ ^(heartbeat:|chore\(catalog\)|chore\(mesh\):|chore\(sweep\):
   exit 0
 fi
 
-# OPT-1 (C-321): lockfile-only commits from any author — never trigger deploys.
+# OPT-1 (C-321): lockfile-only commits — only skip when no app code actually changed.
+# Guard: check git diff to prevent message-match from swallowing real code changes.
 if [[ "$subject" =~ ^chore(\([^\)]*\))?:?[[:space:]]*(sync pnpm.lock|update lockfile|pnpm-lock) ]]; then
-  echo "Skipping: lockfile-only commit — $subject"
-  exit 0
+  changed_non_lock="$(git diff --name-only HEAD~1 HEAD 2>/dev/null \
+    | grep -vE '^(pnpm-lock\.yaml|package-lock\.json|yarn\.lock|docs/)' | head -1 || true)"
+  if [[ -z "$changed_non_lock" ]]; then
+    echo "Skipping: lockfile-only commit (verified via diff) — $subject"
+    exit 0
+  fi
 fi
 
 # OPT-1 (C-321): catalog / mesh refresh commits.

--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -64,6 +64,34 @@ if [[ "$subject" =~ ^(heartbeat:|chore\(catalog\)|chore\(mesh\):|chore\(sweep\):
   exit 0
 fi
 
+# OPT-1 (C-321): lockfile-only commits from any author — never trigger deploys.
+if [[ "$subject" =~ ^chore(\([^\)]*\))?:?[[:space:]]*(sync pnpm.lock|update lockfile|pnpm-lock) ]]; then
+  echo "Skipping: lockfile-only commit — $subject"
+  exit 0
+fi
+
+# OPT-1 (C-321): catalog / mesh refresh commits.
+if [[ "$subject" =~ ^chore(\([^\)]*\))?:?[[:space:]]*(update Mobius Catalog|refresh cycle state) ]]; then
+  echo "Skipping: catalog/mesh refresh commit — $subject"
+  exit 0
+fi
+
+# OPT-2 (C-321): cursor/* branches never deploy — agent branches are noise.
+branch="${VERCEL_GIT_COMMIT_REF:-}"
+if [[ -z "$branch" ]]; then
+  branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+fi
+if [[ "$branch" =~ ^cursor/ ]]; then
+  echo "Skipping: cursor/* branch ($branch)"
+  exit 0
+fi
+
+# OPT-2 (C-321): claude/* agent branches don't deploy unless explicitly tagged.
+if [[ "$branch" =~ ^claude/ ]] && [[ "$subject" != *"[deploy]"* ]]; then
+  echo "Skipping: claude/* agent branch ($branch) without [deploy] tag"
+  exit 0
+fi
+
 # Skip commits that only modify docs/catalog/ (no app code changes)
 changed_outside_docs="$(git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -v '^docs/' | head -1 || true)"
 if [[ -z "$changed_outside_docs" ]]; then


### PR DESCRIPTION
## C-321 · 10 Terminal Optimizations

**GI at scan:** 0.63 (terminal) / 0.82 (ATLAS sentinel commits — not yet in prod)
**Root cause:** 20 consecutive CANCELED Vercel deploys — GI progress is real but not landing.

---

## Summary

- **OPT-1/2** (`ignore-build.sh`): Add lockfile-only commit filter + `cursor/*` / `claude/*` branch guards. Ends the deploy cascade immediately — only `main`, `staging`, `deploy/*`, or `[deploy]`-tagged commits reach Vercel.
- **OPT-3** (`useShellSnapshot.ts`): Cold-start retry with exponential backoff (0 / 600ms / 1.4s / 3s). Saves last-known snapshot to `sessionStorage` on each successful fetch.
- **OPT-4** (`VaultPageClient.tsx`): 10s `AbortController` timeout on `/api/vault/status`. Replaces 30s silent hang with a degraded state showing actionable env-var hint.
- **OPT-6** (`SentinelPageClient.tsx`): Fallback "offline" agent cards for all 8 agents when heartbeat KV keys are absent. Sentinel no longer renders blank.
- **OPT-7** (`TerminalShell.tsx`): Stale GI display — shows `GI 0.63~` (tilde = last-known) instead of `GI —` on cold boot. Reads from `sessionStorage` populated by prior successful loads.
- **OPT-8** (`sweep/route.ts` + `SentinelPageClient.tsx`): ZEUS dispute indicator. Sweep cron writes `zeus:dispute:latest` to KV on probe fail (2h TTL, auto-clears on pass). Sentinel page fetches server-side and renders an orange banner with cycle, message, and age.
- **OPT-9** (`heartbeat/route.ts` + `shell/route.ts`): Heartbeat cron persists `terminal:last-known-snapshot` to KV (24h TTL). Shell route serves stale last-known in error path, returning `_stale: true` so the header shows real values instead of all-dashes after cold deploy.
- **OPT-10** (`watchdog/route.ts` + `SentinelPageClient.tsx`): Tiered EPICON escalation — `warn@50`, `error@300`, `critical@900`, `alert@2000` failures. At 2,276+ failures this fires `alert` / "EPICON multi-day outage". Escalation state written to `watchdog:epicon:escalation` KV; Sentinel surfaces it via server-side `page.tsx` prop pass.

*OPT-5 (Journal empty state) was already implemented in the prior cycle — the journal has full loading/empty/error states in the current codebase.*

## Files Changed

| File | OPT |
|---|---|
| `scripts/ignore-build.sh` | 1, 2 |
| `hooks/useShellSnapshot.ts` | 3 |
| `components/terminal/TerminalShell.tsx` | 7 |
| `app/terminal/vault/VaultPageClient.tsx` | 4 |
| `app/terminal/sentinel/SentinelPageClient.tsx` | 6, 8, 10 |
| `app/terminal/sentinel/page.tsx` | 8, 10 |
| `app/api/cron/sweep/route.ts` | 8 |
| `app/api/cron/heartbeat/route.ts` | 9 |
| `app/api/terminal/shell/route.ts` | 9 |
| `app/api/cron/watchdog/route.ts` | 10 |

## No env var changes needed

Substrate gate unchanged: `SUBSTRATE_TOKEN`, `TERMINAL_ID`, `TERMINAL_API_BASE` still required for write paths.

---

## Test plan

- [ ] Verify Vercel deploy list stops showing CANCELED for lockfile-only commits after merge
- [ ] Verify `cursor/*` branch commits no longer appear in Vercel deploy list
- [ ] Cold-load the terminal and confirm header shows `GI 0.XX~` rather than `GI —` after the first successful poll
- [ ] Open `/terminal/vault` and kill the network — confirm 10s timeout fires with degraded message instead of infinite spinner
- [ ] Open `/terminal/sentinel` with no KV heartbeat data — confirm 8 offline fallback cards render
- [ ] Trigger a ZEUS probe fail in sweep cron — confirm orange dispute banner appears in Sentinel within one sweep cycle
- [ ] Check Vercel runtime logs after next watchdog run — confirm `[watchdog] EPICON multi-day outage: 2276 failures (tier: alert)` replaces flat `threshold breached` message

Cycle: C-321

https://claude.ai/code/session_015DD2VYZmnKoR1R3gMAayYT

---
_Generated by [Claude Code](https://claude.ai/code/session_015DD2VYZmnKoR1R3gMAayYT)_