### PR TITLE
perf(terminal): pause echo digest client polling in background tabs

### DIFF
--- a/hooks/useEchoDigest.ts
+++ b/hooks/useEchoDigest.ts
@@ -17,6 +17,7 @@ export function useEchoDigest(enabled = true) {
     let mounted = true;
 
     async function load() {
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
       try {
         const res = await fetch('/api/echo/digest', { cache: 'no-store' });
         const json = (await res.json()) as EchoDigestPayload;
@@ -32,10 +33,28 @@ export function useEchoDigest(enabled = true) {
     }
 
     void load();
-    const id = window.setInterval(load, POLL_MS);
+    let intervalId: number | null = null;
+    const arm = () => {
+      if (intervalId !== null) window.clearInterval(intervalId);
+      intervalId = null;
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
+      void load();
+      intervalId = window.setInterval(() => void load(), POLL_MS);
+    };
+    arm();
+    const onVis = () => {
+      if (document.visibilityState === 'visible') arm();
+      else if (intervalId !== null) {
+        window.clearInterval(intervalId);
+        intervalId = null;
+      }
+    };
+    document.addEventListener('visibilitychange', onVis);
+
     return () => {
       mounted = false;
-      window.clearInterval(id);
+      document.removeEventListener('visibilitychange', onVis);
+      if (intervalId !== null) window.clearInterval(intervalId);
     };
   }, [enabled, context]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`useEchoDigest` falls back to its own `/api/echo/digest` polling when no provider context is present. That 20s interval continued in background tabs.

## Changes

- Skip digest fetches while hidden; tear down the interval when the tab is backgrounded; restart with an immediate fetch when visible again.

## Validation

- `pnpm exec tsc --noEmit` — pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

