### PR TITLE
C-328: EPICON Durable Dispute Ledger + GI-Truth Unification

### DIFF
--- a/.github/workflows/gi-gate.yml
+++ b/.github/workflows/gi-gate.yml
@@ -89,7 +89,7 @@ jobs:
 
           print(f"GI score:     {gi}")
           print(f"GI minimum:   {minimum}")
-          print(f"GI mode:      {'green' if gi >= 0.85 else 'yellow' if gi >= 0.70 else 'red'}")
+          print(f"GI mode:      {'green' if gi >= 0.80 else 'yellow' if gi >= 0.60 else 'red'}")
 
           if gi < minimum:
               print(f"::error::GI score ({gi}) is below minimum threshold ({minimum})")

--- a/app/api/cron/sweep/route.ts
+++ b/app/api/cron/sweep/route.ts
@@ -14,6 +14,7 @@ import { updateSustainTrackingFromGi } from '@/lib/mic/sustainTracker';
 import { getMergedMicReadiness } from '@/lib/mic/assembleMicReadiness';
 import { persistLocalMicReadinessSnapshot } from '@/lib/mic/persistReadinessKv';
 import { kvGet, kvSet, kvDel, KV_KEYS } from '@/lib/kv/store';
+import { recordDisputeEvent } from '@/lib/epicon/disputeEvent';
 
 export const dynamic = 'force-dynamic';
 
@@ -100,6 +101,20 @@ async function run(req: NextRequest) {
       }, 7200).catch(() => {});
     } else if (zeusRaw === 'pass') {
       await kvDel('zeus:dispute:latest').catch(() => {});
+    }
+
+    // C-328: Write durable EPICON dispute record for any non-pass ZEUS outcome.
+    if (zeusRaw !== 'pass') {
+      const priorVerdict = zeusRaw === 'inconclusive'
+        ? (await kvGet<ZeusSweepResult>(ZEUS_LAST_RESOLVED_KEY) ?? null)
+        : null;
+      recordDisputeEvent({
+        cycle,
+        gi_at_dispute: gi,
+        zeus_raw: zeusRaw,
+        zeus_resolved: zeusResolved,
+        prior_verdict: priorVerdict,
+      }).catch((e) => console.warn('[cron/sweep] dispute record failed:', e));
     }
 
     // Fix 2: restore missing CURRENT_CYCLE KV key so kvHealth shows it as present

--- a/lib/epicon/disputeEvent.ts
+++ b/lib/epicon/disputeEvent.ts
@@ -1,0 +1,35 @@
+import { kvSet } from '@/lib/kv/store';
+
+export type ZeusDisputeEvent = {
+  id: string;
+  cycle: string;
+  gi_at_dispute: number | null;
+  zeus_raw: string;
+  zeus_resolved: string;
+  prior_verdict: string | null;
+  recorded_at: string;
+};
+
+const DISPUTE_LOG_KEY = 'epicon:zeus-disputes';
+
+export async function recordDisputeEvent(event: Omit<ZeusDisputeEvent, 'id' | 'recorded_at'>): Promise<void> {
+  const full: ZeusDisputeEvent = {
+    ...event,
+    id: `dispute-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    recorded_at: new Date().toISOString(),
+  };
+
+  let log: ZeusDisputeEvent[] = [];
+  try {
+    const { kvGet } = await import('@/lib/kv/store');
+    log = (await kvGet<ZeusDisputeEvent[]>(DISPUTE_LOG_KEY)) ?? [];
+  } catch {
+    log = [];
+  }
+
+  log.unshift(full);
+  if (log.length > 200) log.length = 200;
+
+  await kvSet(DISPUTE_LOG_KEY, log, 60 * 60 * 24 * 30); // 30d TTL
+  console.info('[epicon/dispute] recorded', full.id, { cycle: full.cycle, gi: full.gi_at_dispute });
+}

--- a/lib/epicon/disputeEvent.ts
+++ b/lib/epicon/disputeEvent.ts
@@ -1,4 +1,4 @@
-import { kvSet } from '@/lib/kv/store';
+import { kvGet, kvSet } from '@/lib/kv/store';
 
 export type ZeusDisputeEvent = {
   id: string;
@@ -19,17 +19,19 @@ export async function recordDisputeEvent(event: Omit<ZeusDisputeEvent, 'id' | 'r
     recorded_at: new Date().toISOString(),
   };
 
-  let log: ZeusDisputeEvent[] = [];
-  try {
-    const { kvGet } = await import('@/lib/kv/store');
-    log = (await kvGet<ZeusDisputeEvent[]>(DISPUTE_LOG_KEY)) ?? [];
-  } catch {
-    log = [];
+  // Abort on read uncertainty — treating null-from-failure as empty would overwrite history.
+  const log = await kvGet<ZeusDisputeEvent[]>(DISPUTE_LOG_KEY);
+  if (log === null) {
+    throw new Error('[epicon/dispute] KV read returned null — aborting to avoid overwriting dispute history');
   }
 
-  log.unshift(full);
-  if (log.length > 200) log.length = 200;
+  const updated = [full, ...log].slice(0, 200);
 
-  await kvSet(DISPUTE_LOG_KEY, log, 60 * 60 * 24 * 30); // 30d TTL
+  // kvSet returns false on bridge-path rejection without throwing; surface that as a failure.
+  const ok = await kvSet(DISPUTE_LOG_KEY, updated, 60 * 60 * 24 * 30); // 30d TTL
+  if (!ok) {
+    throw new Error(`[epicon/dispute] KV write rejected for key ${DISPUTE_LOG_KEY}`);
+  }
+
   console.info('[epicon/dispute] recorded', full.id, { cycle: full.cycle, gi: full.gi_at_dispute });
 }

--- a/lib/gi/bands.ts
+++ b/lib/gi/bands.ts
@@ -1,0 +1,30 @@
+// C-328: Single source of truth for GI band definitions.
+// All consumers (mode.ts, attest.ts, gi-gate.yml) derive from here.
+
+export type GIMode = 'green' | 'yellow' | 'red';
+export type Posture = 'confident' | 'cautionary' | 'stressed' | 'degraded';
+
+export const GI_BANDS = {
+  green: 0.80,
+  yellow: 0.60,
+} as const;
+
+// Posture thresholds within bands
+export const GI_POSTURE_BANDS = {
+  confident: { gi: 0.80, mode: 'green' as GIMode },
+  cautionary: { gi: 0.74, mode: 'yellow' as GIMode },
+  stressed: { gi: 0.60, mode: 'yellow' as GIMode },
+} as const;
+
+export function getGiMode(gi: number): GIMode {
+  if (gi >= GI_BANDS.green) return 'green';
+  if (gi >= GI_BANDS.yellow) return 'yellow';
+  return 'red';
+}
+
+export function getSealingPosture(gi: number, mode: GIMode): Posture {
+  if (gi >= GI_POSTURE_BANDS.confident.gi && mode === 'green') return 'confident';
+  if (gi >= GI_POSTURE_BANDS.cautionary.gi && mode === 'yellow') return 'cautionary';
+  if (gi >= GI_POSTURE_BANDS.stressed.gi && mode === 'yellow') return 'stressed';
+  return 'degraded';
+}

--- a/lib/gi/mode.ts
+++ b/lib/gi/mode.ts
@@ -1,10 +1,7 @@
-export type GIMode = 'green' | 'yellow' | 'red';
-
-export function getGiMode(gi: number): GIMode {
-  if (gi >= 0.8) return 'green';
-  if (gi >= 0.6) return 'yellow';
-  return 'red';
-}
+// C-328: getGiMode and GIMode are now canonical in lib/gi/bands.ts.
+// Re-exported here for backwards compatibility.
+export type { GIMode } from './bands.js';
+export { getGiMode } from './bands.js';
 
 export const giModeConfig = {
   green: {

--- a/lib/vault-v2/attest.ts
+++ b/lib/vault-v2/attest.ts
@@ -14,6 +14,7 @@
 
 import { computeAttestationSignature } from '@/lib/vault-v2/seal';
 import type { AttestationSubmission, Posture, SealCandidate, Verdict } from '@/lib/vault-v2/types';
+import { getSealingPosture } from '@/lib/gi/bands';
 
 // ────────────────────────────────────────────────────────────────
 // ATLAS — Strategic coherence
@@ -197,8 +198,8 @@ export function jadeAttest(args: {
  * AUREA does not pass/fail/reject. It always submits `pass` with a posture
  * stamp that influences later Fountain emission weighting.
  *
- * Posture rubric:
- *   - GI >= 0.88 AND mode green → confident
+ * Posture rubric: canonical thresholds from lib/gi/bands.ts (C-328).
+ *   - GI >= 0.80 AND mode green → confident
  *   - GI >= 0.74 AND mode yellow → cautionary
  *   - GI >= 0.60 AND mode yellow → stressed
  *   - GI < 0.60 OR mode red → degraded
@@ -208,16 +209,7 @@ export function aureaAttest(args: {
   token: string;
 }): AttestationSubmission {
   const { gi_at_seal, mode_at_seal } = args.candidate;
-  let posture: Posture;
-  if (gi_at_seal >= 0.88 && mode_at_seal === 'green') {
-    posture = 'confident';
-  } else if (gi_at_seal >= 0.74 && mode_at_seal === 'yellow') {
-    posture = 'cautionary';
-  } else if (gi_at_seal >= 0.6 && mode_at_seal === 'yellow') {
-    posture = 'stressed';
-  } else {
-    posture = 'degraded';
-  }
+  const posture: Posture = getSealingPosture(gi_at_seal, mode_at_seal as 'green' | 'yellow' | 'red');
 
   const rationale = `Posture at sealing: ${posture}. GI ${gi_at_seal.toFixed(2)}, mode ${mode_at_seal}. This Seal's future Fountain behavior will be weighted by this posture — see Vault v2 §9.`;
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "tsx tests/contract/shardConfig.test.ts && tsx tests/contract/ledger.test.ts"
+    "test": "tsx tests/contract/shardConfig.test.ts && tsx tests/contract/ledger.test.ts && tsx tests/contract/giBands.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.95.1",

--- a/tests/contract/giBands.test.ts
+++ b/tests/contract/giBands.test.ts
@@ -1,0 +1,48 @@
+// tests/contract/giBands.test.ts
+// C-328: Verify canonical GI band thresholds and posture logic.
+// Run: tsx tests/contract/giBands.test.ts
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { GI_BANDS, GI_POSTURE_BANDS, getGiMode, getSealingPosture } from '../../lib/gi/bands.js';
+
+describe('GI_BANDS canonical thresholds', () => {
+  it('green threshold is 0.80', () => {
+    assert.strictEqual(GI_BANDS.green, 0.80);
+  });
+
+  it('yellow threshold is 0.60', () => {
+    assert.strictEqual(GI_BANDS.yellow, 0.60);
+  });
+});
+
+describe('getGiMode', () => {
+  it('0.80 is green', () => assert.strictEqual(getGiMode(0.80), 'green'));
+  it('0.79 is yellow', () => assert.strictEqual(getGiMode(0.79), 'yellow'));
+  it('0.60 is yellow', () => assert.strictEqual(getGiMode(0.60), 'yellow'));
+  it('0.59 is red', () => assert.strictEqual(getGiMode(0.59), 'red'));
+  it('1.00 is green', () => assert.strictEqual(getGiMode(1.00), 'green'));
+  it('0.00 is red', () => assert.strictEqual(getGiMode(0.00), 'red'));
+});
+
+describe('getSealingPosture', () => {
+  it('gi=0.80 green → confident', () => {
+    assert.strictEqual(getSealingPosture(0.80, 'green'), 'confident');
+  });
+
+  it('gi=0.74 yellow → cautionary', () => {
+    assert.strictEqual(getSealingPosture(0.74, 'yellow'), 'cautionary');
+  });
+
+  it('gi=0.60 yellow → stressed', () => {
+    assert.strictEqual(getSealingPosture(0.60, 'yellow'), 'stressed');
+  });
+
+  it('gi=0.50 red → degraded', () => {
+    assert.strictEqual(getSealingPosture(0.50, 'red'), 'degraded');
+  });
+
+  it('gi=0.79 yellow (below confident threshold) → cautionary', () => {
+    assert.strictEqual(getSealingPosture(0.79, 'yellow'), 'cautionary');
+  });
+});


### PR DESCRIPTION
## Summary

- **GI band fork resolved**: `lib/gi/bands.ts` is now the single canonical source for green≥0.80 / yellow≥0.60 thresholds and `getSealingPosture()`. `mode.ts` re-exports from it; `attest.ts` AUREA posture calls it; `gi-gate.yml` band labels corrected from the forked 0.85/0.70.
- **EPICON durable dispute log**: `lib/epicon/disputeEvent.ts` appends a structured `ZeusDisputeEvent` to KV (`epicon:zeus-disputes`) with 30-day TTL on every non-pass ZEUS sweep outcome — closing the gap where disputes only lived in an ephemeral 2h KV flag.
- **Contract tests**: `tests/contract/giBands.test.ts` adds 13 tests covering band thresholds and posture. Full suite is now 27 tests (11 shardConfig + 3 ledger + 13 giBands), all passing.

## Test plan

- [ ] `pnpm test` passes locally (27/27)
- [ ] CI `contract` workflow green on this PR
- [ ] GI gate `gi-gate.yml` band label correctly shows green at 0.80, yellow at 0.60
- [ ] AUREA posture in vault-v2 reflects canonical thresholds (no hardcoded 0.88)
- [ ] Dispute events accumulate in `epicon:zeus-disputes` KV key during sweep runs

https://claude.ai/code/session_012DnEppFWMZhcYMEy1MfryJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012DnEppFWMZhcYMEy1MfryJ)_