### PR TITLE
perf(ux): disable scroll-to-top on terminal chamber tab switches

### DIFF
--- a/components/terminal/ChamberSwitcher.tsx
+++ b/components/terminal/ChamberSwitcher.tsx
@@ -55,6 +55,7 @@ export default function ChamberSwitcher() {
           <Link
             key={tab.href}
             href={tab.href}
+            scroll={false}
             title={tab.shortcut}
             aria-current={active ? 'page' : undefined}
             className={cn(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Chamber navigation uses in-app `Link` transitions. Scrolling the main chamber pane to top on every chamber switch is usually unnecessary and adds work on each navigation.

## Changes

- Set `scroll={false}` on chamber `Link` components (Next.js App Router).

## Validation

- `pnpm exec tsc --noEmit` — pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

