### PR TITLE
perf(terminal): backoff chamber API polling when tab is in background

### DIFF
--- a/hooks/useChamberHydration.ts
+++ b/hooks/useChamberHydration.ts
@@ -222,16 +222,31 @@ export function useChamberHydration<T>(url: string, enabled: boolean, options: U
         window.clearTimeout(timeoutId);
         if (mounted) setLoading(false);
         if (mounted) {
-          timerId = window.setTimeout(() => { void load(); }, currentPollMs);
+          const hidden = typeof document !== 'undefined' && document.visibilityState === 'hidden';
+          const delay = hidden ? Math.min(Math.max(currentPollMs * 4, pollMs), 300_000) : currentPollMs;
+          timerId = window.setTimeout(() => {
+            void load();
+          }, delay);
         }
       }
     }
+
+    const onVisibility = () => {
+      if (!mounted || document.visibilityState !== 'visible') return;
+      if (timerId !== null) {
+        window.clearTimeout(timerId);
+        timerId = null;
+      }
+      void load();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
 
     setLoading(true);
     void load();
     return () => {
       mounted = false;
       if (timerId !== null) window.clearTimeout(timerId);
+      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, [enabled, url, pollMs, requestTimeoutMs, savepointKey, savepointMinCount, getSavepointCount]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`useChamberHydration` powers several terminal chambers with a recursive `setTimeout` poll loop. Background tabs continued to hit chamber APIs at the same cadence as foreground tabs.

## Changes

- When scheduling the next poll while `document.visibilityState === 'hidden'`, stretch the delay (up to 5 minutes cap) instead of hammering serverless routes.
- On `visibilitychange` to `visible`, clear the pending timer and run `load()` once so the operator sees fresh data immediately after returning.

## Validation

- `pnpm exec tsc --noEmit` — pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

