### PR TITLE
perf(seo): dynamic canonical base URL for terminal chamber metadata

### DIFF
--- a/app/terminal/layout.tsx
+++ b/app/terminal/layout.tsx
@@ -2,7 +2,10 @@ import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
 import { WalletProvider } from '@/contexts/WalletContext';
 
-const BASE_URL = 'https://mobius-civic-ai-terminal.vercel.app';
+const BASE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '') ||
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '') ||
+  'https://mobius-civic-ai-terminal.vercel.app';
 
 export function chamberMeta(chamber: string, description: string, path: string): Metadata {
   const title = `${chamber} · Mobius Terminal`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`chamberMeta` used a hard-coded production hostname for canonical / OpenGraph URLs. Preview deployments and alternate domains should advertise their own URLs when env is set.

## Changes

- Prefer `NEXT_PUBLIC_SITE_URL` (trimmed trailing slash), then `https://${VERCEL_URL}` on Vercel, then fall back to the public production default.

## Validation

- `pnpm exec tsc --noEmit` — pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

