### PR TITLE
perf(terminal): pause GI monitor integrity-status polling in background

### DIFF
--- a/components/gi/GIMonitorBadge.tsx
+++ b/components/gi/GIMonitorBadge.tsx
@@ -63,8 +63,10 @@ export default function GIMonitorBadge() {
 
   useEffect(() => {
     let mounted = true;
+    let intervalId: number | null = null;
 
     async function load() {
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
       try {
         const res = await fetch('/api/integrity-status', { cache: 'no-store' });
         const json = await res.json();
@@ -74,12 +76,28 @@ export default function GIMonitorBadge() {
       }
     }
 
-    load();
-    const interval = window.setInterval(load, 15000);
+    const arm = () => {
+      if (intervalId !== null) window.clearInterval(intervalId);
+      intervalId = null;
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
+      void load();
+      intervalId = window.setInterval(() => void load(), 15000);
+    };
+
+    arm();
+    const onVis = () => {
+      if (document.visibilityState === 'visible') arm();
+      else if (intervalId !== null) {
+        window.clearInterval(intervalId);
+        intervalId = null;
+      }
+    };
+    document.addEventListener('visibilitychange', onVis);
 
     return () => {
       mounted = false;
-      window.clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVis);
+      if (intervalId !== null) window.clearInterval(intervalId);
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
   }, []);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`GIMonitorBadge` polled `/api/integrity-status` every 15 seconds unconditionally, including for background tabs.

## Changes

- Tear down the interval when the document is hidden; restart (with an immediate fetch) when visible again.

## Validation

- `pnpm exec tsc --noEmit` — pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

