### PR TITLE
C-337: diagnostic honesty, log hygiene & signal coverage observability (4 OPTs)

### DIFF
--- a/app/api/cron/promote/route.ts
+++ b/app/api/cron/promote/route.ts
@@ -74,7 +74,7 @@ export async function GET(request: NextRequest) {
 
     const body = await res.json().catch(() => null);
     if (!res.ok) {
-      console.error(`[promote] /api/epicon/promote returned ${res.status} — check SUBSTRATE_TOKEN env var`);
+      console.error(`[promote] /api/epicon/promote returned ${res.status} — AGENT_SERVICE_TOKEN rejected at Identity /auth/introspect (SUBSTRATE_TOKEN is the internal cron secret, not the ledger JWT)`);
       if (res.status === 401) {
         // C-332 OPT-3: never log token characters — log only length+presence.
         const tokenLen = (authHeader ?? '').replace(/^Bearer /, '').length;

--- a/app/api/signals/micro/route.ts
+++ b/app/api/signals/micro/route.ts
@@ -44,6 +44,8 @@ export type SignalMicroPayload = {
   instruments: InstrumentResult[];
   fallbacksUsed: number;
   errors: number;
+  /** C-337 OPT-1: names + reasons of errored instruments (GI-neutral diagnostic; makes the `errors` count actionable). */
+  failedInstruments: { id: string; agent: string; error: string }[];
   generatedAt: number;
   cycle: string;
   // Legacy fields — preserved for backward compat with chambers/signals and SignalsPageClient
@@ -162,6 +164,9 @@ export async function GET() {
     instruments,
     fallbacksUsed: instruments.filter((i) => i.source === 'fallback').length,
     errors: instruments.filter((i) => i.source === 'error').length,
+    failedInstruments: instruments
+      .filter((i) => i.source === 'error')
+      .map((i) => ({ id: i.id, agent: i.agent, error: i.error ?? 'unknown' })),
     generatedAt: Date.now(),
     cycle: process.env.CURRENT_CYCLE ?? 'C-306',
     // Legacy compat

--- a/app/api/treasury/alerts/route.ts
+++ b/app/api/treasury/alerts/route.ts
@@ -51,7 +51,7 @@ export async function GET() {
     );
   } catch (error) {
     const reason = await classifyAlertsFailure();
-    console.error('[treasury/alerts] upstream failure', { reason, error });
+    console.warn('[treasury/alerts] upstream degraded (expected; serving last-good/fallback)', { reason, error });
 
     return NextResponse.json(
       {

--- a/app/api/treasury/cross-check/route.ts
+++ b/app/api/treasury/cross-check/route.ts
@@ -34,7 +34,7 @@ export async function GET() {
     );
   } catch (error) {
     const reason = classifyCrossCheckFailure(error);
-    console.error('[treasury/cross-check] upstream failure', { reason, error });
+    console.warn('[treasury/cross-check] upstream degraded (expected; serving last-good/fallback)', { reason, error });
 
     return NextResponse.json(
       {


### PR DESCRIPTION
## C-337 — Diagnostic Honesty, Log Hygiene & Signal Coverage Observability

**Scope-guard: PASS — T1, owner. No Tier-3, no GI math, no auth changes.**

---

### Why 4 OPTs, not 20

The tree is already hardened. Four of the five things the morning logs flagged (JADE abort handling, treasury 404 graceful-degrade, journal 502 cascade, cron 401 token-hygiene) are already fixed in `main` — those logs were the stale `dpl_G6vR` build. Manufacturing 20 OPTs to hit a number is the activity-over-measured-integrity move this system exists to refuse. Four real ones ship.

---

### Changes

**OPT-1 — `app/api/signals/micro/route.ts`** (signal coverage observability)
The payload exposed `errors: 10` as a bare count with no instrument names. Added `failedInstruments: { id, agent, error }[]` derived from instruments where `source === 'error'`. The 10/40 failing instruments (THEMIS 3, DAEDALUS 3, HERMES 1, GAIA openaq, ECHO 1, AUREA 1) dragging GI to 0.774 are now nameable — making the drag actionable without touching the composite math.
**GI-neutral by design** — no change to scores, weights, or `lib/integrity`.

**OPT-2 — `app/api/cron/promote/route.ts`** (correct 401 hint)
The error string `check SUBSTRATE_TOKEN env var` named the wrong secret — `SUBSTRATE_TOKEN` is the internal cron secret; the actual 401 failure is `AGENT_SERVICE_TOKEN` rejected at Identity `/auth/introspect`. Corrected to point at the real failure vector.

**OPT-3 — `app/api/treasury/alerts/route.ts`** (log level)
`console.error` → `console.warn` on upstream failure. The route already serves last-good/fallback; logging as error was inflating the error stream for expected degradation.

**OPT-4 — `app/api/treasury/cross-check/route.ts`** (log level)
Same downgrade as OPT-3, same reason.

---

### EPICON Receipts

```
epicon_id: EPICON_C-337_infra_log-hygiene
scope: infra (cron, treasury)
PROBLEM: expected-degraded upstreams logged at error; cron 401 hint named wrong env var.
DECISION: downgrade to warn; correct hint to AGENT_SERVICE_TOKEN/introspect.
BOUNDARIES: no control-flow, response, or auth changes. Log level + string only.

epicon_id: EPICON_C-337_signals_coverage-observability
scope: signals (micro sweep diagnostics)
PROBLEM: GI 0.774 drag opaque — `errors` was a count with no instrument names.
DECISION: surface failed instruments by name/agent/reason. GI-neutral; no math change.
BOUNDARIES: does NOT touch lib/integrity, lib/gi, or the 0.5 empty-handling.
TRADEOFFS: chose honesty over a green number — composite still reflects real source failure.
```

---

### The real GI lift (not in this PR — by design)

GI 0.774 is an **honest** yellow. Ten real external instruments are erroring; THEMIS and DAEDALUS are the drag. Retuning the composite to chase green without repairing the sensors would be gaming the metric. The fix is per-instrument source triage — now actionable via `failedInstruments`. That work ships as a separate, operator-reviewed change when the sources are confirmed fixable.

https://claude.ai/code/session_0137oEmMYWr277TrsRJTpat4

---
_Generated by [Claude Code](https://claude.ai/code/session_0137oEmMYWr277TrsRJTpat4)_