### PR TITLE
C-330: config-class attestation errors no longer falsely fail healthy seals

### DIFF
--- a/app/api/cron/reattest-seals/route.ts
+++ b/app/api/cron/reattest-seals/route.ts
@@ -22,6 +22,7 @@ import { bearerMatchesToken } from '@/lib/vault-v2/auth';
 import { listAllSeals, writeSeal, appendSealToChain, getLatestSealId } from '@/lib/vault-v2/store';
 import { backAttestSeal, buildBackAttestRationale } from '@/lib/vault-v2/back-attest';
 import { attestReserveBlockToSubstrate, dequeueSubstrateRetry } from '@/lib/vault-v2/substrate-attestation';
+import { isConfigClassError } from '@/lib/vault-v2/attestation-error-class';
 import { SENTINEL_AGENTS } from '@/lib/vault-v2/types';
 import { releaseReplayPressureForAttestedSeal } from '@/lib/mic/replayPressure';
 import { kvGet, kvSet, kvDel, isRedisAvailable } from '@/lib/kv/store';
@@ -205,6 +206,13 @@ async function retrySubstratePointer(
     if (opts?.burstMode) {
       recordAttempt = !substrate.ok;
     }
+    // C-330: a server-config failure (e.g. CPC IDENTITY_API_BASE unset → 400
+    // "No API base configured for terminal") is NOT a per-seal failure. Do not
+    // burn this seal's retry budget — it must stay retryable and resume
+    // automatically once the env is fixed.
+    if (!substrate.ok && isConfigClassError(substrateError)) {
+      recordAttempt = false;
+    }
 
     const updatedSeal: Seal = {
       ...seal,
@@ -247,10 +255,17 @@ async function retrySubstratePointer(
       error: substrateError ?? undefined,
     });
   } catch (e) {
-    recordAttempt = true;
     const msg = `[substrate-retry:${reason}] ${seal.seal_id}: ${e instanceof Error ? e.message : String(e)}`;
+    // C-330: only count the attempt if it's not a server-config class failure.
+    recordAttempt = !isConfigClassError(msg);
     errors.push(msg);
-    results.push({ seal_id: seal.seal_id, agent: 'substrate-write', ok: false, error: msg });
+    results.push({
+      seal_id: seal.seal_id,
+      agent: 'substrate-write',
+      ok: false,
+      transition: isConfigClassError(msg) ? 'blocked-on-config' : undefined,
+      error: msg,
+    });
   }
 
   if (recordAttempt) {
@@ -378,6 +393,24 @@ export async function GET(req: NextRequest) {
     // FIX-07: cap total attempts to prevent seals from looping forever.
     const attempts = (await kvGet<number>(`seal:${seal.seal_id}:reattest_attempts`)) ?? 0;
     if (attempts >= MAX_REATTEST_ATTEMPTS) {
+      // C-330: never mark a seal permanently-failed when its outstanding error is
+      // a server-config class failure (e.g. CPC IDENTITY_API_BASE unset). Those
+      // are not the seal's fault and resolve when the env is fixed. Marking them
+      // permanently-failed is what forced the hand-maintained reset list.
+      if (isConfigClassError(seal.substrate_attestation_error)) {
+        console.warn(
+          `[reattest-seals] ${seal.seal_id} hit attempt cap but error is config-class ` +
+            `(${seal.substrate_attestation_error}) — holding retryable, not marking permanently-failed`,
+        );
+        results.push({
+          seal_id: seal.seal_id,
+          agent: 'cap',
+          ok: true,
+          transition: 'held-blocked-on-config',
+          error: seal.substrate_attestation_error ?? undefined,
+        });
+        continue;
+      }
       console.error(
         `[reattest-seals] ${seal.seal_id} exceeded ${MAX_REATTEST_ATTEMPTS} attempts — marking permanently-failed`,
       );

--- a/lib/vault-v2/attestation-error-class.ts
+++ b/lib/vault-v2/attestation-error-class.ts
@@ -1,0 +1,69 @@
+// C-330 — distinguish a SERVER-CONFIG attestation failure from a real per-seal
+// failure, so config errors never burn a seal's retry budget.
+//
+// ROOT CAUSE (confirmed in Civic-Protocol-Core ledger/app/main.py:100-112):
+//   The terminal attests with lab_source "terminal". CPC routes "terminal" →
+//   IDENTITY_API_BASE for token introspection. IDENTITY_API_BASE defaults to ""
+//   on the Render ledger deploy, so every terminal attestation receives:
+//   400 {"detail":"No API base configured for terminal"}.
+//   This is a server env problem, not a per-seal problem — retrying the same
+//   seal cannot succeed until IDENTITY_API_BASE is set on Render.
+//
+// THE BUG THIS FIXES (app/api/cron/reattest-seals/route.ts):
+//   The reattest cron counts every failed attempt toward MAX_REATTEST_ATTEMPTS
+//   (12) and then marks the seal permanently-failed. Because the config 400
+//   fails all 12, healthy seals get falsely marked permanently-failed — which
+//   is exactly why a hand-maintained LEGACY_SEAL_KV_RESET_IDS list (49 entries,
+//   C-288 → C-307) exists to un-stick them after env fixes.
+//
+//   By classifying config-class errors and NOT counting them against the cap,
+//   affected seals stay retryable and auto-resume when IDENTITY_API_BASE is set.
+
+export type AttestationErrorClass = 'config' | 'transient' | 'permanent';
+
+// Substrings identifying a CPC server-configuration failure. Case-insensitive.
+const CONFIG_ERROR_SIGNATURES = [
+  'no api base configured', // CPC main.py:112 — IDENTITY_API_BASE unset
+  'unknown lab source',     // CPC main.py:109 — routing misconfig
+] as const;
+
+// Substrings identifying a transient/retryable failure. SHOULD count toward cap.
+const TRANSIENT_ERROR_SIGNATURES = [
+  'timeout',
+  'timed out',
+  'etimedout',
+  'econnreset',
+  'econnrefused',
+  'enotfound',
+  'eai_again',
+  'fetch failed',
+  'network',
+  'socket hang up',
+  'response not json', // Render HTML cold-start (client.ts C-296 OPT-2)
+  'ledger 502',
+  'ledger 503',
+  'ledger 504',
+  '500',
+] as const;
+
+/**
+ * Classify a substrate attestation error string.
+ * - 'config'    → server misconfigured; do NOT burn retry budget; auto-resumes on fix.
+ * - 'transient' → retryable; counts toward the cap with backoff.
+ * - 'permanent' → unrecognized; treated as a real failure (counts toward cap).
+ *
+ * Config is checked first so a "400" config error is never misread as transient.
+ */
+export function classifyAttestationError(error: string | null | undefined): AttestationErrorClass {
+  if (!error) return 'permanent';
+  const e = error.toLowerCase();
+  if (CONFIG_ERROR_SIGNATURES.some((sig) => e.includes(sig))) return 'config';
+  if (TRANSIENT_ERROR_SIGNATURES.some((sig) => e.includes(sig))) return 'transient';
+  return 'permanent';
+}
+
+/** True when the error is a server-config class failure that should not count
+ *  toward the permanent-fail cap. */
+export function isConfigClassError(error: string | null | undefined): boolean {
+  return classifyAttestationError(error) === 'config';
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "tsx tests/contract/shardConfig.test.ts && tsx tests/contract/ledger.test.ts && tsx tests/contract/giBands.test.ts && tsx tests/contract/attestationCoverage.test.ts"
+    "test": "tsx tests/contract/shardConfig.test.ts && tsx tests/contract/ledger.test.ts && tsx tests/contract/giBands.test.ts && tsx tests/contract/attestationCoverage.test.ts && tsx tests/contract/attestationErrorClass.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.95.1",

--- a/tests/contract/attestationErrorClass.test.ts
+++ b/tests/contract/attestationErrorClass.test.ts
@@ -1,0 +1,61 @@
+// C-330: lock the rule that a server-config attestation failure never burns a
+// seal's retry budget. Reproduces the live CPC error so a regression that
+// reclassifies it (and re-breaks the permanent-fail behavior) fails the build.
+//
+// Run: tsx tests/contract/attestationErrorClass.test.ts
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyAttestationError,
+  isConfigClassError,
+} from '../../lib/vault-v2/attestation-error-class.js';
+
+describe('config-class errors are recognized (must not count toward retry cap)', () => {
+  it('LIVE CPC 400 (IDENTITY_API_BASE unset) classifies as config', () => {
+    const live = 'Error: ledger 400: {"detail":"No API base configured for terminal"}';
+    assert.strictEqual(classifyAttestationError(live), 'config');
+    assert.strictEqual(isConfigClassError(live), true);
+  });
+
+  it('unknown lab source classifies as config', () => {
+    assert.strictEqual(classifyAttestationError('ledger 400: Unknown lab source: terminal'), 'config');
+  });
+
+  it('config match is case-insensitive and survives wrapping', () => {
+    assert.strictEqual(isConfigClassError('NO API BASE CONFIGURED FOR TERMINAL'), true);
+    assert.strictEqual(isConfigClassError('  Error: ledger 400: {"detail":"no api base configured for terminal"} '), true);
+  });
+});
+
+describe('transient errors still count toward the cap', () => {
+  for (const e of [
+    'ledger response not JSON (content-type: text/html)',
+    'fetch failed',
+    'ETIMEDOUT',
+    'socket hang up',
+    'ledger 503: upstream',
+  ]) {
+    it(`"${e.slice(0, 40)}" → transient`, () => {
+      assert.strictEqual(classifyAttestationError(e), 'transient');
+      assert.strictEqual(isConfigClassError(e), false);
+    });
+  }
+});
+
+describe('genuine/unknown failures are permanent (count toward cap)', () => {
+  it('null/empty/undefined → permanent', () => {
+    assert.strictEqual(classifyAttestationError(null), 'permanent');
+    assert.strictEqual(classifyAttestationError(''), 'permanent');
+    assert.strictEqual(classifyAttestationError(undefined), 'permanent');
+  });
+
+  it('real rejection (e.g. signature invalid) → permanent', () => {
+    assert.strictEqual(classifyAttestationError('ledger 422: signature invalid'), 'permanent');
+    assert.strictEqual(isConfigClassError('ledger 422: signature invalid'), false);
+  });
+
+  it('config takes precedence even when message contains "400"', () => {
+    assert.strictEqual(classifyAttestationError('ledger 400: No API base configured for terminal'), 'config');
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause confirmed in CPC source**: `IDENTITY_API_BASE` is unset on the Render ledger deploy. CPC routes `lab_source:"terminal"` → `IDENTITY_API_BASE` for token introspection; empty string → `400 "No API base configured for terminal"` on every terminal attestation. Every terminal attestation maps to `lab_source:"terminal"`, so all 174 fail. The actual unblock is one Render env var on CPC — this PR can't set it, but ensures no seals are wrongly buried meanwhile.
- **The terminal-side defect fixed**: the reattest cron counted all 12 `MAX_REATTEST_ATTEMPTS` against config-class 400s and marked healthy seals `permanently-failed`. That is the direct cause of the hand-maintained `LEGACY_SEAL_KV_RESET_IDS` list (49 hardcoded entries, C-288→C-307, growing every cycle).
- **`lib/vault-v2/attestation-error-class.ts`** (new): `classifyAttestationError()` → `'config'|'transient'|'permanent'`; `isConfigClassError()`. Config checked first so a "400" config error is never misread as transient.
- **`app/api/cron/reattest-seals/route.ts`** (3 edits): config-class errors don't burn retry budget in `retrySubstratePointer`; catch block tags `blocked-on-config`; permanent-fail cap holds seals with config-class errors as `held-blocked-on-config` instead of `permanently-failed`.
- **`tests/contract/attestationErrorClass.test.ts`** (new): 11 tests including the live CPC error string. Full suite now 43 tests, all passing.

## The actual unblock (Civic-Protocol-Core / Render)

Set `IDENTITY_API_BASE` on the `civic-protocol-core-ledger` Render service to the Mobius Identity base that serves `/auth/introspect`. Once set, the 174 errored seals drain through the existing retry queue automatically. With this PR, none will have been wrongly marked `permanently-failed` in the meantime.

## Follow-up (after env confirmed fixed)

Delete the `LEGACY_SEAL_KV_RESET_IDS` array (49 entries) — this PR removes the mechanism that made it necessary.

## Test plan

- [ ] `pnpm test` passes (43/43)
- [ ] CI `contract` workflow green
- [ ] After `IDENTITY_API_BASE` is set on Render: 174 errored seals drain; none marked `permanently-failed`; `LEGACY_SEAL_KV_RESET_IDS` can be deleted

https://claude.ai/code/session_012DnEppFWMZhcYMEy1MfryJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012DnEppFWMZhcYMEy1MfryJ)_