### PR TITLE
fix(redis_bridge): reject wildcard in CORS_ALLOW_ORIGINS when enabling credentials

### DIFF
--- a/api/redis_bridge.py
+++ b/api/redis_bridge.py
@@ -17,11 +17,13 @@ app = FastAPI(title="Mobius Redis Bridge")
 # the "*" fallback. Set CORS_ALLOW_ORIGINS on the Render service to the real
 # terminal/shell origins before enabling credentialed requests.
 _raw_origins = os.getenv("CORS_ALLOW_ORIGINS", "").strip()
-if _raw_origins:
-    _allow_origins = [o.strip() for o in _raw_origins.split(",") if o.strip()]
+# Filter out wildcard entries — CORS spec forbids allow_credentials=True with "*".
+_explicit_origins = [o.strip() for o in _raw_origins.split(",") if o.strip() and o.strip() != "*"]
+if _explicit_origins:
+    _allow_origins = _explicit_origins
     _allow_credentials = True
 else:
-    # Safe default: wildcard without credentials (spec-valid).
+    # Safe default (also handles CORS_ALLOW_ORIGINS="*" explicitly): wildcard without credentials.
     _allow_origins = ["*"]
     _allow_credentials = False
 


### PR DESCRIPTION
## 1. Summary

- **Cycle:** C-332 (follow-up to PR #555 / #556)
- **Type:** `fix`
- **Primary area:** `infra`
- **Files changed:** `api/redis_bridge.py`
- **Files deliberately NOT changed:** all other CORS consumers (no other routes set middleware)

**What changed?**
The OPT-1 CORS fix in C-332 drove origins from `CORS_ALLOW_ORIGINS` env var, but if an operator set `CORS_ALLOW_ORIGINS=*` explicitly the env-branch fired with `allow_credentials=True` — recreating the exact wildcard+credentials combination the fix was meant to eliminate. The parser now strips `*` entries from the list; if no non-wildcard origins remain (including the `CORS_ALLOW_ORIGINS=*` case), the safe default is used: wildcard without credentials.

**Why?**
Codex P2 review on PR #555 identified the edge case. The fix closes the remaining path to wildcard+credentials — the combination is now mathematically unreachable regardless of env var value.

---

## 2. Risk Tier

- [x] **Tier 1** — App logic, no auth/KV schema changes

---

## 3. EPICON Intent

```text
epicon_id: EPICON_C-332_infra_cors-wildcard-edge-case
scope: infra
mode: normal
issued_at: 2026-06-04T23:32:00Z

justification:
  PROBLEM:
    CORS_ALLOW_ORIGINS="*" in env still sets allow_credentials=True,
    which is a CORS spec violation. OPT-1 did not account for this case.

  CONTEXT:
    Identified in Codex P2 review of PR #555. A new Render deployment
    that sets CORS_ALLOW_ORIGINS=* expecting the wildcard-without-
    credentials behavior would instead get the invalid configuration.

  DECISION:
    Strip "*" entries from the parsed list. If the result is empty,
    fall back to wildcard+no-credentials (safe default). Credentials
    only enabled when at least one explicit non-wildcard origin remains.

  BOUNDARIES:
    No change to any route logic, KV, journal, epicon, or auth headers.
    Single-file change to redis_bridge.py middleware config only.

  TRADEOFFS:
    - Removed: the remaining wildcard+credentials path
    - Kept: all existing behavior for explicit origin lists
    - Risk: none — strictly more restrictive

  COUNTERFACTUALS:
    - If CORS_ALLOW_ORIGINS is unset or "*", credentials are off (spec-valid)
    - If CORS_ALLOW_ORIGINS is "*, https://example.com", wildcard is stripped
      and only https://example.com is used with credentials enabled
```

---

## 4. LOCKED BEHAVIOR AUDIT

- [x] This PR does NOT change the key schema in `app/api/agents/journal/route.ts`
- [x] This PR does NOT remove or bypass the LPUSH/LTRIM in `app/api/echo/ingest/route.ts`
- [x] This PR does NOT remove the `Authorization` header from `lib/substrate/github-reader.ts`
- [x] This PR does NOT add crypto price sources to HERMES-µ
- [x] This PR does NOT reassign domain ownership between agents
- [x] This PR does NOT attempt to "fix" `sources.kv: 0` on epicon or journal
- [x] This PR does NOT add seed/genesis data to mask empty KV state

---

## 5. Integrity Impact

- **Estimated MII for this PR:** 0.01
- **Risk level:** Low
- **Lanes affected:** `runtime` (Redis bridge CORS behavior)

### Checklist
- [x] Does not change KV key schemas without operator approval
- [x] Does not remove auth from any route
- [x] Does not introduce duplicate signal sources across agents
- [x] Does not add hardcoded cycle IDs, timestamps, or seed data

---

## 6. Verification

**Pre-merge:**
- [x] Verified all four CORS cases manually:
  - Empty env → wildcard, no credentials ✅
  - `CORS_ALLOW_ORIGINS=*` → wildcard, no credentials ✅
  - `CORS_ALLOW_ORIGINS=https://example.com` → explicit origin, credentials ✅
  - `CORS_ALLOW_ORIGINS=*,https://example.com` → only explicit origin, credentials ✅

---

## 7. Rollback Plan

```bash
git revert 9c5f3ca
# No KV changes — no key cleanup required
```

---

## 8. Stop Conditions Met

- [x] No stop condition triggered — scope is clean (single-line logic change in Python middleware config)

---

## 9. Final Checklist

- [x] Risk tier correctly assessed (Tier 1)
- [x] EPICON intent block completed with BOUNDARIES field
- [x] Locked behavior audit completed
- [x] Rollback plan provided

https://claude.ai/code/session_017VRAQ36hN44d5aCeYf6j9v