### PR TITLE
perf(terminal): pause shared terminal snapshot poller in background tabs

### DIFF
--- a/hooks/useTerminalSnapshot.ts
+++ b/hooks/useTerminalSnapshot.ts
@@ -69,6 +69,7 @@ const FULL_TIMEOUT_MS = 15_000;
 type Subscriber = (snapshot: TerminalSnapshot | null, error: string | null) => void;
 const _subscribers = new Set<Subscriber>();
 let _pollerTimer: ReturnType<typeof setInterval> | null = null;
+let _visibilityRefreshBound = false;
 
 function notify(snapshot: TerminalSnapshot | null, error: string | null) {
   for (const sub of _subscribers) {
@@ -139,8 +140,16 @@ async function loadSnapshot(): Promise<TerminalSnapshot> {
 function ensurePoller() {
   if (_pollerTimer !== null) return;
   if (typeof window === 'undefined') return;
+  if (!_visibilityRefreshBound) {
+    _visibilityRefreshBound = true;
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState !== 'visible' || _subscribers.size === 0) return;
+      void loadSnapshot().catch(() => {});
+    });
+  }
   _pollerTimer = setInterval(() => {
     if (_subscribers.size === 0) return;
+    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
     void loadSnapshot().catch(() => {});
   }, STALE_MS);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The shared `useTerminalSnapshot` singleton runs a 60s `setInterval` for all chambers. When the browser tab is in the background, those ticks still wake work and can trigger serverless snapshot builds for no operator benefit.

## Changes

- Skip `loadSnapshot()` in the poller callback when `document.visibilityState === 'hidden'`.
- On `visibilitychange` back to `visible`, trigger one `loadSnapshot()` so the UI catches up immediately when the operator returns.

## Validation

- `pnpm exec tsc --noEmit` — pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

