### PR TITLE
perf(terminal): dedupe shell snapshot polling + pause when tab hidden

### DIFF
--- a/app/terminal/layout.tsx
+++ b/app/terminal/layout.tsx
@@ -17,6 +17,7 @@ export function chamberMeta(chamber: string, description: string, path: string):
 }
 import CommandSurface from '@/components/terminal/CommandSurface';
 import FooterStatusBar from '@/components/terminal/FooterStatusBar';
+import { ShellSnapshotProvider } from '@/components/terminal/ShellSnapshotProvider';
 import TerminalShell from '@/components/terminal/TerminalShell';
 import { EchoDigestProvider } from '@/components/terminal/EchoDigestProvider';
 
@@ -59,18 +60,20 @@ export default async function TerminalLayout({ children }: { children: ReactNode
   const seed = await loadSeed();
   return (
     <WalletProvider>
-      {seed ? (
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `window.__MOBIUS_SHELL_SEED__=${JSON.stringify(seed)};`,
-          }}
-        />
-      ) : null}
-      <EchoDigestProvider>
-        <TerminalShell>{children}</TerminalShell>
-      </EchoDigestProvider>
-      <CommandSurface />
-      <FooterStatusBar />
+      <ShellSnapshotProvider>
+        {seed ? (
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `window.__MOBIUS_SHELL_SEED__=${JSON.stringify(seed)};`,
+            }}
+          />
+        ) : null}
+        <EchoDigestProvider>
+          <TerminalShell>{children}</TerminalShell>
+        </EchoDigestProvider>
+        <CommandSurface />
+        <FooterStatusBar />
+      </ShellSnapshotProvider>
     </WalletProvider>
   );
 }

--- a/components/journal/JournalPipelinePanel.tsx
+++ b/components/journal/JournalPipelinePanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import DataflowCommandSpine from '@/components/terminal/DataflowCommandSpine';
-import { useShellSnapshot } from '@/hooks/useShellSnapshot';
+import { useShellSnapshot } from '@/components/terminal/ShellSnapshotProvider';
 import { useLaneDiagnosticsChamber } from '@/hooks/useLaneDiagnosticsChamber';
 
 /** Compact pipeline readout for the Journal chamber footer (C-314). */

--- a/components/terminal/FooterStatusBar.tsx
+++ b/components/terminal/FooterStatusBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useShellSnapshot } from '@/hooks/useShellSnapshot';
+import { useShellSnapshot } from '@/components/terminal/ShellSnapshotProvider';
 
 // C-305 OPT-07: age label with "ago" suffix + color-coded staleness thresholds
 function ageLabelFromIso(timestamp: string | null | undefined): string {

--- a/components/terminal/ShellSnapshotProvider.tsx
+++ b/components/terminal/ShellSnapshotProvider.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+import { useShellSnapshotState } from '@/hooks/useShellSnapshot';
+
+export type ShellSnapshotContextValue = ReturnType<typeof useShellSnapshotState>;
+
+const ShellSnapshotContext = createContext<ShellSnapshotContextValue | null>(null);
+
+/** Single subscriber for `/api/terminal/shell` — avoids duplicate 30s polling (header + footer + journal). */
+export function ShellSnapshotProvider({ children }: { children: ReactNode }) {
+  const value = useShellSnapshotState();
+  return <ShellSnapshotContext.Provider value={value}>{children}</ShellSnapshotContext.Provider>;
+}
+
+export function useShellSnapshot(): ShellSnapshotContextValue {
+  const ctx = useContext(ShellSnapshotContext);
+  if (!ctx) {
+    throw new Error('useShellSnapshot must be used within ShellSnapshotProvider');
+  }
+  return ctx;
+}

--- a/components/terminal/TerminalShell.tsx
+++ b/components/terminal/TerminalShell.tsx
@@ -8,7 +8,7 @@ import ShellBridgeBanner from '@/components/terminal/ShellBridgeBanner';
 import { DegradedBanner } from '@/components/terminal/DegradedBanner';
 import SnapshotDiagnostics from '@/components/terminal/SnapshotDiagnostics';
 import DataflowCommandSpine from '@/components/terminal/DataflowCommandSpine';
-import { useShellSnapshot } from '@/hooks/useShellSnapshot';
+import { useShellSnapshot } from '@/components/terminal/ShellSnapshotProvider';
 import { useLaneDiagnosticsChamber } from '@/hooks/useLaneDiagnosticsChamber';
 import { cn } from '@/lib/utils';
 import type { SnapshotLaneState } from '@/lib/terminal/snapshotLanes';

--- a/hooks/useShellSnapshot.ts
+++ b/hooks/useShellSnapshot.ts
@@ -40,7 +40,8 @@ function saveLastKnown(snapshot: ShellSnapshot) {
   } catch {}
 }
 
-export function useShellSnapshot() {
+/** Core shell polling + SSR seed merge; mount once via `ShellSnapshotProvider`. */
+export function useShellSnapshotState() {
   // P2 fix (C-321): distinguish live-fresh from cached init. readSeed() is SSR-injected
   // (live at render time); readLastKnown() is sessionStorage (stale from prior load).
   const [shell, setShell] = useState<ShellSnapshot | null>(() => readSeed() ?? readLastKnown());
@@ -59,6 +60,7 @@ export function useShellSnapshot() {
     // OPT-3 (C-321): retry with backoff on cold-start failure so a 5s serverless
     // wake-up doesn't strand the header at "—boot—" for the full session.
     async function load(attempt = 0): Promise<void> {
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
       const RETRY_DELAYS = [0, 600, 1400, 3000];
       const controller = new AbortController();
       const timeoutId = window.setTimeout(() => controller.abort(), 6_000);
@@ -90,10 +92,20 @@ export function useShellSnapshot() {
     }
 
     void load();
-    const id = window.setInterval(() => void load(), POLL_MS);
+    const id = window.setInterval(() => {
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
+      void load();
+    }, POLL_MS);
+
+    const onVis = () => {
+      if (document.visibilityState === 'visible') void load();
+    };
+    document.addEventListener('visibilitychange', onVis);
+
     return () => {
       mounted = false;
       window.clearInterval(id);
+      document.removeEventListener('visibilitychange', onVis);
     };
   }, []);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Terminal mounted `useShellSnapshot()` in three places (shell chrome, footer, journal pipeline), which meant **three parallel 30s timers** hitting `/api/terminal/shell`.

## Changes

- Add `ShellSnapshotProvider` so the hook runs once per layout tree.
- Rename the implementation to `useShellSnapshotState` (internal); consumers use `useShellSnapshot` from the provider.
- Skip scheduled shell polls while `document.visibilityState === 'hidden'`; run an immediate fetch when the tab becomes visible again.

## Live check

Production `https://mobius-civic-ai-terminal.vercel.app` returned 200 for `/api/health/ping`, `/api/terminal/snapshot-lite`, and `/api/integrity-status` (sub-200ms from this environment).

## Validation

- `pnpm exec tsc --noEmit` — pass locally on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

