### PR TITLE
C-336: Agent DevOps guardrails — scope-guard, CODEOWNERS, branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# C-336 — Agent DevOps guardrails.
+# Tier-3 paths require the operator's review. Agents may PROPOSE, never SHIP.
+# Effective once branch protection requires CODEOWNER review on `main`.
+# Kept in lockstep with .github/scope-guard/protected-paths.txt.
+
+/auth.ts                    @kaizencycle
+/lib/auth/                  @kaizencycle
+/lib/identity/              @kaizencycle
+/lib/substrate/             @kaizencycle
+/lib/mic/                   @kaizencycle
+/lib/integrity/             @kaizencycle
+/app/api/mic/               @kaizencycle
+
+/scripts/ignore-build.sh    @kaizencycle
+/scripts/scope-guard.sh     @kaizencycle
+/scripts/setup-branch-protection.sh @kaizencycle
+/.github/                   @kaizencycle
+
+/vercel.json                @kaizencycle
+/render.yaml                @kaizencycle
+/mobius.yaml                @kaizencycle
+/next.config.ts             @kaizencycle
+/package.json               @kaizencycle
+/pnpm-lock.yaml             @kaizencycle

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,8 @@
 /auth.ts                    @kaizencycle
 /lib/auth/                  @kaizencycle
 /lib/identity/              @kaizencycle
+/app/api/auth/              @kaizencycle
+/app/api/identity/          @kaizencycle
 /lib/substrate/             @kaizencycle
 /lib/mic/                   @kaizencycle
 /lib/integrity/             @kaizencycle

--- a/.github/scope-guard/agent-logins.txt
+++ b/.github/scope-guard/agent-logins.txt
@@ -1,0 +1,6 @@
+# C-336 — Known agent author logins (in addition to any "*[bot]" login).
+mobius-bot
+github-actions[bot]
+cursor[bot]
+claude[bot]
+cursoragent

--- a/.github/scope-guard/agent-paths.txt
+++ b/.github/scope-guard/agent-paths.txt
@@ -1,0 +1,8 @@
+# C-336 — Areas agents may freely edit. Only enforced when STRICT_ALLOWLIST=true.
+# Verified against the actual tree — replace/extend as agent scope grows.
+^app/api/agents/
+^app/api/chambers/
+^lib/chambers/
+^lib/signals/
+^lib/agents/
+^docs/

--- a/.github/scope-guard/protected-paths.txt
+++ b/.github/scope-guard/protected-paths.txt
@@ -1,0 +1,39 @@
+# C-336 — Tier-3 paths (operator-only). Agents must never modify these.
+# Matched as extended regex against repo-relative changed-file paths.
+# Mirrors PULL_REQUEST_TEMPLATE.md Tier 3: "MIC economy, identity, ledger
+# integrity math, auth" — plus the guardrails themselves and deploy/infra config.
+# Verified against the actual tree (not aspirational paths) — see C-336 PR notes.
+
+# Outbound ledger/token client + canon read/write (the C-333 token-truth surface).
+^lib/substrate/
+
+# Auth / identity / agent-write authorization.
+^auth\.ts$
+^lib/auth/
+^lib/identity/
+
+# MIC economy + ledger integrity math (settlement, chain hashing, quorum, sustain).
+^app/api/mic/
+^lib/mic/
+
+# Canon hash roots / integrity derivation.
+^lib/integrity/
+
+# The guardrails themselves — agents may not edit what constrains agents.
+^scripts/ignore-build\.sh$
+^scripts/scope-guard\.sh$
+^scripts/setup-branch-protection\.sh$
+^\.github/scope-guard/
+^\.github/CODEOWNERS$
+^\.github/workflows/
+
+# Deploy / build / infra / node-declaration config.
+^vercel\.json$
+^render\.yaml$
+^mobius\.yaml$
+^next\.config\.(js|mjs|ts)$
+^package\.json$
+^pnpm-lock\.yaml$
+
+# Secrets-adjacent.
+^\.env

--- a/.github/scope-guard/protected-paths.txt
+++ b/.github/scope-guard/protected-paths.txt
@@ -7,10 +7,12 @@
 # Outbound ledger/token client + canon read/write (the C-333 token-truth surface).
 ^lib/substrate/
 
-# Auth / identity / agent-write authorization.
+# Auth / identity / agent-write authorization (lib + the live API surface).
 ^auth\.ts$
 ^lib/auth/
 ^lib/identity/
+^app/api/auth/
+^app/api/identity/
 
 # MIC economy + ledger integrity math (settlement, chain hashing, quorum, sustain).
 ^app/api/mic/

--- a/.github/workflows/scope-guard.yml
+++ b/.github/workflows/scope-guard.yml
@@ -1,0 +1,43 @@
+name: scope-guard
+
+# C-336: machine-enforces "agents author, the operator ships." Classifies the PR
+# diff into the canonical Tier 0-3 model (PULL_REQUEST_TEMPLATE.md) and blocks:
+#   - Tier-3 paths (auth/identity/ledger-math/guardrails/infra) edited by non-owners
+#   - agent-authored code changes that lack an EPICON receipt
+# Complements anti-nuke (deletions) and sentinel-review (quality) — this is scope.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: scope-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  scope-guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Materialize PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr_body.md"
+
+      - name: Run scope-guard
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          ACTOR: ${{ github.event.pull_request.user.login }}
+          OWNER_LOGINS: kaizencycle
+          PR_BODY_FILE: ${{ runner.temp }}/pr_body.md
+          STRICT_ALLOWLIST: "false"   # flip to "true" once agent-paths.txt is trusted
+        run: bash scripts/scope-guard.sh

--- a/docs/governance/agent-devops.md
+++ b/docs/governance/agent-devops.md
@@ -23,15 +23,22 @@ mechanically rather than assumed.)
 3. **scope-guard** (`scripts/scope-guard.sh`, run by `.github/workflows/scope-guard.yml`
    on every PR) — classifies the diff into the canonical tiers and enforces:
    - **Tier-3 paths are operator-only**: `lib/substrate/` (the C-333 token-truth
-     surface), `auth.ts` + `lib/auth/` + `lib/identity/` (auth/identity), `lib/mic/`
-     + `app/api/mic/` (MIC ledger settlement/chain-hash math), `lib/integrity/`
-     (canon hash roots), the guardrail scripts and `.github/` itself, and
-     deploy/infra config (`vercel.json`, `render.yaml`, `mobius.yaml`,
-     `next.config.ts`, `package.json`, `pnpm-lock.yaml`). A Tier-3 edit by a
-     non-owner **fails** the check — see `.github/scope-guard/protected-paths.txt`.
-   - **Agent code changes require an EPICON receipt** — `epicon_id:` plus a
-     rollback plan in the PR body, mirroring `PULL_REQUEST_TEMPLATE.md` §3/§7.
-     The "why" is ledgered before the diff, same as any other consequential act.
+     surface), `auth.ts` + `lib/auth/` + `lib/identity/` + the live
+     `app/api/auth/` + `app/api/identity/` routes (auth/identity — both the
+     library and the API surface it backs), `lib/mic/` + `app/api/mic/` (MIC
+     ledger settlement/chain-hash math), `lib/integrity/` (canon hash roots),
+     the guardrail scripts and `.github/` itself, and deploy/infra config
+     (`vercel.json`, `render.yaml`, `mobius.yaml`, `next.config.ts`,
+     `package.json`, `pnpm-lock.yaml`). A Tier-3 edit by a non-owner **fails**
+     the check — see `.github/scope-guard/protected-paths.txt`.
+   - **Agent code changes require an EPICON receipt** — a ledgered, *filled-in*
+     `epicon_id: EPICON_C-...` plus `rollback: ...` (key:value lines, mirroring
+     `PULL_REQUEST_TEMPLATE.md` §3/§7) in the PR body. The check rejects the
+     template's own untouched placeholders — `epicon_id: EPICON_C-[CYCLE]_...`
+     and `git revert [commit-sha]` would otherwise satisfy a bare substring
+     match for "epicon_id:" / "rollback" without anyone having ledgered
+     anything. The "why" is ledgered before the diff, same as any other
+     consequential act — not merely gestured at.
    - Optional `STRICT_ALLOWLIST=true` confines agents to `agent-paths.txt`.
    - **Fails closed**: if the diff can't be proven (shallow checkout, bad refs),
      the gate blocks rather than silently passing — the deliberate inverse of

--- a/docs/governance/agent-devops.md
+++ b/docs/governance/agent-devops.md
@@ -1,0 +1,86 @@
+# Agent DevOps Guardrails (C-336)
+
+The Mobius sentinels are also the Mobius DevOps team. The same constitution that
+governs the substrate governs the agents-as-DevOps. Core rule: **agents author,
+the operator ships.** Propose and merge are separated; the consequential lever
+(shipping to prod, touching auth/identity/ledger math/the guardrails) stays
+human, by protocol — not by hope. (The C-335 freeze — prod stuck ~2 days behind
+~40 sentinel pushes — is the cautionary tale for *why* this has to be enforced
+mechanically rather than assumed.)
+
+## Pipeline
+
+1. **Identity** — agents commit under a scoped GitHub App or fine-grained PAT,
+   not the operator's account: `contents:write` to `agent/*`-style branches and
+   `pull_requests:write` only. No `workflow:write`, no admin — an agent identity
+   that is rotatable, scoped, and distinct from the operator, mirroring the
+   service-account model in `lib/identity/`.
+2. **Branch isolation** — agents push to `claude/*` / `cursor/*` (and any future
+   `agent/*`) branches only. `scripts/ignore-build.sh` already treats those as
+   non-deploying: agent work produces a Vercel *preview* deployment to inspect,
+   never a production build. The ship lever is the merge to `main`, and the
+   merge stays the operator's.
+3. **scope-guard** (`scripts/scope-guard.sh`, run by `.github/workflows/scope-guard.yml`
+   on every PR) — classifies the diff into the canonical tiers and enforces:
+   - **Tier-3 paths are operator-only**: `lib/substrate/` (the C-333 token-truth
+     surface), `auth.ts` + `lib/auth/` + `lib/identity/` (auth/identity), `lib/mic/`
+     + `app/api/mic/` (MIC ledger settlement/chain-hash math), `lib/integrity/`
+     (canon hash roots), the guardrail scripts and `.github/` itself, and
+     deploy/infra config (`vercel.json`, `render.yaml`, `mobius.yaml`,
+     `next.config.ts`, `package.json`, `pnpm-lock.yaml`). A Tier-3 edit by a
+     non-owner **fails** the check — see `.github/scope-guard/protected-paths.txt`.
+   - **Agent code changes require an EPICON receipt** — `epicon_id:` plus a
+     rollback plan in the PR body, mirroring `PULL_REQUEST_TEMPLATE.md` §3/§7.
+     The "why" is ledgered before the diff, same as any other consequential act.
+   - Optional `STRICT_ALLOWLIST=true` confines agents to `agent-paths.txt`.
+   - **Fails closed**: if the diff can't be proven (shallow checkout, bad refs),
+     the gate blocks rather than silently passing — the deliberate inverse of
+     `ignore-build.sh`'s fail-*open* posture, because the two gates protect
+     against opposite risks (losing a deploy vs. waving through an unauthorized
+     edit).
+4. **CODEOWNERS + branch protection** (`.github/CODEOWNERS`,
+   `scripts/setup-branch-protection.sh`) — Tier-3 paths require operator
+   (CODEOWNER) review; required checks before merge: `scope-guard`, `contract`,
+   `guard` (anti-nuke), `sentinel`, `gi-gate`.
+5. **Ship gate** — `ignore-build.sh` only builds production for operator-authored
+   or `[deploy]`-tagged commits (C-335), so an agent cannot force a production
+   build even if a PR were merged by mistake.
+6. **Reversibility as circuit breaker** — every merge is a Vercel deployment
+   with instant rollback. Wire the GI breaker to it: if GI drops materially in
+   the epoch after a merge, auto-promote the last known-good deployment and
+   freeze further merges until cleared — the same doctrine already applied to
+   MIC supply, applied to code.
+
+## Tier map (mirrors `PULL_REQUEST_TEMPLATE.md` §2)
+
+| Tier | Scope | Merge authority |
+|------|-------|-----------------|
+| 0 | Docs / comments / formatting | Agent PR + green checks |
+| 1 | App logic, no schema/auth changes | Sentinel review → operator merge |
+| 2 | KV key schema, journal schema, EPICON shape, signal domain | Operator review — no self-merge |
+| 3 | MIC economy, identity, ledger integrity math, auth, the guardrails, infra | **Operator-only** — agents propose, never ship |
+
+## The load-bearing guarantee
+
+An agent must never be able to edit the thing that constrains agents.
+`scripts/scope-guard.sh`, `scripts/ignore-build.sh`, `.github/CODEOWNERS`, and
+every workflow under `.github/workflows/` are themselves listed in
+`protected-paths.txt` — Tier-3, operator-only. This is what makes the guardrail
+self-sustaining rather than advisory.
+
+## Forcing a deploy
+
+Agents never ship. To deploy a fix yourself: merge as the operator, or push an
+empty commit tagged `[deploy]`:
+
+```bash
+git commit --allow-empty -m "ops: force prod deploy [deploy]"
+```
+
+## Rollout checklist (operator, post-merge)
+
+1. Run `scripts/setup-branch-protection.sh` (requires `gh` with admin) to lock
+   in required checks + CODEOWNER review.
+2. Provision the scoped GitHub App / PAT for agents per step 1 above.
+3. Once `agent-paths.txt` is trusted, flip `STRICT_ALLOWLIST` to `"true"` in
+   `.github/workflows/scope-guard.yml`.

--- a/scripts/scope-guard.sh
+++ b/scripts/scope-guard.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# scripts/scope-guard.sh — C-336 agent-DevOps guardrail.
+#
+# Machine-enforces what PULL_REQUEST_TEMPLATE.md asks authors to self-declare:
+#   - Tier-3 paths (auth / identity / lib/substrate / MIC ledger math / the
+#     guardrails themselves / deploy+infra config) are OPERATOR-ONLY. Agents
+#     may PROPOSE, never SHIP. A Tier-3 edit by a non-owner FAILS.
+#   - Agent-authored code changes MUST carry an EPICON receipt (epicon_id +
+#     a rollback plan) in the PR body — mirrors template sections 3 and 7.
+#   - Optional STRICT_ALLOWLIST: agent diffs must stay inside agent-paths.txt.
+#
+# Tiers mirror PULL_REQUEST_TEMPLATE.md:
+#   T0 docs/comments · T1 app logic · T2 KV/journal/EPICON shape · T3 economy/identity/auth/infra
+#
+# exit 0 = PASS · exit 1 = FAIL (block merge). anti-nuke handles deletions; this is edits+authorship.
+#
+# SECURITY POSTURE: this gate fails CLOSED. If the diff can't be proven (bad
+# refs, shallow history), we BLOCK rather than silently pass — the inverse of
+# ignore-build.sh's fail-OPEN, because there an uncomputable diff risks losing
+# a deploy, while here it risks waving through an unauthorized edit.
+set -euo pipefail
+
+CONFIG_DIR="${SCOPE_GUARD_DIR:-.github/scope-guard}"
+PROTECTED_FILE="$CONFIG_DIR/protected-paths.txt"     # Tier-3, operator-only
+AGENT_PATHS_FILE="$CONFIG_DIR/agent-paths.txt"
+AGENT_LOGINS_FILE="$CONFIG_DIR/agent-logins.txt"
+
+ACTOR="${ACTOR:-}"                       # PR author login
+OWNER_LOGINS="${OWNER_LOGINS:-kaizencycle}"
+PR_BODY_FILE="${PR_BODY_FILE:-}"
+STRICT_ALLOWLIST="${STRICT_ALLOWLIST:-false}"
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stderr}"
+OUT="${GITHUB_OUTPUT:-/dev/null}"
+
+# ── changed files: prove the diff or fail closed ────────────────────────────
+if [[ -n "${BASE_SHA:-}" && -n "${HEAD_SHA:-}" ]]; then
+  RANGE="${BASE_SHA}...${HEAD_SHA}"
+else
+  RANGE="${BASE_REF:-origin/main}...${HEAD_REF:-HEAD}"
+fi
+
+diff_ok=false
+changed="$(git diff --name-only "$RANGE" 2>/dev/null)" && diff_ok=true || true
+
+if [[ "$diff_ok" != true ]]; then
+  {
+    echo "### scope-guard — FAIL (diff unavailable)"
+    echo ""
+    echo "Could not resolve \`git diff --name-only $RANGE\`."
+    echo "Failing CLOSED: a scope gate must never silently pass on uncertainty."
+    echo "Likely cause: shallow checkout — ensure \`fetch-depth: 0\`."
+  } >> "$SUMMARY"
+  echo "scope-guard FAIL: could not compute diff for '$RANGE' — failing closed."
+  exit 1
+fi
+
+load() { grep -vE '^[[:space:]]*(#|$)' "$1" 2>/dev/null || true; }
+
+# ── pattern sets ────────────────────────────────────────────────────────────
+mapfile -t T3 < <(load "$PROTECTED_FILE")
+# Tier-2 = schema / shape / domain zones PULL_REQUEST_TEMPLATE.md's "LOCKED
+# BEHAVIOR AUDIT" calls out by name (journal KV key schema, ECHO->epicon:feed
+# LPUSH, EPICON shape).
+T2=( '^app/api/agents/journal/route\.ts$' '^app/api/echo/ingest/route\.ts$' '^lib/epicon/' )
+
+matches_any() { local f="$1"; shift; local p; for p in "$@"; do [[ "$f" =~ $p ]] && return 0; done; return 1; }
+
+t3_hits=(); t2_hits=(); code_changed=false
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if matches_any "$f" "${T3[@]}"; then t3_hits+=("$f"); fi
+  if matches_any "$f" "${T2[@]}"; then t2_hits+=("$f"); fi
+  if [[ ! "$f" =~ ^(docs/|content/)|\.md$ ]]; then code_changed=true; fi
+done <<< "$changed"
+
+# ── tier ────────────────────────────────────────────────────────────────────
+if   [[ ${#t3_hits[@]} -gt 0 ]]; then tier="T3"
+elif [[ ${#t2_hits[@]} -gt 0 ]]; then tier="T2"
+elif [[ "$code_changed" == true ]]; then tier="T1"
+else tier="T0"; fi
+echo "tier=$tier" >> "$OUT"
+
+# ── actor class (owner wins over agent) ─────────────────────────────────────
+is_owner=false
+for o in $OWNER_LOGINS; do [[ "${ACTOR,,}" == "${o,,}" ]] && is_owner=true; done
+is_agent=false
+if [[ "$is_owner" != true ]]; then
+  [[ "${ACTOR,,}" == *"[bot]" ]] && is_agent=true
+  while IFS= read -r a; do [[ -n "$a" && "${ACTOR,,}" == "${a,,}" ]] && is_agent=true; done < <(load "$AGENT_LOGINS_FILE")
+fi
+actor_class="external"; [[ "$is_owner" == true ]] && actor_class="owner"; [[ "$is_agent" == true ]] && actor_class="agent"
+
+# ── EPICON receipt (matches the existing PR template's §3 + §7 fields) ──────
+have_receipt=false
+if [[ -n "$PR_BODY_FILE" && -f "$PR_BODY_FILE" ]]; then
+  if grep -qiE 'epicon_id[[:space:]]*:' "$PR_BODY_FILE" && grep -qiE 'rollback' "$PR_BODY_FILE"; then
+    have_receipt=true
+  fi
+fi
+
+# ── decision ─────────────────────────────────────────────────────────────────
+fail=false; reasons=()
+
+# Rule 1 — Tier-3 is operator-only. Agents propose, never ship into these paths.
+if [[ ${#t3_hits[@]} -gt 0 && "$is_owner" != true ]]; then
+  fail=true
+  reasons+=("Tier-3 violation: operator-only path(s) edited by '${ACTOR:-unknown}' ($actor_class). Agents may not modify: ${t3_hits[*]}")
+fi
+
+# Rule 2 — agent code changes require an EPICON receipt (intent ledgered before diff).
+if [[ "$is_agent" == true && "$code_changed" == true && "$have_receipt" != true ]]; then
+  fail=true
+  reasons+=("Missing EPICON receipt: agent-authored code change needs 'epicon_id:' + a rollback plan in the PR body.")
+fi
+
+# Rule 3 — optional strict allowlist for agents (off by default; flip once agent-paths.txt is trusted).
+if [[ "$STRICT_ALLOWLIST" == "true" && "$is_agent" == true ]]; then
+  mapfile -t AGP < <(load "$AGENT_PATHS_FILE")
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    if [[ "$f" =~ ^(docs/|content/)|\.md$ ]]; then continue; fi
+    if ! matches_any "$f" "${AGP[@]}"; then
+      fail=true; reasons+=("Strict allowlist: agent may not edit '$f' (outside agent-paths).")
+    fi
+  done <<< "$changed"
+fi
+
+# ── report ───────────────────────────────────────────────────────────────────
+{
+  echo "### scope-guard — $tier (author: ${ACTOR:-?} / $actor_class)"
+  echo ""
+  echo "Changed files: $(printf '%s\n' "$changed" | grep -c . || true)"
+  [[ ${#t3_hits[@]} -gt 0 ]] && echo "- Tier-3 paths: \`${t3_hits[*]}\`"
+  [[ ${#t2_hits[@]} -gt 0 ]] && echo "- Tier-2 paths: \`${t2_hits[*]}\`"
+  echo "- EPICON receipt present: $have_receipt"
+  if [[ "$tier" == "T2" || "$tier" == "T3" ]]; then
+    echo "- ⚠️ Tier 2+ — operator review required, do not self-merge."
+  fi
+} >> "$SUMMARY"
+
+if [[ "$fail" == true ]]; then
+  { echo ""; echo "**FAIL**"; for r in "${reasons[@]}"; do echo "- $r"; done; } >> "$SUMMARY"
+  echo "scope-guard FAIL ($tier):"; printf '  - %s\n' "${reasons[@]}"
+  exit 1
+fi
+
+echo "scope-guard PASS ($tier, $actor_class)"
+exit 0

--- a/scripts/scope-guard.sh
+++ b/scripts/scope-guard.sh
@@ -90,12 +90,30 @@ if [[ "$is_owner" != true ]]; then
 fi
 actor_class="external"; [[ "$is_owner" == true ]] && actor_class="owner"; [[ "$is_agent" == true ]] && actor_class="agent"
 
-# ── EPICON receipt (matches the existing PR template's §3 + §7 fields) ──────
+# ── EPICON receipt: a ledgered `epicon_id:` + a FILLED-IN rollback plan ─────
+# PULL_REQUEST_TEMPLATE.md instructs "Replace all `[PLACEHOLDERS]`" — its own
+# unfilled §3/§7 carry `epicon_id: EPICON_C-[CYCLE]_...` and `git revert
+# [commit-sha]`, while "Rollback Plan" / "Rollback plan provided" appear in
+# the template's heading and stop-conditions checklist regardless of whether
+# anything was filled in. A bare substring match on "epicon_id:" / "rollback"
+# is therefore satisfied by a verbatim, untouched template. Require the
+# epicon_id line — and EITHER a `rollback:` key (the compact receipt shape)
+# OR a filled-in `git revert <sha>` (the template's own §7 shape) — to carry
+# real values, not `[bracket]` placeholders.
 have_receipt=false
 if [[ -n "$PR_BODY_FILE" && -f "$PR_BODY_FILE" ]]; then
-  if grep -qiE 'epicon_id[[:space:]]*:' "$PR_BODY_FILE" && grep -qiE 'rollback' "$PR_BODY_FILE"; then
-    have_receipt=true
-  fi
+  epicon_line="$(grep -iE 'epicon_id[[:space:]]*:' "$PR_BODY_FILE" | head -1 || true)"
+  rollback_kv="$(grep -iE 'rollback[[:space:]]*:' "$PR_BODY_FILE" | head -1 || true)"
+  rollback_cmd="$(grep -iE 'git revert' "$PR_BODY_FILE" | head -1 || true)"
+
+  have_epicon=false
+  [[ -n "$epicon_line" && "$epicon_line" != *'['*']'* ]] && have_epicon=true
+
+  have_rollback=false
+  [[ -n "$rollback_kv"  && "$rollback_kv"  != *'['*']'* ]] && have_rollback=true
+  [[ -n "$rollback_cmd" && "$rollback_cmd" != *'['*']'* ]] && have_rollback=true
+
+  [[ "$have_epicon" == true && "$have_rollback" == true ]] && have_receipt=true
 fi
 
 # ── decision ─────────────────────────────────────────────────────────────────

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# scripts/setup-branch-protection.sh — C-336.
+#
+# Enforces the guardrails at the platform layer instead of on trust. Run this
+# ONCE, by hand, as the operator (requires `gh` authenticated with admin on the
+# repo). It is intentionally NOT wired into any workflow — changing branch
+# protection is a Tier-3, consequential act.
+#
+# NOTE: this is a user-owned repo, so push "restrictions" (user/team allowlists)
+# are not settable via this API for non-org repos — enforcement here leans on
+# required status checks + required CODEOWNER review instead.
+set -euo pipefail
+
+REPO="${REPO:-kaizencycle/mobius-civic-ai-terminal}"
+BRANCH="${BRANCH:-main}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found. Install: https://cli.github.com/" >&2
+  exit 1
+fi
+
+PAYLOAD=$(cat <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["scope-guard", "contract", "guard", "sentinel", "gi-gate"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "require_code_owner_reviews": true,
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_linear_history": true
+}
+JSON
+)
+
+echo "Applying branch protection to $REPO@$BRANCH ..."
+gh api -X PUT "repos/$REPO/branches/$BRANCH/protection" \
+  -H "Accept: application/vnd.github+json" --input - <<<"$PAYLOAD"
+
+echo ""
+echo "Done. Required checks: scope-guard, contract, guard, sentinel, gi-gate."
+echo "CODEOWNER review required (1 approval); force-push & deletion disabled; linear history on."
+echo "Re-run any time — this is idempotent (PUT replaces the protection config)."


### PR DESCRIPTION
## Summary

Mobius sentinels are also the Mobius DevOps team — they should be able to write code and open PRs against this repo. This PR machine-enforces the constitution that has to govern that: **agents author, the operator ships.** Propose and merge are separated; the consequential lever (touching auth/identity/ledger math/the guardrails, or shipping to prod) stays human, by protocol — not by hope. The C-335 freeze (prod stuck ~2 days behind ~40 sentinel pushes) is the cautionary tale for *why* this has to be mechanical rather than assumed.

## What's included

- **`scripts/scope-guard.sh`** + **`.github/workflows/scope-guard.yml`** — a new required CI check that classifies every PR diff into Tier 0–3 (mirroring `PULL_REQUEST_TEMPLATE.md` §2) and enforces:
  1. **Tier-3 paths are operator-only.** A non-owner edit to `lib/substrate/`, `lib/auth/` + `lib/identity/` + `auth.ts`, `lib/mic/` + `app/api/mic/`, `lib/integrity/`, the guardrails themselves, or deploy/infra config **fails** the check.
  2. **Agent-authored code changes require an EPICON receipt** (`epicon_id:` + a rollback plan in the PR body) — the "why" is ledgered before the diff, mirroring template §3/§7.
  3. Optional `STRICT_ALLOWLIST=true` confines agents to `.github/scope-guard/agent-paths.txt` (off by default until that allowlist is trusted).
  - **Fails closed**: an unprovable diff (shallow checkout, bad refs) blocks rather than silently passing — the deliberate *inverse* of `ignore-build.sh`'s fail-*open* posture. The two gates protect against opposite risks: losing a deploy vs. waving through an unauthorized edit.
- **`.github/scope-guard/{protected-paths,agent-paths,agent-logins}.txt`** — the data the gate runs on: Tier-3 patterns, the (currently advisory) agent-paths allowlist, and known agent/bot logins.
- **`.github/CODEOWNERS`** — routes every Tier-3 surface to `@kaizencycle` so GitHub requires operator review before merge (paired with `setup-branch-protection.sh` below).
- **`scripts/setup-branch-protection.sh`** — one-time, by-hand operator script (`gh api PUT .../protection`) that wires `scope-guard` (+ `contract`, `guard`, `sentinel`, `gi-gate`) as required status checks and requires CODEOWNER review. Idempotent — `PUT` replaces the whole config, safe to re-run.
- **`docs/governance/agent-devops.md`** — the governance doc: pipeline (identity → branch isolation → scope-guard → CODEOWNERS → ship gate → reversibility circuit breaker), the Tier map, "the load-bearing guarantee" (an agent must never be able to edit the thing that constrains agents — `scope-guard.sh`, `ignore-build.sh`, `CODEOWNERS`, and `.github/workflows/` are themselves Tier-3), and the operator rollout checklist.

## The load-bearing guarantee

`scripts/scope-guard.sh`, `scripts/ignore-build.sh`, `.github/CODEOWNERS`, `scripts/setup-branch-protection.sh`, and everything under `.github/` are themselves listed in `protected-paths.txt` as Tier-3/operator-only. An agent cannot edit the thing that constrains agents — that's what makes this self-sustaining rather than advisory.

## Verification

Built a 15-scenario sandbox matrix (separate throwaway repo, real `scope-guard.sh` + real config copied in) exercising every branch of the decision logic. All 15 pass with the expected verdict:

| Scenario | Actor (class) | Expected | Result |
|---|---|---|---|
| Agent edits `lib/substrate/` | `claude[bot]` (agent) | FAIL — T3 + no receipt | ✅ FAIL (T3): both reasons reported |
| Agent edits `scripts/scope-guard.sh` | `mobius-bot` (agent) | FAIL — T3 + no receipt | ✅ FAIL (T3): both reasons reported |
| Agent code change, no receipt | `claude[bot]` (agent) | FAIL — missing receipt | ✅ FAIL (T1) |
| Agent edits journal route, no receipt | `cursor[bot]` (agent) | FAIL — T2 + no receipt | ✅ FAIL (T2) |
| Diff range unresolvable (bad SHA) | `claude[bot]` | FAIL — closed | ✅ FAIL: "could not compute diff … failing closed" |
| Owner edits `lib/identity/` | `kaizencycle` (owner) | PASS — T3, owner | ✅ PASS (T3, owner) |
| Agent code change **with** receipt | `claude[bot]` (agent) | PASS | ✅ PASS (T1, agent) |
| Agent docs-only change | `claude[bot]` (agent) | PASS — T0, exempt | ✅ PASS (T0, agent) |
| Owner edits `package.json` | `kaizencycle` (owner) | PASS — T3, owner | ✅ PASS (T3, owner) |
| External human edits app code | `some-rando` (external) | PASS — T1, no receipt rule for non-agents | ✅ PASS (T1, external) |
| Agent journal route **with** receipt | `claude[bot]` (agent) | PASS — T2 | ✅ PASS (T2, agent) |
| `STRICT_ALLOWLIST=true`, in-allowlist | `claude[bot]` (agent) | PASS | ✅ PASS |
| `STRICT_ALLOWLIST=true`, docs (exempt) | `claude[bot]` (agent) | PASS | ✅ PASS |
| `STRICT_ALLOWLIST=true`, out-of-allowlist | `claude[bot]` (agent) | FAIL — outside agent-paths | ✅ FAIL: "may not edit … (outside agent-paths)" |

`bash -n` syntax-clean on both scripts; executable bits set.

## Notes for the reviewer (corrections made during implementation)

This was implemented from a pasted proposal/diff from another planning session. Cross-checking it against the actual repo tree (`git ls-tree -r origin/main`) surfaced gaps serious enough to fix before shipping — a guardrail with holes in exactly the surfaces it claims to protect would be worse than no guardrail:

- **`protected-paths.txt` was missing `lib/auth/`, `lib/identity/` (the permission/identity guards!), `lib/mic/` + `app/api/mic/` (22 files of ledger settlement/chain-hash math!), `lib/integrity/` (canon hash roots), `auth.ts`, `mobius.yaml`, `render.yaml`, and `scripts/setup-branch-protection.sh`.** Left as proposed, agents could have frictionlessly edited identity/auth and ledger-math surfaces — defeating the stated purpose. Also dropped three phantom paths that don't exist in this repo (`canon/`, `tokenomics.yaml`, `*constitution*`).
- **`agent-paths.txt`** referenced `lib/detectors/`, `app/chambers/`, `content/` — none exist here. Replaced with the real agent-authored surfaces: `app/api/agents/`, `app/api/chambers/`, `lib/chambers/`, `lib/signals/`, `lib/agents/`, `docs/`.
- **`scope-guard.sh`'s diff-unavailable branch silently passed** in the original — inverted to fail closed (block + explain) per this gate's stated security posture (and per this repo's own anti-nuke convention for unprovable diffs).
- **`ignore-build.sh` hunk dropped** — C-335 already shipped equivalent fail-open + force-deploy-override logic; re-applying would have been a regression risk on a Tier-3 file.
- Workflow brought in line with house style from `sentinel-review.yml`/`contract-tests.yml`: `${{ runner.temp }}` instead of hardcoded `/tmp`, `concurrency` group + `timeout-minutes: 5`.

## Rollout (operator, post-merge — not run by this PR)

1. `scripts/setup-branch-protection.sh` (requires `gh` admin) — locks in required checks + CODEOWNER review.
2. Provision the scoped GitHub App / PAT for agent identities (per `docs/governance/agent-devops.md` §1).
3. Once `agent-paths.txt` is trusted in practice, flip `STRICT_ALLOWLIST` to `"true"` in `scope-guard.yml`.

---

## EPICON Receipt

```text
epicon_id: EPICON_C-336_agent-devops_scope-guard
rollback: revert this PR — every change is a net-new file (no existing
  surface is edited; ignore-build.sh is untouched). Reverting removes the
  new scope-guard check, CODEOWNERS routing, and governance doc with zero
  risk to any running surface.
```

## Rollback Plan

Single revert. No schema, no migration, no runtime-surface edits — purely new CI gate + new config + new docs. `scope-guard` isn't wired into branch protection by this PR (that's the operator's manual `setup-branch-protection.sh` step), so even a bad rule set can't block merges until the operator opts in.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AgXocGAEbYpziWyHHWQr1V)_