### PR TITLE
perf(bundle): add motion to Next optimizePackageImports

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -34,7 +34,7 @@ const nextConfig: NextConfig = {
   bundlePagesRouterDependencies: true,
   serverExternalPackages: ['@mobius/integrity-core'],
   experimental: {
-    optimizePackageImports: ['lucide-react', 'recharts'],
+    optimizePackageImports: ['lucide-react', 'recharts', 'motion'],
   },
   async headers() {
     return [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Next.js `experimental.optimizePackageImports` narrows barrel imports to per-module files. `motion/react` is used by terminal UI (e.g. `EventScreener`) and benefits from the same treatment as `lucide-react` and `recharts`.

## Changes

- Add `'motion'` to `optimizePackageImports` in `next.config.ts`.

## Validation

- `pnpm exec tsc --noEmit` — pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

