### PR TITLE
fix: drop .js extension on bands import for Next.js/webpack

### DIFF
--- a/lib/gi/mode.ts
+++ b/lib/gi/mode.ts
@@ -1,7 +1,7 @@
 // C-328: getGiMode and GIMode are now canonical in lib/gi/bands.ts.
 // Re-exported here for backwards compatibility.
-export type { GIMode } from './bands.js';
-export { getGiMode } from './bands.js';
+export type { GIMode } from './bands';
+export { getGiMode } from './bands';
 
 export const giModeConfig = {
   green: {


### PR DESCRIPTION
## Summary

- `lib/gi/mode.ts` imported `./bands.js` which webpack/Next.js can't resolve against a `.ts` source file — caused production build failure: `Module not found: Can't resolve './bands.js'`
- Changed to `./bands` (no extension) which is the correct form for Next.js/webpack

## Test plan

- [ ] Vercel production build passes
- [ ] `pnpm test` still green (27/27)

https://claude.ai/code/session_012DnEppFWMZhcYMEy1MfryJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012DnEppFWMZhcYMEy1MfryJ)_