### PR TITLE
perf(terminal): pause shell UTC clock timer when tab is backgrounded

### DIFF
--- a/components/terminal/TerminalShell.tsx
+++ b/components/terminal/TerminalShell.tsx
@@ -50,8 +50,27 @@ export default function TerminalShell({ children }: { children: ReactNode }) {
   useEffect(() => {
     const tick = () => setClock(new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC');
     tick();
-    const id = window.setInterval(tick, 1000);
-    return () => window.clearInterval(id);
+    let id: number | null = null;
+    const arm = () => {
+      if (id !== null) window.clearInterval(id);
+      id = null;
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
+      tick();
+      id = window.setInterval(tick, 1000);
+    };
+    arm();
+    const onVis = () => {
+      if (document.visibilityState === 'visible') arm();
+      else if (id !== null) {
+        window.clearInterval(id);
+        id = null;
+      }
+    };
+    document.addEventListener('visibilitychange', onVis);
+    return () => {
+      document.removeEventListener('visibilitychange', onVis);
+      if (id !== null) window.clearInterval(id);
+    };
   }, []);
 
   const seededGi = useMemo(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The terminal header runs a 1 Hz `setInterval` to refresh the UTC clock. Background tabs do not need that work.

## Changes

- Clear the interval when `document.visibilityState === 'hidden'`.
- Restart the clock tick + interval when the tab becomes visible again.

## Validation

- `pnpm exec tsc --noEmit` — pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

