### PR TITLE
feat(c323): phase 02 — 12 chamber upgrades (Tripwire, EPICON, Markets)

### DIFF
--- a/app/terminal/epicon/page.tsx
+++ b/app/terminal/epicon/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useState, useMemo } from 'react';
+import EpiconChamber from '@/components/terminal/chambers/EpiconChamber';
 
 type EpiconStance = 'support' | 'oppose' | 'conditional';
 type EpiconStatus = 'pass' | 'needs_clarification' | 'fail';
@@ -8,21 +9,9 @@ type EpiconStatus = 'pass' | 'needs_clarification' | 'fail';
 type EpiconCheckResponse = {
   status: EpiconStatus;
   ecs: number;
-  vote: {
-    support: number;
-    conditional: number;
-    oppose: number;
-  };
-  quorum: {
-    agents: number;
-    min_required: number;
-    independent_ok: boolean;
-  };
-  dissent: Array<{
-    agent: string;
-    stance: EpiconStance;
-    reason: string;
-  }>;
+  vote: { support: number; conditional: number; oppose: number };
+  quorum: { agents: number; min_required: number; independent_ok: boolean };
+  dissent: Array<{ agent: string; stance: EpiconStance; reason: string }>;
 };
 
 type EpiconCheckError = { error?: string };
@@ -53,15 +42,18 @@ const SAMPLE_REPORTS = ['ATLAS', 'ZEUS', 'EVE', 'AUREA', 'JADE'].map((agent) => 
 }));
 
 const STATUS_CLASS: Record<EpiconStatus, string> = {
-  pass: 'text-emerald-300 border-emerald-500/30 bg-emerald-950/20',
-  needs_clarification: 'text-amber-300 border-amber-500/30 bg-amber-950/20',
-  fail: 'text-rose-300 border-rose-500/30 bg-rose-950/20',
+  pass:               'text-emerald-300 border-emerald-500/30 bg-emerald-950/20',
+  needs_clarification:'text-amber-300 border-amber-500/30 bg-amber-950/20',
+  fail:               'text-rose-300 border-rose-500/30 bg-rose-950/20',
 };
 
+type Tab = 'feed' | 'runtime';
+
 export default function EpiconPage() {
-  const [result, setResult] = useState<EpiconCheckResponse | null>(null);
+  const [tab, setTab]         = useState<Tab>('feed');
+  const [result, setResult]   = useState<EpiconCheckResponse | null>(null);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError]     = useState<string | null>(null);
 
   const consensusLabel = useMemo(() => {
     if (!result) return 'not_checked';
@@ -90,60 +82,89 @@ export default function EpiconPage() {
   }
 
   return (
-    <div className="h-full overflow-y-auto p-4 font-mono text-xs text-slate-200">
-      <div className="mb-4">
-        <div className="text-[10px] uppercase tracking-[0.22em] text-slate-500">Mobius Governance</div>
-        <h1 className="mt-1 text-lg font-semibold uppercase tracking-[0.16em] text-violet-200">EPICON Runtime</h1>
-        <p className="mt-2 max-w-2xl text-[11px] leading-relaxed text-slate-500">
-          Runtime visibility for intent, epistemic justification, consensus scoring, and dissent preservation. This panel observes EPICON-03; it does not enforce mutation blocking yet.
-        </p>
+    <div className="h-full flex flex-col">
+      {/* Tab switcher */}
+      <div className="flex items-center gap-1 px-4 py-2 border-b border-slate-800 bg-slate-950 font-mono text-[10px]">
+        {(['feed', 'runtime'] as Tab[]).map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => setTab(t)}
+            className={`px-3 py-0.5 rounded border uppercase tracking-widest transition-colors ${
+              tab === t
+                ? 'bg-fuchsia-950 border-fuchsia-700 text-fuchsia-300'
+                : 'border-slate-700 text-slate-500 hover:text-slate-300'
+            }`}
+          >
+            {t === 'feed' ? '≡ Event Feed' : '⊕ Runtime Check'}
+          </button>
+        ))}
       </div>
 
-      <section className="mb-4 rounded border border-violet-500/25 bg-slate-950/80 p-4">
-        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <div className="text-[10px] uppercase tracking-[0.18em] text-violet-300/80">Consensus Check</div>
-            <div className="mt-1 text-slate-400">Sample Sentinel quorum: ATLAS · ZEUS · EVE · AUREA · JADE</div>
+      {tab === 'feed' && <EpiconChamber />}
+
+      {tab === 'runtime' && (
+        <div className="h-full overflow-y-auto p-4 font-mono text-xs text-slate-200">
+          <div className="mb-4">
+            <div className="text-[10px] uppercase tracking-[0.22em] text-slate-500">Mobius Governance</div>
+            <h1 className="mt-1 text-lg font-semibold uppercase tracking-[0.16em] text-violet-200">EPICON Runtime</h1>
+            <p className="mt-2 max-w-2xl text-[11px] leading-relaxed text-slate-500">
+              Runtime visibility for intent, epistemic justification, consensus scoring, and dissent preservation.
+              This panel observes EPICON-03; it does not enforce mutation blocking yet.
+            </p>
           </div>
-          <button
-            type="button"
-            onClick={runSampleCheck}
-            disabled={loading}
-            className="rounded border border-cyan-500/40 px-3 py-1 text-cyan-200 hover:border-cyan-300 disabled:opacity-50"
-          >
-            {loading ? 'Checking…' : 'Run Sample EPICON Check'}
-          </button>
+
+          <section className="mb-4 rounded border border-violet-500/25 bg-slate-950/80 p-4">
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <div className="text-[10px] uppercase tracking-[0.18em] text-violet-300/80">Consensus Check</div>
+                <div className="mt-1 text-slate-400">Sample Sentinel quorum: ATLAS · ZEUS · EVE · AUREA · JADE</div>
+              </div>
+              <button
+                type="button"
+                onClick={runSampleCheck}
+                disabled={loading}
+                className="rounded border border-cyan-500/40 px-3 py-1 text-cyan-200 hover:border-cyan-300 disabled:opacity-50"
+              >
+                {loading ? 'Checking…' : 'Run Sample EPICON Check'}
+              </button>
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-4">
+              <div className="rounded border border-slate-800 bg-black/20 p-3">
+                <div className="text-slate-500">status</div>
+                <div className={result ? `mt-1 inline-block rounded border px-2 py-1 ${STATUS_CLASS[result.status]}` : 'mt-1 text-slate-400'}>
+                  {consensusLabel}
+                </div>
+              </div>
+              <div className="rounded border border-slate-800 bg-black/20 p-3">
+                <div className="text-slate-500">quorum</div>
+                <div className="mt-1 text-slate-100">{result ? `${result.quorum.agents}/${result.quorum.min_required}` : '—'}</div>
+              </div>
+              <div className="rounded border border-slate-800 bg-black/20 p-3">
+                <div className="text-slate-500">support</div>
+                <div className="mt-1 text-emerald-300">{result?.vote.support ?? '—'}</div>
+              </div>
+              <div className="rounded border border-slate-800 bg-black/20 p-3">
+                <div className="text-slate-500">dissent</div>
+                <div className="mt-1 text-rose-300">{result?.dissent.length ?? '—'}</div>
+              </div>
+            </div>
+
+            {error ? (
+              <div className="mt-3 rounded border border-rose-500/30 bg-rose-950/20 p-2 text-rose-200">{error}</div>
+            ) : null}
+          </section>
+
+          <section className="rounded border border-slate-800 bg-slate-950/70 p-4 text-[11px] text-slate-400">
+            <div className="mb-2 uppercase tracking-[0.18em] text-cyan-300/80">Runtime Law</div>
+            <div>EPICON-01 preserves meaning through EJ.</div>
+            <div>EPICON-02 preserves intent before action.</div>
+            <div>EPICON-03 preserves consensus and dissent before authority.</div>
+            <div className="mt-3 text-amber-300">Current mode: observe-only. Enforcement begins in the next phase.</div>
+          </section>
         </div>
-
-        <div className="grid gap-3 md:grid-cols-4">
-          <div className="rounded border border-slate-800 bg-black/20 p-3">
-            <div className="text-slate-500">status</div>
-            <div className={result ? `mt-1 inline-block rounded border px-2 py-1 ${STATUS_CLASS[result.status]}` : 'mt-1 text-slate-400'}>{consensusLabel}</div>
-          </div>
-          <div className="rounded border border-slate-800 bg-black/20 p-3">
-            <div className="text-slate-500">quorum</div>
-            <div className="mt-1 text-slate-100">{result ? `${result.quorum.agents}/${result.quorum.min_required}` : '—'}</div>
-          </div>
-          <div className="rounded border border-slate-800 bg-black/20 p-3">
-            <div className="text-slate-500">support</div>
-            <div className="mt-1 text-emerald-300">{result?.vote.support ?? '—'}</div>
-          </div>
-          <div className="rounded border border-slate-800 bg-black/20 p-3">
-            <div className="text-slate-500">dissent</div>
-            <div className="mt-1 text-rose-300">{result?.dissent.length ?? '—'}</div>
-          </div>
-        </div>
-
-        {error ? <div className="mt-3 rounded border border-rose-500/30 bg-rose-950/20 p-2 text-rose-200">{error}</div> : null}
-      </section>
-
-      <section className="rounded border border-slate-800 bg-slate-950/70 p-4 text-[11px] text-slate-400">
-        <div className="mb-2 uppercase tracking-[0.18em] text-cyan-300/80">Runtime Law</div>
-        <div>EPICON-01 preserves meaning through EJ.</div>
-        <div>EPICON-02 preserves intent before action.</div>
-        <div>EPICON-03 preserves consensus and dissent before authority.</div>
-        <div className="mt-3 text-amber-300">Current mode: observe-only. Enforcement begins in the next phase.</div>
-      </section>
+      )}
     </div>
   );
 }

--- a/app/terminal/markets/page.tsx
+++ b/app/terminal/markets/page.tsx
@@ -1,20 +1,16 @@
 import { chamberMeta } from '../layout';
+import MarketsChamber from '@/components/terminal/chambers/MarketsChamber';
 
 export const metadata = chamberMeta(
   'Markets',
-  'Real-time market signals — equity indices, energy, commodities, and macro indicators.',
+  'Real-time market signals — integrity-weighted equity, crypto, governance, and macro indicators.',
   'markets'
 );
 
 export default function MarketsPage() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-[40vh] gap-3 px-4 text-center">
-      <div className="font-mono text-2xl text-slate-600">◈</div>
-      <h1 className="font-mono text-sm uppercase tracking-widest text-slate-500">Markets</h1>
-      <p className="text-xs text-slate-600 max-w-sm">
-        Real-time market signals chamber — coming online. Finviz signals available via{' '}
-        <span className="text-slate-400 font-mono">/api/markets/finviz/signals</span>.
-      </p>
+    <div className="h-full flex flex-col">
+      <MarketsChamber />
     </div>
   );
 }

--- a/app/terminal/tripwire/page.tsx
+++ b/app/terminal/tripwire/page.tsx
@@ -1,10 +1,14 @@
 import type { Metadata } from 'next';
-import TripwirePageClient from './TripwirePageClient';
+import TripwireChamber from '@/components/terminal/chambers/TripwireChamber';
 
 export const metadata: Metadata = {
   title: 'Tripwire · Mobius Terminal',
 };
 
 export default function TripwirePage() {
-  return <TripwirePageClient />;
+  return (
+    <div className="h-full flex flex-col">
+      <TripwireChamber />
+    </div>
+  );
 }

--- a/components/terminal/chambers/EpiconChamber.tsx
+++ b/components/terminal/chambers/EpiconChamber.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { fetchEpiconEvents } from '@/lib/terminal/epicon';
+import type { EpiconEvent, ConfidenceTier } from '@/lib/terminal/epicon';
+import { EpiconInspector } from './EpiconInspector';
+import { EpiconFilterBar } from './EpiconFilterBar';
+import { EpiconIngestBadge } from './EpiconIngestBadge';
+
+const TIER_STYLE: Record<ConfidenceTier, string> = {
+  VERIFIED:     'bg-green-950 text-green-300 border border-green-800',
+  PENDING:      'bg-amber-950 text-amber-300 border border-amber-800',
+  CONTRADICTED: 'bg-red-950 text-red-300 border border-red-800',
+  ARCHIVED:     'bg-zinc-800 text-zinc-500 border border-zinc-700',
+};
+
+function confidenceColor(c: number): string {
+  if (c >= 0.80) return 'text-green-400';
+  if (c >= 0.60) return 'text-amber-400';
+  return 'text-red-400';
+}
+
+export default function EpiconChamber() {
+  const [events, setEvents]         = useState<EpiconEvent[]>([]);
+  const [filtered, setFiltered]     = useState<EpiconEvent[]>([]);
+  const [selected, setSelected]     = useState<EpiconEvent | null>(null);
+  const [loading, setLoading]       = useState(true);
+  const [ingestCount, setIngestCount] = useState(0);
+
+  useEffect(() => {
+    fetchEpiconEvents().then((data) => {
+      setEvents(data);
+      setFiltered(data);
+      setLoading(false);
+    });
+    const tick = setInterval(() => setIngestCount((n: number) => n + 1), 4000);
+    return () => clearInterval(tick);
+  }, []);
+
+  if (loading) return (
+    <div className="p-6 font-mono text-amber-400 text-xs animate-pulse">
+      EPICON · loading event ledger…
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col h-full font-mono text-xs">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-2 border-b border-zinc-800 bg-zinc-950">
+        <span className="text-fuchsia-400 font-bold tracking-widest">≡ EPICON FEED</span>
+        <EpiconIngestBadge count={ingestCount} events={events} />
+      </div>
+
+      {/* Filter bar */}
+      <EpiconFilterBar events={events} onFilter={setFiltered} />
+
+      {/* Event table + Inspector split */}
+      <div className="flex flex-1 min-h-0">
+        <div className="flex-1 overflow-y-auto">
+          {filtered.map((ev) => (
+            <div
+              key={ev.id}
+              role="button"
+              tabIndex={0}
+              onClick={() => setSelected(selected?.id === ev.id ? null : ev)}
+              onKeyDown={(e) => e.key === 'Enter' && setSelected(selected?.id === ev.id ? null : ev)}
+              className={`px-4 py-3 border-b border-zinc-800/60 cursor-pointer hover:bg-zinc-900 transition-colors ${
+                selected?.id === ev.id ? 'bg-zinc-900 border-l-2 border-l-fuchsia-500' : ''
+              }`}
+            >
+              <div className="flex items-center gap-2 mb-1">
+                <span className={`px-1.5 py-0.5 rounded text-[10px] ${TIER_STYLE[ev.tier]}`}>
+                  {ev.tier}
+                </span>
+                <span className="text-zinc-600">{ev.cycle}</span>
+                <span className="text-sky-400">{ev.agent}</span>
+                <span className={`ml-auto font-bold ${confidenceColor(ev.confidence)}`}>
+                  {(ev.confidence * 100).toFixed(0)}%
+                </span>
+              </div>
+              <div className="text-zinc-100 mb-0.5 leading-snug">{ev.label}</div>
+              <div className="text-zinc-500 truncate">{ev.summary}</div>
+            </div>
+          ))}
+          {filtered.length === 0 && (
+            <div className="p-6 text-zinc-600 text-center">No events match filter</div>
+          )}
+        </div>
+
+        {selected && (
+          <EpiconInspector event={selected} onClose={() => setSelected(null)} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/terminal/chambers/EpiconFilterBar.tsx
+++ b/components/terminal/chambers/EpiconFilterBar.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+import type { EpiconEvent, ConfidenceTier } from '@/lib/terminal/epicon';
+
+const TIERS: ConfidenceTier[] = ['VERIFIED', 'PENDING', 'CONTRADICTED', 'ARCHIVED'];
+const AGENTS = ['ATLAS', 'ZEUS', 'EVE', 'JADE', 'HERMES', 'ECHO', 'AUREA', 'DAEDALUS'];
+
+type TierFilter = ConfidenceTier | 'ALL';
+
+interface Props {
+  events: EpiconEvent[];
+  onFilter: (filtered: EpiconEvent[]) => void;
+}
+
+export function EpiconFilterBar({ events, onFilter }: Props) {
+  const [tier, setTier]   = useState<TierFilter>('ALL');
+  const [agent, setAgent] = useState<string>('ALL');
+  const [query, setQuery] = useState('');
+
+  function apply(newTier = tier, newAgent = agent, newQuery = query) {
+    let out = events;
+    if (newTier  !== 'ALL') out = out.filter((e) => e.tier  === newTier);
+    if (newAgent !== 'ALL') out = out.filter((e) => e.agent === newAgent);
+    if (newQuery)            out = out.filter((e) =>
+      e.label.toLowerCase().includes(newQuery.toLowerCase()) ||
+      e.summary.toLowerCase().includes(newQuery.toLowerCase())
+    );
+    onFilter(out);
+  }
+
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 border-b border-zinc-800 bg-zinc-950/40 flex-wrap font-mono text-[10px]">
+      <div className="flex gap-1 flex-wrap">
+        {(['ALL', ...TIERS] as TierFilter[]).map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => { setTier(t); apply(t); }}
+            className={`px-2 py-0.5 rounded border transition-colors ${
+              tier === t
+                ? 'bg-fuchsia-950 border-fuchsia-700 text-fuchsia-300'
+                : 'border-zinc-700 text-zinc-500 hover:text-zinc-300'
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      <select
+        value={agent}
+        onChange={(e) => { setAgent(e.target.value); apply(tier, e.target.value); }}
+        className="bg-zinc-900 border border-zinc-700 text-zinc-400 rounded px-2 py-0.5 text-[10px] font-mono hover:border-zinc-500 transition-colors"
+      >
+        <option value="ALL">ALL AGENTS</option>
+        {AGENTS.map((a) => <option key={a} value={a}>{a}</option>)}
+      </select>
+
+      <input
+        value={query}
+        onChange={(e) => { setQuery(e.target.value); apply(tier, agent, e.target.value); }}
+        placeholder="search events…"
+        className="flex-1 min-w-[120px] bg-zinc-900 border border-zinc-700 text-zinc-300 rounded px-2 py-0.5 text-[10px] font-mono placeholder-zinc-700 focus:outline-none focus:border-fuchsia-700 transition-colors"
+      />
+    </div>
+  );
+}

--- a/components/terminal/chambers/EpiconIngestBadge.tsx
+++ b/components/terminal/chambers/EpiconIngestBadge.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import type { EpiconEvent } from '@/lib/terminal/epicon';
+
+interface Props {
+  count: number;
+  events: EpiconEvent[];
+}
+
+export function EpiconIngestBadge({ count, events }: Props) {
+  const newest = events.reduce((max, ev) => (ev.ts > max ? ev.ts : max), 0);
+  const ageSec = Math.floor((Date.now() - newest) / 1000);
+  const ageStr =
+    ageSec < 60   ? `${ageSec}s` :
+    ageSec < 3600 ? `${Math.floor(ageSec / 60)}m` :
+                    `${Math.floor(ageSec / 3600)}h`;
+  const fresh = ageSec < 300;
+
+  return (
+    <div className="flex items-center gap-3 ml-auto text-[10px]">
+      <div className="flex items-center gap-1.5">
+        <span
+          className={`w-1.5 h-1.5 rounded-full transition-colors ${
+            count % 2 === 0 ? 'bg-fuchsia-400' : 'bg-fuchsia-700'
+          }`}
+        />
+        <span className="text-zinc-500">
+          INGEST <span className="text-fuchsia-400">{count}</span>
+        </span>
+      </div>
+      <div className={`px-2 py-0.5 rounded border ${
+        fresh
+          ? 'bg-green-950 border-green-800 text-green-300'
+          : 'bg-amber-950 border-amber-800 text-amber-300'
+      }`}>
+        LAST {ageStr} · {fresh ? 'FRESH' : 'STALE'}
+      </div>
+    </div>
+  );
+}

--- a/components/terminal/chambers/EpiconInspector.tsx
+++ b/components/terminal/chambers/EpiconInspector.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import type { EpiconEvent, ConfidenceTier } from '@/lib/terminal/epicon';
+
+const TIER_BAR: Record<ConfidenceTier, { pct: number; color: string }> = {
+  VERIFIED:     { pct: 85, color: 'bg-green-500' },
+  PENDING:      { pct: 55, color: 'bg-amber-500' },
+  CONTRADICTED: { pct: 25, color: 'bg-red-500' },
+  ARCHIVED:     { pct: 30, color: 'bg-zinc-500' },
+};
+
+interface Props {
+  event: EpiconEvent;
+  onClose: () => void;
+}
+
+export function EpiconInspector({ event, onClose }: Props) {
+  const bar = TIER_BAR[event.tier];
+  const confColor =
+    event.confidence >= 0.80 ? 'text-green-400' :
+    event.confidence >= 0.60 ? 'text-amber-400' :
+    'text-red-400';
+
+  return (
+    <div className="w-80 border-l border-zinc-800 bg-zinc-950 flex flex-col font-mono text-xs overflow-y-auto flex-shrink-0">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-zinc-800">
+        <span className="text-fuchsia-400 font-bold">INSPECTOR</span>
+        <button type="button" onClick={onClose} className="text-zinc-600 hover:text-zinc-300 transition-colors">✕</button>
+      </div>
+      <div className="px-4 py-3 space-y-4">
+        <div className="flex gap-4">
+          <div>
+            <div className="text-zinc-600 text-[10px] uppercase tracking-widest">Event</div>
+            <div className="text-zinc-300">{event.id.toUpperCase()}</div>
+          </div>
+          <div>
+            <div className="text-zinc-600 text-[10px] uppercase tracking-widest">Cycle</div>
+            <div className="text-amber-400">{event.cycle}</div>
+          </div>
+        </div>
+
+        <div>
+          <div className="text-zinc-600 text-[10px] uppercase tracking-widest mb-1">Summary</div>
+          <div className="text-zinc-200 leading-relaxed">{event.summary}</div>
+        </div>
+
+        <div>
+          <div className="text-zinc-600 text-[10px] uppercase tracking-widest mb-2">Confidence Ladder</div>
+          <div className="flex items-center gap-2 mb-1">
+            <div className="flex-1 bg-zinc-800 rounded-full h-1.5">
+              <div
+                className={`h-1.5 rounded-full ${bar.color} transition-all`}
+                style={{ width: `${bar.pct}%` }}
+              />
+            </div>
+            <span className={`font-bold ${confColor}`}>
+              {(event.confidence * 100).toFixed(0)}%
+            </span>
+          </div>
+          <div className="text-zinc-600">{event.tier}</div>
+        </div>
+
+        <div>
+          <div className="text-zinc-600 text-[10px] uppercase tracking-widest mb-2">Source Stack</div>
+          <ol className="space-y-1">
+            {event.sources.map((src, i) => (
+              <li key={src} className="flex gap-2 text-zinc-400">
+                <span className="text-zinc-700">{i + 1}.</span>
+                <span className="text-sky-400">{src}</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+
+        {event.contradictions?.length ? (
+          <div className="border border-red-800/50 bg-red-950/20 rounded p-3">
+            <div className="text-red-400 text-[10px] uppercase tracking-widest mb-2">Contradictions</div>
+            {event.contradictions.map((c) => (
+              <div key={c} className="text-red-300 flex gap-2">
+                <span className="text-red-700">✕</span>
+                <span>{c}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        <div>
+          <div className="text-zinc-600 text-[10px] uppercase tracking-widest mb-1">Attested By</div>
+          <div className="text-sky-400">{event.agent}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/terminal/chambers/MarketsChamber.tsx
+++ b/components/terminal/chambers/MarketsChamber.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { fetchMarketSignals, gatedConfidence } from '@/lib/terminal/markets';
+import type { MarketSignal, SignalCategory } from '@/lib/terminal/markets';
+import { fetchTripwires } from '@/lib/terminal/tripwire';
+import type { TripwireEntry } from '@/lib/terminal/tripwire';
+import { fetchIntegrity } from '@/lib/terminal/integrity';
+import { MarketsCorrelation } from './MarketsCorrelation';
+import { MarketsFreshnessTicker } from './MarketsFreshnessTicker';
+
+const CAT_STYLE: Record<SignalCategory, string> = {
+  MACRO:      'bg-sky-950 text-sky-300 border border-sky-800',
+  CRYPTO:     'bg-violet-950 text-violet-300 border border-violet-800',
+  GOVERNANCE: 'bg-emerald-950 text-emerald-300 border border-emerald-800',
+  SOVEREIGN:  'bg-amber-950 text-amber-300 border border-amber-800',
+};
+
+type TabId = 'signals' | 'correlation';
+
+export default function MarketsChamber() {
+  const router = useRouter();
+  const [signals, setSignals]     = useState<MarketSignal[]>([]);
+  const [gi, setGi]               = useState<number | null>(null);
+  const [tripwires, setTripwires] = useState<TripwireEntry[]>([]);
+  const [loading, setLoading]     = useState(true);
+  const [tab, setTab]             = useState<TabId>('signals');
+
+  useEffect(() => {
+    Promise.all([
+      fetchMarketSignals(),
+      fetchIntegrity(),
+      fetchTripwires(),
+    ]).then(([sigs, integrity, tw]) => {
+      setSignals(sigs);
+      setGi(integrity.gi);
+      setTripwires(tw.filter((t) => !t.resolved));
+      setLoading(false);
+    });
+  }, []);
+
+  if (loading) return (
+    <div className="p-6 font-mono text-amber-400 text-xs animate-pulse">
+      MARKETS · loading signals…
+    </div>
+  );
+
+  const giLabel =
+    gi === null     ? null :
+    gi >= 0.75      ? 'SIGNALS TRUSTED' :
+    gi >= 0.65      ? 'SIGNALS CAUTIOUS' :
+    'SIGNALS GATED';
+
+  const giBadgeClass =
+    gi === null     ? '' :
+    gi >= 0.75      ? 'bg-green-950 border-green-800 text-green-300' :
+    gi >= 0.65      ? 'bg-amber-950 border-amber-800 text-amber-300' :
+    'bg-red-950 border-red-800 text-red-300';
+
+  return (
+    <div className="flex flex-col h-full font-mono text-xs">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-2 border-b border-zinc-800 bg-zinc-950">
+        <span className="text-sky-400 font-bold tracking-widest">◈ MARKETS</span>
+        {gi !== null && (
+          <span className={`text-[10px] px-2 py-0.5 rounded border ${giBadgeClass}`}>
+            GI {gi.toFixed(2)} · {giLabel}
+          </span>
+        )}
+        <div className="flex gap-1 ml-auto">
+          {(['signals', 'correlation'] as TabId[]).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTab(t)}
+              className={`px-3 py-0.5 rounded border text-[10px] transition-colors ${
+                tab === t
+                  ? 'bg-sky-950 border-sky-700 text-sky-300'
+                  : 'border-zinc-700 text-zinc-500 hover:text-zinc-300'
+              }`}
+            >
+              {t.toUpperCase()}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Tripwire cross-ref banner (MK-04) */}
+      {tripwires.length > 0 && (
+        <div className="flex items-center gap-2 px-4 py-1.5 bg-amber-950/40 border-b border-amber-800/40 text-[10px] font-mono">
+          <span className="text-amber-400">⚡</span>
+          <span className="text-amber-300">
+            {tripwires.length} active anomal{tripwires.length === 1 ? 'y' : 'ies'} affecting signal confidence
+          </span>
+          <button
+            type="button"
+            onClick={() => router.push('/terminal/tripwire')}
+            className="ml-auto text-amber-500 hover:text-amber-300 underline transition-colors"
+          >
+            VIEW TRIPWIRE →
+          </button>
+        </div>
+      )}
+
+      {tab === 'signals' && (
+        <>
+          {/* Freshness ticker (MK-03) */}
+          <MarketsFreshnessTicker signals={signals} />
+
+          {/* Signal table (MK-01) */}
+          <div className="flex-1 overflow-y-auto">
+            {signals.map((sig) => {
+              const conf = gatedConfidence(sig, gi);
+              const confColor =
+                conf >= 0.80 ? 'text-green-400' :
+                conf >= 0.60 ? 'text-amber-400' :
+                'text-red-400';
+              const deltaColor =
+                sig.deltaDir === 'up'   ? 'text-green-400' :
+                sig.deltaDir === 'down' ? 'text-red-400' :
+                'text-zinc-400';
+              const isGated = sig.integrityWeight > 0.5 && gi !== null && gi < 0.75;
+              return (
+                <div
+                  key={sig.id}
+                  className="px-4 py-3 border-b border-zinc-800/60 hover:bg-zinc-900 transition-colors"
+                >
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className={`px-1.5 py-0.5 rounded text-[10px] ${CAT_STYLE[sig.category]}`}>
+                      {sig.category}
+                    </span>
+                    <span className="text-zinc-100 font-medium">{sig.label}</span>
+                    <span className={`ml-auto font-bold font-mono ${deltaColor}`}>
+                      {sig.deltaDir === 'up' ? '▲' : sig.deltaDir === 'down' ? '▼' : '—'} {sig.value}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3 text-zinc-500">
+                    <span className="text-zinc-600 truncate">{sig.source}</span>
+                    <span className="ml-auto flex-shrink-0">
+                      CONF{' '}
+                      <span className={confColor}>{(conf * 100).toFixed(0)}%</span>
+                      {isGated && (
+                        <span className="ml-1 text-amber-600">[GI-GATED]</span>
+                      )}
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      {tab === 'correlation' && (
+        <MarketsCorrelation signals={signals} gi={gi} />
+      )}
+    </div>
+  );
+}

--- a/components/terminal/chambers/MarketsCorrelation.tsx
+++ b/components/terminal/chambers/MarketsCorrelation.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { gatedConfidence } from '@/lib/terminal/markets';
+import type { MarketSignal } from '@/lib/terminal/markets';
+
+const GI_HISTORY = [
+  { cycle: 'C-316', gi: 0.82 },
+  { cycle: 'C-317', gi: 0.79 },
+  { cycle: 'C-318', gi: 0.64 },
+  { cycle: 'C-319', gi: 0.70 },
+  { cycle: 'C-320', gi: 0.66 },
+  { cycle: 'C-321', gi: 0.91 },
+  { cycle: 'C-322', gi: 0.80 },
+  { cycle: 'C-323', gi: 0.75 },
+] as const;
+
+const CHART_H = 80;
+
+interface Props {
+  signals: MarketSignal[];
+  gi: number | null;
+}
+
+export function MarketsCorrelation({ signals, gi }: Props) {
+  return (
+    <div className="flex-1 overflow-y-auto px-4 py-4 space-y-6 font-mono text-xs">
+      {/* GI trend */}
+      <div>
+        <div className="text-zinc-500 text-[10px] uppercase tracking-widest mb-2">
+          GI Trend · Last 8 Cycles
+        </div>
+        <div className="flex items-end gap-1" style={{ height: `${CHART_H}px` }}>
+          {GI_HISTORY.map(({ cycle, gi: g }) => {
+            const h = Math.round((g / 1.0) * CHART_H);
+            const color =
+              g >= 0.80 ? 'bg-green-500' :
+              g >= 0.65 ? 'bg-amber-500' :
+              'bg-red-500';
+            return (
+              <div key={cycle} className="flex flex-col items-center gap-0.5 flex-1 group">
+                <div
+                  className={`w-full rounded-sm ${color} opacity-70 group-hover:opacity-100 transition-opacity`}
+                  style={{ height: `${h}px` }}
+                  title={`${cycle}: GI ${g}`}
+                />
+                <span className="text-zinc-700 text-[8px]">{cycle.replace('C-', '')}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Integrity weight matrix */}
+      <div>
+        <div className="text-zinc-500 text-[10px] uppercase tracking-widest mb-2">
+          Integrity Weight by Signal
+        </div>
+        <div className="space-y-3">
+          {signals.map((sig) => {
+            const gated = gatedConfidence(sig, gi);
+            const rawPct = Math.round(sig.confidence * 100);
+            const gatedPct = Math.round(gated * 100);
+            const drop = rawPct - gatedPct;
+            const barColor =
+              gatedPct >= 80 ? 'bg-green-500' :
+              gatedPct >= 60 ? 'bg-amber-500' :
+              'bg-red-500';
+            return (
+              <div key={sig.id}>
+                <div className="flex justify-between mb-1">
+                  <span className="text-zinc-400 truncate mr-2">{sig.label}</span>
+                  <span className="flex-shrink-0 text-zinc-500">
+                    {rawPct}% →{' '}
+                    <span className={drop > 5 ? 'text-amber-400' : 'text-green-400'}>{gatedPct}%</span>
+                    {drop > 5 && <span className="text-red-500 ml-1">↓{drop}pp</span>}
+                  </span>
+                </div>
+                <div className="bg-zinc-800 rounded-full h-1">
+                  <div
+                    className={`h-1 rounded-full ${barColor} transition-all`}
+                    style={{ width: `${gatedPct}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/terminal/chambers/MarketsFreshnessTicker.tsx
+++ b/components/terminal/chambers/MarketsFreshnessTicker.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { MarketSignal } from '@/lib/terminal/markets';
+
+interface Props {
+  signals: MarketSignal[];
+}
+
+function staleness(ts: number): { label: string; color: string } {
+  const ageSec = (Date.now() - ts) / 1000;
+  if (ageSec < 300)    return { label: 'LIVE',  color: 'text-green-400' };
+  if (ageSec < 3_600)  return { label: 'FRESH', color: 'text-green-400' };
+  if (ageSec < 86_400) return { label: 'STALE', color: 'text-amber-400' };
+  return                      { label: 'OLD',   color: 'text-red-400' };
+}
+
+export function MarketsFreshnessTicker({ signals }: Props) {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => setTick((n) => n + 1), 10_000);
+    return () => clearInterval(id);
+  }, []);
+
+  void tick;
+
+  return (
+    <div
+      className="flex items-center gap-0 overflow-x-auto border-b border-zinc-800 bg-zinc-950/40 px-2 py-1.5"
+      style={{ scrollbarWidth: 'none' }}
+    >
+      {signals.map((sig) => {
+        const { label, color } = staleness(sig.ts);
+        const deltaColor =
+          sig.deltaDir === 'up'   ? 'text-green-400' :
+          sig.deltaDir === 'down' ? 'text-red-400' :
+          'text-zinc-400';
+        return (
+          <div
+            key={sig.id}
+            className="flex items-center gap-2 px-3 flex-shrink-0 border-r border-zinc-800 last:border-r-0"
+          >
+            <span className="text-zinc-500 text-[10px]">{sig.label.split(' ').slice(0, 2).join(' ')}</span>
+            <span className={`text-[10px] font-bold ${deltaColor}`}>
+              {sig.deltaDir === 'up' ? '▲' : sig.deltaDir === 'down' ? '▼' : '—'} {sig.value}
+            </span>
+            <span className={`text-[9px] ${color}`}>{label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/terminal/chambers/TripwireChamber.tsx
+++ b/components/terminal/chambers/TripwireChamber.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { fetchTripwires } from '@/lib/terminal/tripwire';
+import type { TripwireEntry, TripwireSeverity } from '@/lib/terminal/tripwire';
+import { TripwireSparkline } from './TripwireSparkline';
+import { TripwireDrillDown } from './TripwireDrillDown';
+
+const SEV_STYLE: Record<TripwireSeverity, string> = {
+  INFO:     'bg-sky-950 text-sky-300 border border-sky-700',
+  WARN:     'bg-amber-950 text-amber-300 border border-amber-700',
+  CRITICAL: 'bg-red-950 text-red-300 border border-red-700',
+};
+
+const SEV_DOT: Record<TripwireSeverity, string> = {
+  INFO:     'bg-sky-400',
+  WARN:     'bg-amber-400',
+  CRITICAL: 'bg-red-400 animate-pulse',
+};
+
+function relativeTime(ts: number): string {
+  const delta = Math.floor((Date.now() - ts) / 1000);
+  if (delta < 60)   return `${delta}s ago`;
+  if (delta < 3600) return `${Math.floor(delta / 60)}m ago`;
+  return `${Math.floor(delta / 3600)}h ago`;
+}
+
+export default function TripwireChamber() {
+  const [entries, setEntries] = useState<TripwireEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<TripwireEntry | null>(null);
+  const [tab, setTab] = useState<'active' | 'resolved'>('active');
+
+  useEffect(() => {
+    fetchTripwires().then((data) => {
+      setEntries(data);
+      setLoading(false);
+    });
+  }, []);
+
+  const visible      = entries.filter((e) => tab === 'active' ? !e.resolved : e.resolved);
+  const activeCount  = entries.filter((e) => !e.resolved).length;
+  const resolvedCount = entries.filter((e) => e.resolved).length;
+
+  if (loading) return (
+    <div className="p-6 font-mono text-amber-400 text-xs animate-pulse">
+      TRIPWIRE · loading anomaly feed…
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col h-full font-mono text-xs">
+      {/* Header bar */}
+      <div className="flex items-center gap-4 px-4 py-2 border-b border-zinc-800 bg-zinc-950">
+        <span className="text-red-400 font-bold tracking-widest">⚡ TRIPWIRE WATCH</span>
+        <div className="flex gap-2 ml-auto">
+          <button
+            type="button"
+            onClick={() => { setTab('active'); setSelected(null); }}
+            className={`px-3 py-0.5 rounded border text-xs transition-colors ${
+              tab === 'active'
+                ? 'bg-red-950 border-red-700 text-red-300'
+                : 'border-zinc-700 text-zinc-500 hover:text-zinc-300'
+            }`}
+          >
+            ACTIVE
+            <span className="ml-1 bg-red-800 text-red-200 rounded px-1">{activeCount}</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => { setTab('resolved'); setSelected(null); }}
+            className={`px-3 py-0.5 rounded border text-xs transition-colors ${
+              tab === 'resolved'
+                ? 'bg-zinc-800 border-zinc-600 text-zinc-300'
+                : 'border-zinc-700 text-zinc-500 hover:text-zinc-300'
+            }`}
+          >
+            RESOLVED
+            <span className="ml-1 bg-zinc-700 text-zinc-300 rounded px-1">{resolvedCount}</span>
+          </button>
+        </div>
+      </div>
+
+      {/* Sparkline */}
+      <TripwireSparkline />
+
+      {/* Feed + drill-down */}
+      <div className="flex flex-1 min-h-0">
+        <div className="flex-1 overflow-y-auto">
+          {visible.length === 0 ? (
+            <div className="p-6 text-zinc-600 text-center">
+              {tab === 'active' ? 'No active anomalies' : 'No resolved anomalies'}
+            </div>
+          ) : (
+            visible.map((entry) => (
+              <div
+                key={entry.id}
+                role="button"
+                tabIndex={0}
+                onClick={() => setSelected(selected?.id === entry.id ? null : entry)}
+                onKeyDown={(e) => e.key === 'Enter' && setSelected(selected?.id === entry.id ? null : entry)}
+                className={`flex items-start gap-3 px-4 py-3 border-b border-zinc-800/60
+                  cursor-pointer transition-colors hover:bg-zinc-900
+                  ${selected?.id === entry.id ? 'bg-zinc-900 border-l-2 border-l-red-500' : ''}
+                `}
+              >
+                <span className={`mt-1 w-2 h-2 rounded-full flex-shrink-0 ${SEV_DOT[entry.severity]}`} />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <span className={`px-1.5 py-0.5 rounded text-[10px] ${SEV_STYLE[entry.severity]}`}>
+                      {entry.severity}
+                    </span>
+                    <span className="text-sky-400">{entry.agent}</span>
+                    <span className="text-zinc-600 ml-auto flex-shrink-0">{relativeTime(entry.ts)}</span>
+                  </div>
+                  <div className="text-zinc-200 truncate">{entry.label}</div>
+                  {entry.resolved && entry.resolvedBy && (
+                    <div className="text-green-600 text-[10px] mt-0.5">✓ {entry.resolvedBy}</div>
+                  )}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        {selected && (
+          <TripwireDrillDown entry={selected} onClose={() => setSelected(null)} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/terminal/chambers/TripwireDrillDown.tsx
+++ b/components/terminal/chambers/TripwireDrillDown.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import type { TripwireEntry } from '@/lib/terminal/tripwire';
+
+const AGENT_CONTEXT: Record<string, {
+  role: string;
+  confidence: number;
+  lastCycle: string;
+  trace: string[];
+  cta: string;
+}> = {
+  DAEDALUS: {
+    role: 'Self-Diagnostic',
+    confidence: 0.41,
+    lastCycle: 'C-319',
+    trace: [
+      'Self-ping issued to /api/v1/system/health',
+      'Received HTTP 401 — auth token expired',
+      'Token rotation not configured in Vercel env',
+      'Confidence degraded from 0.79 → 0.41',
+    ],
+    cta: 'Rotate DAEDALUS_AUTH_TOKEN in Vercel dashboard and re-deploy',
+  },
+  HERMES: {
+    role: 'Narrative Router',
+    confidence: 0.74,
+    lastCycle: 'C-321',
+    trace: [
+      'µ3 narrative signal computed as 0.000',
+      'µ4 narrative signal computed as 0.000',
+      'Root: empty journal lane — KV-to-substrate bridge gap',
+      'GI suppressed by structural zero in HERMES component weight',
+    ],
+    cta: 'Write test journal entry via /api/v1/journal/ingest to unblock µ3/µ4',
+  },
+  ZEUS: {
+    role: 'Verification Engine',
+    confidence: 0.91,
+    lastCycle: 'C-322',
+    trace: [
+      'Verification sweep issued against ATLAS C-323 heartbeat',
+      'Substrate POST returned 422 HTML error body',
+      'Root: wrong write target — terminal writing directly to GitHub',
+      'Resolved C-321: redirected POST to Civic Protocol Core Ledger',
+    ],
+    cta: 'Confirm ledger endpoint matches SUBSTRATE_LEDGER_URL env var',
+  },
+  ATLAS: {
+    role: 'Sentinel Orchestrator',
+    confidence: 0.87,
+    lastCycle: 'C-323',
+    trace: [
+      'GI floor breach detected: confidence dropped to 0.60',
+      'HERMES µ3/µ4 contributing structural zeros to GI',
+      'DAEDALUS degraded — reducing orchestration quorum',
+      'Manual operator override resolved C-320',
+    ],
+    cta: 'Review HERMES µ3/µ4 and DAEDALUS auth as root causes',
+  },
+};
+
+interface Props {
+  entry: TripwireEntry;
+  onClose: () => void;
+}
+
+export function TripwireDrillDown({ entry, onClose }: Props) {
+  const ctx = AGENT_CONTEXT[entry.agent];
+
+  return (
+    <div className="w-72 border-l border-zinc-800 bg-zinc-950 flex flex-col font-mono text-xs overflow-y-auto flex-shrink-0">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-zinc-800">
+        <span className="text-sky-400 font-bold">{entry.agent}</span>
+        <button type="button" onClick={onClose} className="text-zinc-600 hover:text-zinc-300 transition-colors">✕</button>
+      </div>
+      {ctx ? (
+        <div className="px-4 py-3 space-y-4">
+          <div>
+            <div className="text-zinc-500 text-[10px] tracking-widest uppercase mb-1">Role</div>
+            <div className="text-zinc-200">{ctx.role}</div>
+          </div>
+          <div>
+            <div className="text-zinc-500 text-[10px] tracking-widest uppercase mb-1">Confidence</div>
+            <div className={`font-bold ${
+              ctx.confidence < 0.60 ? 'text-red-400' :
+              ctx.confidence < 0.75 ? 'text-amber-400' :
+              'text-green-400'
+            }`}>
+              {ctx.confidence.toFixed(2)}
+            </div>
+          </div>
+          <div>
+            <div className="text-zinc-500 text-[10px] tracking-widest uppercase mb-2">Agent Trace</div>
+            <ol className="space-y-1.5">
+              {ctx.trace.map((step, i) => (
+                <li key={i} className="flex gap-2 text-zinc-400 leading-relaxed">
+                  <span className="text-zinc-700 flex-shrink-0">{i + 1}.</span>
+                  <span>{step}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+          <div className="border border-amber-800/50 bg-amber-950/30 rounded p-3">
+            <div className="text-amber-400 text-[10px] tracking-widest uppercase mb-1">Operator Action</div>
+            <div className="text-amber-200 leading-relaxed">{ctx.cta}</div>
+          </div>
+          {entry.resolved && entry.resolvedBy && (
+            <div className="border border-green-800/50 bg-green-950/30 rounded p-3">
+              <div className="text-green-400 text-[10px] tracking-widest uppercase mb-1">Resolved By</div>
+              <div className="text-green-200">{entry.resolvedBy}</div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="px-4 py-3 text-zinc-500">No trace context available for {entry.agent}.</div>
+      )}
+    </div>
+  );
+}

--- a/components/terminal/chambers/TripwireSparkline.tsx
+++ b/components/terminal/chambers/TripwireSparkline.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+const CYCLE_HISTORY = [
+  { cycle: 'C-313', count: 3, gi: 0.68 },
+  { cycle: 'C-314', count: 1, gi: 0.74 },
+  { cycle: 'C-315', count: 2, gi: 0.71 },
+  { cycle: 'C-316', count: 0, gi: 0.82 },
+  { cycle: 'C-317', count: 1, gi: 0.79 },
+  { cycle: 'C-318', count: 4, gi: 0.64 },
+  { cycle: 'C-319', count: 2, gi: 0.70 },
+  { cycle: 'C-320', count: 5, gi: 0.66 },
+  { cycle: 'C-321', count: 1, gi: 0.91 },
+  { cycle: 'C-322', count: 2, gi: 0.80 },
+  { cycle: 'C-323', count: 2, gi: null },
+] as const;
+
+const MAX_COUNT = Math.max(...CYCLE_HISTORY.map((c) => c.count), 1);
+const BAR_H = 48;
+
+export function TripwireSparkline() {
+  return (
+    <div className="px-4 py-3 border-b border-zinc-800 bg-zinc-950/60">
+      <div className="text-zinc-500 text-[10px] mb-2 tracking-widest uppercase">
+        Anomaly Frequency · Last 10 Cycles
+      </div>
+      <div className="flex items-end gap-1 h-12">
+        {CYCLE_HISTORY.map(({ cycle, count, gi }) => {
+          const h = count === 0 ? 2 : Math.round((count / MAX_COUNT) * BAR_H);
+          const color =
+            gi === null ? 'bg-zinc-600' :
+            gi < 0.65   ? 'bg-red-500' :
+            gi < 0.75   ? 'bg-amber-500' :
+                          'bg-green-500';
+          return (
+            <div key={cycle} className="flex flex-col items-center gap-0.5 flex-1 group">
+              <div
+                className={`w-full rounded-sm ${color} opacity-80 group-hover:opacity-100 transition-opacity`}
+                style={{ height: `${h}px` }}
+                title={`${cycle} · ${count} anomalies · GI ${gi ?? '—'}`}
+              />
+              <span className="text-zinc-600 text-[8px] group-hover:text-zinc-400 transition-colors">
+                {cycle.replace('C-', '')}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="flex gap-3 mt-2 text-[10px] text-zinc-600">
+        <span><span className="inline-block w-2 h-2 bg-green-500 rounded-sm mr-1 align-middle" />GI ≥ 0.75</span>
+        <span><span className="inline-block w-2 h-2 bg-amber-500 rounded-sm mr-1 align-middle" />GI 0.65–0.74</span>
+        <span><span className="inline-block w-2 h-2 bg-red-500 rounded-sm mr-1 align-middle" />GI &lt; 0.65</span>
+      </div>
+    </div>
+  );
+}

--- a/lib/terminal/epicon.ts
+++ b/lib/terminal/epicon.ts
@@ -72,12 +72,62 @@ export const MOCK_EPICON_EVENTS: EpiconEvent[] = [
   },
 ];
 
+function normalizeFeedItem(raw: Record<string, unknown>): EpiconEvent | null {
+  const id = typeof raw.id === 'string' ? raw.id : null;
+  const timestamp = typeof raw.timestamp === 'string' ? raw.timestamp : null;
+  const title = typeof raw.title === 'string' ? raw.title : null;
+  if (!id || !timestamp || !title) return null;
+
+  const ts = new Date(timestamp).getTime();
+  if (!Number.isFinite(ts)) return null;
+
+  const verified = Boolean(raw.verified);
+  const status = raw.status;
+  const tier: ConfidenceTier =
+    verified || status === 'committed' ? 'VERIFIED' :
+    status === 'failed' ? 'CONTRADICTED' :
+    'PENDING';
+
+  const confRaw = raw.confidenceTier;
+  const confidence =
+    typeof confRaw === 'number' && confRaw >= 0 && confRaw <= 4
+      ? confRaw / 4
+      : verified ? 0.8 : 0.5;
+
+  const summary =
+    typeof raw.body === 'string' && raw.body.trim() ? raw.body :
+    typeof raw.summary === 'string' && raw.summary.trim() ? raw.summary :
+    title;
+
+  const agent =
+    typeof raw.agentOrigin === 'string' && raw.agentOrigin.trim()
+      ? raw.agentOrigin.toUpperCase()
+      : typeof raw.author === 'string' && raw.author.trim()
+        ? raw.author.toUpperCase()
+        : 'SYSTEM';
+
+  const cycle =
+    typeof raw.cycleId === 'string' && raw.cycleId ? raw.cycleId :
+    typeof raw.cycle === 'string' && raw.cycle ? raw.cycle :
+    'C-—';
+
+  const sourcesRaw = raw.sources ?? raw.tags;
+  const sources: string[] = Array.isArray(sourcesRaw)
+    ? (sourcesRaw as unknown[]).filter((s): s is string => typeof s === 'string')
+    : [];
+
+  return { id, cycle, ts, tier, label: title, summary, agent, confidence, sources };
+}
+
 export async function fetchEpiconEvents(): Promise<EpiconEvent[]> {
   const raw = await fetchInternal('/api/epicon/feed');
   if (raw && typeof raw === 'object') {
     const items = (raw as { items?: unknown }).items;
     if (Array.isArray(items) && items.length > 0) {
-      return items as EpiconEvent[];
+      const normalized = (items as Record<string, unknown>[])
+        .map(normalizeFeedItem)
+        .filter((e): e is EpiconEvent => e !== null);
+      if (normalized.length > 0) return normalized;
     }
   }
   return MOCK_EPICON_EVENTS;

--- a/lib/terminal/epicon.ts
+++ b/lib/terminal/epicon.ts
@@ -1,0 +1,84 @@
+/**
+ * Phase 02 (C-323): EPICON event feed data layer with mock events seeded
+ * from live scan — ZEUS inconclusive C-323, EU AI Act investigation, G7 renewal.
+ */
+
+import { fetchInternal } from './api-client';
+
+export type ConfidenceTier = 'VERIFIED' | 'PENDING' | 'CONTRADICTED' | 'ARCHIVED';
+
+export interface EpiconEvent {
+  id: string;
+  cycle: string;
+  ts: number;
+  tier: ConfidenceTier;
+  label: string;
+  summary: string;
+  agent: string;
+  confidence: number;
+  sources: string[];
+  contradictions?: string[];
+}
+
+export const MOCK_EPICON_EVENTS: EpiconEvent[] = [
+  {
+    id: 'ep-001',
+    cycle: 'C-323',
+    ts: Date.now() - 1_800_000,
+    tier: 'VERIFIED',
+    label: 'US Senate AI Safety Hearing — markup session concluded',
+    summary:
+      'Senate Commerce Committee approved S.1847 markup with 3 amendments. ATLAS confidence 0.92 after ZEUS cross-verification.',
+    agent: 'ATLAS',
+    confidence: 0.92,
+    sources: ['reuters.com', 'congress.gov', 'politico.com'],
+  },
+  {
+    id: 'ep-002',
+    cycle: 'C-323',
+    ts: Date.now() - 3_600_000,
+    tier: 'PENDING',
+    label: 'EU AI Act enforcement — first Article 53 investigation opened',
+    summary:
+      'Reports of first formal investigation under Article 53 general-purpose AI rules. Single source, not yet cross-verified.',
+    agent: 'EVE',
+    confidence: 0.61,
+    sources: ['euractiv.com'],
+  },
+  {
+    id: 'ep-003',
+    cycle: 'C-322',
+    ts: Date.now() - 28_800_000,
+    tier: 'CONTRADICTED',
+    label: 'OpenAI AGI threshold declaration — disputed',
+    summary:
+      'Initial reports of internal AGI threshold declaration contradicted by official OpenAI communications. ZEUS flagged divergence.',
+    agent: 'ZEUS',
+    confidence: 0.28,
+    sources: ['techcrunch.com', 'theinformation.com'],
+    contradictions: ['openai.com/blog', 'Reuters correction C-322'],
+  },
+  {
+    id: 'ep-004',
+    cycle: 'C-321',
+    ts: Date.now() - 86_400_000,
+    tier: 'VERIFIED',
+    label: 'G7 AI governance communiqué — Hiroshima Process renewal signed',
+    summary:
+      'All G7 members signed renewed Hiroshima Process AI governance framework. JADE integrity score 0.94.',
+    agent: 'JADE',
+    confidence: 0.94,
+    sources: ['g7.gc.ca', 'state.gov', 'consilium.europa.eu'],
+  },
+];
+
+export async function fetchEpiconEvents(): Promise<EpiconEvent[]> {
+  const raw = await fetchInternal('/api/epicon/feed');
+  if (raw && typeof raw === 'object') {
+    const items = (raw as { items?: unknown }).items;
+    if (Array.isArray(items) && items.length > 0) {
+      return items as EpiconEvent[];
+    }
+  }
+  return MOCK_EPICON_EVENTS;
+}

--- a/lib/terminal/integrity.ts
+++ b/lib/terminal/integrity.ts
@@ -54,3 +54,6 @@ export async function getCachedIntegrity(): Promise<IntegrityCacheEntry> {
 export function clearIntegrityCache(): void {
   _cache = null;
 }
+
+/** Alias used by chamber components. */
+export const fetchIntegrity = getCachedIntegrity;

--- a/lib/terminal/markets.ts
+++ b/lib/terminal/markets.ts
@@ -82,13 +82,59 @@ export const MOCK_MARKET_SIGNALS: MarketSignal[] = [
   },
 ];
 
+function finvizRowToSignal(row: Record<string, unknown>, index: number): MarketSignal | null {
+  const ticker =
+    (typeof row.Ticker === 'string' && row.Ticker) ||
+    (typeof row.ticker === 'string' && row.ticker);
+  if (!ticker) return null;
+
+  const price =
+    typeof row.Price === 'string' ? row.Price :
+    typeof row.price === 'string' ? row.price : '';
+  const change =
+    typeof row.Change === 'string' ? row.Change :
+    typeof row.change === 'string' ? row.change : '0.00%';
+  const deltaDir: 'up' | 'down' | 'flat' =
+    change.startsWith('+') ? 'up' :
+    change.startsWith('-') ? 'down' : 'flat';
+
+  return {
+    id: `finviz-${ticker}-${index}`,
+    label: ticker,
+    category: 'MACRO',
+    value: price ? `$${price}` : '—',
+    delta: change,
+    deltaDir,
+    integrityWeight: 0.50,
+    confidence: 0.75,
+    status: 'LIVE',
+    source: 'Finviz screener',
+    cycle: 'current',
+    ts: Date.now(),
+  };
+}
+
 export async function fetchMarketSignals(): Promise<MarketSignal[]> {
-  const raw = await fetchInternal('/api/markets/signals');
+  const raw = await fetchInternal('/api/markets/finviz/signals');
   if (raw && typeof raw === 'object') {
-    const items = (raw as { signals?: unknown; items?: unknown }).signals ??
-      (raw as { items?: unknown }).items;
-    if (Array.isArray(items) && items.length > 0) {
-      return items as MarketSignal[];
+    const rec = raw as Record<string, unknown>;
+    if (rec.ok && !rec.degraded) {
+      const items = rec.items as {
+        momentum?: Record<string, unknown>[];
+        volatility?: Record<string, unknown>[];
+        breadth?: Record<string, unknown>[];
+      } | undefined;
+      if (items) {
+        const all = [
+          ...(items.momentum ?? []),
+          ...(items.volatility ?? []),
+          ...(items.breadth ?? []),
+        ].slice(0, 6);
+        const signals = all
+          .map((row, i) => finvizRowToSignal(row, i))
+          .filter((s): s is MarketSignal => s !== null);
+        if (signals.length > 0) return signals;
+      }
     }
   }
   return MOCK_MARKET_SIGNALS;

--- a/lib/terminal/markets.ts
+++ b/lib/terminal/markets.ts
@@ -1,0 +1,100 @@
+/**
+ * Phase 02 (C-323): Market signal data layer with integrity-weighted confidence.
+ * GI gates displayed confidence: conf × (1 − weight × (1 − gi))
+ */
+
+import { fetchInternal } from './api-client';
+
+export type SignalCategory = 'MACRO' | 'CRYPTO' | 'GOVERNANCE' | 'SOVEREIGN';
+export type SignalStatus = 'LIVE' | 'STALE' | 'UNVERIFIED' | 'GATED';
+
+export interface MarketSignal {
+  id: string;
+  label: string;
+  category: SignalCategory;
+  value: string;
+  delta: string;
+  deltaDir: 'up' | 'down' | 'flat';
+  integrityWeight: number;
+  confidence: number;
+  status: SignalStatus;
+  source: string;
+  cycle: string;
+  ts: number;
+}
+
+export const MOCK_MARKET_SIGNALS: MarketSignal[] = [
+  {
+    id: 'mk-001',
+    label: 'MIC / Integrity Coin',
+    category: 'CRYPTO',
+    value: '0.003 MIC',
+    delta: '+0.001',
+    deltaDir: 'up',
+    integrityWeight: 1.0,
+    confidence: 0.91,
+    status: 'LIVE',
+    source: 'Mobius Substrate ledger',
+    cycle: 'C-323',
+    ts: Date.now() - 900_000,
+  },
+  {
+    id: 'mk-002',
+    label: 'US 10Y Treasury Yield',
+    category: 'SOVEREIGN',
+    value: '4.41%',
+    delta: '+0.03',
+    deltaDir: 'up',
+    integrityWeight: 0.70,
+    confidence: 0.88,
+    status: 'LIVE',
+    source: 'FRED / St. Louis Fed',
+    cycle: 'C-323',
+    ts: Date.now() - 3_600_000,
+  },
+  {
+    id: 'mk-003',
+    label: 'BTC / USD',
+    category: 'CRYPTO',
+    value: '$94,210',
+    delta: '-1.2%',
+    deltaDir: 'down',
+    integrityWeight: 0.45,
+    confidence: 0.74,
+    status: 'LIVE',
+    source: 'CoinGecko',
+    cycle: 'C-323',
+    ts: Date.now() - 600_000,
+  },
+  {
+    id: 'mk-004',
+    label: 'EU AI Act Compliance Index',
+    category: 'GOVERNANCE',
+    value: '0.61',
+    delta: '-0.04',
+    deltaDir: 'down',
+    integrityWeight: 0.90,
+    confidence: 0.63,
+    status: 'UNVERIFIED',
+    source: 'EVE synthesis · C-322',
+    cycle: 'C-322',
+    ts: Date.now() - 86_400_000,
+  },
+];
+
+export async function fetchMarketSignals(): Promise<MarketSignal[]> {
+  const raw = await fetchInternal('/api/markets/signals');
+  if (raw && typeof raw === 'object') {
+    const items = (raw as { signals?: unknown; items?: unknown }).signals ??
+      (raw as { items?: unknown }).items;
+    if (Array.isArray(items) && items.length > 0) {
+      return items as MarketSignal[];
+    }
+  }
+  return MOCK_MARKET_SIGNALS;
+}
+
+export function gatedConfidence(signal: MarketSignal, gi: number | null): number {
+  if (gi === null) return signal.confidence;
+  return signal.confidence * (1 - signal.integrityWeight * (1 - gi));
+}

--- a/lib/terminal/tripwire.ts
+++ b/lib/terminal/tripwire.ts
@@ -62,12 +62,38 @@ const MOCK_CHAMBER_ENTRIES: TripwireEntry[] = [
   },
 ];
 
+function levelToSeverity(level: unknown): TripwireSeverity {
+  if (level === 'high')   return 'CRITICAL';
+  if (level === 'medium') return 'WARN';
+  return 'INFO';
+}
+
 export async function fetchTripwires(): Promise<TripwireEntry[]> {
   const raw = await fetchInternal('/api/tripwire/status');
   if (raw && typeof raw === 'object') {
-    const tw = raw as { tripwires?: unknown };
-    if (Array.isArray(tw.tripwires) && tw.tripwires.length > 0) {
-      return (tw.tripwires as TripwireEntry[]).filter((t) => t && typeof t.id === 'string');
+    const payload = raw as { tripwire?: unknown; tripwires?: unknown };
+
+    // Primary live shape: singular tripwire object from GET /api/tripwire/status
+    if (payload.tripwire && typeof payload.tripwire === 'object') {
+      const t = payload.tripwire as Record<string, unknown>;
+      if (!t.active) return [];
+      return [{
+        id: 'runtime-tripwire',
+        severity: levelToSeverity(t.level),
+        label: typeof t.reason === 'string' && t.reason ? t.reason : 'Runtime tripwire active',
+        agent: typeof t.triggeredBy === 'string' && t.triggeredBy
+          ? t.triggeredBy.toUpperCase()
+          : 'OPERATOR',
+        ts: typeof t.last_updated === 'string'
+          ? (new Date(t.last_updated).getTime() || Date.now())
+          : Date.now(),
+        resolved: false,
+      }];
+    }
+
+    // Array form
+    if (Array.isArray(payload.tripwires) && payload.tripwires.length > 0) {
+      return (payload.tripwires as TripwireEntry[]).filter((t) => t && typeof t.id === 'string');
     }
   }
   return MOCK_CHAMBER_ENTRIES;

--- a/lib/terminal/tripwire.ts
+++ b/lib/terminal/tripwire.ts
@@ -1,12 +1,77 @@
 /**
  * OPT-09 (C-323): Tripwire fetch with MOCK_TRIPWIRES that include mock-safe
  * entries for DAEDALUS (401 auth sentinel) and HERMES (µ3/µ4 signal lanes).
+ * Phase 02: added TripwireEntry (UI chamber type), fetchTripwires(), resolved entries.
  */
 
 import type { Tripwire } from './types';
 import { mockTripwires } from './mock';
 import { fetchInternal, fetchExternal, isLiveAPI } from './api-client';
 import { transformTripwire } from './transforms';
+
+// ── Phase 02 chamber types ───────────────────────────────────
+export type TripwireSeverity = 'INFO' | 'WARN' | 'CRITICAL';
+
+export interface TripwireEntry {
+  id: string;
+  severity: TripwireSeverity;
+  label: string;
+  agent: string;
+  ts: number;
+  resolved: boolean;
+  resolvedAt?: number;
+  resolvedBy?: string;
+}
+
+const MOCK_CHAMBER_ENTRIES: TripwireEntry[] = [
+  {
+    id: 'tw-001',
+    severity: 'CRITICAL',
+    label: 'DAEDALUS Auth Sentinel — 401 upstream',
+    agent: 'DAEDALUS',
+    ts: Date.now() - 7_200_000,
+    resolved: false,
+  },
+  {
+    id: 'tw-002',
+    severity: 'WARN',
+    label: 'HERMES µ3 / µ4 signal lanes — structural zero',
+    agent: 'HERMES',
+    ts: Date.now() - 14_400_000,
+    resolved: false,
+  },
+  {
+    id: 'tw-003',
+    severity: 'WARN',
+    label: 'Substrate ledger POST returned 422 — HTML error body',
+    agent: 'ZEUS',
+    ts: Date.now() - 172_800_000,
+    resolved: true,
+    resolvedAt: Date.now() - 86_400_000,
+    resolvedBy: 'ZEUS · C-321 sweep',
+  },
+  {
+    id: 'tw-004',
+    severity: 'CRITICAL',
+    label: 'GI floor breach — ATLAS confidence below 0.60',
+    agent: 'ATLAS',
+    ts: Date.now() - 259_200_000,
+    resolved: true,
+    resolvedAt: Date.now() - 172_800_000,
+    resolvedBy: 'Operator · C-320 manual override',
+  },
+];
+
+export async function fetchTripwires(): Promise<TripwireEntry[]> {
+  const raw = await fetchInternal('/api/tripwire/status');
+  if (raw && typeof raw === 'object') {
+    const tw = raw as { tripwires?: unknown };
+    if (Array.isArray(tw.tripwires) && tw.tripwires.length > 0) {
+      return (tw.tripwires as TripwireEntry[]).filter((t) => t && typeof t.id === 'string');
+    }
+  }
+  return MOCK_CHAMBER_ENTRIES;
+}
 
 export const MOCK_TRIPWIRES: Tripwire[] = [
   ...mockTripwires,


### PR DESCRIPTION
## C-323 Phase 02 — Chamber Upgrade Pass

12 integrity-gated UI upgrades across 3 stub chambers (4 per chamber). Tripwire, EPICON, and Markets were empty stubs after PR #542 merge. All chambers now render substantive content on cold load — mock-safe, no API required.

### Scan intelligence used

| Finding | Impact |
|---------|--------|
| DAEDALUS 401 confirmed | TW-04 drill-down has exact trace + CTA |
| HERMES µ3/µ4 structural zero | TW-04 HERMES trace wired; MK-04 cross-ref flags it |
| ZEUS inconclusive C-323 | EP-01 mock includes ZEUS CONTRADICTED entry |
| ATLAS heartbeats GI 0.64–0.92 (C-313–C-323) | TW-03 sparkline uses real cycle history |
| GI oscillating yellow band | MK-01 signal confidence gated: `conf × (1 − weight × (1 − gi))` |

### TRIPWIRE (TW-01–04)

- **TW-01** `TripwireChamber.tsx` — Full anomaly feed with CRITICAL/WARN/INFO severity badges + relative timestamps
- **TW-02** — Active/Resolved tab toggle with count badges; resolved mock entries (ZEUS 422, ATLAS GI floor breach)
- **TW-03** `TripwireSparkline.tsx` — 10-cycle frequency sparkline (C-313–C-323), GI-color coded bars
- **TW-04** `TripwireDrillDown.tsx` — Row click opens agent panel: trace chain, confidence score, operator CTA
- New types in `lib/terminal/tripwire.ts`: `TripwireEntry`, `TripwireSeverity`, `fetchTripwires()`

### EPICON (EP-01–04)

- **EP-01** `EpiconChamber.tsx` — Event ledger with VERIFIED/PENDING/CONTRADICTED badges + confidence %; 4 mock events seeded from C-321–C-323 scan
- **EP-02** `EpiconInspector.tsx` — Row click opens inspector: confidence ladder, source stack, contradictions list
- **EP-03** `EpiconIngestBadge.tsx` — Live ingest counter (ticks every 4s) + freshness badge (FRESH/STALE + age)
- **EP-04** `EpiconFilterBar.tsx` — Filter by tier × agent × text search
- EPICON page: tabbed UI (Event Feed | Runtime Check) — existing quorum check fully preserved
- New `lib/terminal/epicon.ts` data layer

### MARKETS (MK-01–04)

- **MK-01** `MarketsChamber.tsx` — Integrity-weighted signal table: GI gates displayed confidence per signal
- **MK-02** `MarketsCorrelation.tsx` — Correlation tab: 8-cycle GI trend sparkline + weight matrix showing pp drop
- **MK-03** `MarketsFreshnessTicker.tsx` — Per-signal LIVE/FRESH/STALE/OLD ticker, updates every 10s
- **MK-04** — Cross-ref banner when active tripwires exist; VIEW TRIPWIRE → navigates via `useRouter`
- New `lib/terminal/markets.ts` with `gatedConfidence()` helper

### Gate status

| Gate | Status |
|------|--------|
| G-TW-1 Feed renders ≥1 row with severity badge | ✅ |
| G-TW-2 Active/Resolved toggle + count badges | ✅ |
| G-TW-3 Sparkline for last 10 cycles | ✅ |
| G-TW-4 Row click → drill-down with trace + CTA | ✅ |
| G-EP-1 Event ledger with confidence tier badge | ✅ |
| G-EP-2 Inspector: source stack + confidence ladder | ✅ |
| G-EP-3 Ingest counter ticks + freshness badge | ✅ |
| G-EP-4 Filter bar narrows rows | ✅ |
| G-MK-1 Signal table with integrity-weight column | ✅ |
| G-MK-2 GI correlation panel | ✅ |
| G-MK-3 Freshness ticker per signal | ✅ |
| G-MK-4 Cross-ref flag → Tripwire nav | ✅ |

https://claude.ai/code/session_015DD2VYZmnKoR1R3gMAayYT

---
_Generated by [Claude Code](https://claude.ai/code/session_015DD2VYZmnKoR1R3gMAayYT)_