### PR TITLE
C-338: mint Identity JWT at runtime for /ledger/attest

### DIFF
--- a/app/api/admin/substrate-rejection/route.ts
+++ b/app/api/admin/substrate-rejection/route.ts
@@ -4,10 +4,34 @@ import { kvGet } from '@/lib/kv/store';
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  const rejection = await kvGet<string>('substrate:last_rejection');
-  return NextResponse.json({
-    ok: true,
-    rejection: rejection ? JSON.parse(rejection) : null,
-    timestamp: new Date().toISOString(),
-  });
+  try {
+    // C-338 fix: @upstash/redis auto-deserializes JSON values on GET, so this
+    // key may arrive as an object. The previous unconditional JSON.parse threw
+    // on objects → 500, hiding the very breadcrumb this route exists to show.
+    const raw = await kvGet<unknown>('substrate:last_rejection');
+    const rejection =
+      typeof raw === 'string'
+        ? (() => {
+            try {
+              return JSON.parse(raw);
+            } catch {
+              return { raw };
+            }
+          })()
+        : raw;
+    return NextResponse.json({
+      ok: true,
+      rejection: rejection ?? null,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : 'kv_read_failed',
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
 }

--- a/lib/substrate/client.ts
+++ b/lib/substrate/client.ts
@@ -268,7 +268,10 @@ export type AttestToLedgerResult = { ok: boolean; entryId?: string; error?: stri
  */
 export async function attestToLedger(entry: SubstrateEntry): Promise<AttestToLedgerResult> {
   const LEDGER_BASE = resolveSubstrateLedgerUrl();
-  const AGENT_TOKEN = getAgentBearerToken();
+  // C-338: /ledger/attest verifies via Identity introspection — mint a runtime
+  // JWT (falls back to the static agent token when creds are unconfigured).
+  const { getAttestBearerToken } = await import('@/lib/substrate/identityToken');
+  const AGENT_TOKEN = await getAttestBearerToken();
   const authorization = AGENT_TOKEN.length > 0 ? `Bearer ${AGENT_TOKEN}` : '';
   const eventId = entry.id ?? `${entry.agentOrigin}-${entry.cycle}-${Date.now()}`;
   const attestTimestamp = new Date().toISOString();
@@ -350,6 +353,12 @@ export async function attestToLedger(entry: SubstrateEntry): Promise<AttestToLed
         : undefined;
       console.warn('[substrate] ledger attest rejected', { ...safeDebug, hint });
       await persistLastLedgerRejection(safeDebug);
+      if (res.status === 401) {
+        // C-338: cached identity JWT may have expired mid-window — force a
+        // re-mint so the next cron tick attests with a fresh token.
+        const { invalidateIdentityToken } = await import('@/lib/substrate/identityToken');
+        invalidateIdentityToken();
+      }
       throw new Error(`ledger ${res.status}${detail ? `: ${detail}` : ''}`);
     }
     // C-296 OPT-2: guard Content-Type before JSON.parse — Render cold-starts

--- a/lib/substrate/client.ts
+++ b/lib/substrate/client.ts
@@ -377,12 +377,15 @@ export async function attestToLedger(entry: SubstrateEntry): Promise<AttestToLed
     void markSubmitted(entryId);
 
     const MIC_URL = (process.env.MIC_WALLET_URL ?? process.env.RENDER_MIC_URL ?? '').trim();
-    if (MIC_URL.length > 0 && AGENT_TOKEN.length > 0) {
+    // C-338 Codex review: keep MIC earn on the static service token — the
+    // minted Identity JWT (AGENT_TOKEN above) is for /ledger/attest only.
+    const MIC_TOKEN = getAgentBearerToken();
+    if (MIC_URL.length > 0 && MIC_TOKEN.length > 0) {
       void fetch(`${MIC_URL.replace(/\/+$/, '')}/mic/earn`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${AGENT_TOKEN}`,
+          Authorization: `Bearer ${MIC_TOKEN}`,
         },
         body: JSON.stringify({
           source: 'agent_epicon_attest',

--- a/lib/substrate/identityToken.ts
+++ b/lib/substrate/identityToken.ts
@@ -1,0 +1,161 @@
+// C-338 — Runtime Identity JWT minting for ledger attestation.
+//
+// ROOT CAUSE (C-326→C-338 attestation saga): the ledger's /ledger/attest
+// verifies bearers via Identity introspection (verify_token in CPC
+// ledger/app/main.py) — it has NO shared-secret path. The Terminal was
+// sending AGENT_SERVICE_TOKEN (a shared secret valid for /api/vault/* and
+// /api/epicon/ingest, which compare by string equality), so introspection
+// rejected every attest with 401. No token VALUE fixes a protocol mismatch.
+//
+// INTENDED DESIGN (scripts/provision_service_account.py in CPC): a robot
+// identity exists at the Mobius Identity Service; "JWTs are minted at
+// runtime via login." This module implements the minting half the Terminal
+// never had.
+//
+// Behavior:
+//   - If IDENTITY_SERVICE_EMAIL + IDENTITY_SERVICE_PASSWORD are configured,
+//     mint an access token via POST {IDENTITY_API_BASE}/auth/login, cache it
+//     (module memory + KV) and serve it for attest calls.
+//   - If creds are absent, fall back to getAgentBearerToken() — current
+//     behavior, graceful degradation, nothing breaks if env isn't set yet.
+//   - invalidateIdentityToken() lets callers force a re-mint after a 401
+//     (token expiry mid-cache-window).
+//
+// EPICON note: this changes only HOW the Terminal authenticates to
+// /ledger/attest. Event content, EPICON criteria, and KV-first write order
+// (resilientWrite) are untouched.
+//
+// CC0 Public Domain
+
+import { getAgentBearerToken } from '@/lib/substrate/client';
+
+const DEFAULT_IDENTITY_BASE = 'https://mobius-identity-service.onrender.com';
+const KV_KEY = 'substrate:identity_jwt';
+// Conservative cache window; tokens are re-minted well before typical JWT
+// expiry. Override with IDENTITY_JWT_CACHE_SECONDS if the Identity service's
+// expiry is known to be shorter.
+const DEFAULT_CACHE_SECONDS = 600;
+
+type CachedToken = { token: string; expiresAt: number };
+
+let memoryCache: CachedToken | null = null;
+let inflight: Promise<string | null> | null = null;
+
+function identityBase(): string {
+  return (process.env.IDENTITY_API_BASE ?? DEFAULT_IDENTITY_BASE).trim().replace(/\/+$/, '');
+}
+
+function cacheSeconds(): number {
+  const raw = Number(process.env.IDENTITY_JWT_CACHE_SECONDS ?? DEFAULT_CACHE_SECONDS);
+  return Number.isFinite(raw) && raw > 30 ? raw : DEFAULT_CACHE_SECONDS;
+}
+
+function credsConfigured(): boolean {
+  return (
+    (process.env.IDENTITY_SERVICE_EMAIL ?? '').trim().length > 0 &&
+    (process.env.IDENTITY_SERVICE_PASSWORD ?? '').trim().length > 0
+  );
+}
+
+async function readKvCache(): Promise<CachedToken | null> {
+  try {
+    const { kvGet } = await import('@/lib/kv/store');
+    const raw = await kvGet<CachedToken | string>(KV_KEY);
+    if (!raw) return null;
+    // Upstash auto-deserializes JSON; tolerate both shapes (see the
+    // substrate-rejection double-parse bug fixed this cycle).
+    const parsed: CachedToken = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    if (typeof parsed?.token === 'string' && typeof parsed?.expiresAt === 'number') {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeKvCache(entry: CachedToken): Promise<void> {
+  try {
+    const { kvSet } = await import('@/lib/kv/store');
+    const ttl = Math.max(60, Math.floor((entry.expiresAt - Date.now()) / 1000));
+    await kvSet(KV_KEY, JSON.stringify(entry), ttl);
+  } catch {
+    // KV unavailable — memory cache still applies for this lambda instance.
+  }
+}
+
+async function mintToken(): Promise<string | null> {
+  const email = (process.env.IDENTITY_SERVICE_EMAIL ?? '').trim();
+  const password = (process.env.IDENTITY_SERVICE_PASSWORD ?? '').trim();
+  let res: Response;
+  try {
+    res = await fetch(`${identityBase()}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+      signal: AbortSignal.timeout(10_000),
+      cache: 'no-store',
+    });
+  } catch (err) {
+    console.error('[identity-token] login network error:', err instanceof Error ? err.message : err);
+    return null;
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    console.error('[identity-token] login rejected', { status: res.status, body: body.slice(0, 300) });
+    return null;
+  }
+  const data = (await res.json().catch(() => null)) as { access_token?: string } | null;
+  const token = data?.access_token?.trim() ?? '';
+  if (token.length === 0) {
+    console.error('[identity-token] login response missing access_token');
+    return null;
+  }
+  const entry: CachedToken = { token, expiresAt: Date.now() + cacheSeconds() * 1000 };
+  memoryCache = entry;
+  await writeKvCache(entry);
+  console.info('[identity-token] minted identity JWT for ledger attest', {
+    base: identityBase(),
+    cache_seconds: cacheSeconds(),
+  });
+  return token;
+}
+
+/** Force a re-mint on next call (use after a ledger 401 with a cached token). */
+export function invalidateIdentityToken(): void {
+  memoryCache = null;
+  void (async () => {
+    try {
+      const { kvDel } = await import('@/lib/kv/store');
+      await kvDel(KV_KEY);
+    } catch {
+      /* best effort */
+    }
+  })();
+}
+
+/**
+ * Bearer for /ledger/attest. Identity JWT when service creds are configured
+ * (the protocol the ledger's verify_token actually speaks); falls back to the
+ * static agent token otherwise so behavior is unchanged until env is set.
+ */
+export async function getAttestBearerToken(): Promise<string> {
+  if (!credsConfigured()) return getAgentBearerToken();
+
+  if (memoryCache && memoryCache.expiresAt > Date.now()) return memoryCache.token;
+
+  const kvCached = await readKvCache();
+  if (kvCached && kvCached.expiresAt > Date.now()) {
+    memoryCache = kvCached;
+    return kvCached.token;
+  }
+
+  if (!inflight) {
+    inflight = mintToken().finally(() => {
+      inflight = null;
+    });
+  }
+  const minted = await inflight;
+  // If minting failed, degrade to the static token rather than sending nothing.
+  return minted ?? getAgentBearerToken();
+}

--- a/lib/terminal/attest.ts
+++ b/lib/terminal/attest.ts
@@ -1,6 +1,5 @@
 // C-305 OPT-03: Substrate write — hardcoded Render endpoint, no GitHub fallback.
 // CIVIC_LEDGER_URL must be set; if absent, write is aborted and error is logged.
-import { getAgentBearerToken } from '@/lib/substrate/client';
 
 export type AttestPayload = {
   cycle?: string;
@@ -34,10 +33,10 @@ export async function attestToSubstrate(payload: AttestPayload): Promise<AttestR
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        // C-333 OPT-1: use the canonical token resolver. SUBSTRATE_TOKEN is the
-        // INTERNAL cron→endpoint shared secret, NOT the outbound Identity JWT.
-        // Sending it to the ledger caused the Branch-C 401 at /auth/introspect.
-        Authorization: `Bearer ${getAgentBearerToken()}`,
+        // C-338: /ledger/attest speaks Identity introspection, not shared
+        // secret. Mint a runtime JWT (getAttestBearerToken falls back to the
+        // static agent token when IDENTITY_SERVICE_* env is unconfigured).
+        Authorization: `Bearer ${await (await import('@/lib/substrate/identityToken')).getAttestBearerToken()}`,
       },
       body: JSON.stringify(enriched),
     });


### PR DESCRIPTION
## EPICON Receipt

- **epicon_id**: C-338
- **scope**: `lib/substrate/identityToken.ts` (new), `lib/substrate/client.ts`, `lib/terminal/attest.ts`, `app/api/admin/substrate-rejection/route.ts`
- **justification**:
  - **PROBLEM**: `/ledger/attest` on Civic-Protocol-Core verifies bearers via Identity introspection (`verify_token`, `ledger/app/main.py`). The Terminal sends `AGENT_SERVICE_TOKEN` — a shared secret accepted by string-equality on `/api/vault/*` and `/api/epicon/ingest`, but the Identity service rejects it outright since it's not an Identity-issued JWT. Every attest 401s. This is a protocol mismatch; PR #562 hardened *which* token was sent, but the C-326→C-338 401s persisted because the route speaks a different auth protocol entirely. `/ledger/stats` shows `total_events: 0` — the 50-seal backlog is parked in KV via `resilientWrite`'s `pending_immortalization`, exactly as designed, just never flushed.
  - **DECISION**: Implement the minting half of the existing `scripts/provision_service_account.py` design. New `lib/substrate/identityToken.ts` mints an Identity JWT at runtime via `POST /auth/login` when `IDENTITY_SERVICE_EMAIL`/`IDENTITY_SERVICE_PASSWORD` are configured, caches it (module memory + KV `substrate:identity_jwt`, single-flight, default 600s window), and exposes `getAttestBearerToken()` / `invalidateIdentityToken()`. `attestToLedger` (client.ts) and `attestToSubstrate` (terminal/attest.ts) now use the minted JWT, invalidating the cache on a 401 so the next cron tick re-mints. Falls back to the existing static agent token (`getAgentBearerToken()`) when Identity creds are unconfigured — **zero behavior change until the env vars are set**. Also fixes a separate bug found while tracing this: `app/api/admin/substrate-rejection/route.ts` was 500ing because `@upstash/redis` auto-deserializes JSON on `kvGet`, so the route's unconditional `JSON.parse` threw on an already-parsed object — this hid the very breadcrumb that would have shortened this saga.
  - **BOUNDARIES**: No GI/composite math touched, no changes to `lib/integrity/` or `lib/gi/`. Event content, EPICON criteria, and the KV-first `resilientWrite` order are untouched — this changes only *how* the Terminal authenticates to `/ledger/attest`. The shared secret remains correct and unchanged for `/api/vault/*` and `/api/epicon/ingest` (intra-service, string-equality).
  - **TRADEOFFS**: Requires provisioning a robot identity account at the Identity service and setting `IDENTITY_SERVICE_EMAIL`/`IDENTITY_SERVICE_PASSWORD` (+ optional `IDENTITY_API_BASE`, `IDENTITY_JWT_CACHE_SECONDS`) in Vercel for the fix to take effect — until then, behavior is identical to today (still 401, still parking in KV). Two dynamic `import()`s are used in hot paths (`client.ts`, `terminal/attest.ts`) to avoid a module cycle with `identityToken.ts` (which itself imports `getAgentBearerToken` from `client.ts` for fallback).
- **rollback**: revert this commit. Restores prior static-token-only `attestToLedger`/`attestToSubstrate` and the prior (occasionally-500ing) `substrate-rejection` route.

Scope-guard: PASS — T1, owner.

**Operator follow-up required** (not part of this PR):
1. Provision the robot identity (`scripts/provision_service_account.py signup` + `smoke` in Civic-Protocol-Core).
2. Set `IDENTITY_SERVICE_EMAIL` / `IDENTITY_SERVICE_PASSWORD` in Vercel (Production).
3. After deploy, confirm Vercel logs show `[identity-token] minted identity JWT` → `[substrate] ledger attest confirmed`, and `/ledger/stats` shows `total_events > 0`.


---
_Generated by [Claude Code](https://claude.ai/code/session_0137oEmMYWr277TrsRJTpat4)_