### PR TITLE
C-337: themis-datagov cross-host fallback

### DIFF
--- a/lib/signals/registry.ts
+++ b/lib/signals/registry.ts
@@ -214,9 +214,15 @@ const THEMIS_INSTRUMENTS: SignalInstrument[] = [
     agent: 'THEMIS',
     label: 'data.gov dataset freshness',
     primary: 'https://catalog.data.gov/api/3/action/package_search?q=civic&rows=5&sort=metadata_modified+desc',
-    // C-337: data.gov CKAN API intermittently down; fallback to data.gov status page API.
-    fallback: 'https://catalog.data.gov/api/3/action/site_read',
-    normalize: (d: unknown) => ((d as { success?: boolean })?.success ? 0.9 : 0.3),
+    // C-337: catalog.data.gov occasionally goes down host-wide, which previously took out
+    // both primary and fallback (site_read shares the same host). Fallback now points at
+    // GSA's data.gov repo on api.github.com — a different host, so a catalog.data.gov
+    // outage doesn't blind this instrument too.
+    fallback: 'https://api.github.com/repos/GSA/data.gov/commits?per_page=1',
+    normalize: (d: unknown) => {
+      if (Array.isArray(d)) return d.length > 0 ? 0.8 : 0.3;
+      return (d as { success?: boolean })?.success ? 0.9 : 0.3;
+    },
     weight: 1,
   },
   {


### PR DESCRIPTION
## EPICON Receipt

- **epicon_id**: C-337
- **scope**: `lib/signals/registry.ts` — single instrument (`themis-datagov`), URL + normalize only
- **justification**:
  - **PROBLEM**: `themis-datagov` was in `failedInstruments` (score 0). Its fallback (`catalog.data.gov/api/3/action/site_read`) shares the same host as primary (`catalog.data.gov/api/3/action/package_search`), so a host-wide `catalog.data.gov` outage takes out both primary and fallback simultaneously — the fallback provides no real redundancy.
  - **DECISION**: Replace the fallback with `https://api.github.com/repos/GSA/data.gov/commits?per_page=1` — a different host (api.github.com), no key required, already a proven-reliable pattern elsewhere in this registry (DAEDALUS GitHub polling). `normalize` now handles both response shapes: CKAN's `{ success: boolean }` from primary, or a commits array from the GitHub fallback.
  - **BOUNDARIES**: No GI/composite math touched. No changes to `lib/integrity/` or `lib/gi/`. Registry-only edit (URL + normalize for one instrument).
  - **TRADEOFFS**: The fallback signal (GSA data.gov repo commit activity) is a looser proxy for "data.gov dataset freshness" than the primary CKAN catalog query, but only activates when primary fails — preserves the honest signal in the common case while giving real redundancy during a `catalog.data.gov` outage.
- **rollback**: revert this commit; restores prior `fallback`/`normalize` for `themis-datagov`.

Scope-guard: PASS — T1, owner.

Continuation of C-337 per-instrument GI triage (follow-up to #564/#565).


---
_Generated by [Claude Code](https://claude.ai/code/session_0137oEmMYWr277TrsRJTpat4)_