### PR TITLE
perf(terminal): pause router chamber polling in background tabs

### DIFF
--- a/app/terminal/router/RouterPageClient.tsx
+++ b/app/terminal/router/RouterPageClient.tsx
@@ -45,6 +45,7 @@ export default function RouterPageClient() {
     let mounted = true;
 
     async function load() {
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
       const [nextMetrics, nextReasoning] = await Promise.all([
         getJson<RouterMetrics>('/api/router/metrics'),
         getJson<AgentReasoning>('/api/agents/reasoning'),
@@ -54,12 +55,28 @@ export default function RouterPageClient() {
       setReasoning(nextReasoning);
     }
 
-    void load();
-    const timer = window.setInterval(() => void load(), 5000);
+    let timer: number | null = null;
+    const arm = () => {
+      if (timer !== null) window.clearInterval(timer);
+      timer = null;
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
+      void load();
+      timer = window.setInterval(() => void load(), 5000);
+    };
+    arm();
+    const onVis = () => {
+      if (document.visibilityState === 'visible') arm();
+      else if (timer !== null) {
+        window.clearInterval(timer);
+        timer = null;
+      }
+    };
+    document.addEventListener('visibilitychange', onVis);
 
     return () => {
       mounted = false;
-      window.clearInterval(timer);
+      document.removeEventListener('visibilitychange', onVis);
+      if (timer !== null) window.clearInterval(timer);
     };
   }, []);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Router chamber polled `/api/router/metrics` and `/api/agents/reasoning` every **5 seconds**. That cadence is useful when the operator is watching the page, but wasteful for background tabs.

## Changes

- Stop the interval while `document.visibilityState === 'hidden'`.
- Restart polling (with an immediate refresh) when the tab becomes visible again.

## Validation

- `pnpm exec tsc --noEmit` — pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4a7ee1-b71e-46e7-a680-f05236a76622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

